### PR TITLE
fix(atomic): increase input border contrast (WCAG 1.4.11)

### DIFF
--- a/.changeset/fix-input-border-contrast.md
+++ b/.changeset/fix-input-border-contrast.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": patch
+---
+
+Increased `input-primary` border contrast from 1.23:1 to 5.56:1 to meet WCAG 1.4.11 Non-text Contrast (3:1 minimum).

--- a/packages/atomic-a11y/a11y/reports/manual-audit-common.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-common.json
@@ -6,8 +6,8 @@
       "status": "complete",
       "wcag22Criteria": {
         "1.4.11-non-text-contrast": {
-          "conformance": "partial",
-          "remarks": "Input border uses border-neutral (#e5e8e8) at 1.23:1 vs white, failing 3:1 for the input boundary. Focus indicator passes at 4.94:1. See KIT-5807."
+          "conformance": "pass",
+          "remarks": "Input border uses border-neutral-dark (#626971) at 5.56:1 vs white, passing 3:1. Focus indicator passes at 4.94:1."
         }
       }
     }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-common.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-common.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "atomic-facet-number-input",
+    "category": "common",
+    "manual": {
+      "status": "complete",
+      "wcag22Criteria": {
+        "1.4.11-non-text-contrast": {
+          "conformance": "partial",
+          "remarks": "Input border uses border-neutral (#e5e8e8) at 1.23:1 vs white, failing 3:1 for the input boundary. Focus indicator passes at 4.94:1. See KIT-5807."
+        }
+      }
+    }
+  },
+  {
+    "name": "atomic-refine-toggle",
+    "category": "common",
+    "manual": {
+      "status": "complete",
+      "wcag22Criteria": {
+        "1.4.11-non-text-contrast": {
+          "conformance": "partial",
+          "remarks": "Contains a switch component. OFF state track uses bg-neutral (#e5e8e8) at 1.23:1 vs white, failing 3:1. ON state passes with primary bg at 4.94:1. See KIT-5806."
+        }
+      }
+    }
+  }
+]

--- a/packages/atomic/src/utils/tailwind-utilities/components.css
+++ b/packages/atomic/src/utils/tailwind-utilities/components.css
@@ -5,7 +5,7 @@
 
 @layer components {
   .input-primary {
-    @apply border-neutral bg-background hover:border-primary-light focus-visible:border-primary focus-visible:ring-ring-primary rounded border focus-visible:ring-2 focus-visible:outline-none;
+    @apply border-neutral-dark bg-background hover:border-primary-light focus-visible:border-primary focus-visible:ring-ring-primary rounded border focus-visible:ring-2 focus-visible:outline-none;
   }
 
   .btn-radio {


### PR DESCRIPTION
[KIT-5807](https://coveord.atlassian.net/browse/KIT-5807)

## Problem
The `input-primary` class uses `border-neutral` (#e5e8e8) which has only 1.23:1 contrast against white, failing the 3:1 minimum required by WCAG 1.4.11 for UI component boundaries.

## Solution
Changed border color to `border-neutral-dark` (#626971, 5.56:1 contrast ratio).

[KIT-5807]: https://coveord.atlassian.net/browse/KIT-5807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ