### PR TITLE
feat(atomic): migrate commerce facet stories to MSW

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.new.stories.tsx
@@ -9,6 +9,10 @@ import {
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.js';
 import '@/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
+commerceApiHarness.enableInteractiveFacets();
 
 const {play, decorator} = wrapInCommerceInterface({
   includeCodeRoot: false,
@@ -26,6 +30,9 @@ const meta: Meta = {
   decorators: [commerceFacetWidthDecorator, decorator],
   parameters: {
     ...parameters,
+    msw: {
+      handlers: commerceApiHarness.handlers,
+    },
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -33,6 +40,9 @@ const meta: Meta = {
   },
   args,
   argTypes,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.new.stories.tsx
@@ -9,6 +9,10 @@ import {
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.js';
 import '@/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
+commerceApiHarness.enableInteractiveFacets();
 
 const {play, decorator} = wrapInCommerceInterface({
   includeCodeRoot: false,
@@ -26,6 +30,9 @@ const meta: Meta = {
   decorators: [commerceFacetWidthDecorator, decorator],
   parameters: {
     ...parameters,
+    msw: {
+      handlers: commerceApiHarness.handlers,
+    },
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -33,6 +40,9 @@ const meta: Meta = {
   },
   args,
   argTypes,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.new.stories.tsx
@@ -6,6 +6,10 @@ import {
 } from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
+commerceApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInCommerceInterface({
   skipFirstRequest: true,
@@ -23,6 +27,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -32,6 +37,9 @@ const meta: Meta = {
   argTypes,
 
   play,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
@@ -9,6 +9,10 @@ import {
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.js';
 import '@/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
+commerceApiHarness.enableInteractiveFacets();
 
 const {play, decorator} = wrapInCommerceInterface({
   includeCodeRoot: false,
@@ -26,6 +30,9 @@ const meta: Meta = {
   decorators: [commerceFacetWidthDecorator, decorator],
   parameters: {
     ...parameters,
+    msw: {
+      handlers: commerceApiHarness.handlers,
+    },
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -33,6 +40,9 @@ const meta: Meta = {
   },
   args,
   argTypes,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.new.stories.tsx
@@ -9,6 +9,10 @@ import {
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.js';
 import '@/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
+commerceApiHarness.enableInteractiveFacets();
 
 const {play, decorator} = wrapInCommerceInterface({
   engineConfig: {
@@ -37,6 +41,9 @@ const meta: Meta = {
   decorators: [commerceFacetWidthDecorator, decorator],
   parameters: {
     ...parameters,
+    msw: {
+      handlers: commerceApiHarness.handlers,
+    },
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -44,6 +51,9 @@ const meta: Meta = {
   },
   args,
   argTypes,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;


### PR DESCRIPTION
## Problem
Commerce storybook stories for facet components don't use MSW for API mocking, making them less reliable and harder to test in isolation.

## Solution
Migrate atomic-commerce-facet, atomic-commerce-facets, atomic-commerce-numeric-facet, atomic-commerce-category-facet, and atomic-commerce-timeframe-facet stories to use `MockCommerceApi` MSW handlers.

Each story now:
- Imports and instantiates `MockCommerceApi`
- Adds `msw: {handlers: [...commerceApiHarness.handlers]}` to parameters
- Adds `beforeEach: () => { commerceApiHarness.clearAll(); }` for test isolation