### PR TITLE
chore: rename 'Prerelease (CDN)' environment to 'CDN Deploy' j:KIT-5712

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -217,7 +217,7 @@ jobs:
     name: Upload commit artifacts to S3
     needs: [build-cdn, release]
     runs-on: ubuntu-latest
-    environment: 'Prerelease (CDN)'
+    environment: 'CDN Deploy'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -39,7 +39,7 @@ jobs:
     name: Deploy hotfix to CDN
     needs: build-cdn
     runs-on: ubuntu-latest
-    environment: 'Prerelease (CDN)'
+    environment: 'CDN Deploy'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0


### PR DESCRIPTION
[KIT-5712](https://coveord.atlassian.net/browse/KIT-5712)

## Problem

The GitHub environment 'Prerelease (CDN)' is used by both the regular CD workflow and the hotfix workflow. The name 'Prerelease' is misleading for the hotfix use case since hotfixes bypass the prerelease/bake flow entirely.

## Solution

Renamed to 'CDN Deploy' which accurately describes its purpose: providing access to the UI_KIT_CD_DISPATCHER secret for cross-repo dispatch to ui-kit-cd.

## Post-merge action required

⚠️ **Louis**: After this PR is merged, you need to rename the actual environment in GitHub Settings:
- Go to https://github.com/coveo/ui-kit/settings/environments
- Rename 'Prerelease (CDN)' → 'CDN Deploy'


[KIT-5712]: https://coveord.atlassian.net/browse/KIT-5712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ