### PR TITLE
chore: add TODO for environment rename (KIT-5712)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -217,6 +217,7 @@ jobs:
     name: Upload commit artifacts to S3
     needs: [build-cdn, release]
     runs-on: ubuntu-latest
+    # TODO(KIT-5712): Rename to 'CDN Deploy' once token vending machine is available
     environment: 'Prerelease (CDN)'
     steps:
       - name: Harden Runner

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -39,6 +39,7 @@ jobs:
     name: Deploy hotfix to CDN
     needs: build-cdn
     runs-on: ubuntu-latest
+    # TODO(KIT-5712): Rename to 'CDN Deploy' once token vending machine is available
     environment: 'Prerelease (CDN)'
     steps:
       - name: Harden Runner


### PR DESCRIPTION
[KIT-5712](https://coveord.atlassian.net/browse/KIT-5712)

## Problem
The GitHub environment 'Prerelease (CDN)' name is misleading for hotfix workflow.

## Solution
Add TODO comments to defer renaming until token vending machine is available. Moved ticket to Continuous Improvement epic.

[KIT-5712]: https://coveord.atlassian.net/browse/KIT-5712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ