### PR TITLE
a11y: manual audit for WCAG 3.3.1 Error Identification

### DIFF
--- a/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
@@ -10,6 +10,9 @@
     "1.4.11-non-text-contrast": {
       "conformance": "partial",
       "remarks": "Numeric facet input border uses border-neutral (#e5e8e8) at 1.23:1 contrast against white, failing the 3:1 requirement. Rating stars (active #f6ce3c at 1.52:1, inactive #e5e8e8 at 1.23:1) also fail — stars are the only way sighted users identify the rating value. Users with low vision cannot perceive these UI boundaries and graphical indicators, making it difficult to identify form fields or understand rating values."
+    },
+    "3.3.1-error-identification": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
@@ -7,6 +7,9 @@
     "1.4.11-non-text-contrast": {
       "conformance": "partial",
       "remarks": "Numeric facet input border uses border-neutral (#e5e8e8) at 1.23:1 contrast against white, failing the 3:1 requirement. Users with low vision cannot perceive the input field boundaries, making it difficult to identify where to enter values."
+    },
+    "3.3.1-error-identification": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-search.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-search.json
@@ -11,6 +11,9 @@
     "1.4.11-non-text-contrast": {
       "conformance": "partial",
       "remarks": "Numeric facet input border uses border-neutral (#e5e8e8) at 1.23:1 contrast against white, failing the 3:1 requirement. Rating stars (active #f6ce3c at 1.52:1, inactive #e5e8e8 at 1.23:1) also fail — stars are the only way sighted users identify the rating value. Refine-toggle switch OFF state track uses bg-neutral at 1.23:1. Users with low vision cannot perceive these UI boundaries and graphical indicators, making it difficult to identify form fields, understand rating values, or determine toggle state."
+    },
+    "3.3.1-error-identification": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/reports/openacr.yaml
+++ b/packages/atomic-a11y/reports/openacr.yaml
@@ -247,10 +247,8 @@ chapters:
         components:
           - name: web
             adherence:
-              level: does-not-support
-              notes:
-                'WCAG 3.3.1: no automated, interactive, or manual coverage. [Manual audit
-                required]'
+              level: supports
+              notes: Supports — manual audit found Supports.
       - num: 3.3.2
         components:
           - name: web


### PR DESCRIPTION
https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html

[KIT-5792](https://coveord.atlassian.net/browse/KIT-5792)

## Problem
WCAG 3.3.1 Error Identification (Level A) was marked "Does Not Support" in the Atomic VPAT because no manual audit coverage existed.

## Solution
Manually audited 8 components across search, commerce, and insight surfaces:
- **Numeric facets** (`atomic-numeric-facet`, `atomic-commerce-numeric-facet`, `atomic-insight-numeric-facet`): use native HTML5 constraint validation (`type=number`, `required`, `min`/`max`). Browsers automatically identify the field in error and describe it in text.
- **Timeframe facets** (`atomic-timeframe-facet`, `atomic-commerce-timeframe-facet`, `atomic-insight-timeframe-facet`): same pattern with `type=date`.
- **Generated answer** (`atomic-generated-answer`, `atomic-insight-generated-answer`): feedback modal uses custom JS validation with `role=alert` + inline error text per field.

All components **pass**. Criterion 3.3.1 now reports "Supports" in the VPAT.

[KIT-5792]: https://coveord.atlassian.net/browse/KIT-5792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ