### PR TITLE
feat(atomic): migrate product component stories (B) to MSW

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-children/atomic-product-children.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-children/atomic-product-children.new.stories.tsx
@@ -1,12 +1,27 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceProductList} from '@/storybook-utils/commerce/commerce-product-list-wrapper';
 import {wrapInProductTemplate} from '@/storybook-utils/commerce/commerce-product-template-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-children/atomic-product-children.js';
 import '@/src/components/commerce/atomic-product-section-children/atomic-product-section-children.js';
+
+const commerceApiHarness = new MockCommerceApi();
+
+// Limit to 1 product so e2e selectors don't hit strict mode violations
+commerceApiHarness.searchEndpoint.mock((response) => ({
+  ...response,
+  products: response.products.slice(0, 1),
+  pagination: {
+    ...response.pagination,
+    totalCount: 1,
+    perPage: 1,
+    totalPages: 1,
+  },
+}));
 
 const {decorator: commerceInterfaceDecorator, play} = wrapInCommerceInterface({
   engineConfig: {
@@ -46,6 +61,7 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -55,6 +71,9 @@ const meta: Meta = {
   argTypes,
 
   play,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-product-description/atomic-product-description.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-description/atomic-product-description.new.stories.tsx
@@ -5,11 +5,14 @@ import type {
 } from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceProductList} from '@/storybook-utils/commerce/commerce-product-list-wrapper';
 import {wrapInProductTemplate} from '@/storybook-utils/commerce/commerce-product-template-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-description/atomic-product-description.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {decorator: commerceInterfaceDecorator, play} = wrapInCommerceInterface({
   engineConfig: {
@@ -44,6 +47,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -62,6 +66,9 @@ const meta: Meta = {
     commerceInterfaceDecorator,
   ],
   play,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.new.stories.tsx
@@ -1,10 +1,13 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceProductList} from '@/storybook-utils/commerce/commerce-product-list-wrapper';
 import {wrapInProductTemplate} from '@/storybook-utils/commerce/commerce-product-template-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {decorator: commerceInterfaceDecorator, play} = wrapInCommerceInterface({
   engineConfig: {
@@ -39,6 +42,7 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -51,6 +55,9 @@ const meta: Meta = {
     ...args,
     'default-slot': `<span>Render me if <strong>ec_name</strong> is defined.</span>`,
     'if-defined': 'ec_name',
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.new.stories.tsx
@@ -1,10 +1,25 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceProductList} from '@/storybook-utils/commerce/commerce-product-list-wrapper';
 import {wrapInProductTemplate} from '@/storybook-utils/commerce/commerce-product-template-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.js';
+
+const commerceApiHarness = new MockCommerceApi();
+
+// Limit to 1 product so e2e selectors don't hit strict mode violations
+commerceApiHarness.searchEndpoint.mock((response) => ({
+  ...response,
+  products: response.products.slice(0, 1),
+  pagination: {
+    ...response.pagination,
+    totalCount: 1,
+    perPage: 1,
+    totalPages: 1,
+  },
+}));
 
 const {decorator: productDecorator} = wrapInProductTemplate();
 const {decorator: commerceProductListDecorator} = wrapInCommerceProductList(
@@ -34,6 +49,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -50,6 +66,9 @@ const meta: Meta = {
   args: {
     ...args,
     field: 'cat_available_sizes',
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-product-numeric-field-value/atomic-product-numeric-field-value.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-numeric-field-value/atomic-product-numeric-field-value.new.stories.tsx
@@ -9,6 +9,24 @@ import '@/src/components/commerce/atomic-product-numeric-field-value/atomic-prod
 
 const commerceApiHarness = new MockCommerceApi();
 
+// Limit to 1 product with no children to avoid strict mode violations in e2e tests
+commerceApiHarness.searchEndpoint.mock((response) => ({
+  ...response,
+  products: [
+    {
+      ...response.products[0],
+      children: [],
+      totalNumberOfChildren: 0,
+    },
+  ],
+  pagination: {
+    ...response.pagination,
+    totalCount: 1,
+    perPage: 1,
+    totalPages: 1,
+  },
+}));
+
 const {decorator: commerceInterfaceDecorator, play} = wrapInCommerceInterface({
   engineConfig: {
     preprocessRequest: (request) => {

--- a/packages/atomic/src/components/commerce/atomic-product-numeric-field-value/atomic-product-numeric-field-value.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-numeric-field-value/atomic-product-numeric-field-value.new.stories.tsx
@@ -1,10 +1,13 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceProductList} from '@/storybook-utils/commerce/commerce-product-list-wrapper';
 import {wrapInProductTemplate} from '@/storybook-utils/commerce/commerce-product-template-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-numeric-field-value/atomic-product-numeric-field-value.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {decorator: commerceInterfaceDecorator, play} = wrapInCommerceInterface({
   engineConfig: {
@@ -39,6 +42,7 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -50,6 +54,9 @@ const meta: Meta = {
   args: {
     ...args,
     field: 'ec_rating',
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.new.stories.tsx
@@ -1,10 +1,13 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {wrapInCommerceProductList} from '@/storybook-utils/commerce/commerce-product-list-wrapper';
 import {wrapInProductTemplate} from '@/storybook-utils/commerce/commerce-product-template-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-product-rating/atomic-product-rating.js';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {
   decorator: commerceInterfaceDecorator,
@@ -54,6 +57,7 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -63,6 +67,9 @@ const meta: Meta = {
   argTypes,
 
   play: initializeCommerceInterface,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;


### PR DESCRIPTION
## Problem
Commerce storybook stories for product components don't use MSW for API mocking, making them less reliable and harder to test in isolation.

## Solution
Migrate atomic-product-rating, atomic-product-description, atomic-product-multi-value-text, atomic-product-numeric-field-value, atomic-product-field-condition, and atomic-product-children stories to use `MockCommerceApi` MSW handlers.

Each story now:
- Imports and instantiates `MockCommerceApi`
- Adds `msw: {handlers: [...commerceApiHarness.handlers]}` to parameters
- Adds `beforeEach: () => { commerceApiHarness.clearAll(); }` for test isolation