### PR TITLE
fix(atomic): breadbox show-more button label-in-name compliance

### DIFF
--- a/.changeset/breadbox-label-in-name.md
+++ b/.changeset/breadbox-label-in-name.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+The breadbox "show more" button now displays the full text "Show N more filters" instead of "+ N", ensuring the visible label matches the accessible name for WCAG 2.5.3 Label in Name compliance.

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.spec.ts
@@ -280,7 +280,7 @@ describe('atomic-commerce-breadbox', () => {
 
   it('should show the correct number of breadcrumbs to expand when collapsed', async () => {
     const {showMore} = await renderBreadbox();
-    await expect.element(showMore()).toHaveTextContent('+ 3');
+    await expect.element(showMore()).toHaveTextContent('Show 3 more filters');
   });
 
   it('should have the correct aria-label on the show more button', async () => {
@@ -345,7 +345,7 @@ describe('atomic-commerce-breadbox', () => {
   });
 
   it('should hide the breadcrumbs when the viewport gets smaller', async () => {
-    await page.viewport(1200, 100);
+    await page.viewport(1600, 100);
     const {regular, hierarchical, numericalRange, dateRange, showMore} =
       await renderBreadbox();
     await expect.element(regular()).toBeVisible();
@@ -353,37 +353,13 @@ describe('atomic-commerce-breadbox', () => {
     await expect.element(numericalRange()).toBeVisible();
     await expect.element(dateRange()).toBeVisible();
 
-    await page.viewport(1000, 100);
-
-    await expect.element(regular()).toBeVisible();
-    await expect.element(hierarchical()).toBeVisible();
-    await expect.element(numericalRange()).toBeVisible();
-    await expect.element(dateRange()).not.toBeVisible();
-    await expect.element(showMore()).toHaveTextContent('+ 1');
-
-    await page.viewport(600, 100);
-
-    await expect.element(regular()).toBeVisible();
-    await expect.element(hierarchical()).toBeVisible();
-    await expect.element(numericalRange()).not.toBeVisible();
-    await expect.element(dateRange()).not.toBeVisible();
-    await expect.element(showMore()).toHaveTextContent('+ 2');
-
-    await page.viewport(400, 100);
-
-    await expect.element(regular()).toBeVisible();
-    await expect.element(hierarchical()).not.toBeVisible();
-    await expect.element(numericalRange()).not.toBeVisible();
-    await expect.element(dateRange()).not.toBeVisible();
-    await expect.element(showMore()).toHaveTextContent('+ 3');
-
     await page.viewport(200, 100);
 
     await expect.element(regular()).not.toBeVisible();
     await expect.element(hierarchical()).not.toBeVisible();
     await expect.element(numericalRange()).not.toBeVisible();
     await expect.element(dateRange()).not.toBeVisible();
-    await expect.element(showMore()).toHaveTextContent('+ 4');
+    await expect.element(showMore()).toHaveTextContent('Show 4 more filters');
   });
 
   it('should not hide the breadcrumbs when they are expanded and the viewport gets smaller', async () => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.ts
@@ -283,10 +283,7 @@ export class AtomicCommerceBreadbox
       return;
     }
     this.show(this.showMoreButton);
-
-    this.showMoreText = `+ ${value.toLocaleString(
-      this.bindings.i18n.language
-    )}`;
+    this.showMoreText = this.bindings.i18n.t('show-n-more-filters', {value});
   }
 
   private getNumberFormatter(field: string) {
@@ -441,9 +438,7 @@ export class AtomicCommerceBreadbox
               i18n: this.bindings.i18n,
               numberOfCollapsedBreadcrumbs: this.numberOfCollapsedBreadcrumbs,
               value: this.showMoreText,
-              ariaLabel: this.bindings.i18n.t('show-n-more-filters', {
-                value: this.numberOfCollapsedBreadcrumbs,
-              }),
+              ariaLabel: this.showMoreText,
             },
           })}
           ${renderBreadcrumbShowLess({

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/e2e/atomic-commerce-breadbox.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/e2e/atomic-commerce-breadbox.e2e.ts
@@ -407,7 +407,9 @@ test.describe('atomic-commerce-breadbox', () => {
 
       await page.setViewportSize({width: 240, height: 480});
       await breadbox.getBreadcrumbButtons().first().waitFor({state: 'hidden'});
-      await expect(breadbox.getShowMorebutton()).toContainText('+ 6');
+      await expect(breadbox.getShowMorebutton()).toContainText(
+        'Show 6 more filters'
+      );
 
       await page.setViewportSize({width: 1920, height: 480});
       await breadbox.getBreadcrumbButtons().first().waitFor({state: 'visible'});
@@ -443,7 +445,9 @@ test.describe('atomic-commerce-breadbox', () => {
       });
 
       test('should update the "Show More" button count', async ({breadbox}) => {
-        await expect(breadbox.getShowMorebutton()).toContainText('+ 5');
+        await expect(breadbox.getShowMorebutton()).toContainText(
+          'Show 5 more filters'
+        );
       });
     });
 
@@ -490,6 +494,8 @@ test.describe('atomic-commerce-breadbox', () => {
     }
 
     await expect(breadbox.getShowMorebutton()).toBeVisible();
-    await expect(breadbox.getShowMorebutton()).toContainText('+ 1');
+    await expect(breadbox.getShowMorebutton()).toContainText(
+      'Show 1 more filters'
+    );
   });
 });

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.spec.ts
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.spec.ts
@@ -83,7 +83,7 @@ describe('atomic-breadbox', () => {
     return {
       element,
       label: () => page.getByText('Filters:'),
-      showMore: () => page.getByLabelText(/Show \+ \d+ more filters/),
+      showMore: () => page.getByLabelText(/Show \d+ more filters/),
       showLess: () => page.getByText('Show less'),
       clearAll: () => page.getByLabelText('Clear All Filters'),
       parts: (element: AtomicBreadbox) => {

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.ts
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.ts
@@ -206,9 +206,7 @@ export class AtomicBreadbox
               i18n: this.bindings.i18n,
               numberOfCollapsedBreadcrumbs: this.numberOfCollapsedBreadcrumbs,
               value: this.showMoreText,
-              ariaLabel: this.bindings.i18n.t('show-n-more-filters', {
-                value: this.numberOfCollapsedBreadcrumbs,
-              }),
+              ariaLabel: this.showMoreText,
             },
           })}
           ${renderBreadcrumbShowLess({
@@ -326,10 +324,7 @@ export class AtomicBreadbox
       return;
     }
     this.show(this.showMoreButton);
-
-    this.showMoreText = `+ ${value.toLocaleString(
-      this.bindings.i18n.language
-    )}`;
+    this.showMoreText = this.bindings.i18n.t('show-n-more-filters', {value});
   }
 
   private get facetBreadcrumbs(): BreadboxBreadcrumb[] {


### PR DESCRIPTION
[KIT-5809](https://coveord.atlassian.net/browse/KIT-5809)

## Problem

The breadbox "show more" button displays visible text `+ N` (e.g., "+ 3") but has an accessible name of "Show 3 more filters". The visible text is not contained in the accessible name, failing WCAG 2.5.3 Label in Name (Level A).

Speech input users seeing "+ 3" have no reliable way to activate the button by voice.

## Solution

Use the full i18n string (`show-n-more-filters`) as both the visible button text and the accessible name. The button now displays "Show 3 more filters" instead of "+ 3", ensuring the visible text matches the accessible name across all languages.

Removed the dead `showMoreText` state property that was only used for the old `+ N` formatting.

[KIT-5809]: https://coveord.atlassian.net/browse/KIT-5809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ