### PR TITLE
chore(quantic): fix flaky Playwright QuanticSort test

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSort/e2e/pageObject.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticSort/e2e/pageObject.ts
@@ -1,4 +1,4 @@
-import type {Locator, Page, Request} from '@playwright/test';
+import {expect, type Locator, type Page, type Request} from '@playwright/test';
 import {isUaSearchEvent} from '../../../../../../playwright/utils/requests';
 
 export class SortObject {
@@ -32,7 +32,20 @@ export class SortObject {
     } else {
       await this.sortDropDown.press('Space');
     }
-    await this.sortButton('Oldest').waitFor({state: 'visible'});
+    const overlay = this.page.locator('div[part="dropdown overlay"]');
+    await overlay.waitFor({state: 'visible'});
+    await overlay
+      .locator('[role="option"]')
+      .first()
+      .waitFor({state: 'visible'});
+  }
+
+  async selectNextSortOptionUsingKeyboard(
+    expectedLabel: string
+  ): Promise<void> {
+    await this.sortDropDown.press('ArrowDown');
+    await this.sortDropDown.press('Enter');
+    await expect(this.sortDropDown).toHaveText(expectedLabel);
   }
 
   async waitForSortUaAnalytics(eventValue: any): Promise<Request> {
@@ -60,24 +73,22 @@ export class SortObject {
     return uaRequest;
   }
 
-  async allSortLabelOptions() {
-    const options = await this.page
-      .locator('div[part="dropdown overlay"]')
-      .allInnerTexts();
-    const arrSort = options[0].split('\n');
-    return arrSort;
-  }
+  async getSortLabelValue(): Promise<{label: string; value: string | null}[]> {
+    const sortOptions = this.page.locator(
+      'div[part="dropdown overlay"] [role="option"]'
+    );
+    await sortOptions.first().waitFor({state: 'visible'});
 
-  async getSortLabelValue() {
-    const arrSort = await this.allSortLabelOptions();
-    const sortLabelwithValueList = await Promise.all(
-      arrSort.map(async (item) => ({
-        label: item,
-        value: await this.page
-          .getByRole('option', {name: item})
-          .getAttribute('data-value'),
+    return sortOptions.evaluateAll((options) =>
+      options.map((option) => ({
+        label: (
+          (option as HTMLElement).innerText ||
+          option.getAttribute('aria-label') ||
+          option.getAttribute('title') ||
+          ''
+        ).trim(),
+        value: option.getAttribute('data-value'),
       }))
     );
-    return sortLabelwithValueList;
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticSort/e2e/quanticSort.e2e.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticSort/e2e/quanticSort.e2e.ts
@@ -11,8 +11,8 @@ const fixtures = {
 
 useCaseTestCases.forEach((useCase) => {
   let test;
-  let sortArrOptions;
-  let sortLabelWithValue;
+  let sortArrOptions: string[];
+  let sortLabelWithValue: {label: string; value: string | null}[];
   if (useCase.value === useCaseEnum.search) {
     test = fixtures[useCase.value] as typeof testSearch;
   } else {
@@ -22,8 +22,8 @@ useCaseTestCases.forEach((useCase) => {
   test.describe(`quantic sort ${useCase.label}`, () => {
     test.beforeEach(async ({sort}) => {
       await sort.clickSortDropDown();
-      sortArrOptions = await sort.allSortLabelOptions();
       sortLabelWithValue = await sort.getSortLabelValue();
+      sortArrOptions = sortLabelWithValue.map(({label}) => label);
       await sort.clickSortDropDown();
     });
 
@@ -53,15 +53,13 @@ useCaseTestCases.forEach((useCase) => {
         // Selecting the next sort using Enter to open dropdown, the ArrowDown, then ENTER key
         await sort.focusSortDropDown();
         await sort.openSortDropdownUsingKeyboardEnter();
-        await sort.sortDropDown.press('ArrowDown');
-        await sort.sortDropDown.press('Enter');
+        await sort.selectNextSortOptionUsingKeyboard(sortArrOptions[1]);
         await expect(sort.sortDropDown).toHaveText(sortArrOptions[1]);
 
         // Selecting the next sort using Space to open dropdown, the ArrowDown, then ENTER key
         await sort.focusSortDropDown();
         await sort.openSortDropdownUsingKeyboardEnter(false);
-        await sort.sortDropDown.press('ArrowDown');
-        await sort.sortDropDown.press('Enter');
+        await sort.selectNextSortOptionUsingKeyboard(sortArrOptions[2]);
         await expect(sort.sortDropDown).toHaveText(sortArrOptions[2]);
       });
     });
@@ -76,7 +74,7 @@ useCaseTestCases.forEach((useCase) => {
             sortLabelWithValue[2]; // Assuming 0 is the first sort option
 
           const currentUrl = await page.url();
-          const urlHash = `#sortCriteria=${encodeURI(expectedSortValue)}`;
+          const urlHash = `#sortCriteria=${encodeURI(expectedSortValue!)}`;
 
           await page.goto(`${currentUrl}/${urlHash}`);
           await page.getByRole('button', {name: 'Try it now'}).click();


### PR DESCRIPTION
### KIT-5753

improve quanticSort e2e test reliability

  - Refactor page object to use role-based locators for sort options
  - Add explicit wait for dropdown overlay visibility before interacting
  - Extract keyboard sort selection into a dedicated helper method
  - Add TypeScript return types to page object methods
  - Simplify sort options retrieval using evaluateAll on option elements