### PR TITLE
feat(atomic): add MSW handlers to layout & interface stories

### DIFF
--- a/packages/atomic/src/components/search/atomic-html/atomic-html.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-html/atomic-html.new.stories.tsx
@@ -1,8 +1,11 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-html/atomic-html.js';
+
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers('atomic-html', {
@@ -19,6 +22,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
@@ -1,6 +1,7 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {
   playExecuteFirstSearch,
   wrapInSearchInterface,
@@ -75,6 +76,8 @@ const defaultTemplateContent = `<atomic-result-template>
   </template>
 </atomic-result-template>`;
 
+const searchApiHarness = new MockSearchApi();
+
 const {decorator, play} = wrapInSearchInterface({
   config: {
     search: {
@@ -118,6 +121,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     layout: 'fullscreen',
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.new.stories.tsx
@@ -2,6 +2,7 @@ import {getSampleSearchEngineConfiguration} from '@coveo/headless';
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/search/atomic-breadbox/atomic-breadbox.js';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
@@ -13,6 +14,8 @@ import '@/src/components/search/atomic-search-interface/atomic-search-interface.
 import '@/src/components/search/atomic-search-layout/atomic-search-layout.js';
 import '@/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.js';
 import '@/src/components/search/atomic-sort-expression/atomic-sort-expression.js';
+
+const searchApiHarness = new MockSearchApi();
 
 async function initializeSearchInterface(canvasElement: HTMLElement) {
   await customElements.whenDefined('atomic-search-interface');
@@ -36,6 +39,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-search-layout/atomic-search-layout.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-layout/atomic-search-layout.new.stories.tsx
@@ -1,8 +1,11 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-search-layout/atomic-search-layout.js';
+
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -18,6 +21,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-text/atomic-text.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-text/atomic-text.new.stories.tsx
@@ -1,9 +1,12 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import type {AtomicSearchInterface} from '../atomic-search-interface/atomic-search-interface';
 import '@/src/components/search/atomic-text/atomic-text.js';
+
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface({
   skipFirstSearch: true,
@@ -21,6 +24,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },


### PR DESCRIPTION
## Problem
Several storybook stories for layout and interface components lack MSW handlers, meaning they rely on real network calls during testing.

## Solution
Add `MockSearchApi` MSW handlers to:
- `atomic-search-interface`
- `atomic-search-layout`
- `atomic-html`
- `atomic-text`
- `atomic-result-list`

This follows the same pattern as the other MSW migration PRs.