### PR TITLE
A11y: Manual audit for WCAG 2.4.6 Headings and Labels

### DIFF
--- a/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
@@ -1,9 +1,6 @@
 {
-  "surface": "commerce",
+  "surface": "insight",
   "wcag22Criteria": {
-    "3.3.3-error-suggestion": {
-      "conformance": "pass"
-    },
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
     }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
@@ -1,9 +1,6 @@
 {
-  "surface": "commerce",
+  "surface": "ipx",
   "wcag22Criteria": {
-    "3.3.3-error-suggestion": {
-      "conformance": "pass"
-    },
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
     }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
@@ -1,9 +1,6 @@
 {
-  "surface": "commerce",
+  "surface": "recommendations",
   "wcag22Criteria": {
-    "3.3.3-error-suggestion": {
-      "conformance": "pass"
-    },
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
     }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-search.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-search.json
@@ -3,6 +3,10 @@
   "wcag22Criteria": {
     "3.3.3-error-suggestion": {
       "conformance": "pass"
+    },
+    "2.4.6-headings-and-labels": {
+      "conformance": "fail",
+      "remarks": "atomic-tab-manager renders a tablist with aria-label=\"tab-area\" — a non-descriptive technical placeholder. Screen reader users navigating by landmark or tab group hear \"tab-area\" instead of a meaningful description of the tab purpose (e.g., \"Content type tabs\"), making it difficult to understand the interface structure."
     }
   }
 }

--- a/packages/atomic-a11y/reports/openacr.yaml
+++ b/packages/atomic-a11y/reports/openacr.yaml
@@ -14,13 +14,13 @@ vendor:
   email: support@coveo.com
   website: https://www.coveo.com
 report_date: '2026-06-15'
-last_modified_date: '2026-06-15'
+last_modified_date: '2026-06-16'
 version: 1
 notes: Generated from a11y/reports/a11y-report.json. Conformance is derived from
   axe-core results, interactive keyboard tests, and manual audits. Rows marked
   [Manual audit required] have no automated or interactive coverage and are
   reported as Does Not Support pending manual verification.
-evaluation_methods_used: axe-core 4.12.0; Storybook addon-a11y; Storybook
+evaluation_methods_used: axe-core 4.11.4; Storybook addon-a11y; Storybook
   interactive play() tests; Manual audit
 repository: https://github.com/coveo/ui-kit
 feedback: https://github.com/coveo/ui-kit/issues
@@ -36,7 +36,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 173
+                Supports — automated axe-core found no violations across 172
                 component(s).
       - num: 1.2.1
         components:
@@ -64,7 +64,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 173
+                Supports — automated axe-core found no violations across 172
                 component(s); interactive keyboard testing passed across 2
                 component(s).
       - num: 1.3.2
@@ -89,7 +89,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 173
+                Supports — automated axe-core found no violations across 172
                 component(s).
       - num: 1.4.2
         components:
@@ -103,7 +103,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 175
+                Supports — automated axe-core found no violations across 174
                 component(s); interactive keyboard testing passed across 34
                 component(s).
       - num: 2.1.2
@@ -175,7 +175,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 173
+                Supports — automated axe-core found no violations across 172
                 component(s).
       - num: 2.5.1
         components:
@@ -257,7 +257,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 173
+                Supports — automated axe-core found no violations across 172
                 component(s).
       - num: 3.3.7
         components:
@@ -273,7 +273,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 173
+                Supports — automated axe-core found no violations across 172
                 component(s); interactive keyboard testing passed across 4
                 component(s).
   success_criteria_level_aa:
@@ -309,7 +309,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 173
+                Supports — automated axe-core found no violations across 172
                 component(s).
       - num: 1.4.3
         components:
@@ -317,7 +317,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 173
+                Supports — automated axe-core found no violations across 172
                 component(s).
       - num: 1.4.4
         components:
@@ -325,7 +325,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 173
+                Supports — automated axe-core found no violations across 172
                 component(s).
       - num: 1.4.5
         components:
@@ -359,7 +359,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 173
+                Supports — automated axe-core found no violations across 172
                 component(s).
       - num: 1.4.13
         components:
@@ -382,9 +382,13 @@ chapters:
           - name: web
             adherence:
               level: does-not-support
-              notes:
-                'WCAG 2.4.6: no automated, interactive, or manual coverage. [Manual audit
-                required]'
+              notes: Does Not Support — manual audit found Does Not Support
+                (atomic-tab-manager renders a tablist with aria-label="tab-area"
+                — a non-descriptive technical placeholder. Screen reader users
+                navigating by landmark or tab group hear "tab-area" instead of a
+                meaningful description of the tab purpose (e.g., "Content type
+                tabs"), making it difficult to understand the interface
+                structure.).
       - num: 2.4.7
         components:
           - name: web
@@ -418,7 +422,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 173
+                Supports — automated axe-core found no violations across 172
                 component(s).
       - num: 3.1.2
         components:
@@ -426,7 +430,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 173
+                Supports — automated axe-core found no violations across 172
                 component(s).
       - num: 3.2.3
         components:


### PR DESCRIPTION
[KIT-5797](https://coveord.atlassian.net/browse/KIT-5797)

## Problem
WCAG 2.4.6 Headings and Labels (Level AA) was marked "Does Not Support" in the Atomic VPAT because no manual audit coverage existed.

## Solution
Manually audited 36 components across search, commerce, insight, ipx, and recommendations categories against WCAG 2.4.6.

Results: 35 pass, 1 fail (`atomic-tab-manager`: non-descriptive tablist `aria-label="tab-area"`). Follow-up fix: KIT-5805.

Files added:
- `manual-audit-search.json` (16 components)
- `manual-audit-commerce.json` (9 components)
- `manual-audit-insight.json` (9 components)
- `manual-audit-ipx.json` (1 component)
- `manual-audit-recommendations.json` (1 component)

[KIT-5797]: https://coveord.atlassian.net/browse/KIT-5797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ