### PR TITLE
a11y(2.5.1): Manual audit – Pointer Gestures not applicable

### DIFF
--- a/packages/atomic-a11y/a11y/a11y-overrides.json
+++ b/packages/atomic-a11y/a11y/a11y-overrides.json
@@ -64,6 +64,11 @@
       "reason": "Multiple navigation ways are a host application concern, not a component library concern."
     },
     {
+      "criterion": "2.5.1",
+      "conformance": "not-applicable",
+      "reason": "Atomic does not implement multipoint or path-based gestures. Carousels use button-based navigation, scrollable containers use native browser scroll with arrow buttons, and touch events (touchstart/touchend) are used only as single-point tap equivalents for analytics timing."
+    },
+    {
       "criterion": "2.5.4",
       "conformance": "not-applicable",
       "reason": "Atomic does not include functionality operated by device or user motion."


### PR DESCRIPTION
[KIT-5787](https://coveord.atlassian.net/browse/KIT-5787)

## Problem
WCAG 2.5.1 Pointer Gestures (Level A) was marked "Does Not Support" in the Atomic VPAT because no audit coverage existed.

## Solution
Audited all Atomic components for multipoint or path-based gestures:

- **Carousels** (`carousel.ts`, `image-carousel.ts`): use button-based navigation only, no swipe/flick gestures
- **`atomic-segmented-facet-scrollable`**: uses native browser `overflow-x: scroll` + arrow buttons; `touchmove` listener only updates arrow visibility state
- **Modals** (`atomic-modal`, `atomic-ipx-modal`): use `touchmove` with `preventDefault()` solely to prevent background scrolling — not a functional gesture
- **Link analytics** (`bind-analytics-to-link.ts`, `result-utils.ts`): use `touchstart`/`touchend` as single-point tap equivalents for analytics timing
- **`atomic-product-children`**: uses `touchstart` as a tap equivalent (same as click/hover)

**Conclusion:** No Atomic components implement multipoint or path-based gestures. Criterion marked as "Not Applicable" via `a11y-overrides.json`.

`pnpm a11y:vpat` validates successfully and the VPAT now shows 2.5.1 as "Not Applicable".

[KIT-5787]: https://coveord.atlassian.net/browse/KIT-5787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ