### PR TITLE
feat(quantic): made the quanticGeneratedAnswer content section scrollable

### DIFF
--- a/.changeset/grumpy-mirrors-melt.md
+++ b/.changeset/grumpy-mirrors-melt.md
@@ -1,0 +1,5 @@
+---
+"@coveo/quantic": patch
+---
+
+Made the quanticGeneratedAnswer content scrollable

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/__tests__/quanticGeneratedAnswer.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/__tests__/quanticGeneratedAnswer.test.js
@@ -786,21 +786,8 @@ describe('c-quantic-generated-answer', () => {
       });
 
       describe('when follow-ups are enabled', () => {
-        beforeEach(() => {
-          generatedAnswerState = {
-            ...initialGeneratedAnswerState,
-            isStreaming: false,
-            answer: exampleAnswer,
-            answerContentFormat: exampleAnswerContentFormat,
-            citations: exampleCitations,
-            followUpAnswers: {
-              isEnabled: true,
-            },
-          };
-          mockSuccessfulHeadlessInitialization();
-          prepareHeadlessState();
-        });
-        it('should render the content section with the scrollable class and ignore the collapsible feature', async () => {
+        // TODO SFINT-6786: Add test cases to cover the behavior of the component when follow-ups are enabled based on the actual implementation of the follow-up feature in the state.
+        it.skip('should render the content section with the scrollable class and ignore the collapsible feature', async () => {
           mockAnswerHeight = defaultAnswerHeight + 100;
           const element = createTestComponent({
             ...defaultOptions,

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/__tests__/quanticGeneratedAnswer.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/__tests__/quanticGeneratedAnswer.test.js
@@ -785,11 +785,26 @@ describe('c-quantic-generated-answer', () => {
         expect(generatedAnswerCitations.disableCitationAnchoring).toBe(false);
       });
 
-      describe('when the scrollable property is set to true', () => {
-        it('should render the content section with the scrollable class', async () => {
+      describe('when follow-ups are enabled', () => {
+        beforeEach(() => {
+          generatedAnswerState = {
+            ...initialGeneratedAnswerState,
+            isStreaming: false,
+            answer: exampleAnswer,
+            answerContentFormat: exampleAnswerContentFormat,
+            citations: exampleCitations,
+            followUpAnswers: {
+              isEnabled: true,
+            },
+          };
+          mockSuccessfulHeadlessInitialization();
+          prepareHeadlessState();
+        });
+        it('should render the content section with the scrollable class and ignore the collapsible feature', async () => {
+          mockAnswerHeight = defaultAnswerHeight + 100;
           const element = createTestComponent({
             ...defaultOptions,
-            scrollable: true,
+            collapsible: true,
           });
           await flushPromises();
 
@@ -803,16 +818,6 @@ describe('c-quantic-generated-answer', () => {
               'generated-answer__content--scrollable'
             )
           ).toBe(true);
-        });
-
-        it('should ignore collapsible when scrollable is enabled', async () => {
-          mockAnswerHeight = defaultAnswerHeight + 100;
-          const element = createTestComponent({
-            ...defaultOptions,
-            scrollable: true,
-            collapsible: true,
-          });
-          await flushPromises();
 
           const generatedAnswerCollapseToggle =
             element.shadowRoot.querySelector(
@@ -823,7 +828,7 @@ describe('c-quantic-generated-answer', () => {
         });
       });
 
-      describe('when the scrollable property is not set', () => {
+      describe('when follow-ups are not enabled', () => {
         it('should not render the content section with the scrollable class', async () => {
           const element = createTestComponent();
           await flushPromises();

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/__tests__/quanticGeneratedAnswer.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/__tests__/quanticGeneratedAnswer.test.js
@@ -784,6 +784,62 @@ describe('c-quantic-generated-answer', () => {
         expect(generatedAnswerCitations).not.toBeNull();
         expect(generatedAnswerCitations.disableCitationAnchoring).toBe(false);
       });
+
+      describe('when the scrollable property is set to true', () => {
+        it('should render the content section with the scrollable class', async () => {
+          const element = createTestComponent({
+            ...defaultOptions,
+            scrollable: true,
+          });
+          await flushPromises();
+
+          const generatedAnswerBody = element.shadowRoot.querySelector(
+            selectors.generatedAnswerBody
+          );
+
+          expect(generatedAnswerBody).not.toBeNull();
+          expect(
+            generatedAnswerBody.classList.contains(
+              'generated-answer__content--scrollable'
+            )
+          ).toBe(true);
+        });
+
+        it('should ignore collapsible when scrollable is enabled', async () => {
+          mockAnswerHeight = defaultAnswerHeight + 100;
+          const element = createTestComponent({
+            ...defaultOptions,
+            scrollable: true,
+            collapsible: true,
+          });
+          await flushPromises();
+
+          const generatedAnswerCollapseToggle =
+            element.shadowRoot.querySelector(
+              selectors.generatedAnswerCollapseToggle
+            );
+
+          expect(generatedAnswerCollapseToggle).toBeNull();
+        });
+      });
+
+      describe('when the scrollable property is not set', () => {
+        it('should not render the content section with the scrollable class', async () => {
+          const element = createTestComponent();
+          await flushPromises();
+
+          const generatedAnswerBody = element.shadowRoot.querySelector(
+            selectors.generatedAnswerBody
+          );
+
+          expect(generatedAnswerBody).not.toBeNull();
+          expect(
+            generatedAnswerBody.classList.contains(
+              'generated-answer__content--scrollable'
+            )
+          ).toBe(false);
+        });
+      });
     });
 
     describe('when the answer cannot be generated after a query is executed', () => {

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
@@ -130,14 +130,6 @@ export default class QuanticGeneratedAnswer extends LightningElement {
    * @default false
    */
   @api disableCitationAnchoring = false;
-  /**
-   * Whether the generated answer content section should be scrollable with a fixed height.
-   * When enabled, the collapsible behavior is ignored.
-   * @api
-   * @type {boolean}
-   * @default false
-   */
-  @api scrollable = false;
 
   labels = {
     generatedAnswerForYou,
@@ -179,6 +171,8 @@ export default class QuanticGeneratedAnswer extends LightningElement {
   ariaLiveMessage;
   /** @type {boolean} */
   hasInitializationError = false;
+  /** @type {boolean} */
+  _areFollowUpsEnabled = false;
   /** @type {boolean} */
   _exceedsMaximumHeight = false;
   /** @type {boolean} */
@@ -264,6 +258,7 @@ export default class QuanticGeneratedAnswer extends LightningElement {
 
   updateState() {
     this.state = this.generatedAnswer.state;
+    this._areFollowUpsEnabled = !!this.state?.followUpAnswers?.isEnabled;
     this.updateFeedbackState();
     this.ariaLiveMessage.dispatchMessage(this.getGeneratedAnswerStatus());
 
@@ -489,8 +484,13 @@ export default class QuanticGeneratedAnswer extends LightningElement {
     return this.state.isVisible;
   }
 
+  get areFollowUpsEnabled() {
+    // TODO SFINT-6786: Modify this getter to return the actual value from the state for follow-up enabled/agentId.
+    return this._areFollowUpsEnabled;
+  }
+
   get isCollapsibleEnabled() {
-    return this.collapsible && !this.scrollable;
+    return this.collapsible && !this.areFollowUpsEnabled;
   }
 
   get isAnswerCollapsed() {
@@ -516,7 +516,7 @@ export default class QuanticGeneratedAnswer extends LightningElement {
   get contentSectionClass() {
     const baseClass =
       'generated-answer__content slds-p-top_medium slds-p-horizontal_large';
-    return this.scrollable
+    return this.areFollowUpsEnabled
       ? `${baseClass} generated-answer__content--scrollable`
       : baseClass;
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
@@ -130,6 +130,14 @@ export default class QuanticGeneratedAnswer extends LightningElement {
    * @default false
    */
   @api disableCitationAnchoring = false;
+  /**
+   * Whether the generated answer content section should be scrollable with a fixed height.
+   * When enabled, the collapsible behavior is ignored.
+   * @api
+   * @type {boolean}
+   * @default false
+   */
+  @api scrollable = false;
 
   labels = {
     generatedAnswerForYou,
@@ -196,7 +204,7 @@ export default class QuanticGeneratedAnswer extends LightningElement {
 
   renderedCallback() {
     initializeWithHeadless(this, this.engineId, this.initialize);
-    if (this.collapsible) {
+    if (this.isCollapsibleEnabled) {
       this._exceedsMaximumHeight = this.isMaximumHeightExceeded();
     }
   }
@@ -259,7 +267,7 @@ export default class QuanticGeneratedAnswer extends LightningElement {
     this.updateFeedbackState();
     this.ariaLiveMessage.dispatchMessage(this.getGeneratedAnswerStatus());
 
-    if (this.collapsible) {
+    if (this.isCollapsibleEnabled) {
       this.updateGeneratedAnswerCSSVariables();
     }
   }
@@ -400,7 +408,7 @@ export default class QuanticGeneratedAnswer extends LightningElement {
 
   handleAnswerContentUpdated = (event) => {
     event.stopPropagation();
-    if (this.collapsible) {
+    if (this.isCollapsibleEnabled) {
       this._exceedsMaximumHeight = this.isMaximumHeightExceeded();
     }
     this.updateGeneratedAnswerCSSVariables();
@@ -481,6 +489,10 @@ export default class QuanticGeneratedAnswer extends LightningElement {
     return this.state.isVisible;
   }
 
+  get isCollapsibleEnabled() {
+    return this.collapsible && !this.scrollable;
+  }
+
   get isAnswerCollapsed() {
     // Answer is considered collapsed only if it exceeds the maximum height and was not expanded.
     return this._exceedsMaximumHeight && !this.isExpanded;
@@ -499,6 +511,14 @@ export default class QuanticGeneratedAnswer extends LightningElement {
         : 'generated-answer__answer--collapsed';
     }
     return `generated-answer__answer ${collapsedStateClass}`;
+  }
+
+  get contentSectionClass() {
+    const baseClass =
+      'generated-answer__content slds-p-top_medium slds-p-horizontal_large';
+    return this.scrollable
+      ? `${baseClass} generated-answer__content--scrollable`
+      : baseClass;
   }
 
   get hasRetryableError() {

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/quanticGeneratedAnswer.js
@@ -258,7 +258,6 @@ export default class QuanticGeneratedAnswer extends LightningElement {
 
   updateState() {
     this.state = this.generatedAnswer.state;
-    this._areFollowUpsEnabled = !!this.state?.followUpAnswers?.isEnabled;
     this.updateFeedbackState();
     this.ariaLiveMessage.dispatchMessage(this.getGeneratedAnswerStatus());
 

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.css
@@ -9,6 +9,11 @@
   word-wrap: break-word;
 }
 
+.generated-answer__content--scrollable {
+  overflow-y: auto;
+  height: var(--quantic-generated-answer-content-fixed-height, 50vh);
+}
+
 .generated-answer__footer {
   gap: 1rem;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/generatedAnswer.html
@@ -27,7 +27,7 @@
       <template lwc:if={isVisible}>
         <section
           data-testid="generated-answer__body"
-          class="generated-answer__content slds-p-top_medium slds-p-horizontal_large"
+          class={contentSectionClass}
         >
           <div
             data-testid="generated-answer__answer"


### PR DESCRIPTION
[SFINT-6787](https://coveord.atlassian.net/browse/SFINT-6787)

## IN THIS PR:

- Made the content section of the `quanticGeneratedAnswer` component scrollable when set.
- Added tests

### Notes on the solution:

- Simple and non-breaking
- When scrollable is enabled, the answer is no longer collapsible
- When we integrate the full loop for search agent in quantic we will need to modify the getter to rely on the `agentId` and `areFollowUpsEnabled`

## DEMO:

https://github.com/user-attachments/assets/0507db50-a48d-4ca9-a7a6-59d7067f2f94



[SFINT-6787]: https://coveord.atlassian.net/browse/SFINT-6787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ