### PR TITLE
a11y: manual audit for WCAG 3.3.4 Error Prevention

### DIFF
--- a/packages/atomic-a11y/a11y/a11y-overrides.json
+++ b/packages/atomic-a11y/a11y/a11y-overrides.json
@@ -104,6 +104,11 @@
       "reason": "Consistent help placement across pages is a host application concern; Atomic components do not control page-level layout or ordering of help mechanisms."
     },
     {
+      "criterion": "3.3.4",
+      "conformance": "not-applicable",
+      "reason": "Atomic does not itself complete legal commitments or financial transactions. Any persistent data changes (e.g., attaching a result to a case) are handled by the host application via cancelable events; the built-in attach-to-case callback is reversible through detach. Feedback modals submit anonymous analytics (not user-viewable data)."
+    },
+    {
       "criterion": "3.3.7",
       "conformance": "not-applicable",
       "reason": "Atomic does not include multi-step forms that require redundant data entry."

--- a/packages/atomic-a11y/reports/openacr.yaml
+++ b/packages/atomic-a11y/reports/openacr.yaml
@@ -456,10 +456,14 @@ chapters:
         components:
           - name: web
             adherence:
-              level: does-not-support
+              level: not-applicable
               notes:
-                'WCAG 3.3.4: no automated, interactive, or manual coverage. [Manual audit
-                required]'
+                Atomic does not itself complete legal commitments or financial
+                transactions. Any persistent data changes (e.g., attaching a
+                result to a case) are handled by the host application via
+                cancelable events; the built-in attach-to-case callback is
+                reversible through detach. Feedback modals submit anonymous
+                analytics (not user-viewable data).
       - num: 3.3.8
         components:
           - name: web


### PR DESCRIPTION
[KIT-5801](https://coveord.atlassian.net/browse/KIT-5801)

## Problem
WCAG 3.3.4 Error Prevention (Legal, Financial, Data) was marked "Does Not Support" in the Atomic VPAT because no audit coverage existed.

## Solution
Added a global override marking 3.3.4 as "Not Applicable" — Atomic does not cause legal commitments, financial transactions, or modifications to user-controllable data. Feedback modals submit anonymous analytics (not user-viewable data), and the attach-to-case action delegates to the host application and is inherently reversible.

[KIT-5801]: https://coveord.atlassian.net/browse/KIT-5801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ