### PR TITLE
feat(atomic): migrate commerce search box, layout & misc stories to MSW

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.new.stories.tsx
@@ -3,6 +3,9 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {decorator, play} = wrapInCommerceInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -18,6 +21,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -29,6 +33,9 @@ const meta: Meta = {
   args: {
     ...args,
     'default-slot': `<span>Layout content</span>`,
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.new.stories.tsx
@@ -23,6 +23,9 @@ import '@/src/components/commerce/atomic-product-section-visual/atomic-product-s
 import '@/src/components/commerce/atomic-product-template/atomic-product-template.js';
 import '@/src/components/commerce/atomic-product-text/atomic-product-text.js';
 import '@/src/components/search/atomic-table-element/atomic-table-element.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-commerce-product-list',
@@ -72,6 +75,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -79,6 +83,9 @@ const meta: Meta = {
   },
   argTypes,
   play,
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
+  },
 };
 
 export default meta;

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.new.stories.tsx
@@ -24,6 +24,14 @@ import '@/src/components/commerce/atomic-product-section-name/atomic-product-sec
 import '@/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.js';
 import '@/src/components/commerce/atomic-product-template/atomic-product-template.js';
 import '@/src/components/commerce/atomic-product-text/atomic-product-text.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+import {richResponse as richRecommendationResponse} from '@/storybook-utils/api/commerce/recommendation-response';
+
+const commerceApiHarness = new MockCommerceApi();
+
+commerceApiHarness.recommendationEndpoint.mock(
+  () => richRecommendationResponse
+);
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-commerce-recommendation-interface',
@@ -49,6 +57,7 @@ const meta: Meta = {
   decorators: [(story) => html`<div id="code-root">${story()}</div>`],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -92,6 +101,9 @@ const meta: Meta = {
   },
   play: async (context) => {
     await initializeCommerceRecommendationInterface(context.canvasElement);
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.new.stories.tsx
@@ -1,6 +1,7 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+import {richResponse as richRecommendationResponse} from '@/storybook-utils/api/commerce/recommendation-response';
 import {wrapInCommerceRecommendationInterface} from '@/storybook-utils/commerce/commerce-recommendation-interface-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.js';
@@ -22,6 +23,8 @@ import '@/src/components/commerce/atomic-product-template/atomic-product-templat
 import '@/src/components/commerce/atomic-product-text/atomic-product-text.js';
 
 const mockCommerceApi = new MockCommerceApi();
+
+mockCommerceApi.recommendationEndpoint.mock(() => richRecommendationResponse);
 
 const {decorator, play} = wrapInCommerceRecommendationInterface({});
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -69,7 +72,7 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    handlers: [...mockCommerceApi.handlers],
+    msw: {handlers: [...mockCommerceApi.handlers]},
   },
   beforeEach: async () => {
     mockCommerceApi.recommendationEndpoint.clear();

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.new.stories.tsx
@@ -5,6 +5,9 @@ import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-inter
 import {wrapInCommerceSearchBox} from '@/storybook-utils/commerce/commerce-search-box-wrapper';
 import {parameters} from '@/storybook-utils/common/search-box-suggestions-parameters';
 import '@/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-commerce-search-box-query-suggestions',
@@ -22,6 +25,7 @@ const meta: Meta = {
   decorators: [commerceSearchBoxDecorator, commerceInterfaceDecorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -35,6 +39,9 @@ const meta: Meta = {
     const searchBox =
       await context.canvas.findAllByShadowPlaceholderText('Search');
     await userEvent.click(searchBox[0]);
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.new.stories.tsx
@@ -5,6 +5,9 @@ import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-inter
 import {wrapInCommerceSearchBox} from '@/storybook-utils/commerce/commerce-search-box-wrapper';
 import {parameters} from '@/storybook-utils/common/search-box-suggestions-parameters';
 import '@/src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.js';
+import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+
+const commerceApiHarness = new MockCommerceApi();
 
 const {decorator: commerceInterfaceDecorator, play: commerceInterfacePlay} =
   wrapInCommerceInterface({includeCodeRoot: false});
@@ -22,6 +25,7 @@ const meta: Meta = {
   decorators: [commerceSearchBoxDecorator, commerceInterfaceDecorator],
   parameters: {
     ...parameters,
+    msw: {handlers: [...commerceApiHarness.handlers]},
     chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
@@ -35,6 +39,9 @@ const meta: Meta = {
     const searchBox =
       await context.canvas.findAllByShadowPlaceholderText('Search');
     await userEvent.click(searchBox[0]);
+  },
+  beforeEach: () => {
+    commerceApiHarness.clearAll();
   },
 };
 


### PR DESCRIPTION
## Problem
Commerce storybook stories for search box sub-components, layout, product list, and recommendation interface don't use MSW for API mocking. Additionally, atomic-commerce-recommendation-list had handlers at the wrong level (`parameters.handlers` instead of `parameters.msw.handlers`).

## Solution
Migrate atomic-commerce-search-box-query-suggestions, atomic-commerce-search-box-recent-queries, atomic-commerce-layout, atomic-commerce-product-list, and atomic-commerce-recommendation-interface stories to use `MockCommerceApi` MSW handlers.

Also fix atomic-commerce-recommendation-list to use the correct `msw: {handlers: [...]}` structure.

Each migrated story now:
- Imports and instantiates `MockCommerceApi`
- Adds `msw: {handlers: [...commerceApiHarness.handlers]}` to parameters
- Adds `beforeEach: () => { commerceApiHarness.clearAll(); }` for test isolation