### PR TITLE
feat(atomic): add testSwitchA11y helper and wire to generated-answer stories

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.new.stories.tsx
@@ -5,6 +5,7 @@ import type {
 } from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit/static-html.js';
+import {testSwitchA11y} from '@/storybook-utils/a11y/switch.js';
 import {MockAnswerApi} from '@/storybook-utils/api/answer/mock';
 import {MockInsightApi} from '@/storybook-utils/api/insight/mock';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
@@ -94,5 +95,17 @@ export const DisableCitationAnchoring: Story = {
   name: 'Citation anchoring disabled',
   args: {
     'disable-citation-anchoring': true,
+  },
+};
+
+export const A11ySwitch: Story = {
+  name: 'A11y Switch (Toggle)',
+  tags: ['a11y', 'test'],
+  args: {
+    'with-toggle': true,
+  },
+  play: async (context) => {
+    await meta.play!(context as any);
+    await testSwitchA11y(context);
   },
 };

--- a/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.new.stories.tsx
@@ -100,7 +100,7 @@ export const DisableCitationAnchoring: Story = {
 
 export const A11ySwitch: Story = {
   name: 'A11y Switch (Toggle)',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   args: {
     'with-toggle': true,
   },

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
@@ -9,6 +9,7 @@ import {html} from 'lit/static-html.js';
 import {userEvent, waitFor} from 'storybook/test';
 import {testHoverContentA11y} from '@/storybook-utils/a11y/hover-content.js';
 import {testStatusMessageSequenceA11y} from '@/storybook-utils/a11y/status-message.js';
+import {testSwitchA11y} from '@/storybook-utils/a11y/switch.js';
 import {MockAgentApi} from '@/storybook-utils/api/agent/mock';
 import {MockAnswerApi} from '@/storybook-utils/api/answer/mock';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
@@ -221,5 +222,19 @@ export const A11yStatusMessage: Story = {
       ],
       timeout: 12000,
     });
+  },
+};
+
+export const A11ySwitch: Story = {
+  name: 'A11y Switch (Toggle)',
+  tags: ['a11y', 'test'],
+  args: {
+    'with-toggle': true,
+    'answer-configuration-id': 'fc581be0-6e61-4039-ab26-a3f2f52f308f',
+  },
+  play: async (context) => {
+    await play(context);
+    await submitGeneratedAnswerQuery(context);
+    await testSwitchA11y(context);
   },
 };

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
@@ -228,7 +228,7 @@ export const A11yStatusMessage: Story = {
 
 export const A11ySwitch: Story = {
   name: 'A11y Switch (Toggle)',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   args: {
     'with-toggle': true,
     'answer-configuration-id': 'fc581be0-6e61-4039-ab26-a3f2f52f308f',

--- a/packages/atomic/storybook-utils/a11y/index.ts
+++ b/packages/atomic/storybook-utils/a11y/index.ts
@@ -48,3 +48,8 @@ export {
   testCheckboxA11y,
   type CheckboxA11yOptions,
 } from './checkbox.js';
+export {
+  COVERED_CRITERIA as SWITCH_COVERED_CRITERIA,
+  testSwitchA11y,
+  type SwitchA11yOptions,
+} from './switch.js';

--- a/packages/atomic/storybook-utils/a11y/switch.ts
+++ b/packages/atomic/storybook-utils/a11y/switch.ts
@@ -1,0 +1,122 @@
+import type {StoryContext} from '@storybook/web-components-vite';
+import {within} from 'shadow-dom-testing-library';
+import {expect, userEvent, waitFor} from 'storybook/test';
+
+/**
+ * WCAG 2.2 AA criteria covered by switch interaction tests.
+ *
+ * - 2.1.1 Keyboard: all functionality operable via keyboard
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/switch/ — WAI-ARIA Switch Pattern
+ * @see https://www.w3.org/TR/WCAG22/#keyboard — WCAG 2.2 SC 2.1.1 Keyboard (Level A)
+ */
+export const COVERED_CRITERIA = ['2.1.1'] as const;
+
+export interface SwitchA11yOptions {
+  /** Matches aria-label of the switch. If omitted, uses first role="switch" found. */
+  name?: string | RegExp;
+}
+
+async function findSwitch(
+  root: ReturnType<typeof within>,
+  options?: SwitchA11yOptions
+): Promise<HTMLElement> {
+  const queryOptions: Record<string, unknown> = {};
+  if (options?.name !== undefined) {
+    queryOptions.name = options.name;
+  }
+
+  let elements: HTMLElement[];
+  try {
+    elements = await root.findAllByShadowRole('switch', queryOptions, {
+      timeout: 5000,
+    });
+  } catch {
+    elements = [];
+  }
+
+  if (elements.length === 0) {
+    const criteria = options?.name
+      ? `role="switch" with name matching "${String(options.name)}"`
+      : `role="switch"`;
+
+    throw new Error(
+      `[testSwitchA11y] No switch found matching {${criteria}}.\n\n` +
+        `Either this component does not implement the WAI-ARIA switch pattern, ` +
+        `or the name option needs to be adjusted.`
+    );
+  }
+
+  return elements[0];
+}
+
+/**
+ * Tests the WAI-ARIA Switch pattern.
+ *
+ * Verifies that:
+ * 1. A switch with aria-checked exists and has an accessible label
+ * 2. Space toggles aria-checked
+ * 3. Enter toggles aria-checked
+ */
+export async function testSwitchA11y(
+  context: StoryContext,
+  options?: SwitchA11yOptions
+): Promise<void> {
+  const {canvasElement, step} = context;
+  const root = within(canvasElement);
+
+  let status: 'passed' | 'failed' = 'passed';
+
+  try {
+    let switchEl!: HTMLElement;
+
+    await step('Find switch with role="switch" and aria-checked', async () => {
+      switchEl = await findSwitch(root, options);
+      expect(switchEl).toHaveAttribute('aria-checked');
+    });
+
+    await step('Switch has accessible label', async () => {
+      const hasLabel =
+        switchEl.hasAttribute('aria-label') ||
+        switchEl.hasAttribute('aria-labelledby') ||
+        switchEl.textContent?.trim();
+      expect(hasLabel).toBeTruthy();
+    });
+
+    await step('Space toggles aria-checked (2.1.1)', async () => {
+      const initial = switchEl.getAttribute('aria-checked');
+      const toggled = initial === 'true' ? 'false' : 'true';
+      switchEl.focus();
+      await userEvent.keyboard(' ');
+      await waitFor(
+        () => {
+          expect(switchEl.getAttribute('aria-checked')).toBe(toggled);
+        },
+        {timeout: 3000}
+      );
+    });
+
+    await step('Enter toggles aria-checked (2.1.1)', async () => {
+      const current = switchEl.getAttribute('aria-checked');
+      const toggled = current === 'true' ? 'false' : 'true';
+      switchEl.focus();
+      await userEvent.keyboard('{Enter}');
+      await waitFor(
+        () => {
+          expect(switchEl.getAttribute('aria-checked')).toBe(toggled);
+        },
+        {timeout: 3000}
+      );
+    });
+  } catch (error) {
+    status = 'failed';
+    throw error;
+  } finally {
+    context.reporting?.addReport?.({
+      type: 'a11y-interactive',
+      version: 1,
+      status,
+      result: {criteriaCovered: [...COVERED_CRITERIA]},
+    });
+  }
+}


### PR DESCRIPTION
[KIT-5777](https://coveord.atlassian.net/browse/KIT-5777)

## Problem
The WAI-ARIA Switch pattern is implemented in `common/switch.ts` but had no accessibility test helper validating it against the APG spec, and no wired stories exercising it.

## Solution
- Created `testSwitchA11y` helper in `storybook-utils/a11y/` that verifies `role="switch"`, `aria-checked`, accessible label, and Space/Enter keyboard toggling (WCAG 2.1.1)
- Exported from the a11y index barrel
- Wired the helper to `atomic-generated-answer` and `atomic-insight-generated-answer` stories with `with-toggle=true`

[KIT-5777]: https://coveord.atlassian.net/browse/KIT-5777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ