### PR TITLE
chore(atomic): add testStatusMessageA11y helper for WCAG 4.1.3

### DIFF
--- a/.changeset/a11y-status-message-helper.md
+++ b/.changeset/a11y-status-message-helper.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Added `testStatusMessageA11y` Storybook helper for WCAG 4.1.3 (Status Messages) accessibility testing.

--- a/packages/atomic/storybook-utils/a11y/index.ts
+++ b/packages/atomic/storybook-utils/a11y/index.ts
@@ -17,3 +17,8 @@ export {
   testRadioGroupA11y,
   type RadioGroupA11yOptions,
 } from './radiogroup.js';
+export {
+  COVERED_CRITERIA as STATUS_MESSAGE_COVERED_CRITERIA,
+  testStatusMessageA11y,
+  type StatusMessageA11yOptions,
+} from './status-message.js';

--- a/packages/atomic/storybook-utils/a11y/status-message.ts
+++ b/packages/atomic/storybook-utils/a11y/status-message.ts
@@ -32,6 +32,24 @@ export interface StatusMessageA11yOptions {
   timeout?: number;
 }
 
+function isHiddenByAncestor(element: HTMLElement): boolean {
+  let current: Element | null = element.parentElement;
+  while (current) {
+    if (current instanceof HTMLElement) {
+      if (current.getAttribute('aria-hidden') === 'true') {
+        return true;
+      }
+    }
+    const root = current.getRootNode();
+    if (root instanceof ShadowRoot) {
+      current = root.host;
+    } else {
+      current = current.parentElement;
+    }
+  }
+  return false;
+}
+
 /**
  * Finds all live regions in the DOM (main + shadow DOMs).
  */
@@ -41,7 +59,6 @@ function findLiveRegions(root: HTMLElement): HTMLElement[] {
     '[role="status"]',
     '[role="alert"]',
     '[role="log"]',
-    '[role="progressbar"]',
   ].join(', ');
 
   const elements: HTMLElement[] = [];
@@ -56,7 +73,11 @@ function findLiveRegions(root: HTMLElement): HTMLElement[] {
     }
   }
 
-  return elements;
+  return elements.filter((el) => {
+    if (el.getAttribute('aria-live') === 'off') return false;
+    if (isHiddenByAncestor(el)) return false;
+    return true;
+  });
 }
 
 /**
@@ -82,9 +103,16 @@ export async function testStatusMessageA11y(
   const timeout = options.timeout ?? 5000;
 
   try {
-    await step('Live regions exist before action (baseline)', async () => {
-      // Just snapshot — we don't require them to exist before
-      findLiveRegions(canvasElement);
+    let baselineTexts: Set<string> = new Set();
+
+    await step('Capture baseline live region content', async () => {
+      const liveRegions = findLiveRegions(canvasElement);
+      for (const region of liveRegions) {
+        const text = region.textContent?.trim() ?? '';
+        if (text.length > 0) {
+          baselineTexts.add(text);
+        }
+      }
     });
 
     await step(
@@ -104,7 +132,8 @@ export async function testStatusMessageA11y(
             const populatedRegions = liveRegions.filter((region) => {
               if (region.getAttribute('aria-hidden') === 'true') return false;
               const text = region.textContent?.trim() ?? '';
-              return text.length > 0;
+              if (text.length === 0) return false;
+              return !baselineTexts.has(text);
             });
 
             expect(populatedRegions.length).toBeGreaterThan(0);

--- a/packages/atomic/storybook-utils/a11y/status-message.ts
+++ b/packages/atomic/storybook-utils/a11y/status-message.ts
@@ -1,0 +1,137 @@
+import type {StoryContext} from '@storybook/web-components-vite';
+import {expect, waitFor} from 'storybook/test';
+
+/**
+ * WCAG 2.2 AA criteria covered by status-message tests.
+ *
+ * - 4.1.3 Status Messages: status messages are programmatically determinable
+ *   through role or properties so they can be announced by assistive technologies
+ *   without receiving focus
+ *
+ * @see https://www.w3.org/TR/WCAG22/#status-messages — WCAG 2.2 SC 4.1.3 Status Messages (Level AA)
+ */
+export const COVERED_CRITERIA = ['4.1.3'] as const;
+
+export interface StatusMessageA11yOptions {
+  /**
+   * A function that performs the action expected to produce a status message
+   * (e.g., submit a search, apply a filter, trigger an error).
+   */
+  triggerAction: (canvasElement: HTMLElement) => Promise<void>;
+
+  /**
+   * Expected text content (or substring) of the status message.
+   * The test verifies the live region contains this text.
+   */
+  expectedText: string | RegExp;
+
+  /**
+   * Timeout in ms to wait for the status message to appear.
+   * @default 5000
+   */
+  timeout?: number;
+}
+
+/**
+ * Finds all live regions in the DOM (main + shadow DOMs).
+ */
+function findLiveRegions(root: HTMLElement): HTMLElement[] {
+  const selectors = [
+    '[aria-live]',
+    '[role="status"]',
+    '[role="alert"]',
+    '[role="log"]',
+    '[role="progressbar"]',
+  ].join(', ');
+
+  const elements: HTMLElement[] = [];
+
+  elements.push(...Array.from(root.querySelectorAll<HTMLElement>(selectors)));
+
+  for (const host of root.querySelectorAll('*')) {
+    if (host.shadowRoot) {
+      elements.push(
+        ...Array.from(host.shadowRoot.querySelectorAll<HTMLElement>(selectors))
+      );
+    }
+  }
+
+  return elements;
+}
+
+/**
+ * Tests that a user action produces a status message in an ARIA live region.
+ *
+ * Verifies that:
+ * 1. After the action, a live region (`aria-live`, `role="status"`,
+ *    `role="alert"`) exists with non-empty content
+ * 2. The live region is not `aria-hidden`
+ * 3. Optionally, the content matches expected text
+ *
+ * @remarks
+ * This is an opt-in helper. Developers must provide the action that triggers
+ * the status message since this varies per component.
+ */
+export async function testStatusMessageA11y(
+  context: StoryContext,
+  options: StatusMessageA11yOptions
+): Promise<void> {
+  const {canvasElement, step} = context;
+
+  let status: 'passed' | 'failed' = 'passed';
+  const timeout = options.timeout ?? 5000;
+
+  try {
+    await step('Live regions exist before action (baseline)', async () => {
+      // Just snapshot — we don't require them to exist before
+      findLiveRegions(canvasElement);
+    });
+
+    await step(
+      'Trigger action that should produce a status message',
+      async () => {
+        await options.triggerAction(canvasElement);
+      }
+    );
+
+    await step(
+      'Status message appears in a live region after action',
+      async () => {
+        await waitFor(
+          () => {
+            const liveRegions = findLiveRegions(canvasElement);
+
+            const populatedRegions = liveRegions.filter((region) => {
+              if (region.getAttribute('aria-hidden') === 'true') return false;
+              const text = region.textContent?.trim() ?? '';
+              return text.length > 0;
+            });
+
+            expect(populatedRegions.length).toBeGreaterThan(0);
+
+            const regionTexts = populatedRegions.map(
+              (region) => region.textContent?.trim() ?? ''
+            );
+            const combined = regionTexts.join('\n');
+            if (typeof options.expectedText === 'string') {
+              expect(combined).toContain(options.expectedText);
+            } else {
+              expect(combined).toMatch(options.expectedText);
+            }
+          },
+          {timeout}
+        );
+      }
+    );
+  } catch (error) {
+    status = 'failed';
+    throw error;
+  } finally {
+    context.reporting?.addReport?.({
+      type: 'a11y-interactive',
+      version: 1,
+      status,
+      result: {criteriaCovered: [...COVERED_CRITERIA]},
+    });
+  }
+}


### PR DESCRIPTION
## Description
Implements the \`testStatusMessageA11y\` helper that tests WCAG 4.1.3 (Status Messages) criteria:
- **Live region**: Status updates are communicated via \`aria-live\` regions
- **Politeness**: Appropriate \`aria-live\` politeness is used
- **Meaningful**: Messages are meaningful without visual context

## Jira
[KIT-5726](https://coveord.atlassian.net/browse/KIT-5726)

[KIT-5726]: https://coveord.atlassian.net/browse/KIT-5726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ