### PR TITLE
feat(atomic): add MSW handlers to common component stories

### DIFF
--- a/packages/atomic/src/components/common/atomic-aria-live/atomic-aria-live.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-aria-live/atomic-aria-live.new.stories.tsx
@@ -1,9 +1,11 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/common/atomic-aria-live/atomic-aria-live.js';
 
+const searchApiHarness = new MockSearchApi();
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-aria-live',
@@ -18,6 +20,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...searchApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/common/atomic-component-error/atomic-component-error.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-component-error/atomic-component-error.new.stories.tsx
@@ -1,10 +1,12 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/common/atomic-component-error/atomic-component-error.js';
 
+const searchApiHarness = new MockSearchApi();
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes} = getStorybookHelpers('atomic-component-error', {
   excludeCategories: ['methods'],
@@ -24,6 +26,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...searchApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/common/atomic-icon/atomic-icon.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-icon/atomic-icon.new.stories.tsx
@@ -3,6 +3,7 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {expect, userEvent, waitFor} from 'storybook/test';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import AssetsList from '../../../../docs/assets.json';
@@ -14,6 +15,7 @@ function snakeToCamel(value: string) {
     .replace(/([_][a-z])/g, (group) => group.toUpperCase().replace('_', ''));
 }
 
+const searchApiHarness = new MockSearchApi();
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers('atomic-icon', {
   excludeCategories: ['methods'],
@@ -28,6 +30,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...searchApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/common/atomic-layout-section/atomic-layout-section.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-layout-section/atomic-layout-section.new.stories.tsx
@@ -1,9 +1,11 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/common/atomic-layout-section/atomic-layout-section.js';
 
+const searchApiHarness = new MockSearchApi();
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-layout-section',
@@ -18,6 +20,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...searchApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/common/atomic-numeric-range/atomic-numeric-range.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-numeric-range/atomic-numeric-range.new.stories.tsx
@@ -1,11 +1,13 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-numeric-facet/atomic-numeric-facet.js';
 import '@/src/components/common/atomic-numeric-range/atomic-numeric-range.js';
 
+const searchApiHarness = new MockSearchApi();
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-numeric-range',
@@ -21,6 +23,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...searchApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,


### PR DESCRIPTION
## Problem
Several storybook stories for common components lack MSW handlers, meaning they rely on real network calls during testing.

## Solution
Add `MockSearchApi` MSW handlers to:
- `atomic-icon`
- `atomic-component-error`
- `atomic-layout-section`
- `atomic-aria-live`
- `atomic-numeric-range`

This follows the same pattern as the other MSW migration PRs.