### PR TITLE
feat(atomic): add Storybook coverage for generated-answer-feedback-modal

### DIFF
--- a/.changeset/polite-modals-glow.md
+++ b/.changeset/polite-modals-glow.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Improve accessibility of the generated answer feedback modal to comply with WCAG 4.1.3 (Status Messages). The success confirmation and validation errors are now announced by assistive technologies without requiring focus.

--- a/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.new.stories.tsx
@@ -14,7 +14,7 @@ const generatedAnswer = {
   sendFeedback: () => {},
 } as unknown as GeneratedAnswer;
 
-const {decorator, play} = wrapInSearchInterface();
+const {decorator, play} = wrapInSearchInterface({skipFirstSearch: true});
 
 async function playAfterModalAnimation(context: Parameters<typeof play>[0]) {
   await play(context);
@@ -25,19 +25,20 @@ async function waitForModalAnimationEnd(canvasElement: HTMLElement) {
   const feedbackModal = canvasElement.querySelector(
     'atomic-generated-answer-feedback-modal'
   );
+
+  let container: Element | null | undefined = null;
   await waitFor(() => {
-    expect(
-      feedbackModal?.shadowRoot?.querySelector('atomic-modal')
-    ).toBeTruthy();
+    const modal = feedbackModal?.shadowRoot?.querySelector('atomic-modal');
+    expect(modal).toBeTruthy();
+    container = modal?.shadowRoot?.querySelector('[part="container"]');
+    expect(container).toBeTruthy();
   });
 
-  const modal = feedbackModal?.shadowRoot?.querySelector('atomic-modal');
-  const container = modal?.shadowRoot?.querySelector('[part="container"]');
   if (!container) {
     return;
   }
 
-  const animations = container.getAnimations();
+  const animations = (container as Element).getAnimations();
   await Promise.all(animations.map((animation) => animation.finished));
 }
 

--- a/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.new.stories.tsx
@@ -1,0 +1,89 @@
+import type {GeneratedAnswer} from '@coveo/headless';
+import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
+import {html} from 'lit';
+import {within} from 'shadow-dom-testing-library';
+import {expect, userEvent, waitFor} from 'storybook/test';
+import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
+import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import '@/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.js';
+
+const generatedAnswer = {
+  openFeedbackModal: () => {},
+  closeFeedbackModal: () => {},
+  sendFeedback: () => {},
+} as unknown as GeneratedAnswer;
+
+const {decorator, play} = wrapInSearchInterface();
+
+async function playAfterModalAnimation(context: Parameters<typeof play>[0]) {
+  await play(context);
+  await waitForModalAnimationEnd(context.canvasElement);
+}
+
+async function waitForModalAnimationEnd(canvasElement: HTMLElement) {
+  const feedbackModal = canvasElement.querySelector(
+    'atomic-generated-answer-feedback-modal'
+  );
+  await waitFor(() => {
+    expect(
+      feedbackModal?.shadowRoot?.querySelector('atomic-modal')
+    ).toBeTruthy();
+  });
+
+  const modal = feedbackModal?.shadowRoot?.querySelector('atomic-modal');
+  const container = modal?.shadowRoot?.querySelector('[part="container"]');
+  if (!container) {
+    return;
+  }
+
+  const animations = container.getAnimations();
+  await Promise.all(animations.map((animation) => animation.finished));
+}
+
+const meta: Meta = {
+  component: 'atomic-generated-answer-feedback-modal',
+  title: 'Common/Generated Answer Feedback Modal',
+  id: 'atomic-generated-answer-feedback-modal',
+  render: () => html`
+    <atomic-generated-answer-feedback-modal
+      .generatedAnswer=${generatedAnswer}
+      is-open
+    ></atomic-generated-answer-feedback-modal>
+  `,
+  decorators: [decorator],
+  parameters: {
+    ...parameters,
+  },
+  play: playAfterModalAnimation,
+};
+
+export default meta;
+
+export const Default: Story = {};
+
+export const A11yStatusMessage: Story = {
+  name: 'A11y Status Message',
+  tags: ['a11y', 'test', '!dev'],
+  play: async (context) => {
+    await playAfterModalAnimation(context);
+    await testStatusMessageA11y(context, {
+      triggerAction: async () => {
+        const canvas = within(context.canvasElement);
+        const yesOptions = await canvas.findAllByShadowRole('radio', {
+          name: 'Yes',
+        });
+        for (const option of yesOptions) {
+          await userEvent.click(option);
+        }
+        const submitButton = await canvas.findByShadowRole('button', {
+          name: 'Send feedback',
+        });
+        await userEvent.click(submitButton);
+      },
+      expectedText:
+        'Thank you! Your feedback will help us improve the answers generated.',
+      timeout: 5000,
+    });
+  },
+};

--- a/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.new.stories.tsx
@@ -55,6 +55,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    chromatic: {disableSnapshot: true},
   },
   play: playAfterModalAnimation,
 };

--- a/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.spec.ts
+++ b/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.spec.ts
@@ -146,6 +146,17 @@ describe('atomic-generated-answer-feedback-modal', () => {
       expect(textarea?.rows).toBe(4);
       expect(textarea?.name).toBe('answer-details');
     });
+
+    it('should not add labels to visual option wrappers', async () => {
+      const {element} = await renderFeedbackModal({isOpen: true});
+
+      const optionWrappers = element.shadowRoot?.querySelectorAll('.options');
+
+      expect(optionWrappers).toHaveLength(FEEDBACK_CATEGORIES.length);
+      optionWrappers?.forEach((optionWrapper) => {
+        expect(optionWrapper).not.toHaveAttribute('aria-label');
+      });
+    });
   });
 
   describe('when submitting the form without required fields', () => {
@@ -158,6 +169,19 @@ describe('atomic-generated-answer-feedback-modal', () => {
       form?.dispatchEvent(new Event('submit'));
 
       expect(mockedGeneratedAnswer.sendFeedback).not.toHaveBeenCalled();
+    });
+
+    it('should expose the required fields error as an alert', async () => {
+      const {element} = await renderFeedbackModal({isOpen: true});
+
+      const form = element.shadowRoot?.querySelector('form');
+      form?.dispatchEvent(new Event('submit'));
+      await element.updateComplete;
+
+      const alert = element.shadowRoot?.querySelector('[role="alert"]');
+      expect(alert).toBeInTheDocument();
+      expect(alert).toHaveTextContent('This field is required.');
+      expect(alert).not.toHaveClass('hidden');
     });
   });
 
@@ -192,6 +216,31 @@ describe('atomic-generated-answer-feedback-modal', () => {
 
       const successIcon = element.shadowRoot?.querySelector('atomic-icon');
       expect(successIcon).toBeTruthy();
+    });
+
+    it('should expose the success message as a polite status message', async () => {
+      const {element} = await renderFeedbackModal({isOpen: true});
+
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- accessing private property for testing
+      (element as any).currentAnswer = {
+        correctTopic: 'yes',
+        hallucinationFree: 'yes',
+        documented: 'yes',
+        readable: 'yes',
+      };
+      await element.updateComplete;
+
+      const form = element.shadowRoot?.querySelector('form');
+      form?.dispatchEvent(new Event('submit'));
+      await element.updateComplete;
+
+      const status = element.shadowRoot?.querySelector('[role="status"]');
+      expect(status).toBeInTheDocument();
+      expect(status).toHaveAttribute('aria-live', 'polite');
+      expect(status).toHaveAttribute('aria-atomic', 'true');
+      expect(status).toHaveTextContent(
+        'Thank you! Your feedback will help us improve the answers generated.'
+      );
     });
   });
 

--- a/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.ts
+++ b/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.ts
@@ -334,6 +334,20 @@ export class AtomicGeneratedAnswerFeedbackModal
     `;
   }
 
+  private renderRequiredFieldsAlert() {
+    return html`
+      <span
+        class=${multiClassMap({
+          'sr-only': true,
+          hidden: !this.answerEvaluationRequired,
+        })}
+        role="alert"
+      >
+        ${this.bindings.i18n.t('required-fields-error')}
+      </span>
+    `;
+  }
+
   private renderFeedbackOptions() {
     return html`
       <fieldset>
@@ -359,7 +373,6 @@ export class AtomicGeneratedAnswerFeedbackModal
                   class=${multiClassMap({
                     'options flex flex-shrink-0 text-base': true,
                   })}
-                  aria-label=${this.bindings.i18n.t(localeKey)}
                 >
                   ${this.renderFeedbackOption('yes', correspondingAnswer)}
                   ${this.renderFeedbackOption('unknown', correspondingAnswer)}
@@ -428,8 +441,8 @@ export class AtomicGeneratedAnswerFeedbackModal
         @submit=${(e: Event) => this.handleSubmit(e)}
         class=${multiClassMap({'flex flex-col gap-8 leading-4': true})}
       >
-        ${this.renderFeedbackOptions()} ${this.renderLinkToCorrectAnswerField()}
-        ${this.renderAddNotesField()}
+        ${this.renderRequiredFieldsAlert()} ${this.renderFeedbackOptions()}
+        ${this.renderLinkToCorrectAnswerField()} ${this.renderAddNotesField()}
       </form>
     `;
   }
@@ -444,7 +457,12 @@ export class AtomicGeneratedAnswerFeedbackModal
           icon=${Success}
           class=${multiClassMap({'w-48': true})}
         ></atomic-icon>
-        <p class=${multiClassMap({'text-base': true})}>
+        <p
+          class=${multiClassMap({'text-base': true})}
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
           ${this.bindings.i18n.t('generated-answer-feedback-success')}
         </p>
       </div>
@@ -468,7 +486,9 @@ export class AtomicGeneratedAnswerFeedbackModal
           class=${multiClassMap({'flex items-center justify-between': true})}
         >
           <div class=${multiClassMap({'required-label text-base': true})}>
-            <span class=${multiClassMap({'text-error mr-0.5': true})}>*</span>
+            <span class=${multiClassMap({'text-error-red mr-0.5': true})}
+              >*</span
+            >
             ${this.bindings.i18n.t('required-fields')}
           </div>
           <div class=${multiClassMap({'flex gap-2': true})}>


### PR DESCRIPTION
## Summary

Adds accessibility improvements to the `atomic-generated-answer-feedback-modal` component and provides Storybook coverage to validate them.

### Why these changes are needed

The feedback modal had several accessibility gaps that prevented assistive technology users from being informed of important state changes:

1. **Missing status announcement on success (WCAG 4.1.3):** After submitting feedback, the success message ("Thank you! Your feedback will help us improve...") was rendered as a plain `<p>` with no live-region semantics. Screen readers would not announce this confirmation unless the user manually navigated to it. Adding `role="status" aria-live="polite" aria-atomic="true"` ensures the message is announced automatically.

2. **Missing validation error announcement (WCAG 4.1.3):** When submitting without completing required fields, the error messages were only shown visually inline. A screen-reader-only `role="alert"` element now broadcasts the validation error immediately so users know something went wrong.

3. **Invalid `aria-label` on non-interactive container (axe: `aria-prohibited-attr`):** The `.options` wrapper `<div>` had an `aria-label` attribute, which is invalid on generic `<div>` elements without an explicit interactive role. This caused an axe violation. Removing it resolves the issue without affecting the user experience since the radio buttons already have their own accessible names.

### Changes

**Component (`atomic-generated-answer-feedback-modal.ts`):**
- Add `role="status" aria-live="polite" aria-atomic="true"` to success message `<p>`
- Add `renderRequiredFieldsAlert()` with `role="alert"` for form validation errors
- Remove invalid `aria-label` from `.options` wrapper div

**Tests (`atomic-generated-answer-feedback-modal.spec.ts`):**
- New test: "should expose the success message as a polite status message"
- New test: "should expose the required fields error as an alert"
- New test: "should not add labels to visual option wrappers"

**Storybook (`atomic-generated-answer-feedback-modal.new.stories.tsx`):**
- Default story with axe accessibility checks
- `A11yStatusMessage` story using `testStatusMessageA11y` helper to validate WCAG 4.1.3 compliance
- `waitForModalAnimationEnd()` utility to avoid transient color-contrast false positives during modal fade-in animation

https://coveord.atlassian.net/browse/KIT-5759