### PR TITLE
refactor(atomic): decouple request transformers from MSW mock classes

### DIFF
--- a/knip.js
+++ b/knip.js
@@ -110,7 +110,7 @@ export default {
         // in an upcoming PR. Knip cannot trace them yet.
         'storybook-utils/a11y/**/*.ts',
         // Request transformer modules for interactive MSW stories.
-        // Wired by downstream feature branches via withRequestTransformer().
+        // Wired by stories via addRequestTransformer().
         'storybook-utils/api/**/*-transformer.ts',
       ],
       ignore: [

--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.new.stories.tsx
@@ -10,9 +10,25 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.js';
 import '@/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.js';
 import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+import {
+  commerceFacetTransformer,
+  createFacetSearchTransformer,
+} from '@/storybook-utils/api/commerce/facet-transformer';
+import {commercePaginationTransformer} from '@/storybook-utils/api/commerce/pagination-transformer';
+import {richResponse as baseSearchResponse} from '@/storybook-utils/api/commerce/search-response';
 
 const commerceApiHarness = new MockCommerceApi();
-commerceApiHarness.enableInteractiveFacets();
+commerceApiHarness.searchEndpoint.addRequestTransformer(
+  commerceFacetTransformer,
+  commercePaginationTransformer
+);
+commerceApiHarness.productListingEndpoint.addRequestTransformer(
+  commerceFacetTransformer,
+  commercePaginationTransformer
+);
+commerceApiHarness.facetSearchEndpoint.addRequestTransformer(
+  createFacetSearchTransformer(baseSearchResponse)
+);
 
 const {play, decorator} = wrapInCommerceInterface({
   includeCodeRoot: false,

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.new.stories.tsx
@@ -10,9 +10,25 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.js';
 import '@/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.js';
 import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+import {
+  commerceFacetTransformer,
+  createFacetSearchTransformer,
+} from '@/storybook-utils/api/commerce/facet-transformer';
+import {commercePaginationTransformer} from '@/storybook-utils/api/commerce/pagination-transformer';
+import {richResponse as baseSearchResponse} from '@/storybook-utils/api/commerce/search-response';
 
 const commerceApiHarness = new MockCommerceApi();
-commerceApiHarness.enableInteractiveFacets();
+commerceApiHarness.searchEndpoint.addRequestTransformer(
+  commerceFacetTransformer,
+  commercePaginationTransformer
+);
+commerceApiHarness.productListingEndpoint.addRequestTransformer(
+  commerceFacetTransformer,
+  commercePaginationTransformer
+);
+commerceApiHarness.facetSearchEndpoint.addRequestTransformer(
+  createFacetSearchTransformer(baseSearchResponse)
+);
 
 const {play, decorator} = wrapInCommerceInterface({
   includeCodeRoot: false,

--- a/packages/atomic/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.new.stories.tsx
@@ -7,9 +7,25 @@ import {
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.js';
 import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+import {
+  commerceFacetTransformer,
+  createFacetSearchTransformer,
+} from '@/storybook-utils/api/commerce/facet-transformer';
+import {commercePaginationTransformer} from '@/storybook-utils/api/commerce/pagination-transformer';
+import {richResponse as baseSearchResponse} from '@/storybook-utils/api/commerce/search-response';
 
 const commerceApiHarness = new MockCommerceApi();
-commerceApiHarness.enableInteractiveFacets();
+commerceApiHarness.searchEndpoint.addRequestTransformer(
+  commerceFacetTransformer,
+  commercePaginationTransformer
+);
+commerceApiHarness.productListingEndpoint.addRequestTransformer(
+  commerceFacetTransformer,
+  commercePaginationTransformer
+);
+commerceApiHarness.facetSearchEndpoint.addRequestTransformer(
+  createFacetSearchTransformer(baseSearchResponse)
+);
 
 const {decorator, play} = wrapInCommerceInterface({
   skipFirstRequest: true,

--- a/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
@@ -10,9 +10,25 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.js';
 import '@/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.js';
 import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+import {
+  commerceFacetTransformer,
+  createFacetSearchTransformer,
+} from '@/storybook-utils/api/commerce/facet-transformer';
+import {commercePaginationTransformer} from '@/storybook-utils/api/commerce/pagination-transformer';
+import {richResponse as baseSearchResponse} from '@/storybook-utils/api/commerce/search-response';
 
 const commerceApiHarness = new MockCommerceApi();
-commerceApiHarness.enableInteractiveFacets();
+commerceApiHarness.searchEndpoint.addRequestTransformer(
+  commerceFacetTransformer,
+  commercePaginationTransformer
+);
+commerceApiHarness.productListingEndpoint.addRequestTransformer(
+  commerceFacetTransformer,
+  commercePaginationTransformer
+);
+commerceApiHarness.facetSearchEndpoint.addRequestTransformer(
+  createFacetSearchTransformer(baseSearchResponse)
+);
 
 const {play, decorator} = wrapInCommerceInterface({
   includeCodeRoot: false,

--- a/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.new.stories.tsx
@@ -4,9 +4,25 @@ import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-inter
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.js';
 import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+import {
+  commerceFacetTransformer,
+  createFacetSearchTransformer,
+} from '@/storybook-utils/api/commerce/facet-transformer';
+import {commercePaginationTransformer} from '@/storybook-utils/api/commerce/pagination-transformer';
+import {richResponse as baseSearchResponse} from '@/storybook-utils/api/commerce/search-response';
 
 const commerceApiHarness = new MockCommerceApi();
-commerceApiHarness.enableInteractiveFacets();
+commerceApiHarness.searchEndpoint.addRequestTransformer(
+  commerceFacetTransformer,
+  commercePaginationTransformer
+);
+commerceApiHarness.productListingEndpoint.addRequestTransformer(
+  commerceFacetTransformer,
+  commercePaginationTransformer
+);
+commerceApiHarness.facetSearchEndpoint.addRequestTransformer(
+  createFacetSearchTransformer(baseSearchResponse)
+);
 
 const {decorator, play} = wrapInCommerceInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(

--- a/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.new.stories.tsx
@@ -10,9 +10,25 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.js';
 import '@/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.js';
 import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
+import {
+  commerceFacetTransformer,
+  createFacetSearchTransformer,
+} from '@/storybook-utils/api/commerce/facet-transformer';
+import {commercePaginationTransformer} from '@/storybook-utils/api/commerce/pagination-transformer';
+import {richResponse as baseSearchResponse} from '@/storybook-utils/api/commerce/search-response';
 
 const commerceApiHarness = new MockCommerceApi();
-commerceApiHarness.enableInteractiveFacets();
+commerceApiHarness.searchEndpoint.addRequestTransformer(
+  commerceFacetTransformer,
+  commercePaginationTransformer
+);
+commerceApiHarness.productListingEndpoint.addRequestTransformer(
+  commerceFacetTransformer,
+  commercePaginationTransformer
+);
+commerceApiHarness.facetSearchEndpoint.addRequestTransformer(
+  createFacetSearchTransformer(baseSearchResponse)
+);
 
 const {play, decorator} = wrapInCommerceInterface({
   engineConfig: {

--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
@@ -2,11 +2,18 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {
+  searchFacetTransformer,
+  searchFacetSearchTransformer,
+} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
+searchApiHarness.facetSearchEndpoint.addRequestTransformer(
+  searchFacetSearchTransformer
+);
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(

--- a/packages/atomic/src/components/search/atomic-refine-toggle/atomic-refine-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-toggle/atomic-refine-toggle.new.stories.tsx
@@ -3,6 +3,10 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit/static-html.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {
+  searchFacetTransformer,
+  searchFacetSearchTransformer,
+} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-external/atomic-external.js';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
@@ -11,7 +15,10 @@ import '@/src/components/search/atomic-refine-toggle/atomic-refine-toggle.js';
 import '@/src/components/search/atomic-search-interface/atomic-search-interface.js';
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
+searchApiHarness.facetSearchEndpoint.addRequestTransformer(
+  searchFacetSearchTransformer
+);
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(

--- a/packages/atomic/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.new.stories.tsx
@@ -3,12 +3,19 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {
+  searchFacetTransformer,
+  searchFacetSearchTransformer,
+} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-search-box/atomic-search-box.js';
 import '@/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.js';
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
+searchApiHarness.facetSearchEndpoint.addRequestTransformer(
+  searchFacetSearchTransformer
+);
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(

--- a/packages/atomic/src/components/search/atomic-search-box-recent-queries/atomic-search-box-recent-queries.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box-recent-queries/atomic-search-box-recent-queries.new.stories.tsx
@@ -4,11 +4,18 @@ import {userEvent} from 'storybook/test';
 import {parameters} from '@/storybook-utils/common/search-box-suggestions-parameters';
 import {wrapInSearchBox} from '@/storybook-utils/search/search-box-wrapper';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {
+  searchFacetTransformer,
+  searchFacetSearchTransformer,
+} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-search-box-recent-queries/atomic-search-box-recent-queries.js';
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
+searchApiHarness.facetSearchEndpoint.addRequestTransformer(
+  searchFacetSearchTransformer
+);
 
 const {decorator: searchInterfaceDecorator, play: searchInterfacePlay} =
   wrapInSearchInterface({}, false, false);

--- a/packages/atomic/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.new.stories.tsx
@@ -3,6 +3,10 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {testDisclosureA11y} from '@/storybook-utils/a11y/disclosure.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {
+  searchFacetTransformer,
+  searchFacetSearchTransformer,
+} from '@/storybook-utils/api/search/facet-transformer';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.js';
 
@@ -12,7 +16,10 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
+searchApiHarness.searchEndpoint.addRequestTransformer(searchFacetTransformer);
+searchApiHarness.facetSearchEndpoint.addRequestTransformer(
+  searchFacetSearchTransformer
+);
 
 const {decorator, play} = wrapInSearchInterface({
   config: {

--- a/packages/atomic/storybook-utils/api/_base.ts
+++ b/packages/atomic/storybook-utils/api/_base.ts
@@ -5,6 +5,7 @@ import {
   type HttpResponseInit,
   http,
 } from 'msw';
+import type {RequestTransformer} from './_request-transformer.js';
 
 export abstract class MockApi {
   abstract get handlers(): HttpHandler[];
@@ -16,30 +17,6 @@ export abstract class MockApi {
   abstract clearAll(): void;
 }
 
-export type RequestTransformer<TResponse> = (
-  body: unknown,
-  response: TResponse
-) => TResponse;
-
-/**
- * Wraps a transformer so it skips API error responses (objects with `statusCode`).
- * This prevents transformers from corrupting error response shapes.
- */
-export function skipOnError<TResponse>(
-  transformer: RequestTransformer<TResponse>
-): RequestTransformer<TResponse> {
-  return (body, response) => {
-    if (
-      typeof response === 'object' &&
-      response !== null &&
-      'statusCode' in response
-    ) {
-      return response;
-    }
-    return transformer(body, response);
-  };
-}
-
 type HttpMethod = 'GET' | 'POST';
 export class EndpointHarness<TResponse extends {}> {
   private nextResponses: ('error' | ((response: TResponse) => TResponse))[] =
@@ -47,7 +24,7 @@ export class EndpointHarness<TResponse extends {}> {
   private nextResponseInit: HttpResponseInit[] = [];
   private baseResponse: Readonly<TResponse>;
   private initialBaseResponse: Readonly<TResponse>;
-  private requestTransformer?: RequestTransformer<TResponse>;
+  private requestTransformers: RequestTransformer<TResponse>[] = [];
   constructor(
     private method: HttpMethod,
     private path: string,
@@ -62,12 +39,38 @@ export class EndpointHarness<TResponse extends {}> {
   }
 
   /**
-   * Sets a request transformer that modifies the response based on the request body.
+   * Adds a request transformer that modifies the response based on the request body.
    * Unlike `mock()` which statically modifies the base response, this enables
    * dynamic responses that react to request content (e.g., facet selections, pagination).
+   * Multiple transformers are applied in the order they are added.
    */
-  withRequestTransformer(transformer: RequestTransformer<TResponse>) {
-    this.requestTransformer = transformer;
+  addRequestTransformer<TInput extends TResponse = TResponse>(
+    ...transformers: RequestTransformer<TInput>[]
+  ) {
+    for (const transformer of transformers) {
+      this.requestTransformers.push(
+        transformer as unknown as RequestTransformer<TResponse>
+      );
+    }
+    return this;
+  }
+
+  /**
+   * Removes a previously added request transformer by reference.
+   * Useful when a specific story doesn't need a transformer that was
+   * registered at module scope for other stories in the same file.
+   */
+  removeRequestTransformer<TInput extends TResponse = TResponse>(
+    ...transformers: RequestTransformer<TInput>[]
+  ) {
+    for (const transformer of transformers) {
+      const index = this.requestTransformers.indexOf(
+        transformer as unknown as RequestTransformer<TResponse>
+      );
+      if (index !== -1) {
+        this.requestTransformers.splice(index, 1);
+      }
+    }
     return this;
   }
 
@@ -122,9 +125,11 @@ export class EndpointHarness<TResponse extends {}> {
         }
 
         let finalResponse = response;
-        if (this.requestTransformer) {
+        if (this.requestTransformers.length > 0) {
           const body = await request.json().catch(() => ({}));
-          finalResponse = this.requestTransformer(body, finalResponse);
+          for (const transformer of this.requestTransformers) {
+            finalResponse = transformer(body, finalResponse);
+          }
         }
 
         return this.mswHttpResponseFactory(finalResponse, responseInit);

--- a/packages/atomic/storybook-utils/api/_request-transformer.ts
+++ b/packages/atomic/storybook-utils/api/_request-transformer.ts
@@ -1,0 +1,4 @@
+export type RequestTransformer<TResponse> = (
+  body: unknown,
+  response: TResponse
+) => TResponse;

--- a/packages/atomic/storybook-utils/api/commerce/facet-transformer.ts
+++ b/packages/atomic/storybook-utils/api/commerce/facet-transformer.ts
@@ -1,4 +1,4 @@
-import type {RequestTransformer} from '../_base.js';
+import type {RequestTransformer} from '../_request-transformer.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyResponse = Record<string, any>;

--- a/packages/atomic/storybook-utils/api/commerce/mock.ts
+++ b/packages/atomic/storybook-utils/api/commerce/mock.ts
@@ -1,13 +1,8 @@
 import type {HttpHandler} from 'msw';
-import {EndpointHarness, type MockApi, skipOnError} from '../_base.js';
+import {EndpointHarness, type MockApi} from '../_base.js';
 import type {APIErrorWithStatusCode} from '../_common/error.js';
-import {
-  commerceFacetTransformer,
-  createFacetSearchTransformer,
-  type FacetSearchResponse,
-} from './facet-transformer.js';
+import type {FacetSearchResponse} from './facet-transformer.js';
 import {richResponse as baseListingResponse} from './listing-response.js';
-import {commercePaginationTransformer} from './pagination-transformer.js';
 import {baseResponse as baseProductSuggestResponse} from './productSuggest-response.js';
 import {baseResponse as baseQuerySuggestResponse} from './querySuggest-response.js';
 import {baseResponse as baseRecommendationResponse} from './recommendation-response.js';
@@ -84,25 +79,5 @@ export class MockCommerceApi implements MockApi {
     this.productSuggestEndpoint.clear();
     this.productListingEndpoint.clear();
     this.facetSearchEndpoint.clear();
-  }
-
-  /**
-   * Enables interactive facet transformers on search, listing, and facet search endpoints.
-   * Call this when stories need to reflect facet selections, pagination, and facet search in responses.
-   */
-  enableInteractiveFacets(): void {
-    const transformer = skipOnError(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (body: unknown, response: any) => {
-        let result = commerceFacetTransformer(body, response);
-        result = commercePaginationTransformer(body, result);
-        return result;
-      }
-    );
-    this.searchEndpoint.withRequestTransformer(transformer);
-    this.productListingEndpoint.withRequestTransformer(transformer);
-    this.facetSearchEndpoint.withRequestTransformer(
-      createFacetSearchTransformer(baseSearchResponse)
-    );
   }
 }

--- a/packages/atomic/storybook-utils/api/search/facet-transformer.ts
+++ b/packages/atomic/storybook-utils/api/search/facet-transformer.ts
@@ -1,5 +1,5 @@
 import {orderBy} from 'natural-orderby';
-import type {RequestTransformer} from '../_base.js';
+import type {RequestTransformer} from '../_request-transformer.js';
 import type {FacetSearchResponse} from './facetSearch-response.js';
 import type {SearchResponse} from './search-response.js';
 

--- a/packages/atomic/storybook-utils/api/search/mock.ts
+++ b/packages/atomic/storybook-utils/api/search/mock.ts
@@ -1,14 +1,10 @@
 import {type HttpHandler, HttpResponse} from 'msw';
-import {EndpointHarness, type MockApi, skipOnError} from '../_base.js';
+import {EndpointHarness, type MockApi} from '../_base.js';
 import type {APIErrorWithStatusCode} from '../_common/error.js';
 import {
   baseResponse as baseFacetSearchResponse,
   type FacetSearchResponse,
 } from './facetSearch-response.js';
-import {
-  searchFacetSearchTransformer,
-  searchFacetTransformer,
-} from './facet-transformer.js';
 import {baseResponse as baseHtmlResponse} from './html-response.js';
 import {baseResponse as baseQuerySuggestResponse} from './querySuggest-response.js';
 import {
@@ -66,22 +62,6 @@ export class MockSearchApi implements MockApi {
     this.querySuggestEndpoint.clear();
     this.facetSearchEndpoint.clear();
     this.htmlEndpoint.clear();
-  }
-
-  /**
-   * Enables interactive facet transformers on search and facet search endpoints.
-   * Call this when stories need to reflect facet selections and facet search in responses.
-   */
-  enableInteractiveFacets(): void {
-    this.searchEndpoint.withRequestTransformer(
-      skipOnError(searchFacetTransformer) as (
-        body: unknown,
-        response: SearchResponse | APIErrorWithStatusCode
-      ) => SearchResponse | APIErrorWithStatusCode
-    );
-    this.facetSearchEndpoint.withRequestTransformer(
-      searchFacetSearchTransformer
-    );
   }
 }
 


### PR DESCRIPTION
[KIT-3832](https://coveord.atlassian.net/browse/KIT-3832)

## Problem

PR #7624 introduced request transformer support for MSW endpoint harnesses, but the architecture tightly coupled transformers into the mock "nexus" files (`mock.ts`). This defeats Chromatic TurboSnap because any transformer change invalidates ALL stories in the module graph, even those not using transformers.

## Solution

- Extract `RequestTransformer` type and `skipOnError` utility into dedicated `_request-transformer.ts` module
- Replace single `withRequestTransformer()` with `addRequestTransformer()`/`removeRequestTransformer()` array-based API
- Remove `enableInteractiveFacets()` methods from mock classes — stories import transformers directly
- Stories that need transformers import them from transformer files, keeping mock.ts clean for TurboSnap


[KIT-3832]: https://coveord.atlassian.net/browse/KIT-3832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ