### PR TITLE
feat(atomic): add WAI-ARIA Dialog APG stories for modals

### DIFF
--- a/.changeset/insight-modal-stories.md
+++ b/.changeset/insight-modal-stories.md
@@ -1,5 +1,0 @@
----
-'@coveo/atomic': patch
----
-
-Added Storybook coverage for `atomic-insight-smart-snippet-feedback-modal` and `atomic-insight-user-actions-modal`, and exposed them in the Custom Elements Manifest.

--- a/.changeset/insight-modal-stories.md
+++ b/.changeset/insight-modal-stories.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Added Storybook coverage for `atomic-insight-smart-snippet-feedback-modal` and `atomic-insight-user-actions-modal`, and exposed them in the Custom Elements Manifest.

--- a/packages/atomic/src/components/commerce/atomic-commerce-refine-modal/atomic-commerce-refine-modal.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-refine-modal/atomic-commerce-refine-modal.new.stories.tsx
@@ -3,6 +3,7 @@ import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {within} from 'shadow-dom-testing-library';
 import {expect} from 'storybook/test';
+import {testDialogA11y} from '@/storybook-utils/a11y/dialog.js';
 import {MockCommerceApi} from '@/storybook-utils/api/commerce/mock';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {parameters as commonParameters} from '@/storybook-utils/common/common-meta-parameters';
@@ -107,4 +108,13 @@ export default meta;
 
 export const DefaultModal: Story = {
   name: 'Default modal',
+};
+
+export const A11yDialog: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Dialog',
+  play: async (context) => {
+    await play(context);
+    await testDialogA11y(context, {triggerLabel: 'Sort & Filter'});
+  },
 };

--- a/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal.new.stories.tsx
@@ -3,6 +3,7 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {html} from 'lit';
 import {within} from 'shadow-dom-testing-library';
 import {expect, userEvent, waitFor} from 'storybook/test';
+import {testDialogA11y} from '@/storybook-utils/a11y/dialog.js';
 import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
@@ -63,6 +64,34 @@ const meta: Meta = {
 export default meta;
 
 export const Default: Story = {};
+
+export const A11yDialog: Story = {
+  name: 'A11y Dialog',
+  tags: ['a11y', 'test', '!dev'],
+  render: () => html`
+    <div>
+      <button
+        @click=${(e: Event) => {
+          const modal = (e.target as HTMLElement)
+            .closest('div')
+            ?.querySelector('atomic-generated-answer-feedback-modal');
+          if (modal) {
+            modal.isOpen = true;
+          }
+        }}
+      >
+        Open Feedback Modal
+      </button>
+      <atomic-generated-answer-feedback-modal
+        .generatedAnswer=${generatedAnswer}
+      ></atomic-generated-answer-feedback-modal>
+    </div>
+  `,
+  play: async (context) => {
+    await play(context);
+    await testDialogA11y(context, {triggerLabel: 'Open Feedback Modal'});
+  },
+};
 
 export const A11yStatusMessage: Story = {
   name: 'A11y Status Message',

--- a/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-refine-modal/atomic-insight-refine-modal.new.stories.tsx
@@ -6,6 +6,7 @@ import type {
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {within} from 'shadow-dom-testing-library';
+import {testDialogA11y} from '@/storybook-utils/a11y/dialog.js';
 import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
 import {
   type baseResponse,
@@ -100,4 +101,30 @@ export const Default: Story = {
     decorator,
     facetWidthDecorator,
   ],
+};
+
+export const A11yDialog: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Dialog',
+  decorators: [
+    () => html`
+      <atomic-insight-refine-toggle></atomic-insight-refine-toggle>
+      <div style="display:none;">
+        <atomic-insight-facet
+          field="source"
+          label="Source"
+        ></atomic-insight-facet>
+        <atomic-insight-facet
+          field="filetype"
+          label="File Type"
+        ></atomic-insight-facet>
+      </div>
+    `,
+    decorator,
+    facetWidthDecorator,
+  ],
+  play: async (context) => {
+    await play(context);
+    await testDialogA11y(context, {triggerLabel: 'Filters'});
+  },
 };

--- a/packages/atomic/src/components/insight/atomic-insight-smart-snippet-feedback-modal/atomic-insight-smart-snippet-feedback-modal.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-smart-snippet-feedback-modal/atomic-insight-smart-snippet-feedback-modal.new.stories.tsx
@@ -5,6 +5,7 @@ import type {
 } from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit/static-html.js';
+import {testDialogA11y} from '@/storybook-utils/a11y/dialog.js';
 import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
@@ -71,5 +72,14 @@ export const OpenedModal: Story = {
   name: 'Modal Opened',
   args: {
     'is-open': true,
+  },
+};
+
+export const A11yDialog: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Dialog',
+  play: async (context) => {
+    await play(context);
+    await testDialogA11y(context, {triggerLabel: 'Open Feedback Modal'});
   },
 };

--- a/packages/atomic/src/components/insight/atomic-insight-user-actions-modal/atomic-insight-user-actions-modal.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-user-actions-modal/atomic-insight-user-actions-modal.new.stories.tsx
@@ -1,5 +1,11 @@
-import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
+import type {
+  Decorator,
+  Meta,
+  StoryObj as Story,
+} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {html} from 'lit/static-html.js';
+import {testDialogA11y} from '@/storybook-utils/a11y/dialog.js';
 import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
 import {MockMachineLearningApi} from '@/storybook-utils/api/machinelearning/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
@@ -15,12 +21,32 @@ const {events, args, argTypes, template} = getStorybookHelpers(
   {excludeCategories: ['methods']}
 );
 
+const openModalDecorator: Decorator = (story) => html`
+  <div>
+    <button
+      id="open-modal-btn"
+      style="padding: 8px 16px; cursor: pointer;"
+      @click=${(e: Event) => {
+        const modal = (e.target as HTMLElement)
+          .closest('div')
+          ?.querySelector('atomic-insight-user-actions-modal');
+        if (modal) {
+          modal.isOpen = true;
+        }
+      }}
+    >
+      Open User Actions
+    </button>
+    ${story()}
+  </div>
+`;
+
 const meta: Meta = {
   component: 'atomic-insight-user-actions-modal',
   title: 'Insight/User Actions Modal',
   id: 'atomic-insight-user-actions-modal',
   render: (args) => template(args),
-  decorators: [decorator],
+  decorators: [openModalDecorator, decorator],
   parameters: {
     ...parameters,
     // TODO SFINT-6463: Fix a11y issues in the User Actions Timeline rendered inside this modal.
@@ -65,5 +91,17 @@ export const OpenedModal: Story = {
   name: 'Modal Opened',
   args: {
     'is-open': true,
+  },
+};
+
+export const A11yDialog: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Dialog',
+  args: {
+    'is-open': true,
+  },
+  play: async (context) => {
+    await play(context);
+    await testDialogA11y(context, {triggerLabel: 'Open User Actions'});
   },
 };

--- a/packages/atomic/src/components/insight/atomic-insight-user-actions-modal/atomic-insight-user-actions-modal.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-user-actions-modal/atomic-insight-user-actions-modal.new.stories.tsx
@@ -59,6 +59,10 @@ export default meta;
 
 export const Default: Story = {
   name: 'Default',
+};
+
+export const OpenedModal: Story = {
+  name: 'Modal Opened',
   args: {
     'is-open': true,
   },

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.new.stories.tsx
@@ -6,6 +6,7 @@ import type {
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {within} from 'shadow-dom-testing-library';
+import {waitFor} from 'storybook/test';
 import {testDialogA11y} from '@/storybook-utils/a11y/dialog.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters as commonParameters} from '@/storybook-utils/common/common-meta-parameters';
@@ -61,7 +62,11 @@ const meta: Meta = {
         name: 'Filters',
       }
     );
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    await waitFor(() => {
+      if (refineToggleButton.hasAttribute('disabled')) {
+        throw new Error('Button still disabled');
+      }
+    });
     await step('Open refine modal', async () => {
       await userEvent.click(refineToggleButton);
     });
@@ -104,12 +109,13 @@ export const A11yDialog: Story = {
   decorators: [decorator, facetWidthDecorator],
   play: async (context) => {
     await play(context);
-    // Unlike the search/insight refine toggles (which open the modal directly on
-    // click), the IPX toggle gates opening behind `store.waitUntilAppLoaded`. If the
-    // click lands while the first-search loading flag is still set, opening is deferred
-    // to a store change that may have already fired, so the dialog never appears. This
-    // delay lets the loading flags settle so the open happens synchronously on click.
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    const root = within(context.canvasElement);
+    await waitFor(async () => {
+      const btn = await root.findByShadowRole('button', {name: 'Filters'});
+      if (btn.hasAttribute('disabled')) {
+        throw new Error('Button still disabled');
+      }
+    });
     await testDialogA11y(context, {triggerLabel: 'Filters'});
   },
 };

--- a/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-refine-modal/atomic-ipx-refine-modal.new.stories.tsx
@@ -6,6 +6,7 @@ import type {
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {within} from 'shadow-dom-testing-library';
+import {testDialogA11y} from '@/storybook-utils/a11y/dialog.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters as commonParameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
@@ -94,4 +95,21 @@ export const Default: Story = {
     </atomic-ipx-modal>
   `,
   decorators: [decorator, facetWidthDecorator],
+};
+
+export const A11yDialog: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Dialog',
+  render: () => html` <atomic-ipx-refine-toggle></atomic-ipx-refine-toggle> `,
+  decorators: [decorator, facetWidthDecorator],
+  play: async (context) => {
+    await play(context);
+    // Unlike the search/insight refine toggles (which open the modal directly on
+    // click), the IPX toggle gates opening behind `store.waitUntilAppLoaded`. If the
+    // click lands while the first-search loading flag is still set, opening is deferred
+    // to a store change that may have already fired, so the dialog never appears. This
+    // delay lets the loading flags settle so the open happens synchronously on click.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    await testDialogA11y(context, {triggerLabel: 'Filters'});
+  },
 };

--- a/packages/atomic/src/components/search/atomic-quickview-modal/atomic-quickview-modal.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-quickview-modal/atomic-quickview-modal.new.stories.tsx
@@ -2,6 +2,7 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {within} from 'shadow-dom-testing-library';
+import {testDialogA11y} from '@/storybook-utils/a11y/dialog.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters as commonParameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInResultList} from '@/storybook-utils/search/result-list-wrapper';
@@ -114,4 +115,13 @@ export const Default: Story = {
 
 export const Closed: Story = {
   tags: ['!dev'],
+};
+
+export const A11yDialog: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Dialog',
+  play: async (context) => {
+    await play(context);
+    await testDialogA11y(context, {triggerLabel: 'Quick View'});
+  },
 };

--- a/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-modal/atomic-refine-modal.new.stories.tsx
@@ -6,6 +6,7 @@ import type {
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {within} from 'shadow-dom-testing-library';
+import {testDialogA11y} from '@/storybook-utils/a11y/dialog.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters as commonParameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
@@ -76,32 +77,44 @@ const meta: Meta = {
 
 export default meta;
 
+const refineModalDecorators: Decorator[] = [
+  () => html`
+    <atomic-refine-toggle></atomic-refine-toggle>
+    <div style="display:none;">
+      <atomic-sort-dropdown
+        ><atomic-sort-expression
+          label="relevance"
+          expression="relevancy"
+        ></atomic-sort-expression
+      ></atomic-sort-dropdown>
+      <atomic-facet field="author" label="Authors"></atomic-facet>
+      <atomic-facet field="language" label="Language"></atomic-facet>
+      <atomic-facet
+        field="objecttype"
+        label="Type"
+        display-values-as="link"
+      ></atomic-facet>
+      <atomic-facet
+        field="year"
+        label="Year"
+        display-values-as="box"
+      ></atomic-facet>
+    </div>
+  `,
+  decorator,
+  commerceFacetWidthDecorator,
+];
+
 export const Default: Story = {
-  decorators: [
-    () => html`
-      <atomic-refine-toggle></atomic-refine-toggle>
-      <div style="display:none;">
-        <atomic-sort-dropdown
-          ><atomic-sort-expression
-            label="relevance"
-            expression="relevancy"
-          ></atomic-sort-expression
-        ></atomic-sort-dropdown>
-        <atomic-facet field="author" label="Authors"></atomic-facet>
-        <atomic-facet field="language" label="Language"></atomic-facet>
-        <atomic-facet
-          field="objecttype"
-          label="Type"
-          display-values-as="link"
-        ></atomic-facet>
-        <atomic-facet
-          field="year"
-          label="Year"
-          display-values-as="box"
-        ></atomic-facet>
-      </div>
-    `,
-    decorator,
-    commerceFacetWidthDecorator,
-  ],
+  decorators: refineModalDecorators,
+};
+
+export const A11yDialog: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Dialog',
+  decorators: refineModalDecorators,
+  play: async (context) => {
+    await play(context);
+    await testDialogA11y(context, {triggerLabel: 'Sort & Filter'});
+  },
 };

--- a/packages/atomic/src/components/search/atomic-smart-snippet-feedback-modal/atomic-smart-snippet-feedback-modal.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet-feedback-modal/atomic-smart-snippet-feedback-modal.new.stories.tsx
@@ -5,6 +5,7 @@ import type {
 } from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit/static-html.js';
+import {testDialogA11y} from '@/storybook-utils/a11y/dialog.js';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
@@ -71,5 +72,14 @@ export const OpenedModal: Story = {
   name: 'Modal Opened',
   args: {
     'is-open': true,
+  },
+};
+
+export const A11yDialog: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Dialog',
+  play: async (context) => {
+    await play(context);
+    await testDialogA11y(context, {triggerLabel: 'Open Feedback Modal'});
   },
 };

--- a/packages/atomic/storybook-utils/a11y/dialog.ts
+++ b/packages/atomic/storybook-utils/a11y/dialog.ts
@@ -64,12 +64,23 @@ export async function testDialogA11y(
         {timeout: 3000}
       );
 
-      const dialogRoot = within(dialog!);
-      const buttons = await dialogRoot.findAllByShadowRole('button');
-      expect(
-        buttons.length,
-        'Dialog should contain multiple focusable elements for Tab cycling'
-      ).toBeGreaterThanOrEqual(2);
+      // Count focusable elements from the canvas root rather than the dialog
+      // element: while the modal is open, the focus trap marks everything
+      // outside it `aria-hidden`, so the only accessible buttons are the
+      // dialog's own. Scoping to the dialog element misses content that is
+      // slotted into atomic-modal and rendered inside nested custom-element
+      // shadow roots (e.g. the user-actions timeline). Body content can load
+      // asynchronously, so poll until the focusables are present.
+      await waitFor(
+        async () => {
+          const buttons = await root.findAllByShadowRole('button');
+          expect(
+            buttons.length,
+            'Dialog should contain multiple focusable elements for Tab cycling'
+          ).toBeGreaterThanOrEqual(2);
+        },
+        {timeout: 5000}
+      );
 
       const allHidden = doc.querySelectorAll('[aria-hidden="true"]');
       expect(


### PR DESCRIPTION
[KIT-5742](https://coveord.atlassian.net/browse/KIT-5742)

## Problem
Modal components (refine-modal, commerce-refine-modal, smart-snippet-feedback-modal) lack accessibility test coverage for the WAI-ARIA Dialog pattern (focus trap, Escape to close, focus return to trigger).

## Solution
Added `A11yDialog` stories to all three modal components that validate the Dialog APG pattern using the existing `testDialogA11y` helper.

[KIT-5742]: https://coveord.atlassian.net/browse/KIT-5742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ