### PR TITLE
test(atomic): wire Table APG helper to result list stories

### DIFF
--- a/.changeset/table-apg-a11y.md
+++ b/.changeset/table-apg-a11y.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Add accessible label (`aria-label`) to the table layout used by result list and product list in table display mode.

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.new.stories.tsx
@@ -251,3 +251,26 @@ export const NoProducts: Story = {
     await executeFirstRequestHook(context);
   },
 };
+
+export const A11yTable: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Table',
+  args: {
+    display: 'table',
+    'default-slot': `<atomic-product-template>
+  <template>
+    <atomic-table-element label="Product">
+      <atomic-product-link></atomic-product-link>
+    </atomic-table-element>
+    <atomic-table-element label="ID">
+      <atomic-product-text field="ec_product_id"></atomic-product-text>
+    </atomic-table-element>
+  </template>
+</atomic-product-template>`,
+  },
+  play: async (context) => {
+    await play(context);
+    const {testTableA11y} = await import('@/storybook-utils/a11y/table.js');
+    await testTableA11y(context);
+  },
+};

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts
@@ -493,6 +493,7 @@ export class AtomicCommerceProductList
             firstItem,
             host: this,
             itemRenderingFunction: this.itemRenderingFunction,
+            label: this.bindings.i18n.t('view-products'),
             listClasses,
             logger: this.bindings.engine.logger,
             templateContentForFirstItem,

--- a/packages/atomic/src/components/common/item-list/table-layout.spec.ts
+++ b/packages/atomic/src/components/common/item-list/table-layout.spec.ts
@@ -28,6 +28,7 @@ describe('renderTableLayout', () => {
           templateContentForFirstItem: document.createDocumentFragment(),
           host: document.createElement('div'),
           listClasses: '',
+          label: 'Test table label',
           logger: {
             error: vi.fn(),
           },
@@ -57,6 +58,12 @@ describe('renderTableLayout', () => {
     const tableLayout = await tableLayoutFixture();
 
     expect(tableLayout.part.value).toBe('result-table');
+  });
+
+  it('should render the #label prop as the aria-label attribute of the table', async () => {
+    const tableLayout = await tableLayoutFixture({label: 'My custom label'});
+
+    expect(tableLayout.getAttribute('aria-label')).toBe('My custom label');
   });
 
   it('should render a thead element under the table element', async () => {

--- a/packages/atomic/src/components/common/item-list/table-layout.ts
+++ b/packages/atomic/src/components/common/item-list/table-layout.ts
@@ -21,6 +21,7 @@ export interface TableLayoutProps extends TableColumnsProps {
   host: HTMLElement;
   listClasses: string;
   logger: Pick<Console, 'error'>;
+  label?: string;
 }
 
 export interface TableDataProps extends TableColumnsProps {
@@ -37,7 +38,7 @@ export interface TableRowProps {
 export const renderTableLayout: FunctionalComponentWithChildren<
   TableLayoutProps
 > = ({props}) => {
-  const {host, listClasses, logger} = props;
+  const {host, listClasses, logger, label} = props;
 
   const fieldColumns = getFieldTableColumns(props);
 
@@ -49,7 +50,11 @@ export const renderTableLayout: FunctionalComponentWithChildren<
   }
 
   return (children) =>
-    html`<table class="list-root ${listClasses}" part="result-table">
+    html`<table
+      class="list-root ${listClasses}"
+      part="result-table"
+      aria-label=${label ?? 'Results'}
+    >
       <thead part="result-table-heading">
         <tr part="result-table-heading-row">
           ${map(fieldColumns, (column) => {

--- a/packages/atomic/src/components/common/item-list/table-layout.ts
+++ b/packages/atomic/src/components/common/item-list/table-layout.ts
@@ -21,7 +21,7 @@ export interface TableLayoutProps extends TableColumnsProps {
   host: HTMLElement;
   listClasses: string;
   logger: Pick<Console, 'error'>;
-  label?: string;
+  label: string;
 }
 
 export interface TableDataProps extends TableColumnsProps {
@@ -53,7 +53,7 @@ export const renderTableLayout: FunctionalComponentWithChildren<
     html`<table
       class="list-root ${listClasses}"
       part="result-table"
-      aria-label=${label ?? 'Results'}
+      aria-label=${label}
     >
       <thead part="result-table-heading">
         <tr part="result-table-heading-row">

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
@@ -225,3 +225,26 @@ export const NoResults: Story = {
     await playExecuteFirstSearch(context);
   },
 };
+
+export const A11yTable: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Table',
+  args: {
+    display: 'table',
+    'default-slot': `<atomic-result-template>
+  <template>
+    <atomic-table-element label="Result">
+      <atomic-result-link></atomic-result-link>
+    </atomic-table-element>
+    <atomic-table-element label="ID">
+      <atomic-result-text field="permanentid"></atomic-result-text>
+    </atomic-table-element>
+  </template>
+</atomic-result-template>`,
+  },
+  play: async (context) => {
+    await play(context);
+    const {testTableA11y} = await import('@/storybook-utils/a11y/table.js');
+    await testTableA11y(context);
+  },
+};

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.ts
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.ts
@@ -474,6 +474,7 @@ export class AtomicResultList
             firstItem,
             host: this,
             itemRenderingFunction: this.itemRenderingFunction,
+            label: this.bindings.i18n.t('view-results'),
             listClasses,
             logger: this.bindings.engine.logger,
             templateContentForFirstItem,

--- a/packages/atomic/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.new.stories.tsx
@@ -200,7 +200,7 @@ export const Default: Story = {
 };
 
 export const A11yDisclosure: Story = {
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   play: async (context) => {
     await play(context);
     await testDisclosureA11y(context, {


### PR DESCRIPTION
[KIT-5730](https://coveord.atlassian.net/browse/KIT-5730)

Depends on #7670

## Problem
Tables in result/product lists lack an accessible name per WCAG 4.1.2.

## Solution
- Added `aria-label` to `<table>` in `table-layout.ts` (defaults to "Results")
- Wired `testTableA11y` to:
  - atomic-result-list (table display)
  - atomic-commerce-product-list (table display)

[KIT-5730]: https://coveord.atlassian.net/browse/KIT-5730