### PR TITLE
feat(atomic-a11y): manual audit for WCAG 2.5.2 Pointer Cancellation

### DIFF
--- a/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
@@ -6,6 +6,9 @@
     },
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
+    },
+    "2.5.2-pointer-cancellation": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
@@ -3,6 +3,9 @@
   "wcag22Criteria": {
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
+    },
+    "2.5.2-pointer-cancellation": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
@@ -3,6 +3,7 @@
   "wcag22Criteria": {
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
-    }
+    },
+    "2.5.2-pointer-cancellation": "pass"
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
@@ -3,6 +3,9 @@
   "wcag22Criteria": {
     "2.4.6-headings-and-labels": {
       "conformance": "pass"
+    },
+    "2.5.2-pointer-cancellation": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-search.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-search.json
@@ -7,6 +7,9 @@
     "2.4.6-headings-and-labels": {
       "conformance": "fail",
       "remarks": "atomic-tab-manager renders a tablist with aria-label=\"tab-area\" — a non-descriptive technical placeholder. Screen reader users navigating by landmark or tab group hear \"tab-area\" instead of a meaningful description of the tab purpose (e.g., \"Content type tabs\"), making it difficult to understand the interface structure."
+    },
+    "2.5.2-pointer-cancellation": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/reports/openacr.yaml
+++ b/packages/atomic-a11y/reports/openacr.yaml
@@ -13,14 +13,14 @@ vendor:
   company_name: Coveo
   email: support@coveo.com
   website: https://www.coveo.com
-report_date: '2026-06-15'
+report_date: '2026-06-16'
 last_modified_date: '2026-06-16'
 version: 1
 notes: Generated from a11y/reports/a11y-report.json. Conformance is derived from
   axe-core results, interactive keyboard tests, and manual audits. Rows marked
   [Manual audit required] have no automated or interactive coverage and are
   reported as Does Not Support pending manual verification.
-evaluation_methods_used: axe-core 4.11.4; Storybook addon-a11y; Storybook
+evaluation_methods_used: axe-core 4.12.0; Storybook addon-a11y; Storybook
   interactive play() tests; Manual audit
 repository: https://github.com/coveo/ui-kit
 feedback: https://github.com/coveo/ui-kit/issues
@@ -36,7 +36,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 1.2.1
         components:
@@ -64,7 +64,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s); interactive keyboard testing passed across 2
                 component(s).
       - num: 1.3.2
@@ -89,7 +89,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 1.4.2
         components:
@@ -103,7 +103,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 174
+                Supports — automated axe-core found no violations across 175
                 component(s); interactive keyboard testing passed across 34
                 component(s).
       - num: 2.1.2
@@ -175,7 +175,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 2.5.1
         components:
@@ -192,10 +192,8 @@ chapters:
         components:
           - name: web
             adherence:
-              level: does-not-support
-              notes:
-                'WCAG 2.5.2: no automated, interactive, or manual coverage. [Manual audit
-                required]'
+              level: supports
+              notes: Supports — manual audit found Supports.
       - num: 2.5.3
         components:
           - name: web
@@ -257,7 +255,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 3.3.7
         components:
@@ -273,7 +271,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s); interactive keyboard testing passed across 4
                 component(s).
   success_criteria_level_aa:
@@ -309,7 +307,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 1.4.3
         components:
@@ -317,7 +315,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 1.4.4
         components:
@@ -325,7 +323,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 1.4.5
         components:
@@ -359,7 +357,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 1.4.13
         components:
@@ -422,7 +420,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 3.1.2
         components:
@@ -430,7 +428,7 @@ chapters:
             adherence:
               level: supports
               notes:
-                Supports — automated axe-core found no violations across 172
+                Supports — automated axe-core found no violations across 173
                 component(s).
       - num: 3.2.3
         components:


### PR DESCRIPTION
https://www.w3.org/WAI/WCAG22/Understanding/pointer-cancellation.html

[KIT-5788](https://coveord.atlassian.net/browse/KIT-5788)

## Problem
WCAG 2.5.2 Pointer Cancellation (Level A) was marked "Does Not Support" in the Atomic VPAT because no manual audit coverage existed.

## Solution
Manually audited all 34 interactive Atomic components against SC 2.5.2. All components pass:

- **Ripple effects** (mousedown): Cosmetic animation only; functional actions fire on click (up-event)
- **Analytics logging** (mousedown/touchstart): Fire-and-forget tracking; navigation uses native link click
- **Focus management** (mousedown/pointerdown): preventDefault to retain focus; no functionality executed
- **Product variant selection** (touchstart): Reversible preview selection (same as mouseenter); primary navigation on click

Results recorded in `packages/atomic-a11y/a11y/reports/manual-audit-{search,commerce,insight,ipx,recommendations}.json`. Criterion now reports **Supports** in the VPAT.

[KIT-5788]: https://coveord.atlassian.net/browse/KIT-5788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ