### PR TITLE
fix(atomic): remove aria-expanded from expandable-text one-way reveal button

### DIFF
--- a/.changeset/remove-aria-expanded-expandable-text.md
+++ b/.changeset/remove-aria-expanded-expandable-text.md
@@ -2,4 +2,4 @@
 '@coveo/atomic': patch
 ---
 
-Removed `aria-expanded` from the expandable text "Show more" button since it is a one-way reveal, not a toggleable disclosure.
+Removed `aria-expanded` from the expandable text "Show more" button when it is a one-way reveal (non-collapsible). The attribute is preserved when `isCollapsible` is true, since that follows the disclosure pattern.

--- a/.changeset/remove-aria-expanded-expandable-text.md
+++ b/.changeset/remove-aria-expanded-expandable-text.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Removed `aria-expanded` from the expandable text "Show more" button since it is a one-way reveal, not a toggleable disclosure.

--- a/packages/atomic/src/components/common/expandable-text/expandable-text.ts
+++ b/packages/atomic/src/components/common/expandable-text/expandable-text.ts
@@ -81,7 +81,6 @@ export const renderExpandableText: FunctionalComponentWithChildren<
           style: 'text-primary',
           class: buttonClassString,
           title: buttonLabel,
-          ariaExpanded: isExpanded ? 'true' : 'false',
           onClick: onToggleExpand,
         },
       })(

--- a/packages/atomic/src/components/common/expandable-text/expandable-text.ts
+++ b/packages/atomic/src/components/common/expandable-text/expandable-text.ts
@@ -81,6 +81,9 @@ export const renderExpandableText: FunctionalComponentWithChildren<
           style: 'text-primary',
           class: buttonClassString,
           title: buttonLabel,
+          ...(isCollapsible && {
+            ariaExpanded: isExpanded ? 'true' : 'false',
+          }),
           onClick: onToggleExpand,
         },
       })(


### PR DESCRIPTION
[KIT-5781](https://coveord.atlassian.net/browse/KIT-5781)

## Problem
The `atomic-product-excerpt` and `atomic-product-description` components use `aria-expanded` on their "Show more" button. However, this button disappears after expanding, making it a one-way reveal — not a true disclosure. `aria-expanded` misrepresents the interaction to assistive technology users who expect to be able to collapse it back.

## Solution
Removed the `ariaExpanded` property from the button rendered in `expandable-text.ts`. The button now honestly represents the one-way "show more" action without claiming disclosure pattern semantics.

[KIT-5781]: https://coveord.atlassian.net/browse/KIT-5781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ