### PR TITLE
fix(cdn): self-contained commit artifacts via CDN_COMMIT_SHA

### DIFF
--- a/.changeset/self-contained-cdn-artifacts.md
+++ b/.changeset/self-contained-cdn-artifacts.md
@@ -1,0 +1,9 @@
+---
+'@coveo/atomic': patch
+'@coveo/headless': patch
+'@coveo/atomic-hosted-page': patch
+'@coveo/atomic-react': patch
+'@coveo/shopify': patch
+---
+
+CDN artifacts now resolve cross-package dependencies using commit-based paths, making each artifact self-contained and independent of version pointer availability.

--- a/.github/actions/build-cdn/action.yml
+++ b/.github/actions/build-cdn/action.yml
@@ -1,6 +1,11 @@
 name: Build CDN
 description: Build with CDN deployment environment and save turbo cache artifact
 
+inputs:
+  commit-sha:
+    description: 'Commit SHA for self-contained CDN artifacts. External dependencies resolve to /package/commits/<SHA>/ paths instead of version-based paths.'
+    required: true
+
 runs:
   using: composite
   steps:
@@ -11,3 +16,4 @@ runs:
         load-cache: 'false'
       env:
         DEPLOYMENT_ENVIRONMENT: CDN
+        CDN_COMMIT_SHA: ${{ inputs.commit-sha }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -216,6 +216,8 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/build-cdn
+        with:
+          commit-sha: ${{ github.sha }}
   commit-artifact-upload:
     name: Upload commit artifacts to S3
     needs: [build-cdn, release]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/build-cdn
+        with:
+          commit-sha: ${{ github.sha }}
   affected:
     name: 'Determine affected projects'
     runs-on: ubuntu-latest

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -34,6 +34,8 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/build-cdn
+        with:
+          commit-sha: ${{ github.sha }}
 
   hotfix-deploy:
     name: Deploy hotfix to CDN

--- a/packages/atomic-hosted-page/scripts/esbuild.js
+++ b/packages/atomic-hosted-page/scripts/esbuild.js
@@ -14,6 +14,7 @@ const headlessJson = JSON.parse(
   readFileSync(resolve(__dirname, '../../headless/package.json'), 'utf8')
 );
 const isNightly = process.env.IS_NIGHTLY === 'true';
+const commitSha = process.env.CDN_COMMIT_SHA;
 
 const headlessVersion = isNightly
   ? `v${headlessJson.version.split('.').shift()}-nightly`
@@ -21,9 +22,17 @@ const headlessVersion = isNightly
 const buenoVersion = isNightly
   ? `v${buenoJson.version.split('.').shift()}-nightly`
   : `v${buenoJson.version}`;
+
+const headlessBase = commitSha
+  ? `/headless/commits/${commitSha}`
+  : `/headless/${headlessVersion}`;
+const buenoBase = commitSha
+  ? `/bueno/commits/${commitSha}`
+  : `/bueno/${buenoVersion}`;
+
 const packageMappings = {
-  '@coveo/headless': `/headless/${headlessVersion}/headless.esm.js`,
-  '@coveo/bueno': `/bueno/${buenoVersion}/bueno.esm.js`,
+  '@coveo/headless': `${headlessBase}/headless.esm.js`,
+  '@coveo/bueno': `${buenoBase}/bueno.esm.js`,
 };
 
 const externalizeDependenciesPlugin = {

--- a/packages/atomic-react/rollup.config.js
+++ b/packages/atomic-react/rollup.config.js
@@ -16,6 +16,7 @@ const __dirname = dirname(__filename);
 
 const isCDN = process.env.DEPLOYMENT_ENVIRONMENT === 'CDN';
 const isNightly = process.env.IS_NIGHTLY === 'true';
+const commitSha = process.env.CDN_COMMIT_SHA;
 
 let headlessVersion;
 let atomicVersion;
@@ -54,24 +55,31 @@ if (isCDN) {
   }
 }
 
+const headlessBase = commitSha
+  ? `/headless/commits/${commitSha}`
+  : `/headless/${headlessVersion}`;
+const atomicBase = commitSha
+  ? `/atomic/commits/${commitSha}`
+  : `/atomic/${atomicVersion}`;
+
 const packageMappings = {
   '@coveo/headless/commerce': {
-    cdn: `/headless/${headlessVersion}/commerce/headless.esm.js`,
+    cdn: `${headlessBase}/commerce/headless.esm.js`,
   },
   '@coveo/headless/insight': {
-    cdn: `/headless/${headlessVersion}/insight/headless.esm.js`,
+    cdn: `${headlessBase}/insight/headless.esm.js`,
   },
   '@coveo/headless/recommendation': {
-    cdn: `/headless/${headlessVersion}/recommendation/headless.esm.js`,
+    cdn: `${headlessBase}/recommendation/headless.esm.js`,
   },
   '@coveo/headless/case-assist': {
-    cdn: `/headless/${headlessVersion}/case-assist/headless.esm.js`,
+    cdn: `${headlessBase}/case-assist/headless.esm.js`,
   },
   '@coveo/headless': {
-    cdn: `/headless/${headlessVersion}/headless.esm.js`,
+    cdn: `${headlessBase}/headless.esm.js`,
   },
   '@coveo/atomic/loader': {
-    cdn: `/atomic/${atomicVersion}/loader/index.js`,
+    cdn: `${atomicBase}/loader/index.js`,
   },
 };
 
@@ -116,9 +124,9 @@ const cdnExternal = [
   'react',
   'react-dom',
   'react-dom/client',
-  /.*\/headless\/v.*/,
-  /.*\/atomic\/v.*/,
-  /.*\/bueno\/v.*/,
+  /.*\/headless\/(v|commits\/).*/,
+  /.*\/atomic\/(v|commits\/).*/,
+  /.*\/bueno\/(v|commits\/).*/,
 ];
 
 /** @returns {import('rollup').OutputOptions} */

--- a/packages/atomic/scripts/externalPackageMappings.mjs
+++ b/packages/atomic/scripts/externalPackageMappings.mjs
@@ -12,6 +12,7 @@ const headlessJson = JSON.parse(
 );
 
 const isNightly = process.env.IS_NIGHTLY === 'true';
+const commitSha = process.env.CDN_COMMIT_SHA;
 
 const headlessVersion = isNightly
   ? `v${headlessJson.version.split('.').shift()}-nightly`
@@ -21,30 +22,37 @@ const buenoVersion = isNightly
   ? `v${buenoJson.version.split('.').shift()}-nightly`
   : `v${buenoJson.version}`;
 
+const headlessBase = commitSha
+  ? `/headless/commits/${commitSha}`
+  : `/headless/${headlessVersion}`;
+const buenoBase = commitSha
+  ? `/bueno/commits/${commitSha}`
+  : `/bueno/${buenoVersion}`;
+
 export function generateExternalPackageMappings() {
   return {
     '@coveo/headless/commerce': {
-      cdn: `/headless/${headlessVersion}/commerce/headless.esm.js`,
+      cdn: `${headlessBase}/commerce/headless.esm.js`,
       local: resolve(headlessBaseDir, './src/commerce.index.ts'),
     },
     '@coveo/headless/insight': {
-      cdn: `/headless/${headlessVersion}/insight/headless.esm.js`,
+      cdn: `${headlessBase}/insight/headless.esm.js`,
       local: resolve(headlessBaseDir, './src/insight.index.ts'),
     },
     '@coveo/headless/recommendation': {
-      cdn: `/headless/${headlessVersion}/recommendation/headless.esm.js`,
+      cdn: `${headlessBase}/recommendation/headless.esm.js`,
       local: resolve(headlessBaseDir, './src/recommendation.index.ts'),
     },
     '@coveo/headless/case-assist': {
-      cdn: `/headless/${headlessVersion}/case-assist/headless.esm.js`,
+      cdn: `${headlessBase}/case-assist/headless.esm.js`,
       local: resolve(headlessBaseDir, './src/case-assist.index.ts'),
     },
     '@coveo/headless': {
-      cdn: `/headless/${headlessVersion}/headless.esm.js`,
+      cdn: `${headlessBase}/headless.esm.js`,
       local: resolve(headlessBaseDir, './src/index.ts'),
     },
     '@coveo/bueno': {
-      cdn: `/bueno/${buenoVersion}/bueno.esm.js`,
+      cdn: `${buenoBase}/bueno.esm.js`,
       local: resolve(buenoBaseDir, './src/index.ts'),
     },
   };

--- a/packages/headless/esbuild.mjs
+++ b/packages/headless/esbuild.mjs
@@ -23,10 +23,16 @@ const require = createRequire(import.meta.url);
 const devMode = process.argv[2] === 'dev';
 
 const isNightly = process.env.IS_NIGHTLY === 'true';
+const commitSha = process.env.CDN_COMMIT_SHA;
 
 const buenoVersion = isNightly
   ? `v${buenoJson.version.split('.').shift()}-nightly`
   : `v${buenoJson.version}`;
+
+const buenoBase = commitSha
+  ? `/bueno/commits/${commitSha}`
+  : `/bueno/${buenoVersion}`;
+const buenoCdnPath = `${buenoBase}/bueno.esm.js`;
 
 function getUmdGlobalName(useCase) {
   const map = {
@@ -80,14 +86,12 @@ const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   // ⚠️  Changing this filename affects CDN pointer files in ui-kit-cd.
   const outfile = `${outDir}/headless.esm.js`;
 
-  const buenoPath = `/bueno/${buenoVersion}/bueno.esm.js`;
-
   let config = {
     entryPoints: [entryPoint],
     outfile,
     format: 'esm',
-    external: [buenoPath],
-    plugins: [getBuenoReplacePlugin(buenoPath)],
+    external: [buenoCdnPath],
+    plugins: [getBuenoReplacePlugin(buenoCdnPath)],
   };
 
   if (devMode) {
@@ -106,7 +110,7 @@ const browserUmd = Object.entries(useCaseEntries).map((entry) => {
   const [useCase, entryPoint] = entry;
   const outDir = getUseCaseDir('cdn', useCase);
   const outfile = `${outDir}/headless.js`;
-  const buenoPath = `/bueno/${buenoVersion}/bueno.esm.js`;
+
   const globalName = getUmdGlobalName(useCase);
 
   return buildBrowserConfig(
@@ -117,9 +121,9 @@ const browserUmd = Object.entries(useCaseEntries).map((entry) => {
       banner: {
         js: `${base.banner.js}`,
       },
-      external: ['crypto', buenoPath],
+      external: ['crypto', buenoCdnPath],
       plugins: [
-        getBuenoReplacePlugin(buenoPath),
+        getBuenoReplacePlugin(buenoCdnPath),
         umdWrapper({libraryName: globalName}),
       ],
     },

--- a/packages/shopify/esbuild.mjs
+++ b/packages/shopify/esbuild.mjs
@@ -13,6 +13,7 @@ const __dirname = dirname(new URL(import.meta.url).pathname).slice(
 const isDevMode = process.argv[2] === 'dev';
 const isCDN = process.env.DEPLOYMENT_ENVIRONMENT === 'CDN';
 const isNightly = process.env.IS_NIGHTLY === 'true';
+const commitSha = process.env.CDN_COMMIT_SHA;
 
 const buenoJsonPath = resolve(__dirname, '../bueno/package.json');
 const buenoJson = JSON.parse(readFileSync(buenoJsonPath, 'utf-8'));
@@ -20,9 +21,10 @@ const buenoJson = JSON.parse(readFileSync(buenoJsonPath, 'utf-8'));
 const buenoVersion = isNightly
   ? `v${buenoJson.version.split('.').shift()}-nightly`
   : `v${buenoJson.version}`;
-const buenoPath = isCDN
-  ? `/bueno/${buenoVersion}/bueno.esm.js`
-  : '@coveo/bueno';
+const buenoBase = commitSha
+  ? `/bueno/commits/${commitSha}`
+  : `/bueno/${buenoVersion}`;
+const buenoPath = isCDN ? `${buenoBase}/bueno.esm.js` : '@coveo/bueno';
 
 /**
  * @type {import('esbuild').BuildOptions}

--- a/turbo.json
+++ b/turbo.json
@@ -65,7 +65,7 @@
     ".oxfmtrc.json",
     ".cspell.json"
   ],
-  "globalEnv": ["DEPLOYMENT_ENVIRONMENT", "NODE_ENV", "CI"],
+  "globalEnv": ["DEPLOYMENT_ENVIRONMENT", "NODE_ENV", "CI", "CDN_COMMIT_SHA"],
   "globalPassThroughEnv": [
     "GITHUB_*",
     "RUNNER_*",


### PR DESCRIPTION
[KIT-5716](https://coveord.atlassian.net/browse/KIT-5716)

## Problem

CDN artifacts (Atomic, Headless, etc.) reference other packages using pinned minor version paths like `/headless/v3.51.2/headless.esm.js`. These version pointers only exist in the stable (`vX/`) channel — they do NOT exist in `preview/` or `private/` channels.

When docs.coveo.com or other internal sites switch to the preview channel (`atomic/preview/v3/...`), the Atomic bundle still tries to load Headless from a non-existent minor version pointer while waiting for the real release to be deployed, resulting in 403 errors.

## Solution

Make CDN builds fully self-contained by resolving cross-package dependencies to the same commit SHA:

- Added `CDN_COMMIT_SHA` env var (required in the `build-cdn` action, provided by CI/CD workflows as `github.sha`)
- All 5 affected packages now resolve to `/package/commits/<SHA>/file.js` instead of `/package/v<version>/file.js`
- Each commit artifact is now independent of other version pointers existing
- When `CDN_COMMIT_SHA` is unset (local dev, storybook), behavior is unchanged — version-based paths are used as fallback
- Added `CDN_COMMIT_SHA` to `turbo.json` `globalEnv` so turbo correctly cache-busts when the SHA changes
- Fixed `atomic-react` rollup `cdnExternal` regex to recognize commit-based paths (was only matching `/v.*/`)

### Packages affected

| Package | Externalizes | File |
|---------|-------------|------|
| atomic | headless + bueno | `scripts/externalPackageMappings.mjs` |
| headless | bueno | `esbuild.mjs` |
| shopify | bueno (CDN mode only) | `esbuild.mjs` |
| atomic-hosted-page | headless + bueno | `scripts/esbuild.js` |
| atomic-react | headless + atomic (CDN mode only) | `rollup.config.js` |

### How it works

```
Before (version-based, broken in preview):
  atomic.esm.js → import "/headless/v3.51.2/headless.esm.js"
                                      ↑ doesn't exist in preview/

After (commit-based, self-contained):
  atomic.esm.js → import "/headless/commits/abc123/headless.esm.js"
                                      ↑ always exists (immutable)
```

### Companion PR

- https://github.com/coveo-platform/ui-kit-cd/pull/175 (sets `CDN_COMMIT_SHA` in `commit-upload.yml`)


[KIT-5716]: https://coveord.atlassian.net/browse/KIT-5716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ