### PR TITLE
A11y: Fix atomic-tab-manager tablist aria-label

### DIFF
--- a/.changeset/fix-tab-manager-aria-label.md
+++ b/.changeset/fix-tab-manager-aria-label.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": patch
+---
+
+A11y: Fix atomic-tab-manager tablist aria-label

--- a/packages/atomic-a11y/a11y/reports/manual-audit-search.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-search.json
@@ -5,8 +5,7 @@
       "conformance": "pass"
     },
     "2.4.6-headings-and-labels": {
-      "conformance": "fail",
-      "remarks": "atomic-tab-manager renders a tablist with aria-label=\"tab-area\" \u2014 a non-descriptive technical placeholder. Screen reader users navigating by landmark or tab group hear \"tab-area\" instead of a meaningful description of the tab purpose (e.g., \"Content type tabs\"), making it difficult to understand the interface structure."
+      "conformance": "pass"
     },
     "2.5.2-pointer-cancellation": {
       "conformance": "pass"

--- a/packages/atomic-a11y/reports/openacr.yaml
+++ b/packages/atomic-a11y/reports/openacr.yaml
@@ -1,7 +1,7 @@
 title: Coveo Accessibility Conformance Report
 product:
   name: Coveo Atomic
-  version: 3.59.6
+  version: 3.59.7
   description: Coveo Atomic is a web component library for building search and
     commerce interfaces.
 author:
@@ -13,8 +13,8 @@ vendor:
   company_name: Coveo
   email: support@coveo.com
   website: https://www.coveo.com
-report_date: '2026-06-22'
-last_modified_date: '2026-06-22'
+report_date: '2026-06-23'
+last_modified_date: '2026-06-23'
 version: 1
 notes: Generated from a11y/reports/a11y-report.json. Conformance is derived from
   axe-core results, interactive keyboard tests, and manual audits. Rows marked
@@ -418,14 +418,8 @@ chapters:
         components:
           - name: web
             adherence:
-              level: does-not-support
-              notes: Does Not Support — manual audit found Does Not Support
-                (atomic-tab-manager renders a tablist with aria-label="tab-area"
-                — a non-descriptive technical placeholder. Screen reader users
-                navigating by landmark or tab group hear "tab-area" instead of a
-                meaningful description of the tab purpose (e.g., "Content type
-                tabs"), making it difficult to understand the interface
-                structure.).
+              level: supports
+              notes: Supports — manual audit found Supports.
       - num: 2.4.7
         components:
           - name: web

--- a/packages/atomic/src/components/search/atomic-tab-manager/atomic-tab-manager.ts
+++ b/packages/atomic/src/components/search/atomic-tab-manager/atomic-tab-manager.ts
@@ -122,7 +122,7 @@ export class AtomicTabManager
       >
         <div
           role="tablist"
-          aria-label="tab-area"
+          aria-label=${this.bindings.i18n.t('tab-list')}
           part="tab-area"
           class="border-neutral mb-2 flex w-full flex-row border-b"
           @keydown=${this.handleTablistKeydown}

--- a/packages/atomic/src/components/search/atomic-tab-manager/e2e/page-object.ts
+++ b/packages/atomic/src/components/search/atomic-tab-manager/e2e/page-object.ts
@@ -11,7 +11,7 @@ export class TabManagerPageObject extends BasePageObject {
   }
 
   get tabArea() {
-    return this.page.getByLabel('tab-area');
+    return this.page.getByLabel('Content type tabs');
   }
 
   get activeTab() {

--- a/packages/atomic/src/locales.json
+++ b/packages/atomic/src/locales.json
@@ -8534,5 +8534,32 @@
     "zh": "会话轮次限制已达。请开始新的会话。",
     "zh-CN": "会话轮次限制已达。请开始新的会话。",
     "zh-TW": "會話輪次限制已達。請開始新的會話。"
+  },
+  "tab-list": {
+    "en": "Content type tabs",
+    "fr": "Onglets de type de contenu",
+    "cs": "Záložky typu obsahu",
+    "da": "Faner for indholdstype",
+    "de": "Inhaltstyp-Tabs",
+    "el": "Καρτέλες τύπου περιεχομένου",
+    "es": "Pestañas de tipo de contenido",
+    "fi": "Sisältötyyppivälilehdet",
+    "hu": "Tartalomtípus-fülek",
+    "id": "Tab jenis konten",
+    "it": "Schede tipo di contenuto",
+    "ja": "コンテンツタイプタブ",
+    "ko": "콘텐츠 유형 탭",
+    "nl": "Tabbladen inhoudstype",
+    "no": "Faner for innholdstype",
+    "pl": "Karty typu treści",
+    "pt": "Guias de tipo de conteúdo",
+    "pt-BR": "Guias de tipo de conteúdo",
+    "ru": "Вкладки типов контента",
+    "sv": "Flikar för innehållstyp",
+    "th": "แท็บประเภทเนื้อหา",
+    "tr": "İçerik türü sekmeleri",
+    "zh": "内容类型标签",
+    "zh-CN": "内容类型标签",
+    "zh-TW": "內容類型標籤"
   }
 }


### PR DESCRIPTION
[KIT-5805](https://coveord.atlassian.net/browse/KIT-5805)

## Problem
`atomic-tab-manager` renders a tablist with `aria-label="tab-area"` — a non-descriptive technical placeholder that doesn't describe the purpose of the tabs. Violates WCAG 2.4.6 (Headings and Labels).

## Solution
- Replace hardcoded `"tab-area"` with `this.bindings.i18n.t('tab-list')` which resolves to "Content type tabs" (localized in 25 languages).
- Update e2e page object to use the new label.
- Update manual audit entry from `fail` to `pass`.

[KIT-5805]: https://coveord.atlassian.net/browse/KIT-5805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ