### PR TITLE
feat(atomic): add WAI-ARIA Tree View semantics to category facets

### DIFF
--- a/.changeset/tree-view-apg-a11y.md
+++ b/.changeset/tree-view-apg-a11y.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Added WAI-ARIA tree view semantics to category facet components (`role="tree"`, `role="treeitem"`, `aria-expanded`) for improved accessibility.

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/e2e/page-object.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/e2e/page-object.ts
@@ -45,7 +45,11 @@ export class AtomicCommerceBreadboxPageObject extends BasePageObject {
 
     const baseLocator = this.page
       .locator(facetTypeLocators[facetType])
-      .getByRole('listitem');
+      .getByRole(
+        facetType === 'category' || facetType === 'nestedCategory'
+          ? 'treeitem'
+          : 'listitem'
+      );
     return value ? baseLocator.filter({hasText: value}) : baseLocator;
   }
 

--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.new.stories.tsx
@@ -72,3 +72,18 @@ export const Default: Story = {
     await hideFacetTypesHook('atomic-commerce-category-facet', context);
   },
 };
+
+export const A11yTreeView: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Tree View',
+  render: () => html`<div id="code-root">
+    <atomic-commerce-facets></atomic-commerce-facets>
+  </div>`,
+  play: async (context) => {
+    await play(context);
+    await hideFacetTypesHook('atomic-commerce-category-facet', context);
+    const {testTreeViewA11y} =
+      await import('@/storybook-utils/a11y/tree-view.js');
+    await testTreeViewA11y(context);
+  },
+};

--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.spec.ts
@@ -65,10 +65,10 @@ describe('atomic-commerce-category-facet', () => {
         return page.getByText('No label', {exact: true});
       },
       getFacetValueByPosition(valuePosition: number) {
-        return page.getByRole('listitem').nth(valuePosition);
+        return page.getByRole('treeitem').nth(valuePosition);
       },
       getFacetValueByLabel(value: string | RegExp) {
-        return page.getByRole('listitem').filter({hasText: value});
+        return page.getByRole('treeitem').filter({hasText: value});
       },
       getFacetValueButtonByLabel(value: string | RegExp) {
         return page.getByLabelText(`Inclusion filter on ${value}`);

--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.ts
@@ -266,7 +266,9 @@ export class AtomicCommerceCategoryFacet
     }
 
     if (isRoot) {
-      return renderCategoryFacetTreeValueContainer()(html`
+      return renderCategoryFacetTreeValueContainer({
+        props: {isExpandable: true, isExpanded: true},
+      })(html`
         ${renderCategoryFacetAllCategoryButton({
           props: {
             i18n: this.bindings.i18n,
@@ -289,7 +291,9 @@ export class AtomicCommerceCategoryFacet
     if (parents.length > 1) {
       const parentValue = parents[0];
 
-      return renderCategoryFacetTreeValueContainer()(html`
+      return renderCategoryFacetTreeValueContainer({
+        props: {isExpandable: true, isExpanded: true},
+      })(html`
         ${renderCategoryFacetParentButton({
           props: {
             i18n: this.bindings.i18n,
@@ -507,7 +511,11 @@ export class AtomicCommerceCategoryFacet
                   this.hasParents,
                   () => html`
                     ${renderCategoryFacetParentAsTreeContainer({
-                      props: {isTopLevel: true, className: 'mt-3'},
+                      props: {
+                        isTopLevel: true,
+                        className: 'mt-3',
+                        label: this.displayName,
+                      },
                     })(
                       html`${when(
                         selectedValueAncestry,
@@ -521,6 +529,8 @@ export class AtomicCommerceCategoryFacet
                     ${renderCategoryFacetChildrenAsTreeContainer({
                       props: {
                         className: 'mt-3',
+                        isTopLevel: true,
+                        label: this.displayName,
                       },
                     })(this.renderChildren())}
                   `

--- a/packages/atomic/src/components/common/facets/category-facet/children-as-tree-container.ts
+++ b/packages/atomic/src/components/common/facets/category-facet/children-as-tree-container.ts
@@ -4,6 +4,8 @@ import type {FunctionalComponentWithChildren} from '@/src/utils/functional-compo
 
 export interface CategoryFacetChildrenAsTreeContainerProps {
   className?: string;
+  isTopLevel?: boolean;
+  label?: string;
 }
 
 export const renderCategoryFacetChildrenAsTreeContainer: FunctionalComponentWithChildren<
@@ -11,7 +13,13 @@ export const renderCategoryFacetChildrenAsTreeContainer: FunctionalComponentWith
 > =
   ({props}) =>
   (children) => {
-    return html`<ul part="values" class=${ifDefined(props.className)}>
+    const role = props.isTopLevel ? 'tree' : 'group';
+    return html`<ul
+      part="values"
+      class=${ifDefined(props.className)}
+      role=${role}
+      aria-label=${ifDefined(props.label)}
+    >
       ${children}
     </ul>`;
   };

--- a/packages/atomic/src/components/common/facets/category-facet/parent-as-tree-container.ts
+++ b/packages/atomic/src/components/common/facets/category-facet/parent-as-tree-container.ts
@@ -5,6 +5,7 @@ import type {FunctionalComponentWithChildren} from '@/src/utils/functional-compo
 export interface CategoryFacetParentAsTreeContainerProps {
   isTopLevel: boolean;
   className?: string;
+  label?: string;
 }
 
 export const renderCategoryFacetParentAsTreeContainer: FunctionalComponentWithChildren<
@@ -13,7 +14,13 @@ export const renderCategoryFacetParentAsTreeContainer: FunctionalComponentWithCh
   ({props}) =>
   (children) => {
     const part = props.isTopLevel ? 'parents' : 'sub-parents';
-    return html`<ul class=${ifDefined(props.className)} part=${part}>
+    const role = props.isTopLevel ? 'tree' : 'group';
+    return html`<ul
+      class=${ifDefined(props.className)}
+      part=${part}
+      role=${role}
+      aria-label=${ifDefined(props.label)}
+    >
       ${children}
     </ul>`;
   };

--- a/packages/atomic/src/components/common/facets/category-facet/value-as-tree-container.ts
+++ b/packages/atomic/src/components/common/facets/category-facet/value-as-tree-container.ts
@@ -1,7 +1,22 @@
-import {html} from 'lit';
-import type {FunctionalComponentWithChildrenNoProps} from '@/src/utils/functional-component-utils';
+import {html, type TemplateResult, type nothing} from 'lit';
+import {ifDefined} from 'lit/directives/if-defined.js';
 
-export const renderCategoryFacetTreeValueContainer: FunctionalComponentWithChildrenNoProps =
-  () => (children) => {
-    return html`<li class="contents">${children}</li>`;
+export interface CategoryFacetTreeValueContainerProps {
+  isExpandable?: boolean;
+  isExpanded?: boolean;
+}
+
+export const renderCategoryFacetTreeValueContainer =
+  ({props}: {props: CategoryFacetTreeValueContainerProps} = {props: {}}) =>
+  (children: TemplateResult | typeof nothing): TemplateResult => {
+    const ariaExpanded = props.isExpandable
+      ? String(props.isExpanded ?? false)
+      : undefined;
+    return html`<li
+      class="contents"
+      role="treeitem"
+      aria-expanded=${ifDefined(ariaExpanded)}
+    >
+      ${children}
+    </li>`;
   };

--- a/packages/atomic/src/components/common/facets/category-facet/value-link.ts
+++ b/packages/atomic/src/components/common/facets/category-facet/value-link.ts
@@ -56,6 +56,8 @@ export const renderCategoryFacetValueLink: FunctionalComponentWithOptionalChildr
         searchQuery,
         part: partNames.join(' '),
         class: 'contents',
+        listItemRole: 'treeitem',
+        listItemAriaExpanded: !isLeafValue ? 'false' : undefined,
         buttonRef: (element) => {
           setRef?.(element);
         },

--- a/packages/atomic/src/components/common/facets/facet-value-link/facet-value-link.ts
+++ b/packages/atomic/src/components/common/facets/facet-value-link/facet-value-link.ts
@@ -7,6 +7,8 @@ import type {FacetValuePropsBase} from '../facet-common';
 
 export interface FacetValueLinkProps extends FacetValuePropsBase {
   subList?: TemplateResult;
+  listItemRole?: string;
+  listItemAriaExpanded?: string;
 }
 
 export const renderFacetValueLink: FunctionalComponentWithChildren<
@@ -33,7 +35,11 @@ export const renderFacetValueLink: FunctionalComponentWithChildren<
     return html`
       ${keyed(
         props.displayValue,
-        html`<li class=${ifDefined(props.class)}>
+        html`<li
+          class=${ifDefined(props.class)}
+          role=${ifDefined(props.listItemRole)}
+          aria-expanded=${ifDefined(props.listItemAriaExpanded)}
+        >
           ${renderButton({
             props: {
               style: 'text-neutral',

--- a/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.new.stories.tsx
@@ -414,3 +414,22 @@ export const WithSelectedChildValueAndMoreAvailable: Story = {
     mockSelectedChildValueWithMoreAvailable();
   },
 };
+
+export const A11yTreeView: Story = {
+  tags: ['a11y', 'test', '!dev'],
+  name: 'A11y Tree View',
+  args: {
+    field: 'geographicalhierarchy',
+    label: 'Geographical Hierarchy',
+  },
+  decorators: [facetDecorator],
+  beforeEach: () => {
+    mockDefaultCategoryFacetResponse();
+  },
+  play: async (context) => {
+    await play(context);
+    const {testTreeViewA11y} =
+      await import('@/storybook-utils/a11y/tree-view.js');
+    await testTreeViewA11y(context);
+  },
+};

--- a/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.ts
+++ b/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.ts
@@ -557,7 +557,9 @@ export class AtomicCategoryFacet
     }
 
     if (isRoot) {
-      return renderCategoryFacetTreeValueContainer()(html`
+      return renderCategoryFacetTreeValueContainer({
+        props: {isExpandable: true, isExpanded: true},
+      })(html`
         ${renderCategoryFacetAllCategoryButton({
           props: {
             i18n: this.bindings.i18n,
@@ -580,7 +582,9 @@ export class AtomicCategoryFacet
     if (valuesAsTrees.length > 1) {
       const parentValue = valuesAsTrees[0];
 
-      return renderCategoryFacetTreeValueContainer()(html`
+      return renderCategoryFacetTreeValueContainer({
+        props: {isExpandable: true, isExpanded: true},
+      })(html`
         ${renderCategoryFacetParentButton({
           props: {
             facetValue: parentValue,
@@ -825,13 +829,15 @@ export class AtomicCategoryFacet
                   this.hasParents,
                   () => html`
                     ${renderCategoryFacetParentAsTreeContainer({
-                      props: {isTopLevel: true, className: 'mt-3'},
+                      props: {isTopLevel: true, className: 'mt-3', label},
                     })(this.renderValuesTree(selectedValueAncestry, true))}
                   `,
                   () => html`
                     ${renderCategoryFacetChildrenAsTreeContainer({
                       props: {
                         className: 'mt-3',
+                        isTopLevel: true,
+                        label,
                       },
                     })(this.renderChildren())}
                   `

--- a/packages/atomic/storybook-utils/a11y/index.ts
+++ b/packages/atomic/storybook-utils/a11y/index.ts
@@ -46,3 +46,7 @@ export {
   testCheckboxA11y,
   type CheckboxA11yOptions,
 } from './checkbox.js';
+export {
+  COVERED_CRITERIA as TREE_VIEW_COVERED_CRITERIA,
+  testTreeViewA11y,
+} from './tree-view.js';

--- a/packages/atomic/storybook-utils/a11y/tree-view.ts
+++ b/packages/atomic/storybook-utils/a11y/tree-view.ts
@@ -1,0 +1,75 @@
+import type {StoryContext} from '@storybook/web-components-vite';
+import {within} from 'shadow-dom-testing-library';
+import {expect, waitFor} from 'storybook/test';
+
+/**
+ * WCAG 2.2 AA criteria covered by tree view semantic tests.
+ *
+ * - 4.1.2 Name, Role, Value: tree/treeitem roles and aria-expanded present
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/treeview/ — WAI-ARIA Tree View Pattern
+ * @see https://www.w3.org/TR/WCAG22/#name-role-value — WCAG 2.2 SC 4.1.2 (Level A)
+ */
+export const COVERED_CRITERIA = ['4.1.2'] as const;
+
+export async function testTreeViewA11y(context: StoryContext): Promise<void> {
+  const {canvasElement, step} = context;
+  const root = within(canvasElement);
+
+  let status: 'passed' | 'failed' = 'passed';
+  try {
+    await step('Tree container with role="tree" is present', async () => {
+      const tree = await waitFor(
+        () => {
+          const el = root.queryByShadowRole('tree');
+          expect(el, 'Expected an element with role="tree"').not.toBeNull();
+          return el!;
+        },
+        {timeout: 5000}
+      );
+
+      expect(
+        tree.getAttribute('aria-label') || tree.getAttribute('aria-labelledby'),
+        'Tree should have an accessible label (aria-label or aria-labelledby)'
+      ).toBeTruthy();
+    });
+
+    await step('Tree items with role="treeitem" are present', async () => {
+      const items = await waitFor(
+        () => {
+          const els = root.queryAllByShadowRole('treeitem');
+          expect(
+            els.length,
+            'Expected at least one element with role="treeitem"'
+          ).toBeGreaterThanOrEqual(1);
+          return els;
+        },
+        {timeout: 5000}
+      );
+
+      const expandableItems = items.filter(
+        (item) => item.getAttribute('aria-expanded') !== null
+      );
+
+      if (expandableItems.length > 0) {
+        for (const item of expandableItems) {
+          const expanded = item.getAttribute('aria-expanded');
+          expect(
+            expanded === 'true' || expanded === 'false',
+            `aria-expanded should be "true" or "false", got "${expanded}"`
+          ).toBe(true);
+        }
+      }
+    });
+  } catch (error) {
+    status = 'failed';
+    throw error;
+  } finally {
+    context.reporting?.addReport?.({
+      type: 'a11y-interactive',
+      version: 1,
+      status,
+      result: {criteriaCovered: [...COVERED_CRITERIA]},
+    });
+  }
+}


### PR DESCRIPTION
[KIT-5732](https://coveord.atlassian.net/browse/KIT-5732)

## Problem
Category facet components render hierarchical data but lack proper WAI-ARIA Tree View semantics (`role="tree"`, `role="treeitem"`, `aria-expanded`), making the hierarchy structure invisible to screen readers.

## Solution
- Added `role="tree"` to top-level containers and `role="group"` to nested containers in `children-as-tree-container.ts` and `parent-as-tree-container.ts`
- Added `role="treeitem"` and `aria-expanded` to `value-as-tree-container.ts`
- Extended `facet-value-link.ts` with optional `listItemRole` and `listItemAriaExpanded` props for category facets
- Created `testTreeViewA11y` helper and wired `A11yTreeView` stories for both search and commerce category facets.

[KIT-5732]: https://coveord.atlassian.net/browse/KIT-5732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ