### PR TITLE
a11y: manual audit for WCAG 2.4.3 Focus Order (Level A)

### DIFF
--- a/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
@@ -27,6 +27,10 @@
     },
     "1.4.10-reflow": {
       "conformance": "pass"
+    },
+    "2.4.3-focus-order": {
+      "conformance": "fail",
+      "remarks": "Focus escapes commerce refine-modal when tabbing, due to broken focus trap. See KIT-5811. All non-modal components pass (search box, facets, breadbox, pager, sort dropdown, products-per-page, product list, load-more)."
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
@@ -21,6 +21,10 @@
     "2.5.3-label-in-name": "pass",
     "1.4.10-reflow": {
       "conformance": "pass"
+    },
+    "2.4.3-focus-order": {
+      "conformance": "fail",
+      "remarks": "Focus escapes insight refine-modal and smart-snippet-feedback-modal when tabbing, due to broken focus trap. See KIT-5811. All non-modal components pass (search box, facets, pager, tabs)."
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
@@ -13,6 +13,10 @@
     "2.5.3-label-in-name": "pass",
     "1.4.10-reflow": {
       "conformance": "pass"
+    },
+    "2.4.3-focus-order": {
+      "conformance": "fail",
+      "remarks": "Focus escapes ipx-modal and ipx-refine-modal when tabbing, due to broken focus trap. See KIT-5811. Tab component passes."
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
@@ -11,6 +11,7 @@
     "2.5.3-label-in-name": "pass",
     "1.4.10-reflow": {
       "conformance": "pass"
-    }
+    },
+    "2.4.3-focus-order": "pass"
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-search.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-search.json
@@ -28,6 +28,10 @@
     },
     "1.4.10-reflow": {
       "conformance": "pass"
+    },
+    "2.4.3-focus-order": {
+      "conformance": "fail",
+      "remarks": "Focus escapes modal dialogs (refine-modal, quickview-modal, smart-snippet-feedback-modal) and popover when tabbing, due to broken focus trap (undefined scope in atomic-focus-trap). See KIT-5811. All non-modal components pass (search box, facets, pager, sort dropdown, results-per-page, tabs, segmented facet, result list, load-more, smart snippet)."
     }
   }
 }


### PR DESCRIPTION
[KIT-5786](https://coveord.atlassian.net/browse/KIT-5786)

## Problem

WCAG 2.4.3 Focus Order (Level A) was marked "Does Not Support" in the Atomic VPAT because no audit coverage existed.

## Solution

Manually audited 48 components across all categories (search, commerce, insight, ipx, common, recommendations) for focus order compliance.

**Results:**
- 36 components pass (correct DOM order, roving tabindex in tabs, proper pager sequencing, breadbox focus management)
- 12 components fail — all modal/dialog components where focus escapes the focus trap

**Root cause of failures:** `atomic-focus-trap` has an undefined `scope` property at runtime, causing its `onFocusChanged` handler to not redirect escaped focus back into the trap. This is a single systemic bug affecting all modals.

**Tickets filed:**
- [KIT-5811](https://coveord.atlassian.net/browse/KIT-5811): Fix focus trap scope + add integration tests for focus containment
- [KIT-5810](https://coveord.atlassian.net/browse/KIT-5810): Load-more-results focus lost to body (UX bug, not a 2.4.3 violation)

**VPAT status after this PR:** 2.4.3 shows "Does Not Support" with detailed per-component remarks referencing KIT-5811.

[KIT-5786]: https://coveord.atlassian.net/browse/KIT-5786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIT-5811]: https://coveord.atlassian.net/browse/KIT-5811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIT-5810]: https://coveord.atlassian.net/browse/KIT-5810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ