### PR TITLE
fix(atomic): increase rating star icon contrast (WCAG 1.4.11)

### DIFF
--- a/.changeset/fix-rating-stars-contrast.md
+++ b/.changeset/fix-rating-stars-contrast.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": patch
+---
+
+Increased default rating star icon contrast to meet WCAG 1.4.11 Non-text Contrast (3:1 minimum). Active stars changed from #f6ce3c (1.52:1) to #b88600 (3.26:1). Inactive stars changed from #e5e8e8 (1.23:1) to #626971 (5.56:1).

--- a/packages/atomic-a11y/a11y/reports/manual-audit-common.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-common.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "atomic-facet-number-input",
+    "category": "common",
+    "manual": {
+      "status": "complete",
+      "wcag22Criteria": {
+        "1.4.11-non-text-contrast": {
+          "conformance": "partial",
+          "remarks": "Input border uses border-neutral (#e5e8e8) at 1.23:1 vs white, failing 3:1 for the input boundary. Focus indicator passes at 4.94:1. See KIT-5807."
+        }
+      }
+    }
+  },
+  {
+    "name": "atomic-refine-toggle",
+    "category": "common",
+    "manual": {
+      "status": "complete",
+      "wcag22Criteria": {
+        "1.4.11-non-text-contrast": {
+          "conformance": "partial",
+          "remarks": "Contains a switch component. OFF state track uses bg-neutral (#e5e8e8) at 1.23:1 vs white, failing 3:1. ON state passes with primary bg at 4.94:1. See KIT-5806."
+        }
+      }
+    }
+  }
+]

--- a/packages/atomic/src/utils/coveo.tw.css
+++ b/packages/atomic/src/utils/coveo.tw.css
@@ -74,9 +74,9 @@
 
   --color-rating-icon-inactive: var(
     --atomic-rating-icon-inactive-color,
-    var(--atomic-neutral)
+    var(--atomic-neutral-dark)
   );
-  --color-rating-icon-active: var(--atomic-rating-icon-active-color, #f6ce3c);
+  --color-rating-icon-active: var(--atomic-rating-icon-active-color, #b88600);
 
   --color-rating-icon-outline: var(--atomic-rating-icon-outline-color, none);
 


### PR DESCRIPTION
[KIT-5808](https://coveord.atlassian.net/browse/KIT-5808)

## Problem
Default rating star colors fail WCAG 1.4.11 Non-text Contrast:
- Active stars (#f6ce3c): 1.52:1 vs white
- Inactive stars (#e5e8e8): 1.23:1 vs white

## Solution
Changed default colors to meet 3:1:
- Active: #b88600 (3.26:1) — darker amber/gold
- Inactive: var(--atomic-neutral-dark) / #626971 (5.56:1)

Custom values via `--atomic-rating-icon-active-color` and `--atomic-rating-icon-inactive-color` CSS properties are unaffected.

[KIT-5808]: https://coveord.atlassian.net/browse/KIT-5808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ