### PR TITLE
chore(atomic-a11y): manual audit for WCAG 1.4.11 Non-text Contrast

### DIFF
--- a/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
@@ -6,6 +6,10 @@
     },
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
+    },
+    "1.4.11-non-text-contrast": {
+      "conformance": "partial",
+      "remarks": "Numeric facet input border uses border-neutral (#e5e8e8) at 1.23:1 contrast against white, failing the 3:1 requirement. Rating stars (active #f6ce3c at 1.52:1, inactive #e5e8e8 at 1.23:1) also fail — stars are the only way sighted users identify the rating value. Users with low vision cannot perceive these UI boundaries and graphical indicators, making it difficult to identify form fields or understand rating values."
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
@@ -3,6 +3,10 @@
   "wcag22Criteria": {
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
+    },
+    "1.4.11-non-text-contrast": {
+      "conformance": "partial",
+      "remarks": "Numeric facet input border uses border-neutral (#e5e8e8) at 1.23:1 contrast against white, failing the 3:1 requirement. Users with low vision cannot perceive the input field boundaries, making it difficult to identify where to enter values."
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
@@ -3,6 +3,7 @@
   "wcag22Criteria": {
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
-    }
+    },
+    "1.4.11-non-text-contrast": "pass"
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
@@ -3,6 +3,7 @@
   "wcag22Criteria": {
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
-    }
+    },
+    "1.4.11-non-text-contrast": "pass"
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-search.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-search.json
@@ -7,6 +7,10 @@
     "2.4.6-headings-and-labels": {
       "conformance": "fail",
       "remarks": "atomic-tab-manager renders a tablist with aria-label=\"tab-area\" — a non-descriptive technical placeholder. Screen reader users navigating by landmark or tab group hear \"tab-area\" instead of a meaningful description of the tab purpose (e.g., \"Content type tabs\"), making it difficult to understand the interface structure."
+    },
+    "1.4.11-non-text-contrast": {
+      "conformance": "partial",
+      "remarks": "Numeric facet input border uses border-neutral (#e5e8e8) at 1.23:1 contrast against white, failing the 3:1 requirement. Rating stars (active #f6ce3c at 1.52:1, inactive #e5e8e8 at 1.23:1) also fail — stars are the only way sighted users identify the rating value. Refine-toggle switch OFF state track uses bg-neutral at 1.23:1. Users with low vision cannot perceive these UI boundaries and graphical indicators, making it difficult to identify form fields, understand rating values, or determine toggle state."
     }
   }
 }

--- a/packages/atomic-a11y/reports/openacr.yaml
+++ b/packages/atomic-a11y/reports/openacr.yaml
@@ -13,14 +13,14 @@ vendor:
   company_name: Coveo
   email: support@coveo.com
   website: https://www.coveo.com
-report_date: '2026-06-15'
+report_date: '2026-06-16'
 last_modified_date: '2026-06-16'
 version: 1
 notes: Generated from a11y/reports/a11y-report.json. Conformance is derived from
   axe-core results, interactive keyboard tests, and manual audits. Rows marked
   [Manual audit required] have no automated or interactive coverage and are
   reported as Does Not Support pending manual verification.
-evaluation_methods_used: axe-core 4.11.4; Storybook addon-a11y; Storybook
+evaluation_methods_used: axe-core 4.12.0; Storybook addon-a11y; Storybook
   interactive play() tests; Manual audit
 repository: https://github.com/coveo/ui-kit
 feedback: https://github.com/coveo/ui-kit/issues
@@ -36,7 +36,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 1.2.1
         components:
@@ -64,7 +64,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s); interactive keyboard testing passed across 2
                 component(s).
       - num: 1.3.2
@@ -89,7 +89,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 1.4.2
         components:
@@ -103,7 +103,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 174
+                Supports — automated axe-core found no violations across 175
                 component(s); interactive keyboard testing passed across 34
                 component(s).
       - num: 2.1.2
@@ -175,7 +175,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 2.5.1
         components:
@@ -257,7 +257,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 3.3.7
         components:
@@ -273,7 +273,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s); interactive keyboard testing passed across 4
                 component(s).
   success_criteria_level_aa:
@@ -309,7 +309,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 1.4.3
         components:
@@ -317,7 +317,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 1.4.4
         components:
@@ -325,7 +325,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 1.4.5
         components:
@@ -349,17 +349,35 @@ chapters:
         components:
           - name: web
             adherence:
-              level: does-not-support
+              level: partially-supports
               notes:
-                'WCAG 1.4.11: no automated, interactive, or manual coverage. [Manual
-                audit required]'
+                'Partially Supports — manual audit found Partially Supports (Numeric
+                facet input border uses border-neutral (#e5e8e8) at 1.23:1
+                contrast against white, failing the 3:1 requirement. Rating
+                stars (active #f6ce3c at 1.52:1, inactive #e5e8e8 at 1.23:1)
+                also fail — stars are the only way sighted users identify the
+                rating value. Users with low vision cannot perceive these UI
+                boundaries and graphical indicators, making it difficult to
+                identify form fields or understand rating values.; Numeric facet
+                input border uses border-neutral (#e5e8e8) at 1.23:1 contrast
+                against white, failing the 3:1 requirement. Users with low
+                vision cannot perceive the input field boundaries, making it
+                difficult to identify where to enter values.; Numeric facet
+                input border uses border-neutral (#e5e8e8) at 1.23:1 contrast
+                against white, failing the 3:1 requirement. Rating stars (active
+                #f6ce3c at 1.52:1, inactive #e5e8e8 at 1.23:1) also fail — stars
+                are the only way sighted users identify the rating value.
+                Refine-toggle switch OFF state track uses bg-neutral at 1.23:1.
+                Users with low vision cannot perceive these UI boundaries and
+                graphical indicators, making it difficult to identify form
+                fields, understand rating values, or determine toggle state.).'
       - num: 1.4.12
         components:
           - name: web
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 1.4.13
         components:
@@ -422,7 +440,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 3.1.2
         components:
@@ -430,7 +448,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 3.2.3
         components:


### PR DESCRIPTION
[KIT-5796](https://coveord.atlassian.net/browse/KIT-5796)

## Problem
WCAG 1.4.11 Non-text Contrast (Level AA) was marked "Does Not Support" in the Atomic VPAT because no manual audit coverage existed.

## Solution
Manually audited 23 Atomic components against WCAG 1.4.11. Criterion now reports **Partially Supports** (16 pass, 7 partial).

### Violations found (bug tickets filed)
- **[KIT-5806](https://coveord.atlassian.net/browse/KIT-5806)**: Switch OFF state track contrast (1.23:1 vs required 3:1)
- **[KIT-5807](https://coveord.atlassian.net/browse/KIT-5807)**: Facet number input border contrast (1.23:1 vs required 3:1)
- **[KIT-5808](https://coveord.atlassian.net/browse/KIT-5808)**: Rating star icon contrast (active 1.52:1, inactive 1.23:1)

### User impact
Users with low vision cannot perceive input field boundaries, rating star values, or toggle switch states because these graphical elements do not meet the minimum 3:1 contrast ratio.

### Components that pass
- Checkboxes (border 5.56:1, selected bg 4.94:1)
- Focus indicators (primary border 4.94:1)
- Buttons (identified by text content, border supplementary)
- Search boxes (identified by icon + placeholder, border supplementary)
- Pagers, sort dropdowns, segmented facets (identified by text content)
- Rating facet (stars supplemented by visible text labels)

[KIT-5796]: https://coveord.atlassian.net/browse/KIT-5796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIT-5806]: https://coveord.atlassian.net/browse/KIT-5806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIT-5807]: https://coveord.atlassian.net/browse/KIT-5807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIT-5808]: https://coveord.atlassian.net/browse/KIT-5808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ