### PR TITLE
fix(ci): use tag instead of branch for release/v3 bookmark

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,9 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Update release/v3 bookmark
         if: ${{ steps.changesets.outputs.published == 'true' }}
-        run: git push origin HEAD:refs/heads/release/v3 --force
+        run: |
+          git tag -f release/v3
+          git push origin refs/tags/release/v3 --force
       - name: Call ui-kit-cd
         if: ${{ steps.changesets.outputs.published == 'true' }}
         run: node ./scripts/deploy/trigger-ui-kit-cd.mjs
@@ -78,7 +80,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: 'release/v3'
+          ref: 'refs/tags/release/v3'
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/setup-sfdx
       - name: Promote SFDX package to production
@@ -107,7 +109,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: 'release/v3'
+          ref: 'refs/tags/release/v3'
 
       - name: Set up and build the project
         uses: ./.github/actions/setup
@@ -148,7 +150,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: 'release/v3'
+          ref: 'refs/tags/release/v3'
 
       - name: Set up and build the project
         uses: ./.github/actions/setup
@@ -189,7 +191,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: 'release/v3'
+          ref: 'refs/tags/release/v3'
       - uses: ./.github/actions/setup
       - name: Create GitHub App token for docs dispatch
         id: app-token


### PR DESCRIPTION
[KIT-5757](https://coveord.atlassian.net/browse/KIT-5757)

## Problem

The "Update release/v3 bookmark" step in `cd.yml` force-pushes to `refs/heads/release/v3`. The "Enforce Code Reviews" branch ruleset (updated May 25) now covers `release/**/*` with zero bypass actors, causing the step to fail with `GH013: Repository rule violations`.

This blocks `call-ui-kit-cd` and all downstream jobs even though npm publish succeeds.

## Solution

Use a **tag** (`refs/tags/release/v3`) instead of a branch. Tags are not subject to branch protection rulesets, so the push succeeds without any ruleset changes.

All downstream checkout steps updated to explicitly use `refs/tags/release/v3` to avoid ambiguity if both the branch and tag coexist.

Companion PR: https://github.com/coveo-platform/ui-kit-cd/pull/173

[KIT-5757]: https://coveord.atlassian.net/browse/KIT-5757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ