### PR TITLE
chore: add public API key comments to prevent false-positive secret leak alerts

### DIFF
--- a/packages/atomic/dev/examples/csp.html
+++ b/packages/atomic/dev/examples/csp.html
@@ -18,6 +18,7 @@
 
       // Initialization
       await searchInterface.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
       });

--- a/packages/atomic/dev/examples/custom.html
+++ b/packages/atomic/dev/examples/custom.html
@@ -26,6 +26,7 @@
       await customElements.whenDefined('atomic-search-interface');
       const searchInterface = document.querySelector('atomic-search-interface');
       await searchInterface.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
       });

--- a/packages/atomic/dev/examples/external.html
+++ b/packages/atomic/dev/examples/external.html
@@ -46,6 +46,7 @@
 
       await Promise.all([
         searchInterface1.initialize({
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xxc23ce82a-3733-496e-b37e-9736168c4fd9',
           organizationId: 'electronicscoveodemocomo0n2fu8v',
           analytics: {
@@ -53,6 +54,7 @@
           },
         }),
         searchInterface2.initialize({
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
           analytics: {

--- a/packages/atomic/dev/examples/folding.html
+++ b/packages/atomic/dev/examples/folding.html
@@ -44,6 +44,7 @@
 
         // Initialization
         await searchInterface.initialize({
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
         });

--- a/packages/atomic/dev/examples/genqa.html
+++ b/packages/atomic/dev/examples/genqa.html
@@ -28,6 +28,7 @@
 
       // Initialization
       await searchInterface.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
         search: {

--- a/packages/atomic/dev/examples/headless.html
+++ b/packages/atomic/dev/examples/headless.html
@@ -53,6 +53,7 @@
           'atomic-search-interface'
         );
         await searchInterface.initialize({
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
         });

--- a/packages/atomic/dev/examples/horizontal-facets.html
+++ b/packages/atomic/dev/examples/horizontal-facets.html
@@ -27,6 +27,7 @@
       const searchInterface = document.querySelector('atomic-search-interface');
 
       await searchInterface.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
       });

--- a/packages/atomic/dev/examples/ipx.html
+++ b/packages/atomic/dev/examples/ipx.html
@@ -35,6 +35,7 @@
 
       const initializeSearchInterface = async (searchInterface) => {
         await searchInterface.initialize({
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
         });
@@ -44,6 +45,7 @@
           'atomic-recs-interface'
         );
         await recsInterface.initialize({
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
         });

--- a/packages/atomic/dev/examples/modal.html
+++ b/packages/atomic/dev/examples/modal.html
@@ -27,6 +27,7 @@
 
       const searchInterface = document.querySelector('atomic-search-interface');
       await searchInterface.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
       });

--- a/packages/atomic/dev/examples/slack.html
+++ b/packages/atomic/dev/examples/slack.html
@@ -44,6 +44,7 @@
 
         // Initialization
         await searchInterface.initialize({
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
         });

--- a/packages/atomic/dev/examples/standalone-results.html
+++ b/packages/atomic/dev/examples/standalone-results.html
@@ -35,6 +35,7 @@
 
         // Initialization
         await searchInterface.initialize({
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
         });

--- a/packages/atomic/dev/examples/standalone.html
+++ b/packages/atomic/dev/examples/standalone.html
@@ -27,6 +27,7 @@
       const searchInterface = document.querySelector('atomic-search-interface');
 
       await searchInterface.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
       });

--- a/packages/atomic/dev/examples/tabs.html
+++ b/packages/atomic/dev/examples/tabs.html
@@ -31,6 +31,7 @@
 
         // Initialization
         await searchInterface.initialize({
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
           search: {

--- a/packages/atomic/dev/index.html
+++ b/packages/atomic/dev/index.html
@@ -31,6 +31,7 @@
 
       // Initialization
       await searchInterface.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
       });

--- a/packages/atomic/dev/themingTests.html
+++ b/packages/atomic/dev/themingTests.html
@@ -30,6 +30,7 @@
 
       // Initialization
       await searchInterface.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
       });

--- a/packages/atomic/dev/visualTests.html
+++ b/packages/atomic/dev/visualTests.html
@@ -28,6 +28,7 @@
 
       // Initialization
       await searchInterface.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
       });

--- a/packages/atomic/src/components/search/atomic-external/atomic-external.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-external/atomic-external.new.stories.tsx
@@ -118,6 +118,7 @@ const meta: Meta = {
     searchInterfaces1.forEach((searchInterface1) => {
       initPromises.push(
         searchInterface1.initialize({
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xxc23ce82a-3733-496e-b37e-9736168c4fd9',
           organizationId: 'electronicscoveodemocomo0n2fu8v',
           analytics: {
@@ -130,6 +131,7 @@ const meta: Meta = {
     searchInterfaces2.forEach((searchInterface2) => {
       initPromises.push(
         searchInterface2.initialize({
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
           analytics: {

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
@@ -50,6 +50,7 @@ const layoutDecorator: Decorator = (story) => html`
 `;
 
 const baseConfig = {
+  // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
   accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
   organizationId: 'searchuisamples',
   search: {

--- a/packages/create-atomic-component-project/template/src/pages/index.ts
+++ b/packages/create-atomic-component-project/template/src/pages/index.ts
@@ -7,6 +7,7 @@ async function main() {
     document.querySelector('atomic-search-interface')!;
   await searchInterface.initialize({
     organizationId: 'searchuisamples',
+    // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
     accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
   });
 

--- a/packages/headless/src/app/commerce-engine/commerce-engine-configuration.ts
+++ b/packages/headless/src/app/commerce-engine/commerce-engine-configuration.ts
@@ -75,6 +75,7 @@ export const commerceEngineConfigurationSchema =
 
 export function getSampleCommerceEngineConfiguration(): CommerceEngineConfiguration {
   return {
+    // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
     accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
     analytics: {
       trackingId: 'sports-ui-samples',

--- a/packages/headless/src/app/engine-configuration.ts
+++ b/packages/headless/src/app/engine-configuration.ts
@@ -204,7 +204,7 @@ export const engineConfigurationDefinitions: SchemaDefinition<EngineConfiguratio
 export function getSampleEngineConfiguration(): EngineConfiguration {
   return {
     organizationId: 'searchuisamples',
-    // deepcode ignore HardcodedNonCryptoSecret: Public key freely available for our documentation
+    // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
     accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
   };
 }

--- a/packages/pkg-new-template/search.html
+++ b/packages/pkg-new-template/search.html
@@ -14,6 +14,7 @@
       const searchInterface = document.querySelector('atomic-search-interface');
 
       await searchInterface.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
       });

--- a/packages/quantic/force-app/custom-token/test/classes/CustomTokenProviderTest.cls
+++ b/packages/quantic/force-app/custom-token/test/classes/CustomTokenProviderTest.cls
@@ -33,6 +33,7 @@ private class CustomTokenProviderTest {
     return settings;
   }
 
+  // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
   static final String sampleHeadlessConfiguration = '{"accessToken":"xx564559b1-0045-48e1-953c-3addd1ee4457","organizationId":"searchuisamples"}';
   static final String invalidTokenSettingsExceptionMessage = 'TokenSettings invalid. Defaulting to sample organization settings.';
 

--- a/packages/quantic/force-app/main/default/classes/HeadlessControllerTest.cls
+++ b/packages/quantic/force-app/main/default/classes/HeadlessControllerTest.cls
@@ -1,5 +1,6 @@
 @isTest
 private class HeadlessControllerTest {
+  // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
   static final String sampleHeadlessConfiguration = '{"accessToken":"xx564559b1-0045-48e1-953c-3addd1ee4457","organizationId":"searchuisamples"}';
   @IsTest
   static void shouldReturnStringifiedConfiguration() {

--- a/packages/quantic/force-app/main/default/classes/InsightControllerTest.cls
+++ b/packages/quantic/force-app/main/default/classes/InsightControllerTest.cls
@@ -1,5 +1,6 @@
 @isTest
 private class InsightControllerTest {
+  // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
   static final String sampleHeadlessConfiguration = '{"accessToken":"xx564559b1-0045-48e1-953c-3addd1ee4457","organizationId":"searchuisamples"}';
   @IsTest
   static void shouldReturnStringifiedConfiguration() {

--- a/packages/quantic/force-app/main/default/classes/RecommendationsControllerTest.cls
+++ b/packages/quantic/force-app/main/default/classes/RecommendationsControllerTest.cls
@@ -1,6 +1,6 @@
 @isTest
 private class RecommendationsControllerTest {
-  // This is a demo token and it's okay to be public.
+  // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
   static final String sampleHeadlessConfiguration = '{"accessToken":"xx564559b1-0045-48e1-953c-3addd1ee4457","organizationId":"searchuisamples"}';
   @IsTest
   static void shouldReturnStringifiedConfiguration() {

--- a/packages/quantic/force-app/main/default/classes/SampleTokenProvider.cls
+++ b/packages/quantic/force-app/main/default/classes/SampleTokenProvider.cls
@@ -10,6 +10,7 @@ global with sharing class SampleTokenProvider implements ITokenProvider {
     headlessConfiguration.put('organizationId', 'searchuisamples');
     headlessConfiguration.put(
       'accessToken',
+      // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
       'xx564559b1-0045-48e1-953c-3addd1ee4457'
     );
     return JSON.serialize(headlessConfiguration);

--- a/packages/quantic/force-app/main/default/classes/SampleTokenProviderTest.cls
+++ b/packages/quantic/force-app/main/default/classes/SampleTokenProviderTest.cls
@@ -1,5 +1,6 @@
 @isTest
 private class SampleTokenProviderTest {
+  // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
   static final String sampleHeadlessConfiguration = '{"accessToken":"xx564559b1-0045-48e1-953c-3addd1ee4457","organizationId":"searchuisamples"}';
   @IsTest
   static void shouldReturnStringifiedConfiguration() {

--- a/samples/atomic/search-commerce-angular/src/app/atomic-angular-rga-page/atomic-angular-rga-page.component.ts
+++ b/samples/atomic/search-commerce-angular/src/app/atomic-angular-rga-page/atomic-angular-rga-page.component.ts
@@ -18,6 +18,7 @@ export class AtomicAngularRGAPageComponent implements AfterViewInit {
   async ngAfterViewInit(): Promise<void> {
     this.searchInterface
       ?.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
         search: {

--- a/samples/atomic/search-commerce-angular/src/app/atomic-angular-search-page/atomic-angular-search-page.component.ts
+++ b/samples/atomic/search-commerce-angular/src/app/atomic-angular-search-page/atomic-angular-search-page.component.ts
@@ -14,6 +14,7 @@ export class AtomicAngularSearchPageComponent implements AfterViewInit {
   async ngAfterViewInit(): Promise<void> {
     this.searchInterface
       ?.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         organizationId: 'searchuisamples',
         analytics: {

--- a/samples/atomic/search-commerce-angular/src/app/atomic-commerce-angular-page/atomic-commerce-angular-page.component.ts
+++ b/samples/atomic/search-commerce-angular/src/app/atomic-commerce-angular-page/atomic-commerce-angular-page.component.ts
@@ -14,6 +14,7 @@ export class AtomicCommerceAngularPageComponent implements AfterViewInit {
   async ngAfterViewInit(): Promise<void> {
     this.commerceInterface
       ?.initialize({
+        // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
         accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
         analytics: {
           trackingId: 'sports-ui-samples',

--- a/samples/atomic/search-commerce-react/src/components/AtomicPageWrapper.tsx
+++ b/samples/atomic/search-commerce-react/src/components/AtomicPageWrapper.tsx
@@ -59,6 +59,7 @@ type Props = {
 };
 
 function getElectronicsConfiguration(): SearchEngineConfiguration {
+  // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
   const accessToken = 'xxc23ce82a-3733-496e-b37e-9736168c4fd9';
   const organizationId = 'electronicscoveodemocomo0n2fu8v';
   const pipeline = 'UI_KIT_E2E';

--- a/samples/atomic/search-commerce-react/src/pages/RecsPage.tsx
+++ b/samples/atomic/search-commerce-react/src/pages/RecsPage.tsx
@@ -33,6 +33,7 @@ export const RecsPage: FunctionComponent = () => {
     () =>
       buildRecommendationEngine({
         configuration: {
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xxc23ce82a-3733-496e-b37e-9736168c4fd9',
           organizationId,
           pipeline: 'UI_KIT_E2E',

--- a/samples/atomic/search-nextjs/src/components/atomic-search-page.tsx
+++ b/samples/atomic/search-nextjs/src/components/atomic-search-page.tsx
@@ -42,6 +42,7 @@ const SearchPage: NextPage = () => {
     () =>
       buildSearchEngine({
         configuration: {
+          // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
           accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
           organizationId: 'searchuisamples',
         },

--- a/samples/atomic/search-vuejs/src/components/SearchPage.vue
+++ b/samples/atomic/search-vuejs/src/components/SearchPage.vue
@@ -13,6 +13,7 @@ async function initInterface() {
 
   // Initialization
   await searchInterface.initialize({
+    // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
     accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
     organizationId: 'searchuisamples',
   });

--- a/samples/headless/commerce-react/src/context/engine.ts
+++ b/samples/headless/commerce-react/src/context/engine.ts
@@ -13,6 +13,7 @@ export const getEngine = () => {
 
   _engine = buildCommerceEngine({
     configuration: {
+      // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
       accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
       organizationId,
       analytics: {


### PR DESCRIPTION
## Problem

Our public sample API keys (used in `getSample*Configuration` functions and inline in samples/dev files) keep getting flagged by GitHub secret scanning, Copilot, and other tools as leaked credentials. Someone recently deactivated one of them thinking it was a real leaked key.

## Solution

Added a plain human-readable comment above every hardcoded occurrence of the two sample API keys across 36 files:

```ts
// This API key is intentionally public — it belongs to a sample organization used for samples/docs.
```

Keys covered:
- `xx564559b1-0045-48e1-953c-3addd1ee4457` (search sample org)
- `xxc23ce82a-3733-496e-b37e-9736168c4fd9` (electronics sample org)

This covers:
- Canonical source definitions in `engine-configuration.ts` and `commerce-engine-configuration.ts`
- All Angular/React/Vue/Next.js samples
- All HTML dev files in `packages/atomic/dev/`
- Storybook stories and project templates
- Salesforce/Apex files in `packages/quantic/`