### PR TITLE
a11y: mark WCAG 3.2.6 Consistent Help as not-applicable

### DIFF
--- a/packages/atomic-a11y/a11y/a11y-overrides.json
+++ b/packages/atomic-a11y/a11y/a11y-overrides.json
@@ -84,6 +84,11 @@
       "reason": "Consistent identification across pages is a host application concern; individual Atomic components use consistent internal naming."
     },
     {
+      "criterion": "3.2.6",
+      "conformance": "not-applicable",
+      "reason": "Consistent help placement across pages is a host application concern; Atomic components do not control page-level layout or ordering of help mechanisms."
+    },
+    {
       "criterion": "3.3.7",
       "conformance": "not-applicable",
       "reason": "Atomic does not include multi-step forms that require redundant data entry."


### PR DESCRIPTION
[KIT-5791](https://coveord.atlassian.net/browse/KIT-5791)

## Problem
WCAG 3.2.6 Consistent Help (Level A) was marked "Does Not Support" in the Atomic VPAT because no audit coverage existed.

## Solution
Added a `not-applicable` override in `a11y-overrides.json`. WCAG 3.2.6 is a page-level concern about consistent placement of help mechanisms across multiple pages — the host application controls this, not the component library. This is analogous to 3.2.3 (Consistent Navigation) and 3.2.4 (Consistent Identification) which are already marked not-applicable for the same reason.

[KIT-5791]: https://coveord.atlassian.net/browse/KIT-5791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ