### PR TITLE
fix(ci): add environment to hotfix workflow for secret access

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -39,6 +39,7 @@ jobs:
     name: Deploy hotfix to CDN
     needs: build-cdn
     runs-on: ubuntu-latest
+    environment: 'Prerelease (CDN)'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0


### PR DESCRIPTION
## Problem

The hotfix workflow (`hotfix.yml`) was missing the `environment: 'Prerelease (CDN)'` declaration on the `hotfix-deploy` job. Without it, the `UI_KIT_CD_DISPATCHER` secret is not exposed and `GH_TOKEN` is empty, causing `trigger-commit-upload.mjs` to fail with:

```
Error: Parameter token or opts.auth is required
```

Failed run: https://github.com/coveo/ui-kit/actions/runs/26450870761

## Solution

Added `environment: 'Prerelease (CDN)'` to the `hotfix-deploy` job, matching how `cd.yml` exposes the same secret.

Verified with a successful hotfix run: https://github.com/coveo/ui-kit/actions/runs/26451238035