### PR TITLE
feat(atomic): migrate commerce query & status stories to MSW

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-did-you-mean/atomic-commerce-did-you-mean.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-did-you-mean/atomic-commerce-did-you-mean.new.stories.tsx
@@ -3,6 +3,18 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-did-you-mean/atomic-commerce-did-you-mean.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
+
+commerceApiHarness.searchEndpoint.mock((response) => ({
+  ...response,
+  queryCorrection: {
+    originalQuery: 'runing shoes',
+    correctedQuery: 'running shoes',
+    corrections: [],
+  },
+}));
 
 const {decorator, play} = wrapInCommerceInterface({
   engineConfig: {
@@ -28,6 +40,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -37,6 +50,9 @@ const meta: Meta = {
   argTypes,
 
   play,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.new.stories.tsx
@@ -10,6 +10,15 @@ import '@/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.
 import '@/src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.js';
 import '@/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.js';
 import '@/src/components/common/atomic-layout-section/atomic-layout-section.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
+
+commerceApiHarness.searchEndpoint.mock((response) => ({
+  ...response,
+  products: [],
+  pagination: {...response.pagination, totalEntries: 0, totalPages: 0},
+}));
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-commerce-no-products',
@@ -36,6 +45,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -45,6 +55,9 @@ const meta: Meta = {
   argTypes,
 
   play: preprocessedPlayed,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.new.stories.tsx
@@ -3,6 +3,9 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {decorator, play} = wrapInCommerceInterface({
   skipFirstRequest: false,
@@ -21,6 +24,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -30,6 +34,9 @@ const meta: Meta = {
   argTypes,
 
   play,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.new.stories.tsx
@@ -3,6 +3,10 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
+commerceApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInCommerceInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -18,6 +22,9 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {
+      handlers: commerceApiHarness.handlers,
+    },
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -27,6 +34,9 @@ const meta: Meta = {
   argTypes,
 
   play,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-commerce-text/atomic-commerce-text.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-text/atomic-commerce-text.new.stories.tsx
@@ -4,6 +4,9 @@ import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-inter
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import type {AtomicCommerceInterface} from '../atomic-commerce-interface/atomic-commerce-interface';
 import '@/src/components/commerce/atomic-commerce-text/atomic-commerce-text.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {decorator, play} = wrapInCommerceInterface({
   skipFirstRequest: true,
@@ -21,6 +24,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -30,6 +34,9 @@ const meta: Meta = {
   argTypes,
 
   play,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;


### PR DESCRIPTION
## Problem
Commerce storybook stories for query and status components don't use MSW for API mocking, making them less reliable and harder to test in isolation.

## Solution
Migrate atomic-commerce-query-summary, atomic-commerce-did-you-mean, atomic-commerce-no-products, atomic-commerce-text, and atomic-commerce-refine-toggle stories to use `MockCommerceApi` MSW handlers.

Each story now:
- Imports and instantiates `MockCommerceApi`
- Adds `msw: {handlers: [...commerceApiHarness.handlers]}` to parameters
- Adds `beforeEach: () => { commerceApiHarness.clearAll(); }` for test isolation