### PR TITLE
test(atomic): wire Checkbox APG helper to facet stories

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.new.stories.tsx
@@ -1,6 +1,7 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {testCheckboxA11y} from '@/storybook-utils/a11y/checkbox.js';
 import {commerceFacetWidthDecorator} from '@/storybook-utils/commerce/commerce-facet-width-decorator';
 import {
   hideFacetTypesHook,
@@ -74,5 +75,21 @@ export const Default: Story = {
   play: async (context) => {
     await play(context);
     await hideFacetTypesHook('atomic-commerce-facet', context);
+  },
+};
+
+export const A11yCheckbox: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  decorators: [
+    (_) => {
+      return html`<div id="code-root">
+        <atomic-commerce-facets></atomic-commerce-facets>
+      </div>`;
+    },
+  ],
+  play: async (context) => {
+    await play(context);
+    await hideFacetTypesHook('atomic-commerce-facet', context);
+    await testCheckboxA11y(context);
   },
 };

--- a/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
@@ -1,6 +1,7 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {testCheckboxA11y} from '@/storybook-utils/a11y/checkbox.js';
 import {commerceFacetWidthDecorator} from '@/storybook-utils/commerce/commerce-facet-width-decorator';
 import {
   hideFacetTypesHook,
@@ -74,5 +75,21 @@ export const Default: Story = {
   play: async (context) => {
     await play(context);
     await hideFacetTypesHook('atomic-commerce-numeric-facet', context);
+  },
+};
+
+export const A11yCheckbox: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  decorators: [
+    (_) => {
+      return html`<div id="code-root">
+        <atomic-commerce-facets></atomic-commerce-facets>
+      </div>`;
+    },
+  ],
+  play: async (context) => {
+    await play(context);
+    await hideFacetTypesHook('atomic-commerce-numeric-facet', context);
+    await testCheckboxA11y(context, {checkboxName: /\$\d/});
   },
 };

--- a/packages/atomic/src/components/insight/atomic-insight-facet/atomic-insight-facet.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-facet/atomic-insight-facet.new.stories.tsx
@@ -1,7 +1,9 @@
 import type {FacetSortCriterion} from '@coveo/headless/insight';
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {testCheckboxA11y} from '@/storybook-utils/a11y/checkbox.js';
 import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
+import {searchFacetTransformer} from '@/storybook-utils/api/search/facet-transformer';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
@@ -154,5 +156,27 @@ export const Collapsed: Story = {
   decorators: [facetDecorator],
   beforeEach: () => {
     mockDefaultFacetResponse();
+  },
+};
+
+export const A11yCheckbox: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  args: {
+    field: 'objecttype',
+  },
+  decorators: [facetDecorator],
+  beforeEach: () => {
+    insightApiHarness.searchEndpoint.addRequestTransformer(
+      searchFacetTransformer
+    );
+    return () => {
+      insightApiHarness.searchEndpoint.removeRequestTransformer(
+        searchFacetTransformer
+      );
+    };
+  },
+  play: async (context) => {
+    await play(context);
+    await testCheckboxA11y(context);
   },
 };

--- a/packages/atomic/src/components/insight/atomic-insight-numeric-facet/atomic-insight-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-numeric-facet/atomic-insight-numeric-facet.new.stories.tsx
@@ -1,6 +1,8 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {testCheckboxA11y} from '@/storybook-utils/a11y/checkbox.js';
 import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
+import {searchFacetTransformer} from '@/storybook-utils/api/search/facet-transformer';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {
   facetDecorator,
@@ -245,5 +247,28 @@ export const WithSelectedValue: Story = {
         },
       ],
     }));
+  },
+};
+
+export const A11yCheckbox: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  args: {
+    field: 'ytviewcount',
+    label: 'YouTube View Count',
+  },
+  decorators: [facetDecorator],
+  beforeEach: () => {
+    insightApiHarness.searchEndpoint.addRequestTransformer(
+      searchFacetTransformer
+    );
+    return () => {
+      insightApiHarness.searchEndpoint.removeRequestTransformer(
+        searchFacetTransformer
+      );
+    };
+  },
+  play: async (context) => {
+    await play(context);
+    await testCheckboxA11y(context);
   },
 };

--- a/packages/atomic/src/components/search/atomic-automatic-facet/atomic-automatic-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-automatic-facet/atomic-automatic-facet.new.stories.tsx
@@ -4,6 +4,7 @@ import type {
   StoryObj as Story,
 } from '@storybook/web-components-vite';
 import {html} from 'lit';
+import {testCheckboxA11y} from '@/storybook-utils/a11y/checkbox.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
@@ -55,5 +56,32 @@ export const Default: Story = {
         ],
       },
     }));
+  },
+};
+
+export const A11yCheckbox: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  beforeEach: async () => {
+    searchApiHarness.searchEndpoint.mockOnce((response) => ({
+      ...response,
+      generateAutomaticFacets: {
+        facets: [
+          {
+            field: 'objecttype',
+            label: 'Type',
+            values: [
+              {value: 'Document', numberOfResults: 45, state: 'idle'},
+              {value: 'PDF', numberOfResults: 32, state: 'idle'},
+              {value: 'Video', numberOfResults: 18, state: 'idle'},
+              {value: 'Image', numberOfResults: 12, state: 'idle'},
+            ],
+          },
+        ],
+      },
+    }));
+  },
+  play: async (context) => {
+    await play(context);
+    await testCheckboxA11y(context);
   },
 };

--- a/packages/atomic/src/components/search/atomic-color-facet/atomic-color-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-color-facet/atomic-color-facet.new.stories.tsx
@@ -1,7 +1,9 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {testCheckboxA11y} from '@/storybook-utils/a11y/checkbox.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {searchFacetTransformer} from '@/storybook-utils/api/search/facet-transformer';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
@@ -215,5 +217,29 @@ export const WithSelectedValue: Story = {
       }
       return response;
     });
+  },
+};
+
+export const A11yCheckbox: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  args: {
+    field: 'filetype',
+    label: 'File Type',
+    'display-values-as': 'checkbox',
+  },
+  decorators: [facetDecorator, colorFacetStylesDecorator],
+  beforeEach: () => {
+    searchApiHarness.searchEndpoint.addRequestTransformer(
+      searchFacetTransformer
+    );
+    return () => {
+      searchApiHarness.searchEndpoint.removeRequestTransformer(
+        searchFacetTransformer
+      );
+    };
+  },
+  play: async (context) => {
+    await play(context);
+    await testCheckboxA11y(context);
   },
 };

--- a/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
@@ -2,6 +2,7 @@ import type {FacetSortCriterion} from '@coveo/headless';
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {testCheckboxA11y} from '@/storybook-utils/a11y/checkbox.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
@@ -134,4 +135,16 @@ export const CustomSort: Story = {
       ></atomic-facet>`;
     },
   ],
+};
+
+export const A11yCheckbox: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  args: {
+    field: 'objecttype',
+  },
+  decorators: [facetDecorator],
+  play: async (context) => {
+    await play(context);
+    await testCheckboxA11y(context);
+  },
 };

--- a/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
@@ -1,6 +1,8 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {testCheckboxA11y} from '@/storybook-utils/a11y/checkbox.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
+import {searchFacetTransformer} from '@/storybook-utils/api/search/facet-transformer';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {
   facetDecorator,
@@ -246,5 +248,28 @@ export const WithSelectedValue: Story = {
         },
       ],
     }));
+  },
+};
+
+export const A11yCheckbox: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  args: {
+    field: 'ytviewcount',
+    label: 'YouTube View Count',
+  },
+  decorators: [facetDecorator],
+  beforeEach: () => {
+    searchApiHarness.searchEndpoint.addRequestTransformer(
+      searchFacetTransformer
+    );
+    return () => {
+      searchApiHarness.searchEndpoint.removeRequestTransformer(
+        searchFacetTransformer
+      );
+    };
+  },
+  play: async (context) => {
+    await play(context);
+    await testCheckboxA11y(context);
   },
 };

--- a/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {testCheckboxA11y} from '@/storybook-utils/a11y/checkbox.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {facetDecorator} from '@/storybook-utils/common/facets-decorator';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
@@ -82,4 +83,16 @@ export const DisplayAsLink: Story = {
     field: 'snrating',
   },
   decorators: [facetDecorator],
+};
+
+export const A11yCheckbox: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  args: {
+    field: 'snrating',
+  },
+  decorators: [facetDecorator],
+  play: async (context) => {
+    await play(context);
+    await testCheckboxA11y(context);
+  },
 };


### PR DESCRIPTION
[KIT-5728](https://coveord.atlassian.net/browse/KIT-5728)

## Problem
The `testCheckboxA11y` helper was only wired to `atomic-facet`, leaving most checkbox-based components without APG a11y coverage.

## Solution
Wire `testCheckboxA11y` to all facet components that implement the WAI-ARIA checkbox pattern:

- `atomic-facet` (search)
- `atomic-color-facet` (search)
- `atomic-numeric-facet` (search)
- `atomic-automatic-facet` (search)
- `atomic-rating-facet` (search)
- `atomic-rating-range-facet` (search)
- `atomic-commerce-facet` (commerce)
- `atomic-commerce-numeric-facet` (commerce)
- `atomic-insight-facet` (insight)
- `atomic-insight-numeric-facet` (insight)

Each gets an `A11yCheckbox` story tagged with `a11y` and `test`.

[KIT-5728]: https://coveord.atlassian.net/browse/KIT-5728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ