### PR TITLE
Implement condition managers for numeric facet lifecycle

### DIFF
--- a/.changeset/honest-forks-trade.md
+++ b/.changeset/honest-forks-trade.md
@@ -1,0 +1,6 @@
+---
+"@coveo/atomic": patch
+---
+
+Ensure atomic-numeric-facet honour conditions properly
+  

--- a/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.spec.ts
+++ b/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.spec.ts
@@ -738,6 +738,53 @@ describe('atomic-numeric-facet', () => {
         }),
       });
     });
+
+    it('should create a condition manager for the range facet', async () => {
+      vi.mocked(buildFacetConditionsManager).mockClear();
+      const {element} = await setupElement();
+
+      expect(buildFacetConditionsManager).toHaveBeenCalledWith(
+        element.bindings.engine,
+        expect.objectContaining({
+          facetId: mockedNumericFacet.state.facetId,
+        })
+      );
+    });
+
+    it('should create condition managers for range facet and filter when withInput is set', async () => {
+      vi.mocked(buildFacetConditionsManager).mockClear();
+      const {element} = await setupElement({withInput: true});
+
+      expect(buildFacetConditionsManager).toHaveBeenCalledTimes(2);
+      expect(buildFacetConditionsManager).toHaveBeenCalledWith(
+        element.bindings.engine,
+        expect.objectContaining({facetId: mockedNumericFacet.state.facetId})
+      );
+      expect(buildFacetConditionsManager).toHaveBeenCalledWith(
+        element.bindings.engine,
+        expect.objectContaining({facetId: mockedNumericFilter.state.facetId})
+      );
+    });
+
+    it('should stop the condition manager when the element is disconnected', async () => {
+      const {element} = await setupElement();
+
+      element.remove();
+
+      expect(mockedFacetConditionsManager.stopWatching).toHaveBeenCalledTimes(
+        1
+      );
+    });
+
+    it('should stop all condition managers when the element is disconnected and withInput is set', async () => {
+      const {element} = await setupElement({withInput: true});
+
+      element.remove();
+
+      expect(mockedFacetConditionsManager.stopWatching).toHaveBeenCalledTimes(
+        2
+      );
+    });
   });
 
   describe('when validating props', () => {

--- a/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.ts
+++ b/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.ts
@@ -276,7 +276,7 @@ export class AtomicNumericFacet
       AtomicNumericFacet.propsSchema
     );
   }
-  private filterDependenciesManager?: FacetConditionsManager;
+  private conditionManagers: FacetConditionsManager[] = [];
   private headerFocus?: FocusTargetController;
   private removeNumberFormatListener?: () => void;
   private removeNumberInputApplyListener?: () => void;
@@ -304,7 +304,7 @@ export class AtomicNumericFacet
   disconnectedCallback() {
     super.disconnectedCallback();
     if (!this.isConnected) {
-      this.filterDependenciesManager?.stopWatching();
+      this.conditionManagers.forEach((manager) => manager.stopWatching());
       this.removeNumberFormatListener?.();
       this.removeNumberInputApplyListener?.();
       this.unsubscribeFacetForRange?.();
@@ -465,6 +465,9 @@ export class AtomicNumericFacet
     this.unsubscribeFacetForRange = this.facetForRange.subscribe(() => {
       this.facetState = this.facetForRange!.state;
     });
+    this.conditionManagers.push(
+      this.initializeDependenciesManager(this.facetState.facetId)
+    );
 
     return this.facetForRange;
   }
@@ -484,11 +487,12 @@ export class AtomicNumericFacet
       },
     });
 
-    this.filterDependenciesManager = this.initializeDependenciesManager(
-      this.filter.state.facetId
+    this.filterState = this.filter.state;
+
+    this.conditionManagers.push(
+      this.initializeDependenciesManager(this.filterState.facetId)
     );
 
-    this.filterState = this.filter.state;
     this.unsubscribeFilter = this.filter.subscribe(() => {
       this.filterState = this.filter!.state;
     });

--- a/packages/atomic/storybook-pages/search/search.new.stories.tsx
+++ b/packages/atomic/storybook-pages/search/search.new.stories.tsx
@@ -63,11 +63,17 @@ import '@/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.js';
 import '@/src/components/search/atomic-sort-expression/atomic-sort-expression.js';
 import '@/src/components/search/atomic-text/atomic-text.js';
 import '@/src/components/common/atomic-timeframe/atomic-timeframe.js';
-import '@/src/components/search/atomic-tab-manager/atomic-tab-manager.js';
-import '@/src/components/search/atomic-tab/atomic-tab.js';
 import '@/src/components/search/atomic-timeframe-facet/atomic-timeframe-facet.js';
 
-// const mockSearchApi = new MockSearchApi();
+async function initializeSearchInterface(canvasElement: HTMLElement) {
+  await customElements.whenDefined('atomic-search-interface');
+  const searchInterface = canvasElement.querySelector(
+    'atomic-search-interface'
+  );
+  await searchInterface!.initialize(getSampleSearchEngineConfiguration());
+}
+
+const mockSearchApi = new MockSearchApi();
 
 const meta: Meta = {
   component: 'rich-search-page',
@@ -76,12 +82,15 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     layout: 'fullscreen',
+    msw: {
+      handlers: [...mockSearchApi.handlers],
+    },
     chromatic: {disableSnapshot: false},
   },
   beforeEach: async () => {
-    // mockSearchApi.searchEndpoint.mock(
-    //   () => richResponse as unknown as typeof baseResponse
-    // );
+    mockSearchApi.searchEndpoint.mock(
+      () => richResponse as unknown as typeof baseResponse
+    );
   },
   render: () => html`
     <atomic-search-interface
@@ -98,24 +107,86 @@ const meta: Meta = {
         </atomic-layout-section>
         <atomic-layout-section section="facets">
           <atomic-facet-manager>
+            <atomic-automatic-facet-generator
+              desired-count="3"
+            ></atomic-automatic-facet-generator>
+            <atomic-category-facet
+              field="geographicalhierarchy"
+              label="World Atlas"
+              with-search
+            ></atomic-category-facet>
+            <atomic-facet field="author" label="Authors"></atomic-facet>
             <atomic-facet
-              field="year"
-              label="Year"
-              tabs-excluded='["article"]'
+              field="source"
+              label="Source"
+              display-values-as="link"
             ></atomic-facet>
+            <atomic-facet
+              field="filetype"
+              label="File Type"
+              display-values-as="box"
+            ></atomic-facet>
+            <atomic-facet field="language" label="Language"></atomic-facet>
+            <atomic-facet field="year" label="Year"></atomic-facet>
             <atomic-numeric-facet
               field="ytviewcount"
               label="YouTube Views"
               with-input="integer"
-              tabs-excluded='["article"]'
             ></atomic-numeric-facet>
+            <atomic-numeric-facet
+              field="ytlikecount"
+              label="YouTube Likes"
+              display-values-as="link"
+            >
+              <atomic-numeric-range
+                start="0"
+                end="1000"
+                label="Unpopular"
+              ></atomic-numeric-range>
+              <atomic-numeric-range
+                start="1000"
+                end="8000"
+                label="Well liked"
+              ></atomic-numeric-range>
+              <atomic-numeric-range
+                start="8000"
+                end="100000"
+                label="Popular"
+              ></atomic-numeric-range>
+              <atomic-numeric-range
+                start="100000"
+                end="999999999"
+                label="Treasured"
+              ></atomic-numeric-range>
+            </atomic-numeric-facet>
+            <atomic-timeframe-facet label="Timeframe" with-date-picker>
+              <atomic-timeframe unit="hour"></atomic-timeframe>
+              <atomic-timeframe unit="day"></atomic-timeframe>
+              <atomic-timeframe unit="week"></atomic-timeframe>
+              <atomic-timeframe unit="month"></atomic-timeframe>
+              <atomic-timeframe unit="quarter"></atomic-timeframe>
+              <atomic-timeframe unit="year"></atomic-timeframe>
+            </atomic-timeframe-facet>
+            <atomic-rating-facet
+              field="snrating"
+              label="Rating"
+              number-of-intervals="5"
+            ></atomic-rating-facet>
+            <atomic-rating-range-facet
+              facet-id="snrating_range"
+              field="snrating"
+              label="Rating Range"
+              number-of-intervals="5"
+            ></atomic-rating-range-facet>
+            <atomic-color-facet
+              field="filetype"
+              label="Files"
+              number-of-values="6"
+              sort-criteria="occurrences"
+            ></atomic-color-facet>
           </atomic-facet-manager>
         </atomic-layout-section>
         <atomic-layout-section section="main">
-          <atomic-tab-manager clear-filters-on-tab-change="false">
-            <atomic-tab name="all" label="All"></atomic-tab>
-            <atomic-tab name="article" label="Articles"></atomic-tab>
-          </atomic-tab-manager>
           <atomic-layout-section section="horizontal-facets">
             <atomic-segmented-facet-scrollable>
               <atomic-segmented-facet
@@ -305,13 +376,10 @@ const meta: Meta = {
     </atomic-search-interface>
   `,
   play: async (context) => {
-    await customElements.whenDefined('atomic-search-interface');
+    await initializeSearchInterface(context.canvasElement);
     const searchInterface = context.canvasElement.querySelector(
       'atomic-search-interface'
     );
-    console.log('Start search interface initialization');
-    await searchInterface!.initialize(getSampleSearchEngineConfiguration());
-    console.log('Search interface initialized, executing first search');
     await searchInterface!.executeFirstSearch();
   },
 };

--- a/packages/atomic/storybook-pages/search/search.new.stories.tsx
+++ b/packages/atomic/storybook-pages/search/search.new.stories.tsx
@@ -63,17 +63,11 @@ import '@/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.js';
 import '@/src/components/search/atomic-sort-expression/atomic-sort-expression.js';
 import '@/src/components/search/atomic-text/atomic-text.js';
 import '@/src/components/common/atomic-timeframe/atomic-timeframe.js';
+import '@/src/components/search/atomic-tab-manager/atomic-tab-manager.js';
+import '@/src/components/search/atomic-tab/atomic-tab.js';
 import '@/src/components/search/atomic-timeframe-facet/atomic-timeframe-facet.js';
 
-async function initializeSearchInterface(canvasElement: HTMLElement) {
-  await customElements.whenDefined('atomic-search-interface');
-  const searchInterface = canvasElement.querySelector(
-    'atomic-search-interface'
-  );
-  await searchInterface!.initialize(getSampleSearchEngineConfiguration());
-}
-
-const mockSearchApi = new MockSearchApi();
+// const mockSearchApi = new MockSearchApi();
 
 const meta: Meta = {
   component: 'rich-search-page',
@@ -82,15 +76,12 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     layout: 'fullscreen',
-    msw: {
-      handlers: [...mockSearchApi.handlers],
-    },
     chromatic: {disableSnapshot: false},
   },
   beforeEach: async () => {
-    mockSearchApi.searchEndpoint.mock(
-      () => richResponse as unknown as typeof baseResponse
-    );
+    // mockSearchApi.searchEndpoint.mock(
+    //   () => richResponse as unknown as typeof baseResponse
+    // );
   },
   render: () => html`
     <atomic-search-interface
@@ -107,86 +98,24 @@ const meta: Meta = {
         </atomic-layout-section>
         <atomic-layout-section section="facets">
           <atomic-facet-manager>
-            <atomic-automatic-facet-generator
-              desired-count="3"
-            ></atomic-automatic-facet-generator>
-            <atomic-category-facet
-              field="geographicalhierarchy"
-              label="World Atlas"
-              with-search
-            ></atomic-category-facet>
-            <atomic-facet field="author" label="Authors"></atomic-facet>
             <atomic-facet
-              field="source"
-              label="Source"
-              display-values-as="link"
+              field="year"
+              label="Year"
+              tabs-excluded='["article"]'
             ></atomic-facet>
-            <atomic-facet
-              field="filetype"
-              label="File Type"
-              display-values-as="box"
-            ></atomic-facet>
-            <atomic-facet field="language" label="Language"></atomic-facet>
-            <atomic-facet field="year" label="Year"></atomic-facet>
             <atomic-numeric-facet
               field="ytviewcount"
               label="YouTube Views"
               with-input="integer"
+              tabs-excluded='["article"]'
             ></atomic-numeric-facet>
-            <atomic-numeric-facet
-              field="ytlikecount"
-              label="YouTube Likes"
-              display-values-as="link"
-            >
-              <atomic-numeric-range
-                start="0"
-                end="1000"
-                label="Unpopular"
-              ></atomic-numeric-range>
-              <atomic-numeric-range
-                start="1000"
-                end="8000"
-                label="Well liked"
-              ></atomic-numeric-range>
-              <atomic-numeric-range
-                start="8000"
-                end="100000"
-                label="Popular"
-              ></atomic-numeric-range>
-              <atomic-numeric-range
-                start="100000"
-                end="999999999"
-                label="Treasured"
-              ></atomic-numeric-range>
-            </atomic-numeric-facet>
-            <atomic-timeframe-facet label="Timeframe" with-date-picker>
-              <atomic-timeframe unit="hour"></atomic-timeframe>
-              <atomic-timeframe unit="day"></atomic-timeframe>
-              <atomic-timeframe unit="week"></atomic-timeframe>
-              <atomic-timeframe unit="month"></atomic-timeframe>
-              <atomic-timeframe unit="quarter"></atomic-timeframe>
-              <atomic-timeframe unit="year"></atomic-timeframe>
-            </atomic-timeframe-facet>
-            <atomic-rating-facet
-              field="snrating"
-              label="Rating"
-              number-of-intervals="5"
-            ></atomic-rating-facet>
-            <atomic-rating-range-facet
-              facet-id="snrating_range"
-              field="snrating"
-              label="Rating Range"
-              number-of-intervals="5"
-            ></atomic-rating-range-facet>
-            <atomic-color-facet
-              field="filetype"
-              label="Files"
-              number-of-values="6"
-              sort-criteria="occurrences"
-            ></atomic-color-facet>
           </atomic-facet-manager>
         </atomic-layout-section>
         <atomic-layout-section section="main">
+          <atomic-tab-manager clear-filters-on-tab-change="false">
+            <atomic-tab name="all" label="All"></atomic-tab>
+            <atomic-tab name="article" label="Articles"></atomic-tab>
+          </atomic-tab-manager>
           <atomic-layout-section section="horizontal-facets">
             <atomic-segmented-facet-scrollable>
               <atomic-segmented-facet
@@ -376,10 +305,13 @@ const meta: Meta = {
     </atomic-search-interface>
   `,
   play: async (context) => {
-    await initializeSearchInterface(context.canvasElement);
+    await customElements.whenDefined('atomic-search-interface');
     const searchInterface = context.canvasElement.querySelector(
       'atomic-search-interface'
     );
+    console.log('Start search interface initialization');
+    await searchInterface!.initialize(getSampleSearchEngineConfiguration());
+    console.log('Search interface initialized, executing first search');
     await searchInterface!.executeFirstSearch();
   },
 };


### PR DESCRIPTION
## Problem

Facets rely on `FacetConditionsManager` to determine when they should be displayed or hidden. `AtomicNumericFacet` internally uses two facets — a range facet and a filter — each requiring their own `FacetConditionsManager` instance. However, the component was only holding a single `conditionManager` reference: when the facet was not using the feature w/ a manager, it would leave the facet w/o condition manager. This meant that facet could remain visible or hidden regardless of the conditions that should control it.

## Solution

Replaced the single `conditionManager` reference with a `conditionManagers` array. Both the range facet and the filter now push their respective `FacetConditionsManager` into the array when initialized, ensuring both are properly tracked. On `disconnectedCallback`, all managers in the array are stopped, preventing memory leaks.

**Test enhancements:**

* Added tests to verify that the correct number of condition managers are created for different configurations (with and without input) and that all managers are stopped when the element is disconnected.
* Coverage is assumed by the UT level (Test fails w/o change). Introducing higher level testing specific to the reported issue is not warranted.

Also tested w/ the repro (now reverted).