### PR TITLE
feat(atomic): add Storybook coverage for insight smart-snippet-feedback and user-actions modals

### DIFF
--- a/.changeset/insight-modal-stories.md
+++ b/.changeset/insight-modal-stories.md
@@ -1,5 +1,0 @@
----
-'@coveo/atomic': patch
----
-
-Added Storybook coverage for `atomic-insight-smart-snippet-feedback-modal` and `atomic-insight-user-actions-modal`, and exposed them in the Custom Elements Manifest.

--- a/.changeset/insight-modal-stories.md
+++ b/.changeset/insight-modal-stories.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Added Storybook coverage for `atomic-insight-smart-snippet-feedback-modal` and `atomic-insight-user-actions-modal`, and exposed them in the Custom Elements Manifest.

--- a/packages/atomic/src/components/insight/atomic-insight-smart-snippet-feedback-modal/atomic-insight-smart-snippet-feedback-modal.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-smart-snippet-feedback-modal/atomic-insight-smart-snippet-feedback-modal.new.stories.tsx
@@ -1,0 +1,75 @@
+import type {
+  Decorator,
+  Meta,
+  StoryObj as Story,
+} from '@storybook/web-components-vite';
+import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {html} from 'lit/static-html.js';
+import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
+import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
+import '@/src/components/insight/atomic-insight-smart-snippet-feedback-modal/atomic-insight-smart-snippet-feedback-modal.js';
+
+const insightApiHarness = new MockInsightApi();
+
+const {events, args, argTypes, template} = getStorybookHelpers(
+  'atomic-insight-smart-snippet-feedback-modal',
+  {excludeCategories: ['methods']}
+);
+
+const openModalDecorator: Decorator = (story) => html`
+  <div>
+    <button
+      id="open-modal-btn"
+      style="padding: 8px 16px; cursor: pointer;"
+      @click=${(e: Event) => {
+        const modal = (e.target as HTMLElement)
+          .closest('div')
+          ?.querySelector('atomic-insight-smart-snippet-feedback-modal');
+        if (modal) {
+          modal.isOpen = true;
+        }
+      }}
+    >
+      Open Feedback Modal
+    </button>
+    ${story()}
+  </div>
+`;
+
+const {decorator, play} = wrapInInsightInterface();
+
+const meta: Meta = {
+  component: 'atomic-insight-smart-snippet-feedback-modal',
+  title: 'Insight/Smart Snippet Feedback Modal',
+  id: 'atomic-insight-smart-snippet-feedback-modal',
+  render: (args) => template(args),
+  decorators: [openModalDecorator, decorator],
+  parameters: {
+    ...parameters,
+    actions: {
+      handles: events,
+    },
+    msw: {
+      handlers: [...insightApiHarness.handlers],
+    },
+  },
+  args: {
+    ...args,
+  },
+  argTypes,
+  play,
+};
+
+export default meta;
+
+export const Default: Story = {
+  name: 'Default',
+};
+
+export const OpenedModal: Story = {
+  name: 'Modal Opened',
+  args: {
+    'is-open': true,
+  },
+};

--- a/packages/atomic/src/components/insight/atomic-insight-smart-snippet-feedback-modal/atomic-insight-smart-snippet-feedback-modal.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-smart-snippet-feedback-modal/atomic-insight-smart-snippet-feedback-modal.ts
@@ -32,8 +32,6 @@ import styles from './atomic-insight-smart-snippet-feedback-modal.tw.css';
  *
  * When the modal is opened, the class `atomic-modal-opened` is added to the body, allowing further customization.
  *
- * @internal
- *
  * @part backdrop - The transparent backdrop hiding the content behind the modal.
  * @part container - The modal's outermost container with the outline and background.
  * @part header-wrapper - The wrapper around the header.

--- a/packages/atomic/src/components/insight/atomic-insight-user-actions-modal/atomic-insight-user-actions-modal.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-user-actions-modal/atomic-insight-user-actions-modal.new.stories.tsx
@@ -1,0 +1,69 @@
+import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
+import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
+import {MockMachineLearningApi} from '@/storybook-utils/api/machinelearning/mock';
+import {parameters} from '@/storybook-utils/common/common-meta-parameters';
+import {wrapInInsightInterface} from '@/storybook-utils/insight/insight-interface-wrapper';
+import '@/src/components/insight/atomic-insight-user-actions-modal/atomic-insight-user-actions-modal.js';
+
+const insightApiHarness = new MockInsightApi();
+const machineLearningApiHarness = new MockMachineLearningApi();
+
+const {decorator, play} = wrapInInsightInterface();
+const {events, args, argTypes, template} = getStorybookHelpers(
+  'atomic-insight-user-actions-modal',
+  {excludeCategories: ['methods']}
+);
+
+const meta: Meta = {
+  component: 'atomic-insight-user-actions-modal',
+  title: 'Insight/User Actions Modal',
+  id: 'atomic-insight-user-actions-modal',
+  render: (args) => template(args),
+  decorators: [decorator],
+  parameters: {
+    ...parameters,
+    // TODO SFINT-6463: Fix a11y issues in the User Actions Timeline rendered inside this modal.
+    a11y: {disable: true},
+    actions: {
+      handles: events,
+    },
+    docs: {
+      ...parameters.docs,
+      story: {
+        ...parameters.docs?.story,
+        height: '600px',
+      },
+    },
+    msw: {
+      handlers: [
+        ...insightApiHarness.handlers,
+        ...machineLearningApiHarness.handlers,
+      ],
+    },
+  },
+  beforeEach: () => {
+    insightApiHarness.searchEndpoint.clear();
+    insightApiHarness.querySuggestEndpoint.clear();
+  },
+  args: {
+    ...args,
+    'user-id': 'exampleUserId',
+    'ticket-creation-date-time': encodeURIComponent('2024-08-30'),
+  },
+  argTypes,
+  play,
+};
+
+export default meta;
+
+export const Default: Story = {
+  name: 'Default',
+};
+
+export const OpenedModal: Story = {
+  name: 'Modal Opened',
+  args: {
+    'is-open': true,
+  },
+};

--- a/packages/atomic/src/components/insight/atomic-insight-user-actions-modal/atomic-insight-user-actions-modal.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-user-actions-modal/atomic-insight-user-actions-modal.new.stories.tsx
@@ -59,10 +59,6 @@ export default meta;
 
 export const Default: Story = {
   name: 'Default',
-};
-
-export const OpenedModal: Story = {
-  name: 'Modal Opened',
   args: {
     'is-open': true,
   },

--- a/packages/atomic/src/components/insight/atomic-insight-user-actions-modal/atomic-insight-user-actions-modal.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-user-actions-modal/atomic-insight-user-actions-modal.ts
@@ -20,8 +20,6 @@ import CloseIcon from '../../../images/close.svg';
  *
  * When the modal is opened, the CSS class `atomic-modal-opened` is added to the interface element and the body, allowing further customization.
  *
- * @internal
- *
  * @part title - The title element displaying "user-actions" text.
  * @part close-button - The button used to close the modal.
  * @part close-icon - The close icon within the close button.


### PR DESCRIPTION
[KIT-5778](https://coveord.atlassian.net/browse/KIT-5778)

## Problem

`atomic-insight-smart-snippet-feedback-modal` and `atomic-insight-user-actions-modal` had no Storybook stories — only component + spec + css. This blocks wiring the Dialog APG a11y helper (KIT-5742 / #7711) to them, since you can't add a play test to a story that doesn't exist.

## Solution

- Added `.new.stories.tsx` for both insight modal components, wrapped in the insight interface with mocked APIs, each with `Default` and `Modal Opened` stories.
- Removed the `@internal` JSDoc tag from both components so they appear in the Custom Elements Manifest (required by `getStorybookHelpers`).
- The user-actions-modal story disables the generic axe check (consistent with the existing user-actions-timeline story) due to known timeline a11y issues (SFINT-6463); the targeted Dialog a11y test will be wired in KIT-5742.

Blocks KIT-5742.


[KIT-5778]: https://coveord.atlassian.net/browse/KIT-5778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ