### PR TITLE
feat(atomic): add WAI-ARIA Combobox APG stories for search box

### DIFF
--- a/.changeset/search-box-escape-collapse.md
+++ b/.changeset/search-box-escape-collapse.md
@@ -2,4 +2,4 @@
 '@coveo/atomic': patch
 ---
 
-Pressing Escape in the search box (search and commerce) now collapses the suggestions popup deterministically, preventing a late asynchronous query-suggestion fetch from re-opening it after dismissal.
+Pressing Escape in the search box (search, commerce and insight) now collapses the suggestions popup deterministically, preventing a late asynchronous query-suggestion fetch from re-opening it after dismissal.

--- a/.changeset/search-box-escape-collapse.md
+++ b/.changeset/search-box-escape-collapse.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Pressing Escape in the search box (search and commerce) now collapses the suggestions popup deterministically, preventing a late asynchronous query-suggestion fetch from re-opening it after dismissal.

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.new.stories.tsx
@@ -6,6 +6,7 @@ import type {
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {HttpResponse, http} from 'msw';
+import {testComboboxA11y} from '@/storybook-utils/a11y/combobox.js';
 import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
@@ -153,5 +154,17 @@ export const WithNoSuggestions: Story = {
         }),
       ],
     },
+  },
+};
+
+export const A11yCombobox: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Combobox',
+  args: {
+    'default-slot': `<atomic-commerce-search-box-query-suggestions></atomic-commerce-search-box-query-suggestions>`,
+  },
+  play: async (context) => {
+    await play(context);
+    await testComboboxA11y(context);
   },
 };

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box/atomic-commerce-search-box.ts
@@ -478,6 +478,7 @@ export class AtomicCommerceSearchBox
         }
         break;
       case 'Escape':
+        this.isExpanded = false;
         this.suggestionManager.clearSuggestions();
         break;
       case 'ArrowDown':

--- a/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.new.stories.tsx
@@ -5,6 +5,7 @@ import type {
 } from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {testComboboxA11y} from '@/storybook-utils/a11y/combobox.js';
 import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
@@ -50,5 +51,14 @@ export const WithDisabledSearch: Story = {
   name: 'With disabled search',
   args: {
     'disable-search': true,
+  },
+};
+
+export const A11yCombobox: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Combobox',
+  play: async (context) => {
+    await play(context);
+    await testComboboxA11y(context);
   },
 };

--- a/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-search-box/atomic-insight-search-box.ts
@@ -183,6 +183,7 @@ export class AtomicInsightSearchBox
         }
         break;
       case 'Escape':
+        this.isExpanded = false;
         this.suggestionManager.clearSuggestions();
         break;
       case 'ArrowDown':

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.new.stories.tsx
@@ -5,6 +5,7 @@ import type {
 } from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
+import {testComboboxA11y} from '@/storybook-utils/a11y/combobox.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
@@ -72,5 +73,17 @@ export const StandaloneSearchBox: Story = {
   args: {
     'redirection-url':
       './iframe.html?id=atomic-search-interface--with-result-list',
+  },
+};
+
+export const A11yCombobox: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Combobox',
+  args: {
+    'default-slot': `<atomic-search-box-query-suggestions></atomic-search-box-query-suggestions>`,
+  },
+  play: async (context) => {
+    await play(context);
+    await testComboboxA11y(context);
   },
 };

--- a/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.ts
+++ b/packages/atomic/src/components/search/atomic-search-box/atomic-search-box.ts
@@ -505,6 +505,7 @@ export class AtomicSearchBox
         }
         break;
       case 'Escape':
+        this.isExpanded = false;
         this.suggestionManager.clearSuggestions();
         break;
       case 'ArrowDown':


### PR DESCRIPTION
[KIT-5743](https://coveord.atlassian.net/browse/KIT-5743)

## Problem
The search box components (search and commerce) lack accessibility test coverage for the WAI-ARIA Combobox pattern, which governs how the suggestions popup interacts with keyboard navigation.

## Solution
Added `A11yCombobox` stories to both `atomic-search-box` and `atomic-commerce-search-box` that validate the Combobox APG pattern (ArrowDown into suggestions, Enter to select, Escape to close).

[KIT-5743]: https://coveord.atlassian.net/browse/KIT-5743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ