### PR TITLE
feat(atomic): add HiddenStateController

### DIFF
--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.ts
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.ts
@@ -172,6 +172,7 @@ export class AtomicBreadbox
   render() {
     const breadcrumbs = this.allBreadcrumbs;
 
+    this.classList.toggle('atomic-hidden', !breadcrumbs.length);
     if (!breadcrumbs.length) {
       return nothing;
     }

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.ts
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.ts
@@ -172,7 +172,6 @@ export class AtomicBreadbox
   render() {
     const breadcrumbs = this.allBreadcrumbs;
 
-    this.classList.toggle('atomic-hidden', !breadcrumbs.length);
     if (!breadcrumbs.length) {
       return nothing;
     }

--- a/packages/atomic/src/utils/hidden-state-controller.spec.ts
+++ b/packages/atomic/src/utils/hidden-state-controller.spec.ts
@@ -1,0 +1,45 @@
+import {LitElement, html} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {fixture} from '@/vitest-utils/testing-helpers/fixture';
+import {HiddenStateController} from './hidden-state-controller';
+
+@customElement('test-hidden-state')
+class TestElement extends LitElement {
+  hiddenState = new HiddenStateController(this);
+
+  render() {
+    return html`<div>content</div>`;
+  }
+}
+
+describe('HiddenStateController', () => {
+  let element: TestElement;
+
+  beforeEach(async () => {
+    element = await fixture<TestElement>(
+      html`<test-hidden-state></test-hidden-state>`
+    );
+  });
+
+  it('should have the empty state by default', () => {
+    expect(element.matches(':state(empty)')).toBe(true);
+  });
+
+  it('should remove the empty state when isEmpty is set to false', () => {
+    element.hiddenState.isEmpty = false;
+    expect(element.matches(':state(empty)')).toBe(false);
+  });
+
+  it('should add the empty state when isEmpty is set to true', () => {
+    element.hiddenState.isEmpty = false;
+    element.hiddenState.isEmpty = true;
+    expect(element.matches(':state(empty)')).toBe(true);
+  });
+
+  it('should report isEmpty correctly', () => {
+    expect(element.hiddenState.isEmpty).toBe(true);
+    element.hiddenState.isEmpty = false;
+    expect(element.hiddenState.isEmpty).toBe(false);
+  });
+});

--- a/packages/atomic/src/utils/hidden-state-controller.ts
+++ b/packages/atomic/src/utils/hidden-state-controller.ts
@@ -1,0 +1,43 @@
+import type {LitElement, ReactiveController} from 'lit';
+
+const shadowSheet = new CSSStyleSheet();
+shadowSheet.replaceSync(':host(:state(empty)) { display: none }');
+
+const lightSheet = new CSSStyleSheet();
+lightSheet.replaceSync(':state(empty) { display: none }');
+
+export class HiddenStateController implements ReactiveController {
+  private internals: ElementInternals;
+
+  constructor(private host: LitElement) {
+    this.internals = host.attachInternals();
+    this.internals.states.add('empty');
+    host.addController(this);
+  }
+
+  hostConnected() {
+    const root = this.host.shadowRoot;
+    if (root) {
+      if (!root.adoptedStyleSheets.includes(shadowSheet)) {
+        root.adoptedStyleSheets.push(shadowSheet);
+      }
+    } else {
+      const parentRoot = this.host.getRootNode() as Document | ShadowRoot;
+      if (!parentRoot.adoptedStyleSheets.includes(lightSheet)) {
+        parentRoot.adoptedStyleSheets.push(lightSheet);
+      }
+    }
+  }
+
+  set isEmpty(value: boolean) {
+    if (value) {
+      this.internals.states.add('empty');
+    } else {
+      this.internals.states.delete('empty');
+    }
+  }
+
+  get isEmpty(): boolean {
+    return this.internals.states.has('empty');
+  }
+}


### PR DESCRIPTION
Adds a reusable Lit reactive controller that hides a component's host element via the [CustomStateSet API](https://developer.mozilla.org/en-US/docs/Web/API/CustomStateSet) when it has no meaningful content to render.

The controller is self-contained — it injects its own CSS and manages the `:state(empty)` custom state internally.

## Usage

```ts
import {HiddenStateController} from '@/src/utils/hidden-state-controller';

class MyComponent extends LitElement {
  #hiddenState = new HiddenStateController(this);

  render() {
    this.#hiddenState.isEmpty = !this.items.length;
    if (!this.items.length) return nothing;
    // ...
  }
}
```

The host element gets `display: none` when `isEmpty` is `true`, preventing empty components from contributing margin/gap in flex/grid layouts.

Defaults to hidden (`isEmpty = true`) to handle the initial render before bindings are ready.