### PR TITLE
fix(atomic): increase switch OFF state contrast (WCAG 1.4.11)

### DIFF
--- a/.changeset/fix-switch-off-contrast.md
+++ b/.changeset/fix-switch-off-contrast.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": patch
+---
+
+Increased switch OFF state track contrast from 1.23:1 to 5.56:1 to meet WCAG 1.4.11 Non-text Contrast (3:1 minimum).

--- a/packages/atomic-a11y/a11y/reports/manual-audit-common.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-common.json
@@ -19,8 +19,8 @@
       "status": "complete",
       "wcag22Criteria": {
         "1.4.11-non-text-contrast": {
-          "conformance": "partial",
-          "remarks": "Contains a switch component. OFF state track uses bg-neutral (#e5e8e8) at 1.23:1 vs white, failing 3:1. ON state passes with primary bg at 4.94:1. See KIT-5806."
+          "conformance": "pass",
+          "remarks": "Switch OFF state track uses bg-neutral-dark (#626971) at 5.56:1 vs white. ON state uses primary bg at 4.94:1. Both pass 3:1."
         }
       }
     }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-common.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-common.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "atomic-facet-number-input",
+    "category": "common",
+    "manual": {
+      "status": "complete",
+      "wcag22Criteria": {
+        "1.4.11-non-text-contrast": {
+          "conformance": "partial",
+          "remarks": "Input border uses border-neutral (#e5e8e8) at 1.23:1 vs white, failing 3:1 for the input boundary. Focus indicator passes at 4.94:1. See KIT-5807."
+        }
+      }
+    }
+  },
+  {
+    "name": "atomic-refine-toggle",
+    "category": "common",
+    "manual": {
+      "status": "complete",
+      "wcag22Criteria": {
+        "1.4.11-non-text-contrast": {
+          "conformance": "partial",
+          "remarks": "Contains a switch component. OFF state track uses bg-neutral (#e5e8e8) at 1.23:1 vs white, failing 3:1. ON state passes with primary bg at 4.94:1. See KIT-5806."
+        }
+      }
+    }
+  }
+]

--- a/packages/atomic/src/components/common/switch.spec.ts
+++ b/packages/atomic/src/components/common/switch.spec.ts
@@ -58,10 +58,10 @@ describe('#renderSwitch', () => {
     expect(button).toHaveAttribute('aria-checked', 'true');
   });
 
-  it('should apply bg-neutral class to container when unchecked', async () => {
+  it('should apply bg-neutral-dark class to container when unchecked', async () => {
     const element = await renderComponent({checked: false});
     const container = locators(element).container;
-    expect(container).toHaveClass('bg-neutral');
+    expect(container).toHaveClass('bg-neutral-dark');
     expect(container).not.toHaveClass('bg-primary');
   });
 
@@ -69,7 +69,7 @@ describe('#renderSwitch', () => {
     const element = await renderComponent({checked: true});
     const container = locators(element).container;
     expect(container).toHaveClass('bg-primary');
-    expect(container).not.toHaveClass('bg-neutral');
+    expect(container).not.toHaveClass('bg-neutral-dark');
   });
 
   it('should apply ml-6 class to handle when checked', async () => {

--- a/packages/atomic/src/components/common/switch.ts
+++ b/packages/atomic/src/components/common/switch.ts
@@ -17,7 +17,7 @@ export const renderSwitch: FunctionalComponent<SwitchProps> = ({props}) => {
   const containerClasses = tw({
     'w-12 h-6 p-1 rounded-full': true,
     'bg-primary': props.checked,
-    'bg-neutral': !props.checked,
+    'bg-neutral-dark': !props.checked,
   });
 
   const handleClasses = tw({


### PR DESCRIPTION
[KIT-5806](https://coveord.atlassian.net/browse/KIT-5806)

## Problem
The switch component's OFF state uses `bg-neutral` (#e5e8e8) for the track background, yielding only 1.23:1 contrast against white — well below the 3:1 minimum required by WCAG 1.4.11.

## Solution
Changed OFF state track to `bg-neutral-dark` (#626971, 5.56:1 contrast ratio). Updated spec test accordingly.

[KIT-5806]: https://coveord.atlassian.net/browse/KIT-5806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ