### PR TITLE
test(atomic): wire testStatusMessageA11y to search component stories

### DIFF
--- a/packages/atomic/src/components/common/atomic-aria-live/atomic-aria-live.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-aria-live/atomic-aria-live.new.stories.tsx
@@ -1,8 +1,10 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import type {AtomicAriaLive} from './atomic-aria-live';
 import '@/src/components/common/atomic-aria-live/atomic-aria-live.js';
 
 const searchApiHarness = new MockSearchApi();
@@ -35,3 +37,26 @@ const meta: Meta = {
 export default meta;
 
 export const Default: Story = {};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const ariaLive = context.canvasElement.querySelector(
+          'atomic-aria-live'
+        ) as AtomicAriaLive;
+        ariaLive.registerRegion('storybook-status', false);
+        ariaLive.updateMessage(
+          'storybook-status',
+          'Storybook status update',
+          false
+        );
+      },
+      expectedText: 'Storybook status update',
+      timeout: 5000,
+    });
+  },
+};

--- a/packages/atomic/src/components/common/atomic-aria-live/atomic-aria-live.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-aria-live/atomic-aria-live.new.stories.tsx
@@ -40,7 +40,7 @@ export const Default: Story = {};
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   play: async (context) => {
     await play(context);
     await testStatusMessageA11y(context, {

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.new.stories.tsx
@@ -1,12 +1,19 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit/static-html.js';
+import {within} from 'shadow-dom-testing-library';
 import {expect, waitFor} from 'storybook/test';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-breadbox/atomic-breadbox.js';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 
+const mockSearchApi = new MockSearchApi();
+mockSearchApi.enableInteractiveFacets();
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-breadbox',
@@ -26,9 +33,13 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
+    msw: {handlers: [...mockSearchApi.handlers]},
   },
   args,
   argTypes,
+  beforeEach: async () => {
+    mockSearchApi.clearAll();
+  },
   play,
 };
 
@@ -71,6 +82,50 @@ export const Default: Story = {
           timeout: 30e3,
         }
       );
+    });
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  decorators: [
+    (story) => html`
+      <atomic-query-summary></atomic-query-summary>
+      ${story()}
+      <div style="display: flex; justify-content: flex-start;">
+        <atomic-facet
+          field="objecttype"
+          style="flex-grow:1"
+          label="Object type"
+        ></atomic-facet>
+      </div>
+    `,
+  ],
+  beforeEach: async () => {
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(120));
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(42));
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(120));
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const facetValue = await canvas.findByShadowLabelText(
+          'Inclusion filter on People',
+          {exact: false}
+        );
+        facetValue.click();
+
+        const breadcrumb = await canvas.findByShadowLabelText(
+          /Remove inclusion filter on/,
+          {exact: false}
+        );
+        breadcrumb.click();
+      },
+      expectedText: 'Results loaded. Results 1-10 of 120',
+      timeout: 5000,
     });
   },
 };

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.new.stories.tsx
@@ -88,7 +88,7 @@ export const Default: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   decorators: [
     (story) => html`
       <atomic-query-summary></atomic-query-summary>

--- a/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.new.stories.tsx
@@ -1,10 +1,15 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-category-facet/atomic-category-facet.js';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 
 const searchApiHarness = new MockSearchApi();
 
@@ -305,6 +310,23 @@ const mockSelectedChildValueWithMoreAvailable = (
   });
 };
 
+const mockCategoryFacetResponseWithResults = (
+  totalCount: number,
+  categoryFacetResponse: ReturnType<typeof createCategoryFacetResponse>
+) => {
+  searchApiHarness.searchEndpoint.mockOnce((response) => {
+    const responseWithResults =
+      buildSearchResponseWithResults(totalCount)(response);
+    if ('facets' in responseWithResults) {
+      return {
+        ...responseWithResults,
+        facets: [...(responseWithResults.facets || []), categoryFacetResponse],
+      };
+    }
+    return responseWithResults;
+  });
+};
+
 const {decorator, play} = wrapInSearchInterface();
 
 const {events, argTypes} = getStorybookHelpers('atomic-category-facet', {
@@ -412,5 +434,47 @@ export const WithSelectedChildValueAndMoreAvailable: Story = {
   decorators: [facetDecorator],
   beforeEach: () => {
     mockSelectedChildValueWithMoreAvailable();
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  args: {
+    field: 'geographicalhierarchy',
+    label: 'Geographical Hierarchy',
+    'with-search': true,
+  },
+  decorators: [
+    facetDecorator,
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+  beforeEach: () => {
+    mockCategoryFacetResponseWithResults(
+      120,
+      createCategoryFacetResponse(baseCategoryFacetValues)
+    );
+    mockCategoryFacetResponseWithResults(
+      42,
+      createSelectedCategoryFacetResponse(
+        ['North America'],
+        northAmericaChildValues
+      )
+    );
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const button = await canvas.findByShadowLabelText(
+          'Inclusion filter on North America',
+          {exact: false}
+        );
+        button.click();
+      },
+      expectedText: 'Results loaded. Results 1-10 of 42',
+      timeout: 5000,
+    });
   },
 };

--- a/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.new.stories.tsx
@@ -439,7 +439,7 @@ export const WithSelectedChildValueAndMoreAvailable: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   args: {
     field: 'geographicalhierarchy',
     label: 'Geographical Hierarchy',

--- a/packages/atomic/src/components/search/atomic-color-facet/atomic-color-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-color-facet/atomic-color-facet.new.stories.tsx
@@ -1,11 +1,15 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-color-facet/atomic-color-facet.js';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 
 const searchApiHarness = new MockSearchApi();
 
@@ -43,6 +47,23 @@ const mockDefaultFacetResponse = () => {
       };
     }
     return response;
+  });
+};
+
+const mockFacetResponseWithResults = (totalCount: number) => {
+  searchApiHarness.searchEndpoint.mockOnce((response) => {
+    const responseWithResults =
+      buildSearchResponseWithResults(totalCount)(response);
+    if ('facets' in responseWithResults) {
+      return {
+        ...responseWithResults,
+        facets: [
+          ...(responseWithResults.facets || []),
+          createFacetResponse(baseFacetValues),
+        ],
+      };
+    }
+    return responseWithResults;
   });
 };
 
@@ -214,6 +235,39 @@ export const WithSelectedValue: Story = {
         };
       }
       return response;
+    });
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  args: {
+    field: 'filetype',
+    label: 'File Type',
+  },
+  decorators: [
+    facetDecorator,
+    colorFacetStylesDecorator,
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+  beforeEach: () => {
+    mockFacetResponseWithResults(120);
+    mockFacetResponseWithResults(42);
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const buttons = await canvas.findAllByShadowLabelText(
+          /Inclusion filter on/,
+          {exact: false}
+        );
+        buttons[0].click();
+      },
+      expectedText: 'Results loaded. Results 1-10 of 42',
+      timeout: 5000,
     });
   },
 };

--- a/packages/atomic/src/components/search/atomic-color-facet/atomic-color-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-color-facet/atomic-color-facet.new.stories.tsx
@@ -241,7 +241,7 @@ export const WithSelectedValue: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   args: {
     field: 'filetype',
     label: 'File Type',

--- a/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.new.stories.tsx
@@ -3,10 +3,14 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit/static-html.js';
+import {within} from 'shadow-dom-testing-library';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-did-you-mean/atomic-did-you-mean.js';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 
 const mockSearchApi = new MockSearchApi();
 
@@ -20,11 +24,10 @@ const meta: Meta = {
   title: 'Search/Did You Mean',
   id: 'atomic-did-you-mean',
   component: 'atomic-did-you-mean',
-  render: (args) => html` <div
-    style="display: flex; justify-content: flex-start;"
-  >
-    ${template(args)}
-  </div>`,
+  render: (args) =>
+    html` <div style="display: flex; justify-content: flex-start;">
+      ${template(args)}
+    </div>`,
   decorators: [decorator],
   parameters: {
     ...parameters,
@@ -78,5 +81,51 @@ export const WithoutAutomaticQueryCorrection: Story = {
         ],
       },
     }));
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  args: {
+    'automatically-correct-query': false,
+  },
+  decorators: [
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+  beforeEach: async () => {
+    mockSearchApi.searchEndpoint.mockOnce((response) => ({
+      ...response,
+      queryCorrection: {
+        corrections: [
+          {
+            correctedQuery: 'coveo',
+            wordCorrections: [
+              {
+                offset: 0,
+                length: 5,
+                originalWord: 'ceveo',
+                correctedWord: 'coveo',
+              },
+            ],
+          },
+        ],
+      },
+    }));
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(84));
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const correction = await canvas.findByShadowRole('button', {
+          name: /coveo/i,
+        });
+        correction.click();
+      },
+      expectedText: 'Results loaded. Results 1-10 of 84',
+      timeout: 5000,
+    });
   },
 };

--- a/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.new.stories.tsx
@@ -86,7 +86,7 @@ export const WithoutAutomaticQueryCorrection: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   args: {
     'automatically-correct-query': false,
   },

--- a/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
@@ -2,10 +2,12 @@ import type {FacetSortCriterion} from '@coveo/headless';
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers('atomic-facet', {
@@ -120,4 +122,31 @@ export const CustomSort: Story = {
       ></atomic-facet>`;
     },
   ],
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  args: {
+    field: 'objecttype',
+  },
+  decorators: [
+    facetDecorator,
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const {canvas} = context;
+        const buttons = await canvas.findAllByShadowLabelText(
+          /Inclusion filter on/,
+          {exact: false}
+        );
+        buttons[0].click();
+      },
+      expectedText: /TODO:/i,
+      timeout: 5000,
+    });
+  },
 };

--- a/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
@@ -2,12 +2,17 @@ import type {FacetSortCriterion} from '@coveo/headless';
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
 import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
 import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
+
+const mockSearchApi = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers('atomic-facet', {
@@ -34,6 +39,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...mockSearchApi.handlers]},
     actions: {
       handles: events,
     },
@@ -63,6 +69,9 @@ const meta: Meta = {
   },
 
   play,
+  beforeEach: async () => {
+    mockSearchApi.clearAll();
+  },
   args: {
     ...args,
     'number-of-values': 8,
@@ -134,18 +143,22 @@ export const A11yStatusMessage: Story = {
     facetDecorator,
     (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
   ],
+  beforeEach: async () => {
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(120));
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(42));
+  },
   play: async (context) => {
     await play(context);
     await testStatusMessageA11y(context, {
       triggerAction: async () => {
-        const {canvas} = context;
+        const canvas = within(context.canvasElement);
         const buttons = await canvas.findAllByShadowLabelText(
           /Inclusion filter on/,
           {exact: false}
         );
         buttons[0].click();
       },
-      expectedText: /TODO:/i,
+      expectedText: 'Results loaded. Results 1-10 of 42',
       timeout: 5000,
     });
   },

--- a/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
@@ -135,7 +135,7 @@ export const CustomSort: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   args: {
     field: 'objecttype',
   },

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
@@ -6,6 +6,7 @@ import type {
 } from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit/static-html.js';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {userEvent} from 'storybook/test';
 import {MockAgentApi} from '@/storybook-utils/api/agent/mock';
 import {MockAnswerApi} from '@/storybook-utils/api/answer/mock';
@@ -148,5 +149,23 @@ export const WithAgentId: Story = {
   play: async (storyContext) => {
     await playWithLegacyAnalytics(storyContext);
     await submitGeneratedAnswerQuery(storyContext);
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  args: {
+    'answer-configuration-id': 'fc581be0-6e61-4039-ab26-a3f2f52f308f',
+  },
+  play: async (storyContext) => {
+    await play(storyContext);
+    await testStatusMessageA11y(storyContext, {
+      triggerAction: async () => {
+        await submitGeneratedAnswerQuery(storyContext);
+      },
+      expectedText: /Generating answer|Generated answer:/,
+      timeout: 10_000,
+    });
   },
 };

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
@@ -154,7 +154,7 @@ export const WithAgentId: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   args: {
     'answer-configuration-id': 'fc581be0-6e61-4039-ab26-a3f2f52f308f',
   },

--- a/packages/atomic/src/components/search/atomic-load-more-results/atomic-load-more-results.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-load-more-results/atomic-load-more-results.new.stories.tsx
@@ -71,7 +71,7 @@ export const Default: Story = {};
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   decorators: [
     (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
   ],

--- a/packages/atomic/src/components/search/atomic-load-more-results/atomic-load-more-results.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-load-more-results/atomic-load-more-results.new.stories.tsx
@@ -1,10 +1,14 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
 
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-load-more-results/atomic-load-more-results.js';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 
 const searchApiHarness = new MockSearchApi();
 
@@ -33,18 +37,30 @@ const meta: Meta = {
   argTypes,
   beforeEach: () => {
     searchApiHarness.searchEndpoint.clear();
-    searchApiHarness.searchEndpoint.mockOnce((response) => ({
-      ...response,
-      results: response.results.slice(0, 40),
-    }));
-    searchApiHarness.searchEndpoint.mockOnce((response) => ({
-      ...response,
-      results: response.results.slice(40, 80),
-    }));
-    searchApiHarness.searchEndpoint.mockOnce((response) => ({
-      ...response,
-      results: response.results.slice(80),
-    }));
+    searchApiHarness.searchEndpoint.mockOnce((response) =>
+      'results' in response
+        ? {
+            ...response,
+            results: response.results.slice(0, 40),
+          }
+        : response
+    );
+    searchApiHarness.searchEndpoint.mockOnce((response) =>
+      'results' in response
+        ? {
+            ...response,
+            results: response.results.slice(40, 80),
+          }
+        : response
+    );
+    searchApiHarness.searchEndpoint.mockOnce((response) =>
+      'results' in response
+        ? {
+            ...response,
+            results: response.results.slice(80),
+          }
+        : response
+    );
   },
   play,
 };
@@ -52,3 +68,25 @@ const meta: Meta = {
 export default meta;
 
 export const Default: Story = {};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  decorators: [
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const button = await canvas.findByShadowRole('button', {
+          name: 'Load more results',
+        });
+        button.click();
+      },
+      expectedText: 'Results loaded. Results 1-80 of 120',
+      timeout: 5000,
+    });
+  },
+};

--- a/packages/atomic/src/components/search/atomic-no-results/atomic-no-results.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-no-results/atomic-no-results.new.stories.tsx
@@ -1,8 +1,10 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import type {AtomicSearchInterface} from '@/src/components/search/atomic-search-interface/atomic-search-interface';
 import '@/src/components/search/atomic-no-results/atomic-no-results.js';
 
 const mockSearchApi = new MockSearchApi();
@@ -46,5 +48,32 @@ export const Default: Story = {
       totalCount: 0,
       totalCountFiltered: 0,
     }));
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  beforeEach: async () => {
+    mockSearchApi.searchEndpoint.mockOnce((response) => response);
+    mockSearchApi.searchEndpoint.mockOnce((response) => ({
+      ...response,
+      results: [],
+      totalCount: 0,
+      totalCountFiltered: 0,
+    }));
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const searchInterface = context.canvasElement.querySelector(
+          'atomic-search-interface'
+        ) as AtomicSearchInterface;
+        await searchInterface.executeFirstSearch();
+      },
+      expectedText: 'No results',
+      timeout: 5000,
+    });
   },
 };

--- a/packages/atomic/src/components/search/atomic-no-results/atomic-no-results.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-no-results/atomic-no-results.new.stories.tsx
@@ -53,7 +53,7 @@ export const Default: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   beforeEach: async () => {
     mockSearchApi.searchEndpoint.mockOnce((response) => response);
     mockSearchApi.searchEndpoint.mockOnce((response) => ({

--- a/packages/atomic/src/components/search/atomic-notifications/atomic-notifications.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-notifications/atomic-notifications.new.stories.tsx
@@ -1,8 +1,10 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import type {AtomicSearchInterface} from '@/src/components/search/atomic-search-interface/atomic-search-interface';
 import '@/src/components/search/atomic-notifications/atomic-notifications.js';
 
 const mockSearchApi = new MockSearchApi();
@@ -13,6 +15,24 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const {decorator, play} = wrapInSearchInterface();
+
+const mockNotificationsResponse = () => {
+  mockSearchApi.searchEndpoint.mockOnce((response) => ({
+    ...response,
+    triggers: [
+      {
+        type: 'notify',
+        content:
+          'This is a demo notification. It contains text that may span over a different number of lines depending on your screen width. Notifications are returned by the Coveo Search API.',
+      },
+      {
+        type: 'notify',
+        content:
+          'This is a different notification. Any number of notifications can be returned by the Coveo Search API.',
+      },
+    ],
+  }));
+};
 
 const meta: Meta = {
   component: 'atomic-notifications',
@@ -32,32 +52,46 @@ const meta: Meta = {
   argTypes,
   beforeEach: async () => {
     mockSearchApi.searchEndpoint.clear();
-    mockSearchApi.searchEndpoint.mockOnce((response) => ({
-      ...response,
-      triggers: [
-        {
-          type: 'notify',
-          content:
-            'This is a demo notification. It contains text that may span over a different number of lines depending on your screen width. Notifications are returned by the Coveo Search API.',
-        },
-        {
-          type: 'notify',
-          content:
-            'This is a different notification. Any number of notifications can be returned by the Coveo Search API.',
-        },
-      ],
-    }));
   },
   play,
 };
 
 export default meta;
 
-export const Default: Story = {};
+export const Default: Story = {
+  beforeEach: async () => {
+    mockNotificationsResponse();
+  },
+};
 
 export const CustomIcon: Story = {
   name: 'With a custom icon',
   args: {
     icon: 'https://raw.githubusercontent.com/coveo/ui-kit/main/packages/atomic/src/images/arrow-top-rounded.svg',
+  },
+  beforeEach: async () => {
+    mockNotificationsResponse();
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  beforeEach: async () => {
+    mockSearchApi.searchEndpoint.mockOnce((response) => response);
+    mockNotificationsResponse();
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const searchInterface = context.canvasElement.querySelector(
+          'atomic-search-interface'
+        ) as AtomicSearchInterface;
+        await searchInterface.executeFirstSearch();
+      },
+      expectedText: 'Notification 1: This is a demo notification.',
+      timeout: 5000,
+    });
   },
 };

--- a/packages/atomic/src/components/search/atomic-notifications/atomic-notifications.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-notifications/atomic-notifications.new.stories.tsx
@@ -76,7 +76,7 @@ export const CustomIcon: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   beforeEach: async () => {
     mockSearchApi.searchEndpoint.mockOnce((response) => response);
     mockNotificationsResponse();

--- a/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
@@ -256,7 +256,7 @@ export const WithSelectedValue: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   decorators: [
     facetDecorator,
     (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,

--- a/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
@@ -1,6 +1,10 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {
   facetDecorator,
@@ -10,6 +14,7 @@ import {
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
 import '@/src/components/search/atomic-numeric-facet/atomic-numeric-facet.js';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 
 const mockSearchApi = new MockSearchApi();
 
@@ -246,5 +251,34 @@ export const WithSelectedValue: Story = {
         },
       ],
     }));
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  decorators: [
+    facetDecorator,
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+  args: {
+    field: 'ytviewcount',
+    label: 'YouTube View Count',
+  },
+  beforeEach: () => {
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(120));
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(42));
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const buttons = await canvas.findAllByShadowRole('checkbox');
+        buttons[0].click();
+      },
+      expectedText: 'Results loaded. Results 1-10 of 42',
+      timeout: 5000,
+    });
   },
 };

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
@@ -1,8 +1,11 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {html} from 'lit';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-pager/atomic-pager.js';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers('atomic-pager', {
@@ -52,5 +55,26 @@ export const WithACustomNumberOfPages: Story = {
   name: 'With a custom number of pages',
   args: {
     'number-of-pages': '10',
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  decorators: [
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const {canvas} = context;
+        const nextButton = await canvas.findByShadowLabelText(/next/i);
+        nextButton.click();
+      },
+      expectedText: /Results loaded. Results .* of .*/i, // TODO: use msw to return a fixed number of results and assert against that for a more deterministic test
+      timeout: 5000,
+    });
   },
 };

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
@@ -1,11 +1,16 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
 import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-pager/atomic-pager.js';
 import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
+
+const mockSearchApi = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers('atomic-pager', {
@@ -22,6 +27,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...mockSearchApi.handlers]},
     actions: {
       handles: events,
     },
@@ -34,6 +40,9 @@ const meta: Meta = {
       '<svg viewBox="0 0 20 20"><path d="m8.5 15.2 4.3-4.6c.3-.4.3-.9 0-1.3l-4.4-4.5c-.3-.4-.9-.4-1.2 0s-.3.9 0 1.3l3.7 4-3.7 3.9c-.3.4-.3.9 0 1.3.4.3 1 .3 1.3-.1z"/></svg>',
   },
   argTypes,
+  beforeEach: async () => {
+    mockSearchApi.clearAll();
+  },
   play,
 };
 
@@ -64,16 +73,20 @@ export const A11yStatusMessage: Story = {
   decorators: [
     (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
   ],
+  beforeEach: async () => {
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(120));
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(120));
+  },
 
   play: async (context) => {
     await play(context);
     await testStatusMessageA11y(context, {
       triggerAction: async () => {
-        const {canvas} = context;
+        const canvas = within(context.canvasElement);
         const nextButton = await canvas.findByShadowLabelText(/next/i);
         nextButton.click();
       },
-      expectedText: /Results loaded. Results .* of .*/i, // TODO: use msw to return a fixed number of results and assert against that for a more deterministic test
+      expectedText: 'Results loaded. Results 11-20 of 120',
       timeout: 5000,
     });
   },

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
@@ -69,7 +69,7 @@ export const WithACustomNumberOfPages: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   decorators: [
     (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
   ],

--- a/packages/atomic/src/components/search/atomic-query-error/atomic-query-error.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-query-error/atomic-query-error.new.stories.tsx
@@ -1,8 +1,13 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
+import {userEvent} from 'storybook/test';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import '@/src/components/search/atomic-search-box/atomic-search-box.js';
 import '@/src/components/search/atomic-query-error/atomic-query-error.js';
 
 const mockSearchApi = new MockSearchApi();
@@ -109,5 +114,39 @@ export const WithOrganizationPaused: Story = {
       }),
       {status: 503}
     );
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  decorators: [
+    (story) => html`<atomic-search-box></atomic-search-box>${story()}`,
+  ],
+  beforeEach: async () => {
+    mockSearchApi.searchEndpoint.mockOnce((response) => response);
+    mockSearchApi.searchEndpoint.mockOnce(
+      () => ({
+        ok: false,
+        status: 418,
+        message: 'Something very weird just happened',
+        statusCode: 418,
+        type: 'ClientError',
+      }),
+      {status: 418}
+    );
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const searchBox = await canvas.findByShadowPlaceholderText('Search');
+        await userEvent.type(searchBox, 'error{enter}');
+      },
+      expectedText:
+        'Something went wrong. If the problem persists contact the administrator.',
+      timeout: 5000,
+    });
   },
 };

--- a/packages/atomic/src/components/search/atomic-query-error/atomic-query-error.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-query-error/atomic-query-error.new.stories.tsx
@@ -119,7 +119,7 @@ export const WithOrganizationPaused: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   decorators: [
     (story) => html`<atomic-search-box></atomic-search-box>${story()}`,
   ],

--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
@@ -1,9 +1,14 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import type {AtomicSearchInterface} from '@/src/components/search/atomic-search-interface/atomic-search-interface';
 import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
+
+const mockSearchApi = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -21,12 +26,16 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...mockSearchApi.handlers]},
     actions: {
       handles: events,
     },
   },
   args,
   argTypes,
+  beforeEach: async () => {
+    mockSearchApi.clearAll();
+  },
 
   play,
 };
@@ -40,17 +49,19 @@ export const Default: Story = {
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
   tags: ['a11y', 'test'],
+  beforeEach: async () => {
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(120));
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(42));
+  },
   play: async (context) => {
-    // The initial search already triggers a status message in atomic-aria-live.
-    // We just need to verify the live region gets populated after the search completes.
     await play(context);
     await testStatusMessageA11y(context, {
-      triggerAction: async () => {
-        // The search already executed during play(). The aria-live region
-        // should already be populated with "Results 1-10 of X" or similar.
-        // We trigger nothing extra — just verify the live region has content.
+      triggerAction: async (canvasElement) => {
+        await canvasElement
+          .querySelector<AtomicSearchInterface>('atomic-search-interface')!
+          .executeFirstSearch();
       },
-      expectedText: /TODO:/i,
+      expectedText: 'Results loaded. Results 1-10 of 42',
       timeout: 5000,
     });
   },

--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
@@ -1,12 +1,9 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
-import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
-
-const searchApiHarness = new MockSearchApi();
-searchApiHarness.enableInteractiveFacets();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -24,7 +21,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
-    msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,
     },
@@ -39,4 +35,23 @@ export default meta;
 
 export const Default: Story = {
   name: 'Default',
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  play: async (context) => {
+    // The initial search already triggers a status message in atomic-aria-live.
+    // We just need to verify the live region gets populated after the search completes.
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        // The search already executed during play(). The aria-live region
+        // should already be populated with "Results 1-10 of X" or similar.
+        // We trigger nothing extra — just verify the live region has content.
+      },
+      expectedText: /TODO:/i,
+      timeout: 5000,
+    });
+  },
 };

--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
@@ -48,7 +48,7 @@ export const Default: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   beforeEach: async () => {
     mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(120));
     mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(42));

--- a/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
@@ -139,7 +139,7 @@ export const DisplayAsLink: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   args: {
     field: 'snrating',
     label: 'Rating',

--- a/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
@@ -1,9 +1,72 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 import '@/src/components/search/atomic-rating-facet/atomic-rating-facet.js';
+
+const mockSearchApi = new MockSearchApi();
+
+const ratingFacetValues = [
+  {
+    start: 4,
+    end: 5,
+    endInclusive: true,
+    state: 'idle',
+    numberOfResults: 57,
+  },
+  {
+    start: 3,
+    end: 4,
+    endInclusive: false,
+    state: 'idle',
+    numberOfResults: 36,
+  },
+  {
+    start: 2,
+    end: 3,
+    endInclusive: false,
+    state: 'idle',
+    numberOfResults: 19,
+  },
+  {
+    start: 1,
+    end: 2,
+    endInclusive: false,
+    state: 'idle',
+    numberOfResults: 8,
+  },
+];
+
+const mockRatingFacetResponseWithResults = (totalCount: number) => {
+  mockSearchApi.searchEndpoint.mockOnce((response) => {
+    const responseWithResults =
+      buildSearchResponseWithResults(totalCount)(response);
+    if ('facets' in responseWithResults) {
+      return {
+        ...responseWithResults,
+        facets: [
+          ...(responseWithResults.facets || []),
+          {
+            facetId: 'snrating',
+            field: 'snrating',
+            moreValuesAvailable: false,
+            values: ratingFacetValues,
+            indexScore: 0.23,
+            domain: {start: 1, end: 5},
+          },
+        ],
+      };
+    }
+    return responseWithResults;
+  });
+};
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -23,6 +86,7 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
+    msw: {handlers: [...mockSearchApi.handlers]},
   },
   argTypes: {
     ...argTypes,
@@ -41,6 +105,9 @@ const meta: Meta = {
   },
 
   play,
+  beforeEach: async () => {
+    mockSearchApi.clearAll();
+  },
   args: {
     ...args,
     'number-of-values': 8,
@@ -68,4 +135,33 @@ export const DisplayAsLink: Story = {
     field: 'snrating',
   },
   decorators: [facetDecorator],
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  args: {
+    field: 'snrating',
+    label: 'Rating',
+  },
+  decorators: [
+    facetDecorator,
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+  beforeEach: () => {
+    mockRatingFacetResponseWithResults(120);
+    mockRatingFacetResponseWithResults(42);
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const buttons = await canvas.findAllByShadowRole('checkbox');
+        buttons[0].click();
+      },
+      expectedText: 'Results loaded. Results 1-10 of 42',
+      timeout: 5000,
+    });
+  },
 };

--- a/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
@@ -130,7 +130,7 @@ export const Default: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   args: {
     field: 'snrating',
     label: 'Rating',

--- a/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
@@ -1,9 +1,72 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 import '@/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.js';
+
+const mockSearchApi = new MockSearchApi();
+
+const ratingRangeFacetValues = [
+  {
+    start: 4,
+    end: 5,
+    endInclusive: true,
+    state: 'idle',
+    numberOfResults: 57,
+  },
+  {
+    start: 3,
+    end: 4,
+    endInclusive: false,
+    state: 'idle',
+    numberOfResults: 36,
+  },
+  {
+    start: 2,
+    end: 3,
+    endInclusive: false,
+    state: 'idle',
+    numberOfResults: 19,
+  },
+  {
+    start: 1,
+    end: 2,
+    endInclusive: false,
+    state: 'idle',
+    numberOfResults: 8,
+  },
+];
+
+const mockRatingRangeFacetResponseWithResults = (totalCount: number) => {
+  mockSearchApi.searchEndpoint.mockOnce((response) => {
+    const responseWithResults =
+      buildSearchResponseWithResults(totalCount)(response);
+    if ('facets' in responseWithResults) {
+      return {
+        ...responseWithResults,
+        facets: [
+          ...(responseWithResults.facets || []),
+          {
+            facetId: 'snrating',
+            field: 'snrating',
+            moreValuesAvailable: false,
+            values: ratingRangeFacetValues,
+            indexScore: 0.23,
+            domain: {start: 1, end: 5},
+          },
+        ],
+      };
+    }
+    return responseWithResults;
+  });
+};
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -23,6 +86,7 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
+    msw: {handlers: [...mockSearchApi.handlers]},
   },
   argTypes: {
     ...argTypes,
@@ -41,6 +105,9 @@ const meta: Meta = {
   },
 
   play,
+  beforeEach: async () => {
+    mockSearchApi.clearAll();
+  },
   args: {
     ...args,
     'number-of-values': 8,
@@ -59,4 +126,36 @@ export const Default: Story = {
     field: 'snrating',
   },
   decorators: [facetDecorator],
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  args: {
+    field: 'snrating',
+    label: 'Rating',
+  },
+  decorators: [
+    facetDecorator,
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+  beforeEach: () => {
+    mockRatingRangeFacetResponseWithResults(120);
+    mockRatingRangeFacetResponseWithResults(42);
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const buttons = await canvas.findAllByShadowLabelText(
+          /Inclusion filter on/,
+          {exact: false}
+        );
+        buttons[0].click();
+      },
+      expectedText: 'Results loaded. Results 1-10 of 42',
+      timeout: 5000,
+    });
+  },
 };

--- a/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
@@ -48,7 +48,7 @@ export const Default: Story = {};
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   decorators: [
     (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
   ],

--- a/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
@@ -1,11 +1,16 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
 import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 import '@/src/components/search/atomic-results-per-page/atomic-results-per-page.js';
+
+const mockSearchApi = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -23,12 +28,16 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...mockSearchApi.handlers]},
     actions: {
       handles: events,
     },
   },
   args,
   argTypes,
+  beforeEach: async () => {
+    mockSearchApi.clearAll();
+  },
 
   play,
 };
@@ -43,27 +52,21 @@ export const A11yStatusMessage: Story = {
   decorators: [
     (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
   ],
+  beforeEach: async () => {
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(120));
+    mockSearchApi.searchEndpoint.mockOnce(
+      buildSearchResponseWithResults(120, 25)
+    );
+  },
   play: async (context) => {
     await play(context);
     await testStatusMessageA11y(context, {
       triggerAction: async () => {
-        const {canvasElement} = context;
-        const resultsPerPage = canvasElement.querySelector(
-          'atomic-results-per-page'
-        )!;
-        const buttons =
-          resultsPerPage.shadowRoot!.querySelectorAll<HTMLButtonElement>(
-            'button'
-          );
-        // Click a non-active button (different page size)
-        const nonActiveButton = Array.from(buttons).find(
-          (btn) =>
-            !btn.classList.contains('active') &&
-            !btn.hasAttribute('aria-pressed')
-        );
-        nonActiveButton?.click();
+        const canvas = within(context.canvasElement);
+        const button = await canvas.findByShadowRole('radio', {name: '25'});
+        button.click();
       },
-      expectedText: /TODO:/i,
+      expectedText: 'Results loaded. Results 1-25 of 120',
       timeout: 5000,
     });
   },

--- a/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
@@ -1,7 +1,10 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {html} from 'lit';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 import '@/src/components/search/atomic-results-per-page/atomic-results-per-page.js';
 
 const {decorator, play} = wrapInSearchInterface();
@@ -33,3 +36,35 @@ const meta: Meta = {
 export default meta;
 
 export const Default: Story = {};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  decorators: [
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const {canvasElement} = context;
+        const resultsPerPage = canvasElement.querySelector(
+          'atomic-results-per-page'
+        )!;
+        const buttons =
+          resultsPerPage.shadowRoot!.querySelectorAll<HTMLButtonElement>(
+            'button'
+          );
+        // Click a non-active button (different page size)
+        const nonActiveButton = Array.from(buttons).find(
+          (btn) =>
+            !btn.classList.contains('active') &&
+            !btn.hasAttribute('aria-pressed')
+        );
+        nonActiveButton?.click();
+      },
+      expectedText: /TODO:/i,
+      timeout: 5000,
+    });
+  },
+};

--- a/packages/atomic/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.new.stories.tsx
@@ -1,6 +1,9 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
+import {userEvent} from 'storybook/test';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
@@ -43,4 +46,21 @@ export default meta;
 
 export const Default: Story = {
   name: 'atomic-search-box-query-suggestions',
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const searchBox = await canvas.findByShadowPlaceholderText('Search');
+        await userEvent.type(searchBox, 'coveo');
+      },
+      expectedText: '5 search suggestions are available for coveo.',
+      timeout: 5000,
+    });
+  },
 };

--- a/packages/atomic/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.new.stories.tsx
@@ -50,7 +50,7 @@ export const Default: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   play: async (context) => {
     await play(context);
     await testStatusMessageA11y(context, {

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.new.stories.tsx
@@ -5,9 +5,14 @@ import type {
 } from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
+import {userEvent} from 'storybook/test';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 import '@/src/components/search/atomic-search-box/atomic-search-box.js';
 import '@/src/components/search/atomic-search-box-instant-results/atomic-search-box-instant-results.js';
 import '@/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.js';
@@ -72,5 +77,31 @@ export const StandaloneSearchBox: Story = {
   args: {
     'redirection-url':
       './iframe.html?id=atomic-search-interface--with-result-list',
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  decorators: [
+    (story) => html`${story()}<atomic-query-summary></atomic-query-summary>`,
+  ],
+  beforeEach: async () => {
+    searchApiHarness.clearAll();
+    searchApiHarness.searchEndpoint.mockOnce(
+      buildSearchResponseWithResults(42)
+    );
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const searchBox = await canvas.findByShadowPlaceholderText('Search');
+        await userEvent.type(searchBox, 'accessibility{enter}');
+      },
+      expectedText: 'Results loaded. Results 1-10 of 42',
+      timeout: 5000,
+    });
   },
 };

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.new.stories.tsx
@@ -82,7 +82,7 @@ export const StandaloneSearchBox: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   decorators: [
     (story) => html`${story()}<atomic-query-summary></atomic-query-summary>`,
   ],

--- a/packages/atomic/src/components/search/atomic-segmented-facet/atomic-segmented-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-segmented-facet/atomic-segmented-facet.new.stories.tsx
@@ -1,9 +1,13 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 import '@/src/components/search/atomic-segmented-facet/atomic-segmented-facet.js';
 
 const searchApiHarness = new MockSearchApi();
@@ -33,6 +37,9 @@ const meta: Meta = {
   },
   argTypes: {
     ...argTypes,
+  },
+  beforeEach: () => {
+    searchApiHarness.clearAll();
   },
   play,
   args: {
@@ -65,4 +72,48 @@ export const Default: Story = {
       ${story()}
     `,
   ],
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  args: {
+    field: 'objecttype',
+    label: 'Object Type',
+  },
+  decorators: [
+    (story) => html`
+      <atomic-query-summary></atomic-query-summary>
+      <style>
+        atomic-segmented-facet {
+          width: 800px;
+          margin: auto;
+          display: block;
+        }
+      </style>
+      ${story()}
+    `,
+  ],
+  beforeEach: () => {
+    searchApiHarness.searchEndpoint.mockOnce(
+      buildSearchResponseWithResults(120)
+    );
+    searchApiHarness.searchEndpoint.mockOnce(
+      buildSearchResponseWithResults(42)
+    );
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const button = await canvas.findByShadowRole('button', {
+          name: /People/,
+        });
+        button.click();
+      },
+      expectedText: 'Results loaded. Results 1-10 of 42',
+      timeout: 5000,
+    });
+  },
 };

--- a/packages/atomic/src/components/search/atomic-segmented-facet/atomic-segmented-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-segmented-facet/atomic-segmented-facet.new.stories.tsx
@@ -76,7 +76,7 @@ export const Default: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   args: {
     field: 'objecttype',
     label: 'Object Type',

--- a/packages/atomic/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.new.stories.tsx
@@ -193,7 +193,7 @@ export const Default: Story = {
 };
 
 export const A11yDisclosure: Story = {
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   play: async (context) => {
     await play(context);
     await testDisclosureA11y(context, {

--- a/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.new.stories.tsx
@@ -1,12 +1,17 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
 import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 import '@/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.js';
 import '@/src/components/search/atomic-sort-expression/atomic-sort-expression.js';
+
+const mockSearchApi = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -23,12 +28,16 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {handlers: [...mockSearchApi.handlers]},
     actions: {
       handles: events,
     },
   },
   args,
   argTypes,
+  beforeEach: async () => {
+    mockSearchApi.clearAll();
+  },
 
   play,
 };
@@ -68,18 +77,22 @@ export const A11yStatusMessage: Story = {
   args: {
     ...Default.args,
   },
+  beforeEach: async () => {
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(120));
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(84));
+  },
   play: async (context) => {
     await play(context);
     await testStatusMessageA11y(context, {
       triggerAction: async () => {
-        const {canvas} = context;
+        const canvas = within(context.canvasElement);
         const select = await canvas.findByShadowRole('combobox', {
           name: /sort by/i,
         });
         (select as HTMLSelectElement).value = 'date descending';
         select.dispatchEvent(new Event('change', {bubbles: true}));
       },
-      expectedText: /TODO:/i,
+      expectedText: 'Results loaded. Results 1-10 of 84',
       timeout: 5000,
     });
   },

--- a/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.new.stories.tsx
@@ -1,7 +1,10 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {html} from 'lit';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 import '@/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.js';
 import '@/src/components/search/atomic-sort-expression/atomic-sort-expression.js';
 
@@ -53,5 +56,31 @@ export const Default: Story = {
         expression="sncost ascending, date descending"
       ></atomic-sort-expression>
     `,
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  decorators: [
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+  args: {
+    ...Default.args,
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const {canvas} = context;
+        const select = await canvas.findByShadowRole('combobox', {
+          name: /sort by/i,
+        });
+        (select as HTMLSelectElement).value = 'date descending';
+        select.dispatchEvent(new Event('change', {bubbles: true}));
+      },
+      expectedText: /TODO:/i,
+      timeout: 5000,
+    });
   },
 };

--- a/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.new.stories.tsx
@@ -70,7 +70,7 @@ export const Default: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   decorators: [
     (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
   ],

--- a/packages/atomic/src/components/search/atomic-tab/atomic-tab.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-tab/atomic-tab.new.stories.tsx
@@ -50,7 +50,7 @@ export const Default: Story = {};
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   decorators: [
     (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
   ],

--- a/packages/atomic/src/components/search/atomic-tab/atomic-tab.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-tab/atomic-tab.new.stories.tsx
@@ -1,11 +1,17 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 import '@/src/components/search/atomic-tab/atomic-tab.js';
 import '@/src/components/search/atomic-tab-manager/atomic-tab-manager.js';
 
+const mockSearchApi = new MockSearchApi();
 const {decorator, play} = wrapInSearchInterface();
 
 const {events, argTypes} = getStorybookHelpers('atomic-tab', {
@@ -16,11 +22,12 @@ const meta: Meta = {
   component: 'atomic-tab',
   title: 'Search/Tab',
   id: 'atomic-tab',
-  render: () => html`<atomic-tab-manager>
-    <atomic-tab label="All" name="all"></atomic-tab>
-    <atomic-tab label="Images" name="images"></atomic-tab>
-    <atomic-tab label="Articles" name="articles"></atomic-tab>
-  </atomic-tab-manager>`,
+  render: () =>
+    html`<atomic-tab-manager>
+      <atomic-tab label="All" name="all"></atomic-tab>
+      <atomic-tab label="Images" name="images"></atomic-tab>
+      <atomic-tab label="Articles" name="articles"></atomic-tab>
+    </atomic-tab-manager>`,
   decorators: [decorator],
   parameters: {
     ...parameters,
@@ -28,11 +35,41 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
+    msw: {handlers: [...mockSearchApi.handlers]},
   },
   argTypes,
+  beforeEach: async () => {
+    mockSearchApi.clearAll();
+  },
   play,
 };
 
 export default meta;
 
 export const Default: Story = {};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  decorators: [
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+  beforeEach: async () => {
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(120));
+    mockSearchApi.searchEndpoint.mockOnce(buildSearchResponseWithResults(42));
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const button = await canvas.findByShadowRole('button', {
+          name: 'Images',
+        });
+        button.click();
+      },
+      expectedText: 'Results loaded. Results 1-10 of 42',
+      timeout: 5000,
+    });
+  },
+};

--- a/packages/atomic/src/components/search/atomic-timeframe-facet/atomic-timeframe-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-timeframe-facet/atomic-timeframe-facet.new.stories.tsx
@@ -301,7 +301,7 @@ export const Collapsed: Story = {
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   decorators: [
     (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
   ],

--- a/packages/atomic/src/components/search/atomic-timeframe-facet/atomic-timeframe-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-timeframe-facet/atomic-timeframe-facet.new.stories.tsx
@@ -1,6 +1,10 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {buildSearchResponseWithResults} from '@/storybook-utils/api/search/search-response-mocks';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {
   facetDecorator,
@@ -10,6 +14,7 @@ import {
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-facet/atomic-facet.js';
 import '@/src/components/common/atomic-timeframe/atomic-timeframe.js';
+import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 import '@/src/components/search/atomic-timeframe-facet/atomic-timeframe-facet.js';
 
 const searchApiHarness = new MockSearchApi();
@@ -77,6 +82,25 @@ const createDateFacetResponse = (
   values,
   label: 'Date',
 });
+
+const mockDateFacetResponseWithResults = (totalCount: number) => {
+  searchApiHarness.searchEndpoint.mockOnce((response) => {
+    const responseWithResults =
+      buildSearchResponseWithResults(totalCount)(response);
+    if ('facets' in responseWithResults) {
+      return {
+        ...responseWithResults,
+        facets: [
+          createDateFacetResponse(baseDateFacetValues),
+          createDateFacetResponse(baseDateFacetValues, {
+            facetId: 'date_input_range',
+          }),
+        ],
+      };
+    }
+    return responseWithResults;
+  });
+};
 
 const {decorator, play} = wrapInSearchInterface();
 
@@ -272,5 +296,42 @@ export const Collapsed: Story = {
         }),
       ],
     }));
+  },
+};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test'],
+  decorators: [
+    (story) => html`<atomic-query-summary></atomic-query-summary>${story()}`,
+  ],
+  args: {
+    'default-slot': `
+      <atomic-timeframe unit="hour"></atomic-timeframe>
+      <atomic-timeframe unit="day"></atomic-timeframe>
+      <atomic-timeframe unit="week"></atomic-timeframe>
+      <atomic-timeframe unit="month"></atomic-timeframe>
+      <atomic-timeframe unit="quarter"></atomic-timeframe>
+      <atomic-timeframe unit="year"></atomic-timeframe>
+    `,
+  },
+  beforeEach: () => {
+    mockDateFacetResponseWithResults(120);
+    mockDateFacetResponseWithResults(42);
+  },
+  play: async (context) => {
+    await play(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const button = await canvas.findByShadowLabelText(
+          'Inclusion filter on Past hour',
+          {exact: false}
+        );
+        button.click();
+      },
+      expectedText: 'Results loaded. Results 1-10 of 42',
+      timeout: 5000,
+    });
   },
 };

--- a/packages/atomic/storybook-utils/a11y/index.ts
+++ b/packages/atomic/storybook-utils/a11y/index.ts
@@ -17,3 +17,8 @@ export {
   testRadioGroupA11y,
   type RadioGroupA11yOptions,
 } from './radiogroup.js';
+export {
+  COVERED_CRITERIA as STATUS_MESSAGE_COVERED_CRITERIA,
+  testStatusMessageA11y,
+  type StatusMessageA11yOptions,
+} from './status-message.js';

--- a/packages/atomic/storybook-utils/a11y/status-message.ts
+++ b/packages/atomic/storybook-utils/a11y/status-message.ts
@@ -1,0 +1,137 @@
+import type {StoryContext} from '@storybook/web-components-vite';
+import {expect, waitFor} from 'storybook/test';
+
+/**
+ * WCAG 2.2 AA criteria covered by status-message tests.
+ *
+ * - 4.1.3 Status Messages: status messages are programmatically determinable
+ *   through role or properties so they can be announced by assistive technologies
+ *   without receiving focus
+ *
+ * @see https://www.w3.org/TR/WCAG22/#status-messages — WCAG 2.2 SC 4.1.3 Status Messages (Level AA)
+ */
+export const COVERED_CRITERIA = ['4.1.3'] as const;
+
+export interface StatusMessageA11yOptions {
+  /**
+   * A function that performs the action expected to produce a status message
+   * (e.g., submit a search, apply a filter, trigger an error).
+   */
+  triggerAction: (canvasElement: HTMLElement) => Promise<void>;
+
+  /**
+   * Expected text content (or substring) of the status message.
+   * The test verifies the live region contains this text.
+   */
+  expectedText: string | RegExp;
+
+  /**
+   * Timeout in ms to wait for the status message to appear.
+   * @default 5000
+   */
+  timeout?: number;
+}
+
+/**
+ * Finds all live regions in the DOM (main + shadow DOMs).
+ */
+function findLiveRegions(root: HTMLElement): HTMLElement[] {
+  const selectors = [
+    '[aria-live]',
+    '[role="status"]',
+    '[role="alert"]',
+    '[role="log"]',
+    '[role="progressbar"]',
+  ].join(', ');
+
+  const elements: HTMLElement[] = [];
+
+  elements.push(...Array.from(root.querySelectorAll<HTMLElement>(selectors)));
+
+  for (const host of root.querySelectorAll('*')) {
+    if (host.shadowRoot) {
+      elements.push(
+        ...Array.from(host.shadowRoot.querySelectorAll<HTMLElement>(selectors))
+      );
+    }
+  }
+
+  return elements;
+}
+
+/**
+ * Tests that a user action produces a status message in an ARIA live region.
+ *
+ * Verifies that:
+ * 1. After the action, a live region (`aria-live`, `role="status"`,
+ *    `role="alert"`) exists with non-empty content
+ * 2. The live region is not `aria-hidden`
+ * 3. Optionally, the content matches expected text
+ *
+ * @remarks
+ * This is an opt-in helper. Developers must provide the action that triggers
+ * the status message since this varies per component.
+ */
+export async function testStatusMessageA11y(
+  context: StoryContext,
+  options: StatusMessageA11yOptions
+): Promise<void> {
+  const {canvasElement, step} = context;
+
+  let status: 'passed' | 'failed' = 'passed';
+  const timeout = options.timeout ?? 5000;
+
+  try {
+    await step('Live regions exist before action (baseline)', async () => {
+      // Just snapshot — we don't require them to exist before
+      findLiveRegions(canvasElement);
+    });
+
+    await step(
+      'Trigger action that should produce a status message',
+      async () => {
+        await options.triggerAction(canvasElement);
+      }
+    );
+
+    await step(
+      'Status message appears in a live region after action',
+      async () => {
+        await waitFor(
+          () => {
+            const liveRegions = findLiveRegions(canvasElement);
+
+            const populatedRegions = liveRegions.filter((region) => {
+              if (region.getAttribute('aria-hidden') === 'true') return false;
+              const text = region.textContent?.trim() ?? '';
+              return text.length > 0;
+            });
+
+            expect(populatedRegions.length).toBeGreaterThan(0);
+
+            const regionTexts = populatedRegions.map(
+              (region) => region.textContent?.trim() ?? ''
+            );
+            const combined = regionTexts.join('\n');
+            if (typeof options.expectedText === 'string') {
+              expect(combined).toContain(options.expectedText);
+            } else {
+              expect(combined).toMatch(options.expectedText);
+            }
+          },
+          {timeout}
+        );
+      }
+    );
+  } catch (error) {
+    status = 'failed';
+    throw error;
+  } finally {
+    context.reporting?.addReport?.({
+      type: 'a11y-interactive',
+      version: 1,
+      status,
+      result: {criteriaCovered: [...COVERED_CRITERIA]},
+    });
+  }
+}

--- a/packages/atomic/storybook-utils/api/search/search-response-mocks.ts
+++ b/packages/atomic/storybook-utils/api/search/search-response-mocks.ts
@@ -1,0 +1,15 @@
+import type {MockSearchApi} from './mock.js';
+
+type SearchEndpointResponse = Parameters<
+  Parameters<MockSearchApi['searchEndpoint']['mockOnce']>[0]
+>[0];
+
+export const buildSearchResponseWithResults =
+  (totalCount: number, numberOfResults = 10) =>
+  (response: SearchEndpointResponse): SearchEndpointResponse => ({
+    ...response,
+    totalCount,
+    totalCountFiltered: totalCount,
+    results:
+      'results' in response ? response.results.slice(0, numberOfResults) : [],
+  });


### PR DESCRIPTION
## Description
Adds \`A11yStatusMessage\` stories that exercise \`testStatusMessageA11y\` for:
- \`atomic-facet\`
- \`atomic-pager\`
- \`atomic-query-summary\`
- \`atomic-results-per-page\`
- \`atomic-sort-dropdown\`

## Dependencies
- Stacked on #7674 (\`a11y/status-message-helper\`)

## Jira
[KIT-5756](https://coveord.atlassian.net/browse/KIT-5756)

[KIT-5756]: https://coveord.atlassian.net/browse/KIT-5756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ