### PR TITLE
refactor(atomic): standardize MSW harness variable naming across stories

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-query-error/atomic-commerce-query-error.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-query-error/atomic-commerce-query-error.new.stories.tsx
@@ -5,7 +5,7 @@ import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-inter
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-query-error/atomic-commerce-query-error.js';
 
-const mockCommerceApi = new MockCommerceApi();
+const commerceApiHarness = new MockCommerceApi();
 
 const {decorator, play} = wrapInCommerceInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -24,12 +24,12 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockCommerceApi.handlers]},
+    msw: {handlers: [...commerceApiHarness.handlers]},
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockCommerceApi.searchEndpoint.clear();
+    commerceApiHarness.searchEndpoint.clear();
   },
   play,
 };
@@ -38,14 +38,14 @@ export default meta;
 
 export const Default: Story = {
   beforeEach: async () => {
-    mockCommerceApi.searchEndpoint.mockErrorOnce();
+    commerceApiHarness.searchEndpoint.mockErrorOnce();
   },
 };
 
 export const With418Error: Story = {
   name: 'With 418 error',
   beforeEach: async () => {
-    mockCommerceApi.searchEndpoint.mockOnce(
+    commerceApiHarness.searchEndpoint.mockOnce(
       () => ({
         ok: false,
         status: 418,

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.new.stories.tsx
@@ -22,9 +22,11 @@ import '@/src/components/commerce/atomic-product-section-visual/atomic-product-s
 import '@/src/components/commerce/atomic-product-template/atomic-product-template.js';
 import '@/src/components/commerce/atomic-product-text/atomic-product-text.js';
 
-const mockCommerceApi = new MockCommerceApi();
+const commerceApiHarness = new MockCommerceApi();
 
-mockCommerceApi.recommendationEndpoint.mock(() => richRecommendationResponse);
+commerceApiHarness.recommendationEndpoint.mock(
+  () => richRecommendationResponse
+);
 
 const {decorator, play} = wrapInCommerceRecommendationInterface({});
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -72,10 +74,10 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockCommerceApi.handlers]},
+    msw: {handlers: [...commerceApiHarness.handlers]},
   },
   beforeEach: async () => {
-    mockCommerceApi.recommendationEndpoint.clear();
+    commerceApiHarness.recommendationEndpoint.clear();
   },
   argTypes,
 
@@ -140,7 +142,7 @@ export const AsCarousel: Story = {
 export const NoRecommendations: Story = {
   name: 'No recommendations',
   beforeEach: async () => {
-    mockCommerceApi.recommendationEndpoint.mockOnce((response) => ({
+    commerceApiHarness.recommendationEndpoint.mockOnce((response) => ({
       ...response,
       products: [],
       pagination: {

--- a/packages/atomic/src/components/commerce/atomic-commerce-refine-modal/atomic-commerce-refine-modal.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-refine-modal/atomic-commerce-refine-modal.new.stories.tsx
@@ -9,7 +9,7 @@ import {parameters as commonParameters} from '@/storybook-utils/common/common-me
 import '@/src/components/commerce/atomic-commerce-refine-modal/atomic-commerce-refine-modal.js';
 import '@/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.js';
 
-const mockCommerceApi = new MockCommerceApi();
+const commerceApiHarness = new MockCommerceApi();
 
 const {decorator, play} = wrapInCommerceInterface();
 const {events, args, argTypes, styleTemplate} = getStorybookHelpers(
@@ -30,7 +30,7 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockCommerceApi.handlers]},
+    msw: {handlers: [...commerceApiHarness.handlers]},
   },
   args: {
     ...args,

--- a/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.new.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: commerceApiHarness.handlers,
+      handlers: [...commerceApiHarness.handlers],
     },
     chromatic: {disableSnapshot: true},
     actions: {

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.new.stories.tsx
@@ -9,7 +9,7 @@ import {parameters} from '@/storybook-utils/common/search-box-suggestions-parame
 import '@/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.js';
 import '@/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.js';
 
-const mockCommerceApi = new MockCommerceApi();
+const commerceApiHarness = new MockCommerceApi();
 
 const {decorator: commerceInterfaceDecorator, play: commerceInterfacePlay} =
   wrapInCommerceInterface({includeCodeRoot: false});
@@ -32,7 +32,7 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockCommerceApi.handlers]},
+    msw: {handlers: [...commerceApiHarness.handlers]},
   },
   args,
   argTypes,

--- a/packages/atomic/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.new.stories.tsx
@@ -5,7 +5,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.js';
 
-const mockedInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const {decorator, play} = wrapInInsightInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -26,12 +26,12 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockedInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   beforeEach: () => {
-    mockedInsightApi.searchEndpoint.clear();
-    mockedInsightApi.querySuggestEndpoint.clear();
+    insightApiHarness.searchEndpoint.clear();
+    insightApiHarness.querySuggestEndpoint.clear();
   },
   args,
   argTypes,

--- a/packages/atomic/src/components/insight/atomic-insight-facet/atomic-insight-facet.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-facet/atomic-insight-facet.new.stories.tsx
@@ -15,10 +15,10 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   }
 );
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const mockDefaultFacetResponse = () => {
-  mockInsightApi.searchEndpoint.mockOnce((response) => response);
+  insightApiHarness.searchEndpoint.mockOnce((response) => response);
 };
 
 const sortCriteriaOptions: FacetSortCriterion[] = [
@@ -44,7 +44,7 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   argTypes: {
@@ -57,7 +57,7 @@ const meta: Meta = {
   },
 
   beforeEach: () => {
-    mockInsightApi.searchEndpoint.clear();
+    insightApiHarness.searchEndpoint.clear();
   },
 
   play,
@@ -123,7 +123,7 @@ export const WithSelectedValue: Story = {
   decorators: [facetDecorator],
   beforeEach: () => {
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- MSW mock response structure is dynamic and known at runtime
-    mockInsightApi.searchEndpoint.mockOnce((response: any) => {
+    insightApiHarness.searchEndpoint.mockOnce((response: any) => {
       const selectedFacets = response.facets?.map(
         (facet: object & {field: string; values: object[]}) => {
           if (facet.field === 'objecttype') {

--- a/packages/atomic/src/components/insight/atomic-insight-folded-result-list/atomic-insight-folded-result-list.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-folded-result-list/atomic-insight-folded-result-list.new.stories.tsx
@@ -32,7 +32,7 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   }
 );
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const TEMPLATE_EXAMPLE = `<template>
   <atomic-result-section-visual>
@@ -101,7 +101,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: [...mockInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
     actions: {
       handles: events,

--- a/packages/atomic/src/components/insight/atomic-insight-full-search-button/atomic-insight-full-search-button.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-full-search-button/atomic-insight-full-search-button.new.stories.tsx
@@ -5,7 +5,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-full-search-button/atomic-insight-full-search-button.js';
 
-const mockedInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const {decorator, play} = wrapInInsightInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -26,12 +26,12 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockedInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   beforeEach: () => {
-    mockedInsightApi.searchEndpoint.clear();
-    mockedInsightApi.querySuggestEndpoint.clear();
+    insightApiHarness.searchEndpoint.clear();
+    insightApiHarness.querySuggestEndpoint.clear();
   },
   args,
   argTypes,

--- a/packages/atomic/src/components/insight/atomic-insight-generate-answer-button/atomic-insight-generate-answer-button.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-generate-answer-button/atomic-insight-generate-answer-button.new.stories.tsx
@@ -5,7 +5,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-generate-answer-button/atomic-insight-generate-answer-button.js';
 
-const mockedInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const {decorator, play} = wrapInInsightInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -26,12 +26,12 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockedInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   beforeEach: () => {
-    mockedInsightApi.searchEndpoint.clear();
-    mockedInsightApi.querySuggestEndpoint.clear();
+    insightApiHarness.searchEndpoint.clear();
+    insightApiHarness.querySuggestEndpoint.clear();
   },
   args,
   argTypes,

--- a/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.new.stories.tsx
@@ -14,9 +14,9 @@ import '@/src/components/insight/atomic-insight-layout/atomic-insight-layout.js'
 import '@/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.js';
 import '@/src/components/common/atomic-layout-section/atomic-layout-section.js';
 
-const mockedAnswerApi = new MockAnswerApi();
-const mockedInsightApi = new MockInsightApi();
-mockedInsightApi.searchEndpoint.mock((response) => ({
+const answerApiHarness = new MockAnswerApi();
+const insightApiHarness = new MockInsightApi();
+insightApiHarness.searchEndpoint.mock((response) => ({
   ...response,
   extendedResults: {
     generativeQuestionAnsweringId: 'fbc64016-5f04-4a47-aad1-0bccaa2c0616',
@@ -50,7 +50,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: [...mockedInsightApi.handlers, ...mockedAnswerApi.handlers],
+      handlers: [...insightApiHarness.handlers, ...answerApiHarness.handlers],
     },
   },
   args: {

--- a/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.new.stories.tsx
@@ -51,8 +51,8 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   {excludeCategories: ['methods']}
 );
 
-const mockedInsightApi = new MockInsightApi();
-mockedInsightApi.searchEndpoint.mock((response) => ({
+const insightApiHarness = new MockInsightApi();
+insightApiHarness.searchEndpoint.mock((response) => ({
   ...response,
   results: response.results.map((result: Record<string, unknown>) => ({
     ...result,
@@ -82,12 +82,12 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockedInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   beforeEach: () => {
-    mockedInsightApi.searchEndpoint.clear();
-    mockedInsightApi.querySuggestEndpoint.clear();
+    insightApiHarness.searchEndpoint.clear();
+    insightApiHarness.querySuggestEndpoint.clear();
   },
   args,
   argTypes,

--- a/packages/atomic/src/components/insight/atomic-insight-layout/atomic-insight-layout.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/atomic-insight-layout.new.stories.tsx
@@ -7,7 +7,7 @@ import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interfac
 import '@/src/components/insight/atomic-insight-layout/atomic-insight-layout.js';
 import '@/src/components/common/atomic-layout-section/atomic-layout-section.js';
 
-const mockedInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const {decorator, play} = wrapInInsightInterface();
 const {events, args, argTypes} = getStorybookHelpers('atomic-insight-layout', {
@@ -34,12 +34,12 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockedInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   beforeEach: () => {
-    mockedInsightApi.searchEndpoint.clear();
-    mockedInsightApi.querySuggestEndpoint.clear();
+    insightApiHarness.searchEndpoint.clear();
+    insightApiHarness.querySuggestEndpoint.clear();
   },
   argTypes,
 

--- a/packages/atomic/src/components/insight/atomic-insight-numeric-facet/atomic-insight-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-numeric-facet/atomic-insight-numeric-facet.new.stories.tsx
@@ -9,7 +9,7 @@ import {
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-numeric-facet/atomic-insight-numeric-facet.js';
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const numericFacetValues = [
   {
@@ -70,7 +70,7 @@ const numericFacetValues = [
   },
 ];
 
-mockInsightApi.searchEndpoint.mock((response) => ({
+insightApiHarness.searchEndpoint.mock((response) => ({
   ...response,
   facets: [
     {
@@ -101,7 +101,7 @@ mockInsightApi.searchEndpoint.mock((response) => ({
 }));
 
 const mockDefaultFacetResponse = () => {
-  mockInsightApi.searchEndpoint.mockOnce((response) => ({
+  insightApiHarness.searchEndpoint.mockOnce((response) => ({
     ...response,
     facets: [
       {
@@ -150,7 +150,7 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockInsightApi.handlers]},
+    msw: {handlers: [...insightApiHarness.handlers]},
   },
   argTypes: {
     ...argTypes,
@@ -159,7 +159,7 @@ const meta: Meta = {
     },
   },
   beforeEach: () => {
-    mockInsightApi.searchEndpoint.clear();
+    insightApiHarness.searchEndpoint.clear();
   },
   play,
   args: {
@@ -232,7 +232,7 @@ export const WithSelectedValue: Story = {
     const selectedValues = numericFacetValues.map((v, i) =>
       i === 0 ? {...v, state: 'selected'} : v
     );
-    mockInsightApi.searchEndpoint.mockOnce((response) => ({
+    insightApiHarness.searchEndpoint.mockOnce((response) => ({
       ...response,
       facets: [
         {

--- a/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.new.stories.tsx
@@ -13,7 +13,7 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   }
 );
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const meta: Meta = {
   component: 'atomic-insight-pager',
@@ -25,7 +25,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: [...mockInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
     actions: {
       handles: events,

--- a/packages/atomic/src/components/insight/atomic-insight-query-error/atomic-insight-query-error.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-query-error/atomic-insight-query-error.new.stories.tsx
@@ -5,7 +5,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-query-error/atomic-insight-query-error.js';
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const {decorator, play} = wrapInInsightInterface({
   accessToken: 'invalidtoken',
@@ -29,12 +29,12 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockInsightApi.handlers]},
+    msw: {handlers: [...insightApiHarness.handlers]},
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockInsightApi.searchEndpoint.clear();
+    insightApiHarness.searchEndpoint.clear();
   },
   play,
 };
@@ -43,14 +43,14 @@ export default meta;
 
 export const Default: Story = {
   beforeEach: async () => {
-    mockInsightApi.searchEndpoint.mockErrorOnce();
+    insightApiHarness.searchEndpoint.mockErrorOnce();
   },
 };
 
 export const WithInvalidToken: Story = {
   name: 'With Invalid Token Error',
   beforeEach: async () => {
-    mockInsightApi.searchEndpoint.mockOnce(
+    insightApiHarness.searchEndpoint.mockOnce(
       () => ({
         ok: false,
         status: 401,
@@ -66,7 +66,7 @@ export const WithInvalidToken: Story = {
 export const WithDisconnected: Story = {
   name: 'With Disconnected Error',
   beforeEach: async () => {
-    mockInsightApi.searchEndpoint.mockOnce(
+    insightApiHarness.searchEndpoint.mockOnce(
       () => ({
         ok: false,
         status: 0,
@@ -82,7 +82,7 @@ export const WithDisconnected: Story = {
 export const WithOrganizationPaused: Story = {
   name: 'With Organization Paused Error',
   beforeEach: async () => {
-    mockInsightApi.searchEndpoint.mockOnce(
+    insightApiHarness.searchEndpoint.mockOnce(
       () => ({
         ok: false,
         status: 503,

--- a/packages/atomic/src/components/insight/atomic-insight-query-summary/atomic-insight-query-summary.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-query-summary/atomic-insight-query-summary.new.stories.tsx
@@ -11,7 +11,7 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   {excludeCategories: ['methods']}
 );
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const meta: Meta = {
   component: 'atomic-insight-query-summary',
@@ -26,7 +26,7 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   args,

--- a/packages/atomic/src/components/insight/atomic-insight-refine-toggle/atomic-insight-refine-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-toggle/atomic-insight-refine-toggle.new.stories.tsx
@@ -11,7 +11,7 @@ import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interfac
 import '@/src/components/insight/atomic-insight-facet/atomic-insight-facet.js';
 import '@/src/components/insight/atomic-insight-refine-toggle/atomic-insight-refine-toggle.js';
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const {decorator, play} = wrapInInsightInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -30,13 +30,13 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockInsightApi.searchEndpoint.mock(
+    insightApiHarness.searchEndpoint.mock(
       () => richResponse as unknown as typeof baseResponse
     );
   },

--- a/packages/atomic/src/components/insight/atomic-insight-result-attach-to-case-indicator/atomic-insight-result-attach-to-case-indicator.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-attach-to-case-indicator/atomic-insight-result-attach-to-case-indicator.new.stories.tsx
@@ -26,7 +26,7 @@ import '@/src/components/search/atomic-result-section-title/atomic-result-sectio
 import '@/src/components/search/atomic-result-text/atomic-result-text.js';
 import '@/src/components/search/atomic-text/atomic-text.js';
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const CASE_ID = 'test-case-1234';
 
@@ -81,13 +81,13 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   args,
   argTypes,
   beforeEach: () => {
-    mockInsightApi.searchEndpoint.clear();
+    insightApiHarness.searchEndpoint.clear();
   },
 };
 

--- a/packages/atomic/src/components/insight/atomic-insight-result-list/atomic-insight-result-list.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-list/atomic-insight-result-list.new.stories.tsx
@@ -32,7 +32,7 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   }
 );
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const TEMPLATE_EXAMPLE = `<template>
   <atomic-result-section-visual>
@@ -101,7 +101,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: [...mockInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
     actions: {
       handles: events,

--- a/packages/atomic/src/components/insight/atomic-insight-result-quickview-action/atomic-insight-result-quickview-action.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-quickview-action/atomic-insight-result-quickview-action.new.stories.tsx
@@ -17,11 +17,11 @@ import '@/src/components/search/atomic-result-section-title/atomic-result-sectio
 import '@/src/components/search/atomic-result-section-visual/atomic-result-section-visual.js';
 import '@/src/components/search/atomic-result-text/atomic-result-text.js';
 
-const mockInsightApi = new MockInsightApi();
-const mockSearchApi = new MockSearchApi();
+const insightApiHarness = new MockInsightApi();
+const searchApiHarness = new MockSearchApi();
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- Mock API response types are loosely defined
-mockInsightApi.searchEndpoint.mock((response: any) => ({
+insightApiHarness.searchEndpoint.mock((response: any) => ({
   ...response,
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- Mock API result types are loosely defined
   results: response.results.slice(0, 3).map((result: any) => ({
@@ -87,8 +87,8 @@ const meta: Meta = {
     },
     msw: {
       handlers: [
-        ...mockInsightApi.handlers,
-        mockSearchApi.htmlEndpoint.generateHandler(),
+        ...insightApiHarness.handlers,
+        searchApiHarness.htmlEndpoint.generateHandler(),
       ],
     },
   },

--- a/packages/atomic/src/components/insight/atomic-insight-result-template/atomic-insight-result-template.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-template/atomic-insight-result-template.new.stories.tsx
@@ -27,7 +27,7 @@ import '@/src/components/search/atomic-result-section-visual/atomic-result-secti
 import '@/src/components/search/atomic-result-text/atomic-result-text.js';
 import '@/src/components/search/atomic-text/atomic-text.js';
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const TEMPLATE_EXAMPLE = `<template>
   <atomic-result-section-visual>
@@ -168,7 +168,7 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   args: {

--- a/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.new.stories.tsx
@@ -16,7 +16,7 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 const {decorator, play} = wrapInInsightInterface({}, true);
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const normalWidthDecorator: Decorator = (story) =>
   html`<div style="min-width: 400px;" id="code-root">${story()}</div>`;
@@ -33,7 +33,7 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   args,

--- a/packages/atomic/src/components/insight/atomic-insight-smart-snippet-suggestions/atomic-insight-smart-snippet-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-smart-snippet-suggestions/atomic-insight-smart-snippet-suggestions.new.stories.tsx
@@ -9,7 +9,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-smart-snippet-suggestions/atomic-insight-smart-snippet-suggestions.js';
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-insight-smart-snippet-suggestions',
@@ -30,13 +30,13 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockInsightApi.searchEndpoint.mock(
+    insightApiHarness.searchEndpoint.mock(
       () => smartSnippetSuggestionsResponse as unknown as typeof baseResponse
     );
   },

--- a/packages/atomic/src/components/insight/atomic-insight-smart-snippet/atomic-insight-smart-snippet.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-smart-snippet/atomic-insight-smart-snippet.new.stories.tsx
@@ -6,7 +6,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-smart-snippet/atomic-insight-smart-snippet.js';
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-insight-smart-snippet',
@@ -27,14 +27,14 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockInsightApi.handlers],
+      handlers: [...insightApiHarness.handlers],
     },
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockInsightApi.searchEndpoint.clear();
-    mockInsightApi.searchEndpoint.mockOnce((response) => {
+    insightApiHarness.searchEndpoint.clear();
+    insightApiHarness.searchEndpoint.mockOnce((response) => {
       if (!('results' in response)) return response;
       const [result] = response.results as Result[];
       return {

--- a/packages/atomic/src/components/insight/atomic-insight-timeframe-facet/atomic-insight-timeframe-facet.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-timeframe-facet/atomic-insight-timeframe-facet.new.stories.tsx
@@ -10,7 +10,7 @@ import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interfac
 import '@/src/components/insight/atomic-insight-timeframe-facet/atomic-insight-timeframe-facet.js';
 import '@/src/components/common/atomic-timeframe/atomic-timeframe.js';
 
-const mockInsightApi = new MockInsightApi();
+const insightApiHarness = new MockInsightApi();
 
 const baseDateFacetValues = [
   {
@@ -76,7 +76,7 @@ const createDateFacetResponse = (
   label: 'Date',
 });
 
-mockInsightApi.searchEndpoint.mock((response) => ({
+insightApiHarness.searchEndpoint.mock((response) => ({
   ...response,
   facets: [
     createDateFacetResponse(baseDateFacetValues),
@@ -87,7 +87,7 @@ mockInsightApi.searchEndpoint.mock((response) => ({
 }));
 
 const mockDefaultFacetResponse = () => {
-  mockInsightApi.searchEndpoint.mockOnce((response) => ({
+  insightApiHarness.searchEndpoint.mockOnce((response) => ({
     ...response,
     facets: [
       createDateFacetResponse(baseDateFacetValues),
@@ -116,7 +116,7 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockInsightApi.handlers]},
+    msw: {handlers: [...insightApiHarness.handlers]},
   },
   argTypes: {
     ...argTypes,
@@ -125,7 +125,7 @@ const meta: Meta = {
     },
   },
   beforeEach: () => {
-    mockInsightApi.searchEndpoint.clear();
+    insightApiHarness.searchEndpoint.clear();
   },
   play,
   args: {
@@ -174,7 +174,7 @@ export const WithSelectedValue: Story = {
     const selectedValues = baseDateFacetValues.map((v) =>
       v.start === 'past-1-month' ? {...v, state: 'selected'} : v
     );
-    mockInsightApi.searchEndpoint.mockOnce((response) => ({
+    insightApiHarness.searchEndpoint.mockOnce((response) => ({
       ...response,
       facets: [
         createDateFacetResponse(selectedValues),

--- a/packages/atomic/src/components/insight/atomic-insight-user-actions-timeline/atomic-insight-user-actions-timeline.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-user-actions-timeline/atomic-insight-user-actions-timeline.new.stories.tsx
@@ -6,8 +6,8 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-user-actions-timeline/atomic-insight-user-actions-timeline.js';
 
-const mockedInsightApi = new MockInsightApi();
-const mockMachineLearningApi = new MockMachineLearningApi();
+const insightApiHarness = new MockInsightApi();
+const machineLearningApiHarness = new MockMachineLearningApi();
 
 const {decorator, play} = wrapInInsightInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -31,14 +31,14 @@ const meta: Meta = {
     },
     msw: {
       handlers: [
-        ...mockedInsightApi.handlers,
-        ...mockMachineLearningApi.handlers,
+        ...insightApiHarness.handlers,
+        ...machineLearningApiHarness.handlers,
       ],
     },
   },
   beforeEach: () => {
-    mockedInsightApi.searchEndpoint.clear();
-    mockedInsightApi.querySuggestEndpoint.clear();
+    insightApiHarness.searchEndpoint.clear();
+    insightApiHarness.querySuggestEndpoint.clear();
   },
   args: {
     ...args,

--- a/packages/atomic/src/components/insight/atomic-insight-user-actions-toggle/atomic-insight-user-actions-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-user-actions-toggle/atomic-insight-user-actions-toggle.new.stories.tsx
@@ -6,8 +6,8 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
 import '@/src/components/insight/atomic-insight-user-actions-toggle/atomic-insight-user-actions-toggle.js';
 
-const mockedInsightApi = new MockInsightApi();
-const mockMachineLearningApi = new MockMachineLearningApi();
+const insightApiHarness = new MockInsightApi();
+const machineLearningApiHarness = new MockMachineLearningApi();
 
 const {decorator, play} = wrapInInsightInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -29,14 +29,14 @@ const meta: Meta = {
     },
     msw: {
       handlers: [
-        ...mockedInsightApi.handlers,
-        ...mockMachineLearningApi.handlers,
+        ...insightApiHarness.handlers,
+        ...machineLearningApiHarness.handlers,
       ],
     },
   },
   beforeEach: () => {
-    mockedInsightApi.searchEndpoint.clear();
-    mockedInsightApi.querySuggestEndpoint.clear();
+    insightApiHarness.searchEndpoint.clear();
+    insightApiHarness.querySuggestEndpoint.clear();
   },
   args: {
     ...args,

--- a/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.new.stories.tsx
@@ -7,7 +7,7 @@ import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-w
 import '@/src/components/ipx/atomic-ipx-button/atomic-ipx-button.js';
 import '@/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface({skipFirstSearch: true});
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -45,14 +45,14 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   args: {
     ...args,
   },
   argTypes,
   beforeEach: () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
 };

--- a/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.new.stories.tsx
@@ -5,7 +5,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/ipx/atomic-ipx-embedded/atomic-ipx-embedded.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -27,7 +27,7 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   argTypes,
   args: {
@@ -37,7 +37,7 @@ const meta: Meta = {
     'footer-slot': `<button>Action Button</button>`,
   },
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
 };

--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.new.stories.tsx
@@ -6,7 +6,7 @@ import {parameters as commonParameters} from '@/storybook-utils/common/common-me
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -46,7 +46,7 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   args: {
     ...args,
@@ -79,7 +79,7 @@ const meta: Meta = {
     },
   },
   beforeEach: () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play: async (context) => {
     await play(context);

--- a/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-ipx-recs-list.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-ipx-recs-list.new.stories.tsx
@@ -16,9 +16,9 @@ import '@/src/components/search/atomic-result-section-title-metadata/atomic-resu
 import '@/src/components/search/atomic-result-section-visual/atomic-result-section-visual.js';
 import '@/src/components/search/atomic-result-text/atomic-result-text.js';
 
-const mockedSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
-mockedSearchApi.searchEndpoint.mock((response) => ({
+searchApiHarness.searchEndpoint.mock((response) => ({
   ...response,
   results: response.results.slice(0, 30),
   totalCount: 30,
@@ -43,11 +43,11 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockedSearchApi.handlers],
+      handlers: [...searchApiHarness.handlers],
     },
   },
   beforeEach: () => {
-    mockedSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   args,
   argTypes,
@@ -132,7 +132,7 @@ export const RecsAsCarousel: Story = {
 export const NotEnoughRecsForCarousel: Story = {
   name: 'Not enough recommendations for carousel',
   beforeEach: () => {
-    mockedSearchApi.searchEndpoint.mockOnce((response) => ({
+    searchApiHarness.searchEndpoint.mockOnce((response) => ({
       ...response,
       results: response.results.slice(0, 3),
       totalCount: 3,

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-toggle/atomic-ipx-refine-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-toggle/atomic-ipx-refine-toggle.new.stories.tsx
@@ -9,7 +9,7 @@ import '@/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.js';
 import '@/src/components/ipx/atomic-ipx-refine-toggle/atomic-ipx-refine-toggle.js';
 import '@/src/components/common/atomic-layout-section/atomic-layout-section.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -56,12 +56,12 @@ const meta: Meta = {
         ...parameters.docs?.story,
       },
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   args,
   argTypes,
   beforeEach: () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
 };

--- a/packages/atomic/src/components/ipx/atomic-ipx-result-link/atomic-ipx-result-link.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-result-link/atomic-ipx-result-link.new.stories.tsx
@@ -14,9 +14,9 @@ import '@/src/components/search/atomic-result-section-excerpt/atomic-result-sect
 import '@/src/components/search/atomic-result-section-title/atomic-result-section-title.js';
 import '@/src/components/search/atomic-result-text/atomic-result-text.js';
 
-const mockedSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
-mockedSearchApi.searchEndpoint.mock((response) => ({
+searchApiHarness.searchEndpoint.mock((response) => ({
   ...response,
   results: (response as SearchResponse).results.slice(0, 1),
   totalCount: 1,
@@ -47,11 +47,11 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: [...mockedSearchApi.handlers],
+      handlers: [...searchApiHarness.handlers],
     },
   },
   beforeEach: () => {
-    mockedSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
 };

--- a/packages/atomic/src/components/recommendations/atomic-recs-error/atomic-recs-error.new.stories.tsx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-error/atomic-recs-error.new.stories.tsx
@@ -5,7 +5,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInRecommendationInterface} from '@/storybook-utils/search/recs-interface-wrapper';
 import '@/src/components/recommendations/atomic-recs-error/atomic-recs-error.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInRecommendationInterface({
   config: {
@@ -30,12 +30,12 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
 };
@@ -44,7 +44,7 @@ export default meta;
 
 export const Default: Story = {
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce(
+    searchApiHarness.searchEndpoint.mockOnce(
       () => ({
         ok: false,
         status: 401,
@@ -60,7 +60,7 @@ export const Default: Story = {
 export const WithDisconnected: Story = {
   name: 'With Disconnected Error',
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce(
+    searchApiHarness.searchEndpoint.mockOnce(
       () => ({
         ok: false,
         status: 0,
@@ -76,7 +76,7 @@ export const WithDisconnected: Story = {
 export const WithOrganizationPaused: Story = {
   name: 'With Organization Paused Error',
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce(
+    searchApiHarness.searchEndpoint.mockOnce(
       () => ({
         ok: false,
         status: 503,

--- a/packages/atomic/src/components/recommendations/atomic-recs-interface/atomic-recs-interface.new.stories.tsx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-interface/atomic-recs-interface.new.stories.tsx
@@ -22,7 +22,7 @@ import '@/src/components/search/atomic-result-section-visual/atomic-result-secti
 import '@/src/components/search/atomic-result-text/atomic-result-text.js';
 import '@/src/components/search/atomic-text/atomic-text.js';
 
-const mockRecommendationApi = new MockRecommendationApi();
+const recommendationApiHarness = new MockRecommendationApi();
 const {decorator, play} = wrapInRecommendationInterface();
 
 const {events, args, argTypes} = getStorybookHelpers('atomic-recs-interface', {
@@ -38,7 +38,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {
-      handlers: [...mockRecommendationApi.handlers],
+      handlers: [...recommendationApiHarness.handlers],
     },
     actions: {
       handles: events,

--- a/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.new.stories.tsx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.new.stories.tsx
@@ -16,9 +16,9 @@ import '@/src/components/search/atomic-result-section-title-metadata/atomic-resu
 import '@/src/components/search/atomic-result-section-visual/atomic-result-section-visual.js';
 import '@/src/components/search/atomic-result-text/atomic-result-text.js';
 
-const mockedSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
-mockedSearchApi.searchEndpoint.mock((response) => ({
+searchApiHarness.searchEndpoint.mock((response) => ({
   ...response,
   results: response.results.slice(0, 30),
   totalCount: 30,
@@ -43,11 +43,11 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockedSearchApi.handlers],
+      handlers: [...searchApiHarness.handlers],
     },
   },
   beforeEach: () => {
-    mockedSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   args,
   argTypes,
@@ -138,7 +138,7 @@ export const RecsAsCarousel: Story = {
 export const NotEnoughRecsForCarousel: Story = {
   name: 'Not enough recommendations for carousel',
   beforeEach: () => {
-    mockedSearchApi.searchEndpoint.mockOnce((response) => ({
+    searchApiHarness.searchEndpoint.mockOnce((response) => ({
       ...response,
       results: response.results.slice(0, 3),
       totalCount: 3,
@@ -151,7 +151,7 @@ export const NotEnoughRecsForCarousel: Story = {
 export const NoRecommendations: Story = {
   name: 'No recommendations',
   beforeEach: async () => {
-    mockedSearchApi.searchEndpoint.mockOnce((response) => ({
+    searchApiHarness.searchEndpoint.mockOnce((response) => ({
       ...response,
       totalCount: 0,
       totalCountFiltered: 0,

--- a/packages/atomic/src/components/recommendations/atomic-recs-result-template/atomic-recs-result-template.new.stories.tsx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-result-template/atomic-recs-result-template.new.stories.tsx
@@ -20,9 +20,9 @@ import '@/src/components/search/atomic-result-section-visual/atomic-result-secti
 import '@/src/components/search/atomic-result-text/atomic-result-text.js';
 import '@/src/components/search/atomic-text/atomic-text.js';
 
-const mockedSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
-mockedSearchApi.searchEndpoint.mock((response) => ({
+searchApiHarness.searchEndpoint.mock((response) => ({
   ...response,
   results: response.results.slice(0, 10),
   totalCount: 10,
@@ -94,11 +94,11 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockedSearchApi.handlers],
+      handlers: [...searchApiHarness.handlers],
     },
   },
   beforeEach: () => {
-    mockedSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   args: {
     ...args,

--- a/packages/atomic/src/components/search/atomic-automatic-facet-generator/atomic-automatic-facet-generator.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-automatic-facet-generator/atomic-automatic-facet-generator.new.stories.tsx
@@ -10,7 +10,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-automatic-facet-generator/atomic-automatic-facet-generator.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const facetWidthDecorator: Decorator = (story) =>
@@ -31,12 +31,12 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   argTypes,
   args,
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
 };

--- a/packages/atomic/src/components/search/atomic-automatic-facet/atomic-automatic-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-automatic-facet/atomic-automatic-facet.new.stories.tsx
@@ -10,7 +10,7 @@ import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-w
 import '@/src/components/search/atomic-automatic-facet/atomic-automatic-facet.js';
 import '@/src/components/search/atomic-automatic-facet-generator/atomic-automatic-facet-generator.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 
@@ -26,10 +26,10 @@ const meta: Meta = {
   decorators: [facetWidthDecorator, decorator],
   parameters: {
     ...parameters,
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
 };
@@ -38,7 +38,7 @@ export default meta;
 
 export const Default: Story = {
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce((response) => ({
+    searchApiHarness.searchEndpoint.mockOnce((response) => ({
       ...response,
       generateAutomaticFacets: {
         facets: [

--- a/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-did-you-mean/atomic-did-you-mean.new.stories.tsx
@@ -8,7 +8,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-did-you-mean/atomic-did-you-mean.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -31,12 +31,12 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
 };
@@ -46,7 +46,7 @@ export default meta;
 export const WithAutomaticQueryCorrection: Story = {
   name: 'With automatic query correction',
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce((response) => ({
+    searchApiHarness.searchEndpoint.mockOnce((response) => ({
       ...response,
       queryCorrection: {
         correctedQuery: 'coveo',
@@ -60,7 +60,7 @@ export const WithAutomaticQueryCorrection: Story = {
 export const WithoutAutomaticQueryCorrection: Story = {
   name: 'Without automatic query correction',
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce((response) => ({
+    searchApiHarness.searchEndpoint.mockOnce((response) => ({
       ...response,
       queryCorrection: {
         corrections: [

--- a/packages/atomic/src/components/search/atomic-facet-manager/atomic-facet-manager.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-facet-manager/atomic-facet-manager.new.stories.tsx
@@ -7,7 +7,7 @@ import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-w
 import '@/src/components/search/atomic-facet/atomic-facet.js';
 import '@/src/components/search/atomic-facet-manager/atomic-facet-manager.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -27,12 +27,12 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
   globals: {
@@ -74,7 +74,7 @@ export const Default: Story = {
     `,
   },
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce((response) => ({
+    searchApiHarness.searchEndpoint.mockOnce((response) => ({
       ...response,
       facets: [
         {

--- a/packages/atomic/src/components/search/atomic-folded-result-list/atomic-folded-result-list.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-folded-result-list/atomic-folded-result-list.new.stories.tsx
@@ -136,7 +136,7 @@ const SLOTS_DEFAULT = `
 </atomic-result-template>
 `;
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 const {events, args, argTypes, template} = getStorybookHelpers(
@@ -155,12 +155,12 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
 };
@@ -172,7 +172,7 @@ export const Default: Story = {
     'default-slot': SLOTS_DEFAULT,
   },
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce(() => ({
+    searchApiHarness.searchEndpoint.mockOnce(() => ({
       ...baseFoldedResponse,
       results: [
         {
@@ -182,7 +182,7 @@ export const Default: Story = {
         baseFoldedResponse.results[1]!,
       ],
     }));
-    mockSearchApi.searchEndpoint.mockOnce(() => ({
+    searchApiHarness.searchEndpoint.mockOnce(() => ({
       ...baseFoldedResponse,
       results: [
         {
@@ -216,7 +216,7 @@ export const WithNoResultChildren: Story = {
     'default-slot': SLOTS_DEFAULT,
   },
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce(() => ({
+    searchApiHarness.searchEndpoint.mockOnce(() => ({
       ...baseFoldedResponse,
       results: [
         {
@@ -237,7 +237,7 @@ export const WithFewResultChildren: Story = {
     'default-slot': SLOTS_DEFAULT,
   },
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce(() => ({
+    searchApiHarness.searchEndpoint.mockOnce(() => ({
       ...baseFoldedResponse,
       results: [
         {
@@ -257,7 +257,7 @@ export const WithMoreResultsAvailableAndNoChildren: Story = {
     'default-slot': SLOTS_DEFAULT,
   },
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce(() => ({
+    searchApiHarness.searchEndpoint.mockOnce(() => ({
       ...baseFoldedResponse,
       results: [
         {

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
@@ -18,10 +18,10 @@ import '@/src/components/search/atomic-query-summary/atomic-query-summary.js';
 import '@/src/components/search/atomic-search-box/atomic-search-box.js';
 import '@/src/components/search/atomic-search-layout/atomic-search-layout.js';
 
-const mockedAgentApi = new MockAgentApi();
-const mockedAnswerApi = new MockAnswerApi();
-const mockedSearchApi = new MockSearchApi();
-mockedSearchApi.searchEndpoint.mock((response) => ({
+const agentApiHarness = new MockAgentApi();
+const answerApiHarness = new MockAnswerApi();
+const searchApiHarness = new MockSearchApi();
+searchApiHarness.searchEndpoint.mock((response) => ({
   ...response,
   extendedResults: {
     generativeQuestionAnsweringId: 'fbc64016-5f04-4a47-aad1-0bccaa2c0616',
@@ -95,9 +95,9 @@ const meta: Meta = {
     },
     msw: {
       handlers: [
-        ...mockedSearchApi.handlers,
-        ...mockedAnswerApi.handlers,
-        ...mockedAgentApi.handlers,
+        ...searchApiHarness.handlers,
+        ...answerApiHarness.handlers,
+        ...agentApiHarness.handlers,
       ],
     },
   },

--- a/packages/atomic/src/components/search/atomic-no-results/atomic-no-results.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-no-results/atomic-no-results.new.stories.tsx
@@ -5,7 +5,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-no-results/atomic-no-results.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 
@@ -25,12 +25,12 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
 };
@@ -40,7 +40,7 @@ export default meta;
 export const Default: Story = {
   name: 'atomic-no-results',
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce((response) => ({
+    searchApiHarness.searchEndpoint.mockOnce((response) => ({
       ...response,
       results: [],
       totalCount: 0,

--- a/packages/atomic/src/components/search/atomic-notifications/atomic-notifications.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-notifications/atomic-notifications.new.stories.tsx
@@ -5,7 +5,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-notifications/atomic-notifications.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-notifications',
@@ -26,13 +26,13 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.clear();
-    mockSearchApi.searchEndpoint.mockOnce((response) => ({
+    searchApiHarness.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.mockOnce((response) => ({
       ...response,
       triggers: [
         {

--- a/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
@@ -11,7 +11,7 @@ import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-w
 import '@/src/components/search/atomic-facet/atomic-facet.js';
 import '@/src/components/search/atomic-numeric-facet/atomic-numeric-facet.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const numericFacetValues = [
   {
@@ -72,7 +72,7 @@ const numericFacetValues = [
   },
 ];
 
-mockSearchApi.searchEndpoint.mock((response) => ({
+searchApiHarness.searchEndpoint.mock((response) => ({
   ...response,
   facets: [
     {
@@ -130,7 +130,7 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   argTypes: {
     ...argTypes,
@@ -145,7 +145,7 @@ const meta: Meta = {
     },
   },
   beforeEach: () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
   args: {
@@ -233,7 +233,7 @@ export const WithSelectedValue: Story = {
     const selectedValues = numericFacetValues.map((v, i) =>
       i === 0 ? {...v, state: 'selected'} : v
     );
-    mockSearchApi.searchEndpoint.mockOnce((response) => ({
+    searchApiHarness.searchEndpoint.mockOnce((response) => ({
       ...response,
       facets: [
         {

--- a/packages/atomic/src/components/search/atomic-query-error/atomic-query-error.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-query-error/atomic-query-error.new.stories.tsx
@@ -5,7 +5,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-query-error/atomic-query-error.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface({
   config: {
@@ -30,12 +30,12 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
   play,
 };
@@ -44,14 +44,14 @@ export default meta;
 
 export const Default: Story = {
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockErrorOnce();
+    searchApiHarness.searchEndpoint.mockErrorOnce();
   },
 };
 
 export const WithInvalidToken: Story = {
   name: 'With Invalid Token Error',
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce(
+    searchApiHarness.searchEndpoint.mockOnce(
       () => ({
         ok: false,
         status: 401,
@@ -67,7 +67,7 @@ export const WithInvalidToken: Story = {
 export const WithDisconnected: Story = {
   name: 'With Disconnected Error',
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce(
+    searchApiHarness.searchEndpoint.mockOnce(
       () => ({
         ok: false,
         status: 0,
@@ -83,7 +83,7 @@ export const WithDisconnected: Story = {
 export const WithNoEndpoints: Story = {
   name: 'With No Endpoints Error',
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce(
+    searchApiHarness.searchEndpoint.mockOnce(
       () => ({
         ok: false,
         status: 404,
@@ -99,7 +99,7 @@ export const WithNoEndpoints: Story = {
 export const WithOrganizationPaused: Story = {
   name: 'With Organization Paused Error',
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mockOnce(
+    searchApiHarness.searchEndpoint.mockOnce(
       () => ({
         ok: false,
         status: 503,

--- a/packages/atomic/src/components/search/atomic-refine-toggle/atomic-refine-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-toggle/atomic-refine-toggle.new.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta = {
     ...parameters,
     chromatic: {disableSnapshot: true},
     msw: {
-      handlers: searchApiHarness.handlers,
+      handlers: [...searchApiHarness.handlers],
     },
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-children-template/atomic-result-children-template.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-children-template/atomic-result-children-template.new.stories.tsx
@@ -22,7 +22,7 @@ import '@/src/components/search/atomic-result-section-visual/atomic-result-secti
 import '@/src/components/search/atomic-result-template/atomic-result-template.js';
 import '@/src/components/search/atomic-result-text/atomic-result-text.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const CHILD_TEMPLATE_EXAMPLE = `<template>
   <style>
@@ -129,7 +129,7 @@ const meta: Meta = {
     ...parameters,
     chromatic: {disableSnapshot: true},
     msw: {
-      handlers: [...mockSearchApi.handlers],
+      handlers: [...searchApiHarness.handlers],
     },
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-search-box-instant-results/atomic-search-box-instant-results.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box-instant-results/atomic-search-box-instant-results.new.stories.tsx
@@ -18,7 +18,7 @@ import '@/src/components/search/atomic-search-box/atomic-search-box.js';
 import '@/src/components/search/atomic-search-box-instant-results/atomic-search-box-instant-results.js';
 import '@/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator: searchInterfaceDecorator, play} = wrapInSearchInterface();
 
@@ -44,7 +44,7 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   tags: ['!test'],
   args,

--- a/packages/atomic/src/components/search/atomic-smart-snippet-feedback-modal/atomic-smart-snippet-feedback-modal.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet-feedback-modal/atomic-smart-snippet-feedback-modal.new.stories.tsx
@@ -10,7 +10,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-smart-snippet-feedback-modal/atomic-smart-snippet-feedback-modal.js';
 
-const mockedSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-smart-snippet-feedback-modal',
@@ -51,7 +51,7 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockedSearchApi.handlers],
+      handlers: [...searchApiHarness.handlers],
     },
   },
   args: {

--- a/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet/atomic-smart-snippet.new.stories.tsx
@@ -6,7 +6,7 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-smart-snippet/atomic-smart-snippet.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-smart-snippet',
@@ -27,14 +27,14 @@ const meta: Meta = {
       handles: events,
     },
     msw: {
-      handlers: [...mockSearchApi.handlers],
+      handlers: [...searchApiHarness.handlers],
     },
   },
   args,
   argTypes,
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.clear();
-    mockSearchApi.searchEndpoint.mockOnce((response) => {
+    searchApiHarness.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.mockOnce((response) => {
       if (!('results' in response)) return response;
       const [result] = response.results as Result[];
       return {

--- a/packages/atomic/src/components/search/atomic-tab-manager/atomic-tab-manager.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-tab-manager/atomic-tab-manager.new.stories.tsx
@@ -11,7 +11,7 @@ import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-w
 import '@/src/components/search/atomic-tab/atomic-tab.js';
 import '@/src/components/search/atomic-tab-manager/atomic-tab-manager.js';
 
-const mockSearchApi = new MockSearchApi();
+const searchApiHarness = new MockSearchApi();
 
 const {decorator, play} = wrapInSearchInterface();
 
@@ -36,7 +36,7 @@ const meta: Meta = {
     actions: {
       handles: events,
     },
-    msw: {handlers: [...mockSearchApi.handlers]},
+    msw: {handlers: [...searchApiHarness.handlers]},
   },
   argTypes,
   args: {
@@ -57,7 +57,7 @@ const meta: Meta = {
   },
   play,
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.clear();
   },
 };
 


### PR DESCRIPTION
## Problem

MSW harness variable naming is inconsistent across ~100 story files, using a mix of `mockSearchApi`, `mockedSearchApi`, `searchApiHarness`, `mockInsightApi`, `mockedInsightApi`, etc.

## Solution

Standardize all mock API harness variables to the `*ApiHarness` naming convention:

- `mockSearchApi` / `mockedSearchApi` → `searchApiHarness`
- `mockCommerceApi` → `commerceApiHarness`
- `mockInsightApi` / `mockedInsightApi` → `insightApiHarness`
- `mockMachineLearningApi` → `machineLearningApiHarness`
- `mockedAnswerApi` → `answerApiHarness`
- `mockedAgentApi` → `agentApiHarness`

Also standardize handlers format to always use spread: `handlers: [...harness.handlers]`
