### PR TITLE
a11y(1.3.4): mark Orientation criterion as not-applicable

### DIFF
--- a/packages/atomic-a11y/a11y/a11y-overrides.json
+++ b/packages/atomic-a11y/a11y/a11y-overrides.json
@@ -34,6 +34,11 @@
       "reason": "Atomic does not include prerecorded video content requiring audio descriptions."
     },
     {
+      "criterion": "1.3.4",
+      "conformance": "not-applicable",
+      "reason": "Atomic does not restrict display orientation. No component uses the Screen Orientation API, @media orientation queries, or CSS transforms that lock the page to portrait or landscape."
+    },
+    {
       "criterion": "1.4.2",
       "conformance": "not-applicable",
       "reason": "Atomic does not include components that auto-play audio."


### PR DESCRIPTION
[KIT-5793](https://coveord.atlassian.net/browse/KIT-5793)

## Problem
WCAG 1.3.4 Orientation (Level AA) was marked "Does Not Support" in the Atomic VPAT because no automated or interactive test coverage existed.

## Solution
Manual audit confirmed that no Atomic component restricts display orientation — there is no usage of the Screen Orientation API, `@media (orientation: ...)` queries, or CSS transforms that lock the page to portrait/landscape. All existing `rotate()` transforms are decorative (SVG shapes, icon arrows).

Added a `not-applicable` override to `a11y-overrides.json`. The VPAT now correctly reports "Not Applicable" for 1.3.4.

[KIT-5793]: https://coveord.atlassian.net/browse/KIT-5793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ