### PR TITLE
a11y(2.5.7): Manual audit for Dragging Movements

### DIFF
--- a/packages/atomic-a11y/a11y/a11y-overrides.json
+++ b/packages/atomic-a11y/a11y/a11y-overrides.json
@@ -92,6 +92,11 @@
       "criterion": "3.3.8",
       "conformance": "not-applicable",
       "reason": "Atomic does not include authentication flows."
+    },
+    {
+      "criterion": "2.5.7",
+      "conformance": "not-applicable",
+      "reason": "No Atomic component implements custom dragging movements. Scrollable containers use native CSS overflow (user-agent scrolling, exempt per 2.5.7) with arrow button alternatives. Modal touchmove listeners only prevent background scrolling."
     }
   ]
 }


### PR DESCRIPTION
[KIT-5799](https://coveord.atlassian.net/browse/KIT-5799)

## Problem
WCAG 2.5.7 Dragging Movements (Level AA) was marked "Does Not Support" in the Atomic VPAT because no automated or manual test coverage existed.

## Solution
After auditing all Atomic components, no custom dragging movements are implemented anywhere. Added a single override in `a11y-overrides.json` marking 2.5.7 as "Not Applicable" with justification:

- No drag-and-drop libraries (sortablejs, dnd-kit, react-dnd) are used
- No `DragEvent`, `pointerdown`+`pointermove` tracking, or `<input type="range">` sliders exist
- `atomic-segmented-facet-scrollable` uses native CSS `overflow-x: scroll` (user-agent scrolling, exempt per 2.5.7) and provides arrow buttons
- Modal `touchmove` listeners only prevent background scrolling (body scroll lock)
- Numeric/date facets use text input fields with Apply button, not range sliders

[KIT-5799]: https://coveord.atlassian.net/browse/KIT-5799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ