### PR TITLE
a11y: manual audit for WCAG 3.3.3 Error Suggestion (Level AA)

### DIFF
--- a/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
@@ -1,0 +1,8 @@
+{
+  "surface": "commerce",
+  "wcag22Criteria": {
+    "3.3.3-error-suggestion": {
+      "conformance": "pass"
+    }
+  }
+}

--- a/packages/atomic-a11y/a11y/reports/manual-audit-search.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-search.json
@@ -1,0 +1,8 @@
+{
+  "surface": "search",
+  "wcag22Criteria": {
+    "3.3.3-error-suggestion": {
+      "conformance": "pass"
+    }
+  }
+}

--- a/packages/atomic-a11y/reports/openacr.yaml
+++ b/packages/atomic-a11y/reports/openacr.yaml
@@ -448,10 +448,8 @@ chapters:
         components:
           - name: web
             adherence:
-              level: does-not-support
-              notes:
-                'WCAG 3.3.3: no automated, interactive, or manual coverage. [Manual audit
-                required]'
+              level: supports
+              notes: Supports — manual audit found Supports.
       - num: 3.3.4
         components:
           - name: web


### PR DESCRIPTION
https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html

[KIT-5800](https://coveord.atlassian.net/browse/KIT-5800)

## Problem
WCAG 3.3.3 Error Suggestion (Level AA) was marked "Does Not Support" in the Atomic VPAT because no manual audit coverage existed.

## Solution
Manually audited 10 components across 5 categories (common, search, commerce, insight, recommendations) for WCAG 3.3.3 conformance.

**Results:** All components pass or are not-applicable — no violations found.

- Form inputs (`atomic-facet-number-input`, `atomic-facet-date-input`, `atomic-commerce-facet-number-input`) use native HTML5 constraint validation which satisfies technique G85
- Did-you-mean components (`atomic-did-you-mean`, `atomic-commerce-did-you-mean`) proactively suggest query corrections
- Error display components (`atomic-query-error`, `atomic-commerce-query-error`, `atomic-insight-query-error`, `atomic-recs-error`, `atomic-component-error`) show system errors, not user input errors — criterion is not applicable

After running `pnpm a11y:vpat`, criterion 3.3.3 now reports **"Supports"**.

[KIT-5800]: https://coveord.atlassian.net/browse/KIT-5800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ