### PR TITLE
feat(samples): add Insight panel page to pkg-pr-new template

### DIFF
--- a/samples/pkg-new-template/index.html
+++ b/samples/pkg-new-template/index.html
@@ -45,6 +45,7 @@
     <ul>
       <li><a href="./search.html">Search page</a></li>
       <li><a href="./commerce.html">Commerce search page</a></li>
+      <li><a href="./insight.html">Insight panel</a></li>
     </ul>
   </body>
 </html>

--- a/samples/pkg-new-template/insight.html
+++ b/samples/pkg-new-template/insight.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Insight Panel — Coveo Atomic PR preview</title>
+    <script type="module">
+      import {defineCustomElements} from '@coveo/atomic/loader';
+      import '@coveo/atomic/themes/coveo.css';
+      defineCustomElements();
+    </script>
+    <script type="module">
+      import {loadCaseContextActions} from '@coveo/headless/insight';
+
+      await customElements.whenDefined('atomic-insight-interface');
+      const insightInterface = document.querySelector(
+        'atomic-insight-interface'
+      );
+
+      await insightInterface.initialize({
+        insightId: 'fc2ee6e0-8bda-4883-bfc6-ffc1b0ce34c7',
+        accessToken: 'xx9446b04d-45d4-44a6-880c-22c6c04573ff',
+        organizationId: 'searchuisamples',
+      });
+
+      const engine = insightInterface.engine;
+      const {setCaseId} = loadCaseContextActions(engine);
+      engine.dispatch(setCaseId('1234'));
+      insightInterface.executeFirstSearch();
+    </script>
+    <style>
+      body {
+        margin: 0;
+        font-family: sans-serif;
+      }
+      nav {
+        padding: 0.75rem 1rem;
+        background: #f5f5f5;
+        border-bottom: 1px solid #ddd;
+        font-size: 0.875rem;
+      }
+      nav a {
+        color: #1a73e8;
+        text-decoration: none;
+      }
+      nav a:hover {
+        text-decoration: underline;
+      }
+      .insight-container {
+        max-width: 600px;
+        margin: 2rem auto;
+      }
+      atomic-insight-interface {
+        width: 100%;
+        height: 800px;
+        display: block;
+        box-shadow: 0px 3px 24px 0px #0000001a;
+      }
+    </style>
+  </head>
+  <body>
+    <nav><a href="./index.html">← Back</a></nav>
+
+    <div class="insight-container">
+      <atomic-insight-interface>
+        <atomic-insight-layout>
+          <atomic-layout-section section="search">
+            <atomic-insight-search-box></atomic-insight-search-box>
+            <atomic-insight-refine-toggle></atomic-insight-refine-toggle>
+            <atomic-insight-tabs>
+              <atomic-insight-tab
+                label="All"
+                expression=""
+                active
+              ></atomic-insight-tab>
+              <atomic-insight-tab
+                label="YouTube"
+                expression="@filetype==YouTubeVideo"
+              ></atomic-insight-tab>
+            </atomic-insight-tabs>
+          </atomic-layout-section>
+          <atomic-layout-section section="facets">
+            <atomic-facet-manager>
+              <atomic-insight-facet
+                field="source"
+                label="Source"
+              ></atomic-insight-facet>
+              <atomic-insight-facet
+                field="filetype"
+                label="File Type"
+              ></atomic-insight-facet>
+            </atomic-facet-manager>
+          </atomic-layout-section>
+          <atomic-layout-section section="status">
+            <atomic-insight-query-summary></atomic-insight-query-summary>
+          </atomic-layout-section>
+          <atomic-layout-section section="results">
+            <atomic-insight-result-list>
+              <atomic-insight-result-template>
+                <template>
+                  <atomic-result-section-title>
+                    <atomic-result-link></atomic-result-link>
+                  </atomic-result-section-title>
+                  <atomic-result-section-excerpt>
+                    <atomic-result-text field="excerpt"></atomic-result-text>
+                  </atomic-result-section-excerpt>
+                </template>
+              </atomic-insight-result-template>
+            </atomic-insight-result-list>
+          </atomic-layout-section>
+          <atomic-layout-section section="pagination">
+            <atomic-insight-pager></atomic-insight-pager>
+          </atomic-layout-section>
+        </atomic-insight-layout>
+      </atomic-insight-interface>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Problem

The pkg-pr-new sample only includes Search and Commerce pages. There is no way to quickly test accessibility changes on Insight panel components via PR preview URLs.

## Solution

Added an `insight.html` page to the `samples/pkg-new-template` sample that renders an Insight panel with:
- Search box with refine toggle
- Tabs (All / YouTube)
- Facets (Source, File Type)
- Query summary
- Result list with title + excerpt
- Pager

This allows reviewers to **easily test accessibility changes** on Insight components directly from the pkg.pr.new preview link without needing a local build.