### PR TITLE
test(atomic): wire testRadioGroupA11y to results-per-page and products-per-page

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.new.stories.tsx
@@ -62,7 +62,7 @@ export const WithCustomChoicesDisplayed: Story = {
 
 export const A11yRadioGroup: Story = {
   name: 'A11y Radio Group',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   play: async (context) => {
     await play(context);
     await testRadioGroupA11y(context);

--- a/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.new.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
+import {testRadioGroupA11y} from '@/storybook-utils/a11y/radiogroup.js';
 import {wrapInCommerceInterface} from '@/storybook-utils/commerce/commerce-interface-wrapper';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import '@/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.js';
@@ -56,5 +57,14 @@ export const WithCustomChoicesDisplayed: Story = {
   args: {
     'choices-displayed': '2,5,10,25',
     'initial-choice': '2',
+  },
+};
+
+export const A11yRadioGroup: Story = {
+  name: 'A11y Radio Group',
+  tags: ['a11y', 'test'],
+  play: async (context) => {
+    await play(context);
+    await testRadioGroupA11y(context);
   },
 };

--- a/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
@@ -80,7 +80,7 @@ export const A11yStatusMessage: Story = {
 
 export const A11yRadioGroup: Story = {
   name: 'A11y Radio Group',
-  tags: ['a11y', 'test'],
+  tags: ['a11y', 'test', '!dev'],
   play: async (context) => {
     await play(context);
     await testRadioGroupA11y(context);

--- a/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
@@ -2,6 +2,7 @@ import type {Meta, StoryObj as Story} from '@storybook/web-components-vite';
 import {getStorybookHelpers} from '@wc-toolkit/storybook-helpers';
 import {html} from 'lit';
 import {within} from 'shadow-dom-testing-library';
+import {testRadioGroupA11y} from '@/storybook-utils/a11y/radiogroup.js';
 import {testStatusMessageA11y} from '@/storybook-utils/a11y/status-message.js';
 import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {MockSearchApi} from '@/storybook-utils/api/search/mock';
@@ -74,5 +75,14 @@ export const A11yStatusMessage: Story = {
       expectedText: 'Results loaded. Results 1-25 of 120',
       timeout: 5000,
     });
+  },
+};
+
+export const A11yRadioGroup: Story = {
+  name: 'A11y Radio Group',
+  tags: ['a11y', 'test'],
+  play: async (context) => {
+    await play(context);
+    await testRadioGroupA11y(context);
   },
 };


### PR DESCRIPTION
[KIT-5745](https://coveord.atlassian.net/browse/KIT-5745)

## Problem
The `testRadioGroupA11y` helper existed but was not wired to the component stories that implement the Radio Group pattern (exclusive selection with arrow-key navigation via `items-per-page/choices.ts`).

## Solution
- Wired `testRadioGroupA11y` to `atomic-results-per-page` and `atomic-commerce-products-per-page` stories
- Note: pager stories are excluded since removes radiogroup semantics from pagers (they are no longer radio groups)

[KIT-5745]: https://coveord.atlassian.net/browse/KIT-5745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ