### PR TITLE
a11y(1.4.5): mark Images of Text as not-applicable

### DIFF
--- a/packages/atomic-a11y/a11y/a11y-overrides.json
+++ b/packages/atomic-a11y/a11y/a11y-overrides.json
@@ -41,7 +41,7 @@
     {
       "criterion": "1.4.5",
       "conformance": "not-applicable",
-      "reason": "Atomic does not render text as images. All text is real HTML styled with CSS. SVG icons are purely symbolic (no <text> elements). Product/result images display user-provided content, not component-generated text."
+      "reason": "Atomic does not render text as images. All text is real HTML styled with CSS. SVG icons are purely symbolic (no `<text>` elements). Product/result images display user-provided content, not component-generated text."
     },
     {
       "criterion": "2.2.1",

--- a/packages/atomic-a11y/a11y/a11y-overrides.json
+++ b/packages/atomic-a11y/a11y/a11y-overrides.json
@@ -1,7 +1,7 @@
 {
   "$schema": "#a11y-overrides",
   "description": "Human-authored overrides for WCAG 2.2 AA conformance. These override automated axe-core results in the OpenACR YAML report. Each entry must include a reason explaining the decision.",
-  "lastUpdated": "2026-05-12",
+  "lastUpdated": "2026-06-09",
   "overrides": [
     {
       "criterion": "2.4.7",
@@ -37,6 +37,11 @@
       "criterion": "1.4.2",
       "conformance": "not-applicable",
       "reason": "Atomic does not include components that auto-play audio."
+    },
+    {
+      "criterion": "1.4.5",
+      "conformance": "not-applicable",
+      "reason": "Atomic does not render text as images. All text is real HTML styled with CSS. SVG icons are purely symbolic (no <text> elements). Product/result images display user-provided content, not component-generated text."
     },
     {
       "criterion": "2.2.1",


### PR DESCRIPTION
[KIT-5794](https://coveord.atlassian.net/browse/KIT-5794)

## Problem
WCAG 1.4.5 Images of Text (Level AA) is marked "Does Not Support" in the Atomic VPAT because no automated or interactive test coverage exists.

## Solution
Manual audit confirms this criterion is **not applicable** to Atomic:
- All text is rendered as real HTML styled with CSS/Tailwind — no component renders text as images for visual presentation
- SVG icons (`atomic-icon`) are purely symbolic with no `<text>` elements, and are marked `aria-hidden="true"`
- `atomic-result-image` / `atomic-product-image` display user-provided content from the search index, not component-generated text
- The only SVG containing text is a logotype in `.storybook/public/` (exempt under 1.4.5, and not shipped in any component)
- No canvas, background-image CSS text, or text-to-image generation exists anywhere in the component source

Added a `"not-applicable"` override in `a11y-overrides.json`. Running `pnpm a11y:vpat` confirms criterion 1.4.5 now reports "Not Applicable" in the OpenACR/VPAT.

[KIT-5794]: https://coveord.atlassian.net/browse/KIT-5794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ