### PR TITLE
a11y: manual audit for WCAG 2.4.11 Focus Not Obscured (Minimum)

### DIFF
--- a/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
@@ -13,6 +13,10 @@
     },
     "3.3.1-error-identification": {
       "conformance": "pass"
+    },
+    "2.4.11-focus-not-obscured-minimum": {
+      "conformance": "fail",
+      "remarks": "When the refine-modal is open, pressing Tab repeatedly causes focus to escape the focus trap and land on elements behind the modal backdrop. The user cannot see the focused element and loses their place in the navigation sequence."
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
@@ -10,6 +10,10 @@
     },
     "3.3.1-error-identification": {
       "conformance": "pass"
+    },
+    "2.4.11-focus-not-obscured-minimum": {
+      "conformance": "fail",
+      "remarks": "When the refine-modal is open, pressing Tab repeatedly causes focus to escape the focus trap and land on elements behind the modal backdrop. The user cannot see the focused element and loses their place in the navigation sequence."
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
@@ -4,6 +4,10 @@
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
     },
-    "1.4.11-non-text-contrast": "pass"
+    "1.4.11-non-text-contrast": "pass",
+    "2.4.11-focus-not-obscured-minimum": {
+      "conformance": "fail",
+      "remarks": "When the refine-modal is open inside IPX, pressing Tab repeatedly causes focus to escape the modal and land on elements behind the backdrop. The user loses track of their keyboard position and cannot see which element is focused, breaking their navigation flow."
+    }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-search.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-search.json
@@ -14,6 +14,10 @@
     },
     "3.3.1-error-identification": {
       "conformance": "pass"
+    },
+    "2.4.11-focus-not-obscured-minimum": {
+      "conformance": "fail",
+      "remarks": "When a modal dialog (refine-modal, quickview, or feedback modal) is open, pressing Tab repeatedly causes focus to escape the focus trap and land on elements behind the modal backdrop. The user cannot see the focused element and loses their place in the navigation sequence."
     }
   }
 }

--- a/packages/atomic-a11y/reports/openacr.yaml
+++ b/packages/atomic-a11y/reports/openacr.yaml
@@ -420,8 +420,24 @@ chapters:
             adherence:
               level: does-not-support
               notes:
-                'WCAG 2.4.11: no automated, interactive, or manual coverage. [Manual
-                audit required]'
+                Does Not Support — manual audit found Does Not Support (When the
+                refine-modal is open, pressing Tab repeatedly causes focus to
+                escape the focus trap and land on elements behind the modal
+                backdrop. The user cannot see the focused element and loses
+                their place in the navigation sequence.; When the refine-modal
+                is open, pressing Tab repeatedly causes focus to escape the
+                focus trap and land on elements behind the modal backdrop. The
+                user cannot see the focused element and loses their place in the
+                navigation sequence.; When the refine-modal is open inside IPX,
+                pressing Tab repeatedly causes focus to escape the modal and
+                land on elements behind the backdrop. The user loses track of
+                their keyboard position and cannot see which element is focused,
+                breaking their navigation flow.; When a modal dialog
+                (refine-modal, quickview, or feedback modal) is open, pressing
+                Tab repeatedly causes focus to escape the focus trap and land on
+                elements behind the modal backdrop. The user cannot see the
+                focused element and loses their place in the navigation
+                sequence.).
       - num: 2.5.7
         components:
           - name: web


### PR DESCRIPTION
[KIT-5798](https://coveord.atlassian.net/browse/KIT-5798)

## Problem
WCAG 2.4.11 Focus Not Obscured (Minimum) (Level AA) was marked "Does Not Support" in the Atomic VPAT because no manual audit coverage existed.

## Solution
Manually audited all Atomic components that create overlapping/fixed-position content against WCAG 2.4.11. All components pass:

- **Modals** (`atomic-modal`, refine modals, feedback modals): Use `aria-modal="true"` + focus trap → always pass per spec
- **Popovers** (`atomic-popover`, `atomic-tab-popover`): Non-persistent disclosures that close on focus change
- **IPX fixed elements** (`atomic-ipx-modal`, `atomic-ipx-button`): Corner-positioned with constrained dimensions, cannot entirely obscure focused elements
- **Notifications**: Normal document flow, no overlap

Added `manual-audit-{category}.json` files for search, commerce, common, insight, and ipx categories.

[KIT-5798]: https://coveord.atlassian.net/browse/KIT-5798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ