### PR TITLE
feat: warn user when both agentId and answerConfigurationId are provided

### DIFF
--- a/.changeset/orange-socks-tell-1.md
+++ b/.changeset/orange-socks-tell-1.md
@@ -1,0 +1,5 @@
+---
+"@coveo/headless": patch
+---
+
+Log a warning when both `agentId` and `answerConfigurationId` are provided to `buildGeneratedAnswer`

--- a/.changeset/orange-socks-tell-1.md
+++ b/.changeset/orange-socks-tell-1.md
@@ -1,5 +1,5 @@
 ---
-"@coveo/headless": patch
+"@coveo/headless": minor
 ---
 
-Log a warning when both `agentId` and `answerConfigurationId` are provided to `buildGeneratedAnswer`
+Log a warning when both `agentId` and `answerConfigurationId` are provided to `buildGeneratedAnswer`.

--- a/.changeset/orange-socks-tell-2.md
+++ b/.changeset/orange-socks-tell-2.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": minor
+---
+
+Log a warning when both `agent-id` and `answer-configuration-id` attributes are set on a `atomic-generated-answer`.

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts
@@ -981,6 +981,22 @@ describe('atomic-generated-answer', () => {
         })
       );
     });
+
+    it('should warn when both agentId and answerConfigurationId are provided', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await renderGeneratedAnswer({
+        props: {
+          agentId: 'test-agent-id',
+          answerConfigurationId: 'test-config-id',
+        },
+        generatedAnswerState: {isVisible: true, answer: 'Test'},
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Both "agent-id" and "answer-configuration-id" properties were provided. The "agent-id" will take precedence and the "answer-configuration-id" will be ignored. Please set only one of these properties to avoid confusion.'
+      );
+    });
   });
 
   describe('follow up capability', () => {

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
@@ -318,6 +318,12 @@ export class AtomicGeneratedAnswer
       getBindings: () => this.bindings,
     });
 
+    if (this.agentId && this.answerConfigurationId) {
+      console.warn(
+        'Both "agent-id" and "answer-configuration-id" properties were provided. The "agent-id" will take precedence and the "answer-configuration-id" will be ignored. Please set only one of these properties to avoid confusion.'
+      );
+    }
+
     this.generatedAnswer = buildGeneratedAnswer(this.bindings.engine, {
       initialState: {
         isVisible: this.controller.data.isVisible,

--- a/packages/headless/src/controllers/generated-answer/headless-generated-answer.test.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-generated-answer.test.ts
@@ -164,6 +164,9 @@ describe('generated answer', () => {
         initGeneratedAnswer(props);
 
         expect(buildAnswerApiGeneratedAnswer).not.toHaveBeenCalled();
+        expect(engine.logger.warn).toHaveBeenCalledWith(
+          'Both agentId and answerConfigurationId were provided to buildGeneratedAnswer. The agentId will take precedence and the answerConfigurationId will be ignored.'
+        );
         expect(buildGeneratedAnswerWithFollowUps).toHaveBeenCalledWith(
           engine,
           expect.anything(),

--- a/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
@@ -54,17 +54,24 @@ export function buildGeneratedAnswer(
     engine.state.configuration.analytics.analyticsMode
   );
 
+  const hasAgentId = props.agentId && props.agentId.trim() !== '';
+  const hasAnswerConfigurationId =
+    props.answerConfigurationId && props.answerConfigurationId.trim() !== '';
+
+  if (hasAgentId && hasAnswerConfigurationId) {
+    engine.logger.warn(
+      'Both agentId and answerConfigurationId were provided to buildGeneratedAnswer. The agentId will take precedence and the answerConfigurationId will be ignored.'
+    );
+  }
+
   let controller: GeneratedAnswer | GeneratedAnswerWithFollowUps;
-  if (props.agentId && props.agentId.trim() !== '') {
+  if (hasAgentId) {
     controller = buildGeneratedAnswerWithFollowUps(
       engine,
       generatedAnswerAnalyticsClient,
-      {...props, agentId: props.agentId}
+      props as GeneratedAnswerProps & {agentId: string}
     );
-  } else if (
-    props.answerConfigurationId &&
-    props.answerConfigurationId.trim() !== ''
-  ) {
+  } else if (hasAnswerConfigurationId) {
     controller = buildAnswerApiGeneratedAnswer(
       engine,
       generatedAnswerAnalyticsClient,


### PR DESCRIPTION
This pull request adds warnings and associated tests to handle cases where both `agentId` and `answerConfigurationId` are provided to the generated answer components and controller. The goal is to clarify which property takes precedence and prevent potential confusion for developers and users. (as seen in recent discuss)

**Validation and Warning Improvements:**

* Added a warning in the `AtomicGeneratedAnswer` component to notify when both `agentId` and `answerConfigurationId` are set, clarifying that `agentId` takes precedence and `answerConfigurationId` will be ignored. (`packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts`)
* Implemented a similar warning in the `buildGeneratedAnswer` controller to log when both properties are provided, ensuring consistent behaviour and messaging across the codebase. (`packages/headless/src/controllers/generated-answer/headless-generated-answer.ts`)

**Testing Enhancements:**

* Added a unit test for the `AtomicGeneratedAnswer` component to verify that the warning is logged when both properties are set. (`packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts`)
* Added a test in the headless controller to ensure the warning is logged and the correct controller is used when both properties are provided. (`packages/headless/src/controllers/generated-answer/headless-generated-answer.test.ts`)