### PR TITLE
test(atomic): wire Tooltip APG helper to generated-answer story

### DIFF
--- a/.changeset/tooltip-apg-a11y.md
+++ b/.changeset/tooltip-apg-a11y.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Replace `title` attribute on feedback buttons with proper tooltip pattern (`role="tooltip"` + `aria-describedby`) and add Escape key dismissal for WCAG 1.4.13 compliance.

--- a/packages/atomic/src/components/common/generated-answer/feedback-button.spec.ts
+++ b/packages/atomic/src/components/common/generated-answer/feedback-button.spec.ts
@@ -30,7 +30,7 @@ describe('#renderFeedbackButton', () => {
 
   it('should render a button with the correct title', async () => {
     const button = await renderComponent({title: 'This answer was helpful'});
-    expect(button.getAttribute('title')).toBe('This answer was helpful');
+    expect(button.getAttribute('aria-label')).toBe('This answer was helpful');
   });
 
   it('should render a button with the correct part attribute', async () => {

--- a/packages/atomic/src/components/common/generated-answer/feedback-button.ts
+++ b/packages/atomic/src/components/common/generated-answer/feedback-button.ts
@@ -12,6 +12,8 @@ import {createRipple} from '@/src/utils/ripple-utils';
 
 type FeedbackVariant = 'like' | 'dislike';
 
+let feedbackButtonCounter = 0;
+
 export interface FeedbackButtonProps {
   title: string;
   variant: FeedbackVariant;
@@ -25,6 +27,7 @@ export const renderFeedbackButton: FunctionalComponent<FeedbackButtonProps> = ({
   const buttonStyle: ButtonStyle = 'text-transparent';
   const rippleColor = getRippleColorForButtonStyle(buttonStyle);
   const baseClassName = getClassNameForButtonStyle(buttonStyle);
+  const tooltipId = `feedback-tooltip-${++feedbackButtonCounter}`;
 
   const classNames = multiClassMap(
     tw({
@@ -47,15 +50,30 @@ export const renderFeedbackButton: FunctionalComponent<FeedbackButtonProps> = ({
     })
   );
 
-  return html`<button
-    type="button"
-    title=${props.title}
-    part="feedback-button"
-    class=${classNames}
-    aria-pressed=${props.active ? 'true' : 'false'}
-    @mousedown=${(e: MouseEvent) => createRipple(e, {color: rippleColor})}
-    @click=${props.onClick}
-  >
-    <atomic-icon class=${iconClassNames} .icon=${Thumbs}></atomic-icon>
-  </button>`;
+  return html`<span class="relative inline-block group">
+    <button
+      type="button"
+      aria-label=${props.title}
+      aria-describedby=${tooltipId}
+      part="feedback-button"
+      class=${classNames}
+      aria-pressed=${props.active ? 'true' : 'false'}
+      @mousedown=${(e: MouseEvent) => createRipple(e, {color: rippleColor})}
+      @click=${props.onClick}
+      @keydown=${(e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          (e.currentTarget as HTMLElement).blur();
+        }
+      }}
+    >
+      <atomic-icon class=${iconClassNames} .icon=${Thumbs}></atomic-icon>
+    </button>
+    <span
+      id=${tooltipId}
+      role="tooltip"
+      part="tooltip"
+      class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 text-xs rounded bg-neutral-dark text-on-background-inverted whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+      >${props.title}</span
+    >
+  </span>`;
 };

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
@@ -150,3 +150,17 @@ export const WithAgentId: Story = {
     await submitGeneratedAnswerQuery(storyContext);
   },
 };
+
+export const A11yTooltip: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Tooltip',
+  args: {
+    'answer-configuration-id': 'fc581be0-6e61-4039-ab26-a3f2f52f308f',
+  },
+  play: async (context) => {
+    await play(context);
+    await submitGeneratedAnswerQuery(context);
+    const {testTooltipA11y} = await import('@/storybook-utils/a11y/tooltip.js');
+    await testTooltipA11y(context);
+  },
+};

--- a/packages/atomic/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.new.stories.tsx
@@ -193,7 +193,7 @@ export const Default: Story = {
 };
 
 export const A11yDisclosure: Story = {
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   play: async (context) => {
     await play(context);
     await testDisclosureA11y(context, {


### PR DESCRIPTION
[KIT-5731](https://coveord.atlassian.net/browse/KIT-5731)

Depends on #7671

## Problem
Feedback buttons use the `title` attribute which has inconsistent screen reader support.

## Solution
- Replaced `title` on feedback buttons with proper tooltip (`role="tooltip"` + `aria-describedby`)
- Added Escape key handler to dismiss tooltip on focus
- Wired `testTooltipA11y` to:
  - atomic-generated-answer (like/dislike feedback buttons)

[KIT-5731]: https://coveord.atlassian.net/browse/KIT-5731