### PR TITLE
fix(ci): increase CDN turbo cache retention to 7 days

### DIFF
--- a/.github/actions/build-cdn/action.yml
+++ b/.github/actions/build-cdn/action.yml
@@ -14,6 +14,7 @@ runs:
         cache-prefix: 'cdn'
         save-cache: 'true'
         load-cache: 'false'
+        cache-retention-days: '7'
       env:
         DEPLOYMENT_ENVIRONMENT: CDN
         CDN_COMMIT_SHA: ${{ inputs.commit-sha }}


### PR DESCRIPTION
## Problem

The `Linux-cdn-turbo` artifact has a default retention of 1 day. When the `cdn-stable` environment approval gate takes longer than 24 hours (bake period, weekends, holidays), the artifact expires and the stable pointer update job fails with `Artifact has expired`.

See: https://github.com/coveo-platform/ui-kit-cd/actions/runs/26880878801/job/79524637801

## Solution

Set `cache-retention-days: 7` in the `build-cdn` action to give enough buffer for the bake period + weekends.