### PR TITLE
fix(headless): correct totalSpotlightContent field name in pagination response 🚶‍♀️ [COMHUB2-2093]

### DIFF
--- a/.changeset/wild-moles-appear.md
+++ b/.changeset/wild-moles-appear.md
@@ -1,0 +1,5 @@
+---
+"@coveo/headless": patch
+---
+
+fix(headless): correct totalSpotlightContent field name in pagination response COMHUB2-2093

--- a/packages/headless/src/api/commerce/commerce-api-client.test.ts
+++ b/packages/headless/src/api/commerce/commerce-api-client.test.ts
@@ -369,7 +369,7 @@ describe('commerce api client', () => {
         totalEntries: 0,
         totalPages: 0,
         totalProducts: 0,
-        totalSpotlights: 0,
+        totalSpotlightContent: 0,
       },
       responseId: '',
       sort: {

--- a/packages/headless/src/api/commerce/common/pagination.ts
+++ b/packages/headless/src/api/commerce/common/pagination.ts
@@ -7,5 +7,5 @@ export interface Pagination {
 
 export interface PaginationWithResultTypeCounts extends Pagination {
   totalProducts: number;
-  totalSpotlights: number;
+  totalSpotlightContent: number;
 }

--- a/packages/headless/src/features/commerce/pagination/pagination-slice.test.ts
+++ b/packages/headless/src/features/commerce/pagination/pagination-slice.test.ts
@@ -48,6 +48,8 @@ describe('pagination slice', () => {
     perPage: 999,
     totalEntries: 999,
     totalPages: 999,
+    totalProducts: 999,
+    totalSpotlightContent: 999,
   };
   const slotId = 'recommendations-slot-id';
 

--- a/packages/headless/src/test/mock-product-listing.ts
+++ b/packages/headless/src/test/mock-product-listing.ts
@@ -11,13 +11,14 @@ export function buildFetchProductListingResponse(
         appliedSort: {sortCriteria: SortBy.Relevance},
         availableSorts: [{sortCriteria: SortBy.Relevance}],
       },
-      pagination: response.pagination ?? {
+      pagination: {
         page: 0,
         perPage: 0,
         totalEntries: 0,
         totalPages: 0,
         totalProducts: 0,
         totalSpotlightContent: 0,
+        ...response.pagination,
       },
       facets: response.facets ?? [],
       products: response.products ?? [],

--- a/packages/headless/src/test/mock-product-listing.ts
+++ b/packages/headless/src/test/mock-product-listing.ts
@@ -17,7 +17,7 @@ export function buildFetchProductListingResponse(
         totalEntries: 0,
         totalPages: 0,
         totalProducts: 0,
-        totalSpotlights: 0,
+        totalSpotlightContent: 0,
       },
       facets: response.facets ?? [],
       products: response.products ?? [],


### PR DESCRIPTION
[COMHUB2-2093](https://coveord.atlassian.net/browse/COMHUB2-2093)


I got this field name wrong last time. 

Here it is console.logged in one of the samples

<img width="603" height="155" alt="image" src="https://github.com/user-attachments/assets/c403a5e7-8660-4a5d-bbdd-301921fbea5b" />


[COMHUB2-2093]: https://coveord.atlassian.net/browse/COMHUB2-2093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ