### PR TITLE
fix(atomic): remove incorrect toolbar/radiogroup ARIA from pager

### DIFF
--- a/.changeset/fix-pager-aria-roles.md
+++ b/.changeset/fix-pager-aria-roles.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Fixed incorrect ARIA roles on `atomic-pager`, `atomic-commerce-pager`, and `atomic-insight-pager`. Removed `role="toolbar"` and `role="radiogroup"` wrappers, replaced radio input page buttons with plain buttons using `aria-current="page"` on the active page. The `<nav aria-label="Pagination">` landmark and all `::part()` selectors are preserved.

--- a/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.spec.ts
@@ -284,9 +284,9 @@ describe('atomic-commerce-pager', () => {
   it('should render the proper value on the page buttons', async () => {
     await renderPager();
 
-    await expect.element(locators.page1).toHaveAttribute('value', '1');
-    await expect.element(locators.page2).toHaveAttribute('value', '2');
-    await expect.element(locators.page3).toHaveAttribute('value', '3');
+    await expect.element(locators.page1).toHaveTextContent('1');
+    await expect.element(locators.page2).toHaveTextContent('2');
+    await expect.element(locators.page3).toHaveTextContent('3');
   });
 
   it('should have the selected button as active', async () => {
@@ -340,9 +340,9 @@ describe('atomic-commerce-pager', () => {
   it('should use keyed directive for page buttons', async () => {
     await renderPager();
 
-    await expect.element(locators.page1).toHaveAttribute('value', '1');
-    await expect.element(locators.page2).toHaveAttribute('value', '2');
-    await expect.element(locators.page3).toHaveAttribute('value', '3');
+    await expect.element(locators.page1).toHaveTextContent('1');
+    await expect.element(locators.page2).toHaveTextContent('2');
+    await expect.element(locators.page3).toHaveTextContent('3');
   });
 
   describe('accessibility and focus', () => {
@@ -352,64 +352,25 @@ describe('atomic-commerce-pager', () => {
       element = await renderPager({state: {page: 2, totalPages: 10}});
     });
 
-    const retrieveButtons = () => {
+    const retrievePageButtons = () => {
       return Array.from(
-        element.shadowRoot?.querySelectorAll<HTMLInputElement>(
-          'input[type="radio"]'
+        element.shadowRoot?.querySelectorAll<HTMLButtonElement>(
+          'button[part~="page-button"]'
         ) || []
       );
     };
 
-    const expectFocusOnButton = async (
-      button: Element,
-      expectedFocusButton: Element
-    ) => {
-      await expect.element(button).toBe(expectedFocusButton);
-    };
-
-    it('should focus on previous button when navigating backward from first page button', async () => {
-      const buttons = retrieveButtons();
-
-      const [firstPageButton, lastPageButton] = [
-        buttons[0],
-        buttons[buttons.length - 1],
-      ];
-
-      await element.handleFocus(buttons, firstPageButton, lastPageButton);
-
-      await expectFocusOnButton(
-        locators.previous.element(),
-        document.activeElement?.shadowRoot?.activeElement
-      );
+    it('should render page buttons', async () => {
+      const buttons = retrievePageButtons();
+      expect(buttons.length).toBeGreaterThan(0);
     });
 
-    it('should focus on next button when navigating forward from last page button', async () => {
-      const buttons = retrieveButtons();
-
-      const [firstPageButton, lastPageButton] = [
-        buttons[0],
-        buttons[buttons.length - 1],
-      ];
-
-      await element.handleFocus(buttons, lastPageButton, firstPageButton);
-
-      await expectFocusOnButton(
-        locators.next.element(),
-        document.activeElement?.shadowRoot?.activeElement
+    it('should set aria-current=page on the active page button', async () => {
+      const buttons = retrievePageButtons();
+      const activeButton = buttons.find(
+        (btn) => btn.getAttribute('aria-current') === 'page'
       );
-    });
-
-    it('should focus on next page button when navigating between page buttons', async () => {
-      const buttons = retrieveButtons();
-
-      const [currentButton, nextButton] = buttons;
-
-      await element.handleFocus(buttons, currentButton, nextButton);
-
-      await expectFocusOnButton(
-        locators.page2.element(),
-        document.activeElement?.shadowRoot?.activeElement
-      );
+      expect(activeButton).toBeDefined();
     });
   });
 });

--- a/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.ts
@@ -32,7 +32,6 @@ import {
   FocusTargetController,
 } from '@/src/utils/accessibility-utils';
 import {buildCustomEvent} from '@/src/utils/event-utils';
-import {randomID} from '@/src/utils/utils';
 import ArrowLeftIcon from '../../../images/arrow-left-rounded.svg';
 import ArrowRightIcon from '../../../images/arrow-right-rounded.svg';
 import type {CommerceBindings} from '../atomic-commerce-interface/atomic-commerce-interface';
@@ -100,8 +99,6 @@ export class AtomicCommercePager
   nextButtonIcon: string = ArrowRightIcon;
 
   protected ariaMessage = new AriaLiveRegionController(this, 'atomic-pager');
-
-  private radioGroupName = randomID('atomic-commerce-pager-');
 
   private previousButton!: FocusTargetController;
   private nextButton!: FocusTargetController;
@@ -180,11 +177,9 @@ export class AtomicCommercePager
                         await this.focusOnFirstResultAndScrollToTop();
                       },
                       page: pageNumber,
-                      groupName: this.radioGroupName,
                       text: (pageNumber + 1).toLocaleString(
                         this.bindings.i18n.language
                       ),
-                      onFocusCallback: this.handleFocus,
                     },
                   })
                 )
@@ -217,23 +212,6 @@ export class AtomicCommercePager
       this.nextButton = new FocusTargetController(this, this.bindings);
     }
   }
-
-  private handleFocus = async (
-    elements: HTMLInputElement[],
-    currentFocus: HTMLInputElement,
-    newFocus: HTMLInputElement
-  ) => {
-    const currentIndex = elements.indexOf(currentFocus);
-    const newIndex = elements.indexOf(newFocus);
-
-    if (currentIndex === elements.length - 1 && newIndex === 0) {
-      await this.nextButton.focus();
-    } else if (currentIndex === 0 && newIndex === elements.length - 1) {
-      await this.previousButton.focus();
-    } else {
-      newFocus.focus();
-    }
-  };
 
   private async focusOnFirstResultAndScrollToTop() {
     await this.bindings.store.state.resultList?.focusOnFirstResultAfterNextSearch();

--- a/packages/atomic/src/components/commerce/atomic-commerce-pager/e2e/page-object.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-pager/e2e/page-object.ts
@@ -15,7 +15,7 @@ export class AtomicCommercePagerLocators extends BasePageObject {
   }
 
   numericButton(pageNumber: number) {
-    return this.page.locator(`[value="${pageNumber}"]`);
+    return this.page.getByLabel(`Page ${pageNumber}`);
   }
 
   get previousButton() {

--- a/packages/atomic/src/components/common/pager/pager-buttons.spec.ts
+++ b/packages/atomic/src/components/common/pager/pager-buttons.spec.ts
@@ -53,19 +53,12 @@ describe('#pagerButtons', () => {
 
   const renderPageButton = async (
     overrides: Partial<{
-      groupName: string;
       page: number;
       isSelected: boolean;
       text: string;
-      onFocusCallback?: (
-        elements: HTMLInputElement[],
-        previousFocus: HTMLInputElement,
-        newFocus: HTMLInputElement
-      ) => Promise<void>;
     }> = {}
   ) => {
     const props = {
-      groupName: 'pager',
       page: 1,
       isSelected: false,
       text: '1',
@@ -76,7 +69,7 @@ describe('#pagerButtons', () => {
     `);
     return {
       element,
-      input: element.querySelector('input'),
+      button: element.querySelector('button'),
     };
   };
 
@@ -87,7 +80,7 @@ describe('#pagerButtons', () => {
     return {
       element,
       div: element.querySelector('div'),
-      inputs: element.querySelectorAll('input'),
+      buttons: element.querySelectorAll('button'),
     };
   };
 
@@ -124,75 +117,53 @@ describe('#pagerButtons', () => {
   });
 
   describe('#pagerPageButton', () => {
-    it('should render the button with the correct attributes', async () => {
-      const {input} = await renderPageButton();
+    it('should render a button with the correct aria-label', async () => {
+      const {button} = await renderPageButton();
 
-      expect(input).toHaveAttribute('aria-label', '1');
-      expect(input).toHaveAttribute('type', 'radio');
-      expect(input).toHaveAttribute('name', 'pager');
-      expect(input).toHaveAttribute('value', '1');
+      expect(button).toHaveAttribute('aria-label', '1');
     });
 
-    it('should render with the correct attributes when not selected', async () => {
-      const {input} = await renderPageButton({isSelected: false});
+    it('should render with aria-current="false" when not selected', async () => {
+      const {button} = await renderPageButton({isSelected: false});
 
-      expect(input).toHaveAttribute('aria-current', 'false');
-      expect(input).toHaveAttribute('part', 'page-button');
+      expect(button).toHaveAttribute('aria-current', 'false');
+      expect(button).toHaveAttribute('part', 'page-button');
     });
 
-    it('should render with the correct attributes when selected', async () => {
-      const {input} = await renderPageButton({isSelected: true});
+    it('should render with aria-current="page" when selected', async () => {
+      const {button} = await renderPageButton({isSelected: true});
 
-      expect(input).toHaveAttribute('aria-current', 'page');
-      expect(input).toHaveAttribute('part', 'page-button active-page-button');
+      expect(button).toHaveAttribute('aria-current', 'page');
+      expect(button).toHaveAttribute('part', 'page-button active-page-button');
     });
   });
 
   describe('#pagerPageButtons', () => {
-    it('should render the list of buttons with the correct attributes', async () => {
+    it('should render the container with the correct attributes', async () => {
       const {div} = await renderPageButtonsGroup(html`
         ${renderPagerPageButton({
-          props: {groupName: 'pager', page: 1, isSelected: true, text: '1'},
+          props: {page: 1, isSelected: true, text: '1'},
         })}
         ${renderPagerPageButton({
-          props: {
-            groupName: 'pager',
-            page: 2,
-            isSelected: false,
-            text: '2',
-          },
+          props: {page: 2, isSelected: false, text: '2'},
         })}
       `);
 
-      expect(div).toHaveAttribute('role', 'radiogroup');
-      expect(div).toHaveAttribute('aria-label', 'Pagination');
       expect(div).toHaveAttribute('part', 'page-buttons');
+      expect(div).not.toHaveAttribute('role');
     });
 
     it('should render the list of children', async () => {
-      const {inputs} = await renderPageButtonsGroup(html`
+      const {buttons} = await renderPageButtonsGroup(html`
         ${renderPagerPageButton({
-          props: {groupName: 'pager', page: 1, isSelected: true, text: '1'},
+          props: {page: 1, isSelected: true, text: '1'},
         })}
         ${renderPagerPageButton({
-          props: {
-            groupName: 'pager',
-            page: 2,
-            isSelected: false,
-            text: '2',
-          },
+          props: {page: 2, isSelected: false, text: '2'},
         })}
       `);
 
-      expect(inputs).toHaveLength(2);
-    });
-  });
-
-  describe('accessibility', () => {
-    it('should render with aria-roledescription set to link', async () => {
-      const {input} = await renderPageButton();
-
-      expect(input).toHaveAttribute('aria-roledescription', 'link');
+      expect(buttons).toHaveLength(2);
     });
   });
 });

--- a/packages/atomic/src/components/common/pager/pager-buttons.ts
+++ b/packages/atomic/src/components/common/pager/pager-buttons.ts
@@ -6,7 +6,6 @@ import type {
   FunctionalComponentWithChildren,
 } from '@/src/utils/functional-component-utils';
 import {type ButtonProps, renderButton} from '../button';
-import {type RadioButtonProps, renderRadioButton} from '../radio-button';
 
 interface PagerNavigationButtonProps extends Omit<
   ButtonProps,
@@ -56,37 +55,27 @@ export const renderPagerNextButton: FunctionalComponent<
   );
 };
 
-interface PagerPageButtonProps extends Omit<
-  RadioButtonProps,
-  'part' | 'style' | 'checked' | 'ariaCurrent' | 'key' | 'class'
-> {
+interface PagerPageButtonProps {
   page: number;
   isSelected: boolean;
   text: string;
-  onFocusCallback?: (
-    elements: HTMLInputElement[],
-    previousFocus: HTMLInputElement,
-    newFocus: HTMLInputElement
-  ) => Promise<void>;
+  ariaLabel?: string;
+  onChecked?(): void;
 }
 
 export const renderPagerPageButton: FunctionalComponent<
   PagerPageButtonProps
 > = ({props}) => {
-  return renderRadioButton({
+  return renderButton({
     props: {
-      ...props,
-      selectWhenFocused: false,
-      key: props.page,
       style: 'outline-neutral',
-      checked: props.isSelected,
+      ariaLabel: props.ariaLabel ?? props.text,
       ariaCurrent: props.isSelected ? 'page' : 'false',
-      class: 'btn-page focus-visible:bg-neutral-light min-h-10 min-w-10 p-1',
+      class: `btn-page focus-visible:bg-neutral-light min-h-10 min-w-10 p-1${props.isSelected ? ' selected' : ''}`,
       part: `page-button${props.isSelected ? ' active-page-button' : ''}`,
-      onFocusCallback: props.onFocusCallback,
-      ariaRoleDescription: 'link',
+      onClick: props.onChecked,
     },
-  });
+  })(html`${props.text}`);
 };
 
 interface PagerPageButtonsProps {
@@ -95,15 +84,6 @@ interface PagerPageButtonsProps {
 
 export const renderPageButtons: FunctionalComponentWithChildren<
   PagerPageButtonsProps
-> =
-  ({props}) =>
-  (children) => {
-    return html` <div
-      part="page-buttons"
-      role="radiogroup"
-      aria-label=${props.i18n.t('pagination')}
-      class="contents"
-    >
-      ${children}
-    </div>`;
-  };
+> = () => (children) => {
+  return html`<div part="page-buttons" class="contents">${children}</div>`;
+};

--- a/packages/atomic/src/components/common/pager/pager-navigation.spec.ts
+++ b/packages/atomic/src/components/common/pager/pager-navigation.spec.ts
@@ -49,13 +49,6 @@ describe('#renderPagerNavigation', () => {
     );
   });
 
-  it('should set the "toolbar" role on the <div>', () => {
-    expect(element.querySelector('nav')?.querySelector('div')).toHaveAttribute(
-      'role',
-      'toolbar'
-    );
-  });
-
   it('should contain the children', () => {
     expect(
       element.querySelector('nav')?.querySelector('div')

--- a/packages/atomic/src/components/common/pager/pager-navigation.ts
+++ b/packages/atomic/src/components/common/pager/pager-navigation.ts
@@ -12,8 +12,6 @@ export const renderPagerNavigation: FunctionalComponentWithChildren<
   ({props}) =>
   (children) => {
     return html`<nav aria-label=${props.i18n.t('pagination')}>
-      <div part="buttons" role="toolbar" class="flex flex-wrap gap-2">
-        ${children}
-      </div>
+      <div part="buttons" class="flex flex-wrap gap-2">${children}</div>
     </nav>`;
   };

--- a/packages/atomic/src/components/insight/atomic-insight-interface/e2e/page-object.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/e2e/page-object.ts
@@ -37,7 +37,7 @@ export class InsightInterfacePageObject extends BasePageObject {
   }
 
   get insightPagerButtons() {
-    return this.insightPager.getByRole('radio');
+    return this.insightPager.getByRole('button');
   }
 
   get insightResults() {

--- a/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.spec.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.spec.ts
@@ -273,9 +273,9 @@ describe('atomic-insight-pager', () => {
   it('should render the proper value on the page buttons', async () => {
     await renderPager();
 
-    await expect.element(locators.page1).toHaveAttribute('value', '1');
-    await expect.element(locators.page2).toHaveAttribute('value', '2');
-    await expect.element(locators.page3).toHaveAttribute('value', '3');
+    await expect.element(locators.page1).toHaveTextContent('1');
+    await expect.element(locators.page2).toHaveTextContent('2');
+    await expect.element(locators.page3).toHaveTextContent('3');
   });
 
   it('should have the selected button as active', async () => {
@@ -294,7 +294,7 @@ describe('atomic-insight-pager', () => {
       element.shadowRoot?.querySelector('[part*="buttons"]')
     ).toBeDefined();
     expect(
-      element.shadowRoot?.querySelector('[part*="page-button"]')
+      element.shadowRoot?.querySelector('button[part~="page-button"]')
     ).toBeDefined();
     expect(
       element.shadowRoot?.querySelector('[part*="previous-button"]')
@@ -399,9 +399,9 @@ describe('atomic-insight-pager', () => {
       pagerState: {currentPages: [3, 4, 5, 6, 7]},
     });
 
-    await expect.element(locators.page3).toHaveAttribute('value', '3');
-    await expect.element(locators.page4).toHaveAttribute('value', '4');
-    await expect.element(locators.page5).toHaveAttribute('value', '5');
+    await expect.element(locators.page3).toHaveTextContent('3');
+    await expect.element(locators.page4).toHaveTextContent('4');
+    await expect.element(locators.page5).toHaveTextContent('5');
   });
 
   describe('accessibility', () => {
@@ -411,16 +411,16 @@ describe('atomic-insight-pager', () => {
       element = await renderPager({pagerState: {currentPage: 2, maxPage: 10}});
     });
 
-    const retrieveButtons = () => {
+    const retrievePageButtons = () => {
       return Array.from(
-        element.shadowRoot?.querySelectorAll<HTMLInputElement>(
-          'input[type="radio"]'
+        element.shadowRoot?.querySelectorAll<HTMLButtonElement>(
+          'button[part~="page-button"]'
         ) || []
       );
     };
 
-    it('should render radio buttons for page navigation', async () => {
-      const buttons = retrieveButtons();
+    it('should render page buttons', async () => {
+      const buttons = retrievePageButtons();
       expect(buttons.length).toBeGreaterThan(0);
     });
 
@@ -434,73 +434,12 @@ describe('atomic-insight-pager', () => {
         .toHaveAttribute('aria-label', 'Page 1');
     });
 
-    it('should have proper radio button grouping', async () => {
-      const buttons = retrieveButtons();
-      const firstButton = buttons[0];
-      const groupName = firstButton?.getAttribute('name');
-
-      expect(groupName).toBeDefined();
-      buttons.forEach((button) => {
-        expect(button.getAttribute('name')).toBe(groupName);
-      });
-    });
-
-    it('should support keyboard navigation between page buttons', async () => {
-      const buttons = retrieveButtons();
-      expect(buttons.length).toBeGreaterThan(1);
-
-      const groupNames = buttons.map((btn) => btn.getAttribute('name'));
-      const uniqueNames = new Set(groupNames);
-      expect(uniqueNames.size).toBe(1);
-
-      buttons.forEach((button) => {
-        expect(button.type).toBe('radio');
-        expect(button.getAttribute('aria-label')).toBeDefined();
-      });
-    });
-
-    it('should handle arrow key navigation focus management', async () => {
-      const buttons = retrieveButtons();
-      const previousBtn = element.shadowRoot?.querySelector(
-        '[part*="previous-button"]'
-      ) as HTMLElement;
-      const nextBtn = element.shadowRoot?.querySelector(
-        '[part*="next-button"]'
-      ) as HTMLElement;
-
-      expect(buttons.length).toBeGreaterThan(0);
-      expect(previousBtn).toBeDefined();
-      expect(nextBtn).toBeDefined();
-
-      expect(previousBtn?.getAttribute('aria-label')).toBe('Previous');
-      expect(nextBtn?.getAttribute('aria-label')).toBe('Next');
-
-      expect(previousBtn?.tabIndex).toBeDefined();
-      expect(nextBtn?.tabIndex).toBeDefined();
-    });
-
-    it('should manage focus correctly for screen reader navigation', async () => {
-      const buttons = retrieveButtons();
-
-      buttons.forEach((button) => {
-        expect(button.type).toBe('radio');
-        expect(button.getAttribute('aria-label')).toBeDefined();
-        expect(button.getAttribute('name')).toBeDefined();
-      });
-
-      await expect
-        .element(locators.previous)
-        .toHaveAttribute('aria-label', 'Previous');
-      await expect.element(locators.next).toHaveAttribute('aria-label', 'Next');
-
-      const prevElement = element.shadowRoot?.querySelector(
-        '[part*="previous-button"]'
+    it('should set aria-current=page on the active page button', async () => {
+      const buttons = retrievePageButtons();
+      const activeButton = buttons.find(
+        (btn) => btn.getAttribute('aria-current') === 'page'
       );
-      const nextElement = element.shadowRoot?.querySelector(
-        '[part*="next-button"]'
-      );
-      expect(prevElement).toBeDefined();
-      expect(nextElement).toBeDefined();
+      expect(activeButton).toBeDefined();
     });
   });
 });

--- a/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-pager/atomic-insight-pager.ts
@@ -32,7 +32,6 @@ import {
   FocusTargetController,
 } from '@/src/utils/accessibility-utils';
 import {buildCustomEvent} from '@/src/utils/event-utils';
-import {randomID} from '@/src/utils/utils';
 import ArrowLeftIcon from '../../../images/arrow-left-rounded.svg';
 import ArrowRightIcon from '../../../images/arrow-right-rounded.svg';
 
@@ -97,8 +96,6 @@ export class AtomicInsightPager
     this,
     'atomic-insight-pager'
   );
-
-  private radioGroupName = randomID('atomic-insight-pager-');
 
   private previousButton!: FocusTargetController;
   private nextButton!: FocusTargetController;
@@ -173,11 +170,9 @@ export class AtomicInsightPager
                       await this.focusOnFirstResultAndScrollToTop();
                     },
                     page: pageNumber,
-                    groupName: this.radioGroupName,
                     text: (pageNumber + 1).toLocaleString(
                       this.bindings.i18n.language
                     ),
-                    onFocusCallback: this.handleFocus,
                   },
                 })
               )
@@ -208,23 +203,6 @@ export class AtomicInsightPager
       this.nextButton = new FocusTargetController(this, this.bindings);
     }
   }
-
-  private handleFocus = async (
-    elements: HTMLInputElement[],
-    currentFocus: HTMLInputElement,
-    newFocus: HTMLInputElement
-  ) => {
-    const currentIndex = elements.indexOf(currentFocus);
-    const newIndex = elements.indexOf(newFocus);
-
-    if (currentIndex === elements.length - 1 && newIndex === 0) {
-      await this.nextButton.focus();
-    } else if (currentIndex === 0 && newIndex === elements.length - 1) {
-      await this.previousButton.focus();
-    } else {
-      newFocus.focus();
-    }
-  };
 
   private async focusOnFirstResultAndScrollToTop() {
     await this.bindings.store.state.resultList?.focusOnFirstResultAfterNextSearch();

--- a/packages/atomic/src/components/insight/atomic-insight-pager/e2e/page-object.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-pager/e2e/page-object.ts
@@ -18,17 +18,19 @@ export class InsightPagerPageObject extends BasePageObject {
 
   pageButton(pageNumber: number): Locator {
     return this.page.locator(
-      `atomic-insight-pager input[type="radio"][aria-label="Page ${pageNumber}"]`
+      `atomic-insight-pager button[aria-label="Page ${pageNumber}"]`
     );
   }
 
   get currentPageButton(): Locator {
     return this.page.locator(
-      'atomic-insight-pager input[type="radio"][checked]'
+      'atomic-insight-pager button[aria-current="page"]'
     );
   }
 
   get pageButtons(): Locator {
-    return this.page.locator('atomic-insight-pager input[type="radio"]');
+    return this.page.locator(
+      'atomic-insight-pager button[part~="page-button"]'
+    );
   }
 }

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.spec.ts
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.spec.ts
@@ -485,9 +485,9 @@ describe('atomic-pager', () => {
   it('should render the proper value on the page buttons', async () => {
     await renderPager();
 
-    await expect.element(locators.page1).toHaveAttribute('value', '1');
-    await expect.element(locators.page2).toHaveAttribute('value', '2');
-    await expect.element(locators.page3).toHaveAttribute('value', '3');
+    await expect.element(locators.page1).toHaveTextContent('1');
+    await expect.element(locators.page2).toHaveTextContent('2');
+    await expect.element(locators.page3).toHaveTextContent('3');
   });
 
   it('should have the selected button as active', async () => {
@@ -530,7 +530,7 @@ describe('atomic-pager', () => {
       element.shadowRoot?.querySelector('[part*="buttons"]')
     ).toBeDefined();
     expect(
-      element.shadowRoot?.querySelector('[part*="page-button"]')
+      element.shadowRoot?.querySelector('button[part~="page-button"]')
     ).toBeDefined();
     expect(
       element.shadowRoot?.querySelector('[part*="previous-button"]')
@@ -636,9 +636,9 @@ describe('atomic-pager', () => {
       pagerState: {currentPages: [3, 4, 5, 6, 7]},
     });
 
-    await expect.element(locators.page3).toHaveAttribute('value', '3');
-    await expect.element(locators.page4).toHaveAttribute('value', '4');
-    await expect.element(locators.page5).toHaveAttribute('value', '5');
+    await expect.element(locators.page3).toHaveTextContent('3');
+    await expect.element(locators.page4).toHaveTextContent('4');
+    await expect.element(locators.page5).toHaveTextContent('5');
   });
 
   describe('accessibility', () => {
@@ -648,16 +648,16 @@ describe('atomic-pager', () => {
       element = await renderPager({pagerState: {currentPage: 2, maxPage: 10}});
     });
 
-    const retrieveButtons = () => {
+    const retrievePageButtons = () => {
       return Array.from(
-        element.shadowRoot?.querySelectorAll<HTMLInputElement>(
-          'input[type="radio"]'
+        element.shadowRoot?.querySelectorAll<HTMLButtonElement>(
+          'button[part~="page-button"]'
         ) || []
       );
     };
 
-    it('should render radio buttons for page navigation', async () => {
-      const buttons = retrieveButtons();
+    it('should render page buttons', async () => {
+      const buttons = retrievePageButtons();
       expect(buttons.length).toBeGreaterThan(0);
     });
 
@@ -671,73 +671,12 @@ describe('atomic-pager', () => {
         .toHaveAttribute('aria-label', 'Page 1');
     });
 
-    it('should have proper radio button grouping', async () => {
-      const buttons = retrieveButtons();
-      const firstButton = buttons[0];
-      const groupName = firstButton?.getAttribute('name');
-
-      expect(groupName).toBeDefined();
-      buttons.forEach((button) => {
-        expect(button.getAttribute('name')).toBe(groupName);
-      });
-    });
-
-    it('should support keyboard navigation between page buttons', async () => {
-      const buttons = retrieveButtons();
-      expect(buttons.length).toBeGreaterThan(1);
-
-      const groupNames = buttons.map((btn) => btn.getAttribute('name'));
-      const uniqueNames = new Set(groupNames);
-      expect(uniqueNames.size).toBe(1);
-
-      buttons.forEach((button) => {
-        expect(button.type).toBe('radio');
-        expect(button.getAttribute('aria-label')).toBeDefined();
-      });
-    });
-
-    it('should handle arrow key navigation focus management', async () => {
-      const buttons = retrieveButtons();
-      const previousBtn = element.shadowRoot?.querySelector(
-        '[part*="previous-button"]'
-      ) as HTMLElement;
-      const nextBtn = element.shadowRoot?.querySelector(
-        '[part*="next-button"]'
-      ) as HTMLElement;
-
-      expect(buttons.length).toBeGreaterThan(0);
-      expect(previousBtn).toBeDefined();
-      expect(nextBtn).toBeDefined();
-
-      expect(previousBtn?.getAttribute('aria-label')).toBe('Previous');
-      expect(nextBtn?.getAttribute('aria-label')).toBe('Next');
-
-      expect(previousBtn?.tabIndex).toBeDefined();
-      expect(nextBtn?.tabIndex).toBeDefined();
-    });
-
-    it('should manage focus correctly for screen reader navigation', async () => {
-      const buttons = retrieveButtons();
-
-      buttons.forEach((button) => {
-        expect(button.type).toBe('radio');
-        expect(button.getAttribute('aria-label')).toBeDefined();
-        expect(button.getAttribute('name')).toBeDefined();
-      });
-
-      await expect
-        .element(locators.previous)
-        .toHaveAttribute('aria-label', 'Previous');
-      await expect.element(locators.next).toHaveAttribute('aria-label', 'Next');
-
-      const prevElement = element.shadowRoot?.querySelector(
-        '[part*="previous-button"]'
+    it('should set aria-current=page on the active page button', async () => {
+      const buttons = retrievePageButtons();
+      const activeButton = buttons.find(
+        (btn) => btn.getAttribute('aria-current') === 'page'
       );
-      const nextElement = element.shadowRoot?.querySelector(
-        '[part*="next-button"]'
-      );
-      expect(prevElement).toBeDefined();
-      expect(nextElement).toBeDefined();
+      expect(activeButton).toBeDefined();
     });
   });
 });

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.ts
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.ts
@@ -34,7 +34,6 @@ import {
   FocusTargetController,
 } from '@/src/utils/accessibility-utils';
 import {buildCustomEvent} from '@/src/utils/event-utils';
-import {randomID} from '@/src/utils/utils';
 import ArrowLeftIcon from '../../../images/arrow-left-rounded.svg';
 import ArrowRightIcon from '../../../images/arrow-right-rounded.svg';
 
@@ -111,8 +110,6 @@ export class AtomicPager
 
   protected ariaMessage = new AriaLiveRegionController(this, 'atomic-pager');
 
-  private radioGroupName = randomID('atomic-pager-');
-
   private previousButton!: FocusTargetController;
   private nextButton!: FocusTargetController;
 
@@ -142,8 +139,6 @@ export class AtomicPager
   @bindingGuard()
   @errorGuard()
   render() {
-    const currentGroupName = `${this.radioGroupName}-${this.pagerState.currentPages.join('-')}`;
-
     const pagesRange = getCurrentPagesRange(
       this.pagerState.currentPage - 1,
       this.numberOfPages,
@@ -189,11 +184,9 @@ export class AtomicPager
                       await this.focusOnFirstResultAndScrollToTop();
                     },
                     page: pageNumber,
-                    groupName: currentGroupName,
                     text: (pageNumber + 1).toLocaleString(
                       this.bindings.i18n.language
                     ),
-                    onFocusCallback: this.handleFocus,
                   },
                 })
               )
@@ -223,23 +216,6 @@ export class AtomicPager
       this.nextButton = new FocusTargetController(this, this.bindings);
     }
   }
-
-  private handleFocus = async (
-    elements: HTMLInputElement[],
-    currentFocus: HTMLInputElement,
-    newFocus: HTMLInputElement
-  ) => {
-    const currentIndex = elements.indexOf(currentFocus);
-    const newIndex = elements.indexOf(newFocus);
-
-    if (currentIndex === elements.length - 1 && newIndex === 0) {
-      await this.nextButton.focus();
-    } else if (currentIndex === 0 && newIndex === elements.length - 1) {
-      await this.previousButton.focus();
-    } else {
-      newFocus.focus();
-    }
-  };
 
   private async focusOnFirstResultAndScrollToTop() {
     await this.bindings.store.state.resultList?.focusOnFirstResultAfterNextSearch();

--- a/packages/atomic/src/components/search/atomic-pager/e2e/page-object.ts
+++ b/packages/atomic/src/components/search/atomic-pager/e2e/page-object.ts
@@ -16,11 +16,11 @@ export class PagerPageObject extends BasePageObject {
 
   pageButton(pageNumber: number): Locator {
     return this.page.locator(
-      `atomic-pager input[type="radio"][aria-label="Page ${pageNumber}"]`
+      `atomic-pager button[aria-label="Page ${pageNumber}"]`
     );
   }
 
   get currentPageButton(): Locator {
-    return this.page.locator('atomic-pager input[type="radio"][checked]');
+    return this.page.locator('atomic-pager button[aria-current="page"]');
   }
 }


### PR DESCRIPTION
[KIT-5776](https://coveord.atlassian.net/browse/KIT-5776)

## Problem
The atomic-pager wrapped page buttons in `role="toolbar"` (unimplemented, no roving focus) containing a `role="radiogroup"` with `role="radio"` buttons re-described as links via `aria-roledescription="link"`. This gave screen readers three conflicting semantics for the same control and did not match any APG pattern.

## Solution
- Removed `role="toolbar"` from `pager-navigation.ts` — the `<nav aria-label="Pagination">` landmark already provides correct grouping
- Replaced radio button page controls with plain `<button>` elements using `aria-current="page"` on the active page
- Removed `renderRadioButton` import and all radiogroup/radio semantics from `pager-buttons.ts`
- Updated callers in `atomic-pager.ts`, `atomic-commerce-pager.ts`, `atomic-insight-pager.ts` (removed `groupName`, `handleFocus`, `onFocusCallback`)
- Updated all spec files to reflect the new button-based DOM structure

[KIT-5776]: https://coveord.atlassian.net/browse/KIT-5776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ