### PR TITLE
feat(samples): add tabs to pkg-pr-new search page

### DIFF
--- a/samples/pkg-new-template/search.html
+++ b/samples/pkg-new-template/search.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Search — Coveo Atomic PR preview</title>
     <script type="module">
-      import { defineCustomElements } from "@coveo/atomic/loader";
-      import "@coveo/atomic/themes/coveo.css";
+      import {defineCustomElements} from '@coveo/atomic/loader';
+      import '@coveo/atomic/themes/coveo.css';
       defineCustomElements();
     </script>
     <script type="module">
-      await customElements.whenDefined("atomic-search-interface");
-      const searchInterface = document.querySelector("atomic-search-interface");
+      await customElements.whenDefined('atomic-search-interface');
+      const searchInterface = document.querySelector('atomic-search-interface');
 
       await searchInterface.initialize({
-        accessToken: "xx564559b1-0045-48e1-953c-3addd1ee4457",
-        organizationId: "searchuisamples",
+        accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
+        organizationId: 'searchuisamples',
       });
 
       searchInterface.executeFirstSearch();

--- a/samples/pkg-new-template/search.html
+++ b/samples/pkg-new-template/search.html
@@ -5,17 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Search — Coveo Atomic PR preview</title>
     <script type="module">
-      import {defineCustomElements} from '@coveo/atomic/loader';
-      import '@coveo/atomic/themes/coveo.css';
+      import { defineCustomElements } from "@coveo/atomic/loader";
+      import "@coveo/atomic/themes/coveo.css";
       defineCustomElements();
     </script>
     <script type="module">
-      await customElements.whenDefined('atomic-search-interface');
-      const searchInterface = document.querySelector('atomic-search-interface');
+      await customElements.whenDefined("atomic-search-interface");
+      const searchInterface = document.querySelector("atomic-search-interface");
 
       await searchInterface.initialize({
-        accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
-        organizationId: 'searchuisamples',
+        accessToken: "xx564559b1-0045-48e1-953c-3addd1ee4457",
+        organizationId: "searchuisamples",
       });
 
       searchInterface.executeFirstSearch();
@@ -50,11 +50,28 @@
         </atomic-layout-section>
         <atomic-layout-section section="facets">
           <atomic-facet-manager>
-            <atomic-facet field="objecttype" label="Type"></atomic-facet>
-            <atomic-facet field="author" label="Author"></atomic-facet>
+            <atomic-facet
+              field="objecttype"
+              label="Type"
+              tabs-excluded='["youtube"]'
+            ></atomic-facet>
+            <atomic-facet
+              field="author"
+              label="Author"
+              tabs-included='["all", "articles"]'
+            ></atomic-facet>
           </atomic-facet-manager>
         </atomic-layout-section>
         <atomic-layout-section section="main">
+          <atomic-tab-manager>
+            <atomic-tab name="all" label="All"></atomic-tab>
+            <atomic-tab name="articles" label="Articles"></atomic-tab>
+            <atomic-tab
+              name="youtube"
+              label="YouTube"
+              expression="@filetype=YouTubeVideo"
+            ></atomic-tab>
+          </atomic-tab-manager>
           <atomic-layout-section section="status">
             <atomic-breadbox></atomic-breadbox>
             <atomic-query-summary></atomic-query-summary>
@@ -66,6 +83,7 @@
               <atomic-sort-expression
                 label="Date (newest)"
                 expression="date descending"
+                tabs-included='["articles"]'
               ></atomic-sort-expression>
             </atomic-sort-dropdown>
             <atomic-did-you-mean></atomic-did-you-mean>


### PR DESCRIPTION
## Problem

The pkg-pr-new sample search page did not include tabs, which are needed to test accessibility changes to the tab components in a realistic integration context.

## Solution

Added `atomic-tab-manager` with three tabs (All, Articles, YouTube) to the search page in `samples/pkg-new-template`. The integration demonstrates:

- Tab-aware facets (`tabs-included` / `tabs-excluded` attributes)
- Tab-aware sort expressions
- A YouTube tab with a filter expression