### PR TITLE
chore: remove stale master branch reference from dependency-review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: 'Dependency Review'
 
 on:
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

The `dependency-review.yml` workflow triggers on `branches: [master, main]`. The `master` branch is frozen thousands of commits behind `main` — it's a leftover from the `master` → `main` rename and receives no PRs.

## Solution

Remove `master` from the branch trigger list.

**Note:** The `origin/master` remote branch itself should also be deleted separately (it's stale and no longer serves any purpose).