### PR TITLE
A11y: Manual audit for WCAG 2.5.3 Label in Name (Level A)

### DIFF
--- a/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
@@ -17,6 +17,10 @@
     "2.4.11-focus-not-obscured-minimum": {
       "conformance": "fail",
       "remarks": "When the refine-modal is open, pressing Tab repeatedly causes focus to escape the focus trap and land on elements behind the modal backdrop. The user cannot see the focused element and loses their place in the navigation sequence."
+    },
+    "2.5.3-label-in-name": {
+      "conformance": "fail",
+      "remarks": "atomic-commerce-breadbox: the show-more button displays visible text \"+ N\" but has accessible name \"Show N more filters\". Voice control users saying \"click plus 3\" will not activate the button because the visible text is not contained in the accessible name."
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
@@ -14,6 +14,7 @@
     "2.4.11-focus-not-obscured-minimum": {
       "conformance": "fail",
       "remarks": "When the refine-modal is open, pressing Tab repeatedly causes focus to escape the focus trap and land on elements behind the modal backdrop. The user cannot see the focused element and loses their place in the navigation sequence."
-    }
+    },
+    "2.5.3-label-in-name": "pass"
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
@@ -8,6 +8,7 @@
     "2.4.11-focus-not-obscured-minimum": {
       "conformance": "fail",
       "remarks": "When the refine-modal is open inside IPX, pressing Tab repeatedly causes focus to escape the modal and land on elements behind the backdrop. The user loses track of their keyboard position and cannot see which element is focused, breaking their navigation flow."
-    }
+    },
+    "2.5.3-label-in-name": "pass"
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
@@ -4,6 +4,7 @@
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
     },
-    "1.4.11-non-text-contrast": "pass"
+    "1.4.11-non-text-contrast": "pass",
+    "2.5.3-label-in-name": "pass"
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-search.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-search.json
@@ -18,6 +18,10 @@
     "2.4.11-focus-not-obscured-minimum": {
       "conformance": "fail",
       "remarks": "When a modal dialog (refine-modal, quickview, or feedback modal) is open, pressing Tab repeatedly causes focus to escape the focus trap and land on elements behind the modal backdrop. The user cannot see the focused element and loses their place in the navigation sequence."
+    },
+    "2.5.3-label-in-name": {
+      "conformance": "fail",
+      "remarks": "atomic-breadbox: the show-more button displays visible text \"+ N\" but has accessible name \"Show N more filters\". Voice control users saying \"click plus 3\" will not activate the button because the visible text is not contained in the accessible name."
     }
   }
 }

--- a/packages/atomic-a11y/reports/openacr.yaml
+++ b/packages/atomic-a11y/reports/openacr.yaml
@@ -201,9 +201,16 @@ chapters:
           - name: web
             adherence:
               level: does-not-support
-              notes:
-                'WCAG 2.5.3: no automated, interactive, or manual coverage. [Manual audit
-                required]'
+              notes: 'Does Not Support — manual audit found Does Not Support
+                (atomic-commerce-breadbox: the show-more button displays visible
+                text "+ N" but has accessible name "Show N more filters". Voice
+                control users saying "click plus 3" will not activate the button
+                because the visible text is not contained in the accessible
+                name.; atomic-breadbox: the show-more button displays visible
+                text "+ N" but has accessible name "Show N more filters". Voice
+                control users saying "click plus 3" will not activate the button
+                because the visible text is not contained in the accessible
+                name.).'
       - num: 2.5.4
         components:
           - name: web


### PR DESCRIPTION
[KIT-5789](https://coveord.atlassian.net/browse/KIT-5789)

## Problem
WCAG 2.5.3 Label in Name (Level A) was marked "Does Not Support" in the Atomic VPAT because no audit coverage existed.

## Solution
Manually audited 48 components across 5 categories (search, commerce, insight, ipx, recommendations) for WCAG 2.5.3 compliance.

**Results: 46 pass, 2 fail.**

### Failures
- `atomic-breadbox` (search) and `atomic-commerce-breadbox` (commerce): the show-more button displays visible text `+ N` but has accessible name `Show N more filters`. The visible text is not contained in the accessible name. Voice control users saying "click plus 3" will not activate the button.
- Fix tracked in [KIT-5809](https://coveord.atlassian.net/browse/KIT-5809).

The criterion now reports "Does Not Support" with specific failure details in the OpenACR.

[KIT-5789]: https://coveord.atlassian.net/browse/KIT-5789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIT-5809]: https://coveord.atlassian.net/browse/KIT-5809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ