### PR TITLE
feat(headless): change follow-up citations clicks events to custom event

### DIFF
--- a/.changeset/deep-bears-occur.md
+++ b/.changeset/deep-bears-occur.md
@@ -1,0 +1,5 @@
+---
+"@coveo/headless": patch
+---
+
+feat(headless): change search agent follow-up citations clicks events to custom event

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -150,6 +150,10 @@ export interface GeneratedAnswerAnalyticsClient {
     citationId: string,
     answerId?: string
   ): CustomAction;
+  logOpenGeneratedAnswerFollowupSource(
+    citationId: string,
+    answerId: string
+  ): CustomAction;
   /** @deprecated */
   logHoverCitation(
     citationId: string,

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -150,7 +150,7 @@ export interface GeneratedAnswerAnalyticsClient {
     citationId: string,
     answerId?: string
   ): CustomAction;
-  logOpenGeneratedAnswerFollowupSource?(
+  logOpenGeneratedAnswerFollowUpSource?(
     citationId: string,
     answerId: string
   ): CustomAction;

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -150,7 +150,7 @@ export interface GeneratedAnswerAnalyticsClient {
     citationId: string,
     answerId?: string
   ): CustomAction;
-  logOpenGeneratedAnswerFollowupSource(
+  logOpenGeneratedAnswerFollowupSource?(
     citationId: string,
     answerId: string
   ): CustomAction;

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-interactive-citation.test.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-interactive-citation.test.ts
@@ -1,9 +1,5 @@
 import type {GeneratedAnswerCitation} from '../../../api/generated-answer/generated-answer-event-payload.js';
 import {configuration} from '../../../app/common-reducers.js';
-import {
-  generatedAnswerAnalyticsClient,
-  logOpenGeneratedAnswerSource,
-} from '../../../features/generated-answer/generated-answer-analytics-actions.js';
 import {buildMockCitation} from '../../../test/mock-citation.js';
 import {
   buildMockSearchEngine,
@@ -13,24 +9,25 @@ import {createMockState} from '../../../test/mock-state.js';
 import {
   buildInteractiveCitationCore,
   type InteractiveCitation,
+  type InteractiveCitationAnalyticsClient,
 } from './headless-core-interactive-citation.js';
-
-vi.mock(
-  '../../../features/generated-answer/generated-answer-analytics-actions'
-);
 
 describe('InteractiveCitation', () => {
   let engine: MockedSearchEngine;
   let mockCitation: GeneratedAnswerCitation;
   let interactiveCitation: InteractiveCitation;
+  let analyticsClient: InteractiveCitationAnalyticsClient;
 
   function initializeInteractiveCitation(delay?: number, answerId?: string) {
     mockCitation = buildMockCitation({
       id: 'some-test-id',
     });
+    analyticsClient = {
+      logCitationOpen: vi.fn(),
+    };
     interactiveCitation = buildInteractiveCitationCore(
       engine,
-      generatedAnswerAnalyticsClient,
+      analyticsClient,
       {
         options: {citation: mockCitation, selectionDelay: delay, answerId},
       }
@@ -47,29 +44,29 @@ describe('InteractiveCitation', () => {
     expect(engine.addReducers).toHaveBeenCalledWith({configuration});
   });
 
-  it('when calling select(), logs openGeneratedAnswerSource', () => {
+  it('when calling select(), calls logCitationOpen with citation id', () => {
     interactiveCitation.select();
-    expect(logOpenGeneratedAnswerSource).toHaveBeenCalledWith(
+    expect(analyticsClient.logCitationOpen).toHaveBeenCalledWith(
       mockCitation.id,
       undefined
     );
   });
 
-  it('when an answerId is provided, passes it to logOpenGeneratedAnswerSource', () => {
+  it('when an answerId is provided, passes it to logCitationOpen', () => {
     initializeInteractiveCitation(undefined, 'answer-id');
 
     interactiveCitation.select();
 
-    expect(logOpenGeneratedAnswerSource).toHaveBeenCalledWith(
+    expect(analyticsClient.logCitationOpen).toHaveBeenCalledWith(
       mockCitation.id,
       'answer-id'
     );
   });
 
-  it('when calling select() more than once, logs openGeneratedAnswerSource only once', () => {
+  it('when calling select() more than once, calls logCitationOpen only once', () => {
     interactiveCitation.select();
     interactiveCitation.select();
 
-    expect(logOpenGeneratedAnswerSource).toHaveBeenCalledTimes(1);
+    expect(analyticsClient.logCitationOpen).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-interactive-citation.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-interactive-citation.ts
@@ -34,17 +34,15 @@ export interface InteractiveCitationProps extends InteractiveResultCoreProps {
  */
 export interface InteractiveCitation extends InteractiveResultCore {}
 
-interface InteractiveCitationAnalyticsClient {
-  logOpenGeneratedAnswerSource(
-    citationId: string,
-    answerId?: string
-  ): CustomAction;
+export interface InteractiveCitationAnalyticsClient {
+  logCitationOpen(citationId: string, answerId?: string): CustomAction;
 }
 
 /**
  * Creates a core `InteractiveCitation` controller instance.
  *
  * @param engine - The headless engine.
+ * @param analyticsClient - The analytics client responsible for logging citation open events.
  * @param props - The configurable `InteractiveCitation` properties.
  * @returns An `InteractiveCitation` controller instance.
  */
@@ -61,7 +59,7 @@ export function buildInteractiveCitationCore(
     }
     wasOpened = true;
     engine.dispatch(
-      analyticsClient.logOpenGeneratedAnswerSource(
+      analyticsClient.logCitationOpen(
         props.options.citation.id,
         props.options.answerId
       )

--- a/packages/headless/src/controllers/generated-answer/headless-interactive-citation.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-interactive-citation.ts
@@ -1,5 +1,9 @@
 import type {SearchEngine} from '../../app/search-engine/search-engine.js';
-import {generatedAnswerAnalyticsClient} from '../../features/generated-answer/generated-answer-analytics-actions.js';
+import {
+  logOpenGeneratedAnswerFollowupSource,
+  logOpenGeneratedAnswerSource,
+} from '../../features/generated-answer/generated-answer-analytics-actions.js';
+import {generativeQuestionAnsweringIdSelector} from '../../features/generated-answer/generated-answer-selectors.js';
 import {
   buildInteractiveCitationCore,
   type InteractiveCitation,
@@ -29,7 +33,24 @@ export function buildInteractiveCitation(
 ): InteractiveCitation {
   return buildInteractiveCitationCore(
     engine,
-    generatedAnswerAnalyticsClient,
+    {
+      logCitationOpen(citationId: string, answerId?: string) {
+        const headAnswerId = generativeQuestionAnsweringIdSelector(
+          engine.state
+        );
+
+        if (
+          answerId !== undefined &&
+          headAnswerId !== undefined &&
+          answerId !== headAnswerId
+        ) {
+          return logOpenGeneratedAnswerFollowupSource(citationId, answerId);
+        }
+        return answerId !== undefined
+          ? logOpenGeneratedAnswerSource(citationId, answerId)
+          : logOpenGeneratedAnswerSource(citationId);
+      },
+    },
     props
   );
 }

--- a/packages/headless/src/controllers/generated-answer/headless-interactive-citation.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-interactive-citation.ts
@@ -1,15 +1,11 @@
 import type {SearchEngine} from '../../app/search-engine/search-engine.js';
 import {
-  logOpenGeneratedAnswerFollowUpSource,
-  logOpenGeneratedAnswerSource,
-} from '../../features/generated-answer/generated-answer-analytics-actions.js';
-import {generativeQuestionAnsweringIdSelector} from '../../features/generated-answer/generated-answer-selectors.js';
-import {
   buildInteractiveCitationCore,
   type InteractiveCitation,
   type InteractiveCitationOptions,
   type InteractiveCitationProps,
 } from '../core/generated-answer/headless-core-interactive-citation.js';
+import {buildInteractiveCitationAnalyticsClient} from './interactive-citation-analytics-client.js';
 
 export type {
   InteractiveCitation,
@@ -33,24 +29,7 @@ export function buildInteractiveCitation(
 ): InteractiveCitation {
   return buildInteractiveCitationCore(
     engine,
-    {
-      logCitationOpen(citationId: string, answerId?: string) {
-        const headAnswerId = generativeQuestionAnsweringIdSelector(
-          engine.state
-        );
-
-        if (
-          answerId !== undefined &&
-          headAnswerId !== undefined &&
-          answerId !== headAnswerId
-        ) {
-          return logOpenGeneratedAnswerFollowUpSource(citationId, answerId);
-        }
-        return answerId !== undefined
-          ? logOpenGeneratedAnswerSource(citationId, answerId)
-          : logOpenGeneratedAnswerSource(citationId);
-      },
-    },
+    buildInteractiveCitationAnalyticsClient(() => engine.state),
     props
   );
 }

--- a/packages/headless/src/controllers/generated-answer/headless-interactive-citation.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-interactive-citation.ts
@@ -1,6 +1,6 @@
 import type {SearchEngine} from '../../app/search-engine/search-engine.js';
 import {
-  logOpenGeneratedAnswerFollowupSource,
+  logOpenGeneratedAnswerFollowUpSource,
   logOpenGeneratedAnswerSource,
 } from '../../features/generated-answer/generated-answer-analytics-actions.js';
 import {generativeQuestionAnsweringIdSelector} from '../../features/generated-answer/generated-answer-selectors.js';
@@ -44,7 +44,7 @@ export function buildInteractiveCitation(
           headAnswerId !== undefined &&
           answerId !== headAnswerId
         ) {
-          return logOpenGeneratedAnswerFollowupSource(citationId, answerId);
+          return logOpenGeneratedAnswerFollowUpSource(citationId, answerId);
         }
         return answerId !== undefined
           ? logOpenGeneratedAnswerSource(citationId, answerId)

--- a/packages/headless/src/controllers/generated-answer/interactive-citation-analytics-client.test.ts
+++ b/packages/headless/src/controllers/generated-answer/interactive-citation-analytics-client.test.ts
@@ -1,0 +1,74 @@
+import {
+  logOpenGeneratedAnswerFollowUpSource,
+  logOpenGeneratedAnswerSource,
+} from '../../features/generated-answer/generated-answer-analytics-actions.js';
+import {generativeQuestionAnsweringIdSelector} from '../../features/generated-answer/generated-answer-selectors.js';
+import {buildInteractiveCitationAnalyticsClient} from './interactive-citation-analytics-client.js';
+
+vi.mock('../../features/generated-answer/generated-answer-analytics-actions');
+vi.mock('../../features/generated-answer/generated-answer-selectors');
+
+describe('buildInteractiveCitationAnalyticsClient', () => {
+  const citationId = 'citation-1';
+  const headAnswerId = 'head-answer-id';
+  const followUpAnswerId = 'follow-up-answer-id';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls logOpenGeneratedAnswerSource when no answerId is provided', () => {
+    vi.mocked(generativeQuestionAnsweringIdSelector).mockReturnValue(
+      headAnswerId
+    );
+    const client = buildInteractiveCitationAnalyticsClient(() => ({}));
+
+    client.logCitationOpen(citationId);
+
+    expect(logOpenGeneratedAnswerSource).toHaveBeenCalledWith(citationId);
+    expect(logOpenGeneratedAnswerFollowUpSource).not.toHaveBeenCalled();
+  });
+
+  it('calls logOpenGeneratedAnswerSource when answerId matches head answer', () => {
+    vi.mocked(generativeQuestionAnsweringIdSelector).mockReturnValue(
+      headAnswerId
+    );
+    const client = buildInteractiveCitationAnalyticsClient(() => ({}));
+
+    client.logCitationOpen(citationId, headAnswerId);
+
+    expect(logOpenGeneratedAnswerSource).toHaveBeenCalledWith(
+      citationId,
+      headAnswerId
+    );
+    expect(logOpenGeneratedAnswerFollowUpSource).not.toHaveBeenCalled();
+  });
+
+  it('calls logOpenGeneratedAnswerFollowUpSource when answerId differs from head answer', () => {
+    vi.mocked(generativeQuestionAnsweringIdSelector).mockReturnValue(
+      headAnswerId
+    );
+    const client = buildInteractiveCitationAnalyticsClient(() => ({}));
+
+    client.logCitationOpen(citationId, followUpAnswerId);
+
+    expect(logOpenGeneratedAnswerFollowUpSource).toHaveBeenCalledWith(
+      citationId,
+      followUpAnswerId
+    );
+    expect(logOpenGeneratedAnswerSource).not.toHaveBeenCalled();
+  });
+
+  it('calls logOpenGeneratedAnswerSource when head answerId is undefined', () => {
+    vi.mocked(generativeQuestionAnsweringIdSelector).mockReturnValue(undefined);
+    const client = buildInteractiveCitationAnalyticsClient(() => ({}));
+
+    client.logCitationOpen(citationId, followUpAnswerId);
+
+    expect(logOpenGeneratedAnswerSource).toHaveBeenCalledWith(
+      citationId,
+      followUpAnswerId
+    );
+    expect(logOpenGeneratedAnswerFollowUpSource).not.toHaveBeenCalled();
+  });
+});

--- a/packages/headless/src/controllers/generated-answer/interactive-citation-analytics-client.ts
+++ b/packages/headless/src/controllers/generated-answer/interactive-citation-analytics-client.ts
@@ -1,0 +1,28 @@
+import type {SearchAppState} from '../../state/search-app-state.js';
+import {
+  logOpenGeneratedAnswerFollowUpSource,
+  logOpenGeneratedAnswerSource,
+} from '../../features/generated-answer/generated-answer-analytics-actions.js';
+import {generativeQuestionAnsweringIdSelector} from '../../features/generated-answer/generated-answer-selectors.js';
+import type {InteractiveCitationAnalyticsClient} from '../core/generated-answer/headless-core-interactive-citation.js';
+
+export function buildInteractiveCitationAnalyticsClient(
+  getState: () => Partial<SearchAppState>
+): InteractiveCitationAnalyticsClient {
+  return {
+    logCitationOpen(citationId: string, answerId?: string) {
+      const headAnswerId = generativeQuestionAnsweringIdSelector(getState());
+
+      if (
+        answerId !== undefined &&
+        headAnswerId !== undefined &&
+        answerId !== headAnswerId
+      ) {
+        return logOpenGeneratedAnswerFollowUpSource(citationId, answerId);
+      }
+      return answerId !== undefined
+        ? logOpenGeneratedAnswerSource(citationId, answerId)
+        : logOpenGeneratedAnswerSource(citationId);
+    },
+  };
+}

--- a/packages/headless/src/controllers/insight/generated-answer/headless-insight-interactive-citation.ts
+++ b/packages/headless/src/controllers/insight/generated-answer/headless-insight-interactive-citation.ts
@@ -29,7 +29,9 @@ export function buildInteractiveCitation(
 ): InteractiveCitation {
   return buildInteractiveCitationCore(
     engine,
-    {logOpenGeneratedAnswerSource},
+    {
+      logCitationOpen: (citationId) => logOpenGeneratedAnswerSource(citationId),
+    },
     props
   );
 }

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
@@ -17,6 +17,7 @@ import {
   logDislikeGeneratedAnswer,
   logHoverCitation,
   logLikeGeneratedAnswer,
+  logOpenGeneratedAnswerFollowupSource,
   logOpenGeneratedAnswerSource,
 } from '../../../features/generated-answer/generated-answer-analytics-actions.js';
 import {getGeneratedAnswerInitialState} from '../../../features/generated-answer/generated-answer-state.js';
@@ -559,18 +560,22 @@ describe('GeneratedAnswerWithFollowUps', () => {
           answerId: 'head-id',
         },
       });
+      engine.state.configuration.knowledge.agentId = 'some-agent-id';
     });
 
-    it('should delegate to core logCitationClick when no answerId is provided', () => {
+    it('should dispatch logOpenGeneratedAnswerSource when no answerId is provided', () => {
       const controller = createGeneratedAnswerWithFollowUps();
 
       controller.logCitationClick(citationId);
 
-      expect(mockCoreCitationClick).toHaveBeenCalledWith(citationId);
-      expect(logOpenGeneratedAnswerSource).not.toHaveBeenCalled();
+      expect(logOpenGeneratedAnswerSource).toHaveBeenCalledWith(
+        citationId,
+        undefined
+      );
+      expect(logOpenGeneratedAnswerFollowupSource).not.toHaveBeenCalled();
     });
 
-    it('should delegate to core logCitationClick when answerId matches head answer', () => {
+    it('should dispatch logOpenGeneratedAnswerSource when answerId matches head answer', () => {
       engine = buildEngineWithGeneratedAnswer({
         generatedAnswer: {
           ...getGeneratedAnswerInitialState(),
@@ -582,20 +587,23 @@ describe('GeneratedAnswerWithFollowUps', () => {
 
       controller.logCitationClick(citationId, headAnswerId);
 
-      expect(mockCoreCitationClick).toHaveBeenCalledWith(citationId);
-      expect(logOpenGeneratedAnswerSource).not.toHaveBeenCalled();
+      expect(logOpenGeneratedAnswerSource).toHaveBeenCalledWith(
+        citationId,
+        headAnswerId
+      );
+      expect(logOpenGeneratedAnswerFollowupSource).not.toHaveBeenCalled();
     });
 
-    it('should dispatch citation click analytics when answerId targets a follow-up answer', () => {
+    it('should dispatch logOpenGeneratedAnswerFollowupSource when answerId targets a follow-up answer', () => {
       const controller = createGeneratedAnswerWithFollowUps();
 
       controller.logCitationClick(citationId, followUpAnswerId);
 
-      expect(logOpenGeneratedAnswerSource).toHaveBeenCalledWith(
+      expect(logOpenGeneratedAnswerFollowupSource).toHaveBeenCalledWith(
         citationId,
         followUpAnswerId
       );
-      expect(mockCoreCitationClick).not.toHaveBeenCalled();
+      expect(logOpenGeneratedAnswerSource).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
@@ -17,7 +17,7 @@ import {
   logDislikeGeneratedAnswer,
   logHoverCitation,
   logLikeGeneratedAnswer,
-  logOpenGeneratedAnswerFollowupSource,
+  logOpenGeneratedAnswerFollowUpSource,
   logOpenGeneratedAnswerSource,
 } from '../../../features/generated-answer/generated-answer-analytics-actions.js';
 import {getGeneratedAnswerInitialState} from '../../../features/generated-answer/generated-answer-state.js';
@@ -572,7 +572,7 @@ describe('GeneratedAnswerWithFollowUps', () => {
         citationId,
         undefined
       );
-      expect(logOpenGeneratedAnswerFollowupSource).not.toHaveBeenCalled();
+      expect(logOpenGeneratedAnswerFollowUpSource).not.toHaveBeenCalled();
     });
 
     it('should dispatch logOpenGeneratedAnswerSource when answerId matches head answer', () => {
@@ -592,15 +592,15 @@ describe('GeneratedAnswerWithFollowUps', () => {
         citationId,
         headAnswerId
       );
-      expect(logOpenGeneratedAnswerFollowupSource).not.toHaveBeenCalled();
+      expect(logOpenGeneratedAnswerFollowUpSource).not.toHaveBeenCalled();
     });
 
-    it('should dispatch logOpenGeneratedAnswerFollowupSource when answerId targets a follow-up answer', () => {
+    it('should dispatch logOpenGeneratedAnswerFollowUpSource when answerId targets a follow-up answer', () => {
       const controller = createGeneratedAnswerWithFollowUps();
 
       controller.logCitationClick(citationId, followUpAnswerId);
 
-      expect(logOpenGeneratedAnswerFollowupSource).toHaveBeenCalledWith(
+      expect(logOpenGeneratedAnswerFollowUpSource).toHaveBeenCalledWith(
         citationId,
         followUpAnswerId
       );

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
@@ -582,6 +582,7 @@ describe('GeneratedAnswerWithFollowUps', () => {
           answerId: headAnswerId,
         },
       });
+      engine.state.configuration.knowledge.agentId = 'some-agent-id';
 
       const controller = createGeneratedAnswerWithFollowUps();
 

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../features/follow-up-answers/follow-up-answers-actions.js';
 import {followUpAnswersReducer as followUpAnswers} from '../../../features/follow-up-answers/follow-up-answers-slice.js';
 import type {FollowUpAnswersState} from '../../../features/follow-up-answers/follow-up-answers-state.js';
+import {generativeQuestionAnsweringIdSelector} from '../../../features/generated-answer/generated-answer-selectors.js';
 import {withGeneratedAnswerSseErrorHelpers} from '../../../features/generated-answer/sse-generated-answer-errors.js';
 import type {GeneratedAnswerState} from '../../../index.js';
 import type {
@@ -209,13 +210,19 @@ export function buildGeneratedAnswerWithFollowUps(
 
     // TODO: SFINT-6665
     logCitationClick(citationId: string, answerId?: string) {
-      if (!answerId || this.state.answerId === answerId) {
-        controller.logCitationClick(citationId);
-        return;
+      const headAnswerId = generativeQuestionAnsweringIdSelector(engine.state);
+      if (!answerId || answerId === headAnswerId) {
+        engine.dispatch(
+          analyticsClient.logOpenGeneratedAnswerSource(citationId, answerId)
+        );
+      } else {
+        engine.dispatch(
+          analyticsClient.logOpenGeneratedAnswerFollowupSource(
+            citationId,
+            answerId
+          )
+        );
       }
-      engine.dispatch(
-        analyticsClient.logOpenGeneratedAnswerSource(citationId, answerId)
-      );
     },
 
     // TODO: SFINT-6665

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
@@ -215,7 +215,7 @@ export function buildGeneratedAnswerWithFollowUps(
         engine.dispatch(
           analyticsClient.logOpenGeneratedAnswerSource(citationId, answerId)
         );
-      } else {
+      } else if (analyticsClient.logOpenGeneratedAnswerFollowupSource) {
         engine.dispatch(
           analyticsClient.logOpenGeneratedAnswerFollowupSource(
             citationId,

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
@@ -215,9 +215,9 @@ export function buildGeneratedAnswerWithFollowUps(
         engine.dispatch(
           analyticsClient.logOpenGeneratedAnswerSource(citationId, answerId)
         );
-      } else if (analyticsClient.logOpenGeneratedAnswerFollowupSource) {
+      } else if (analyticsClient.logOpenGeneratedAnswerFollowUpSource) {
         engine.dispatch(
-          analyticsClient.logOpenGeneratedAnswerFollowupSource(
+          analyticsClient.logOpenGeneratedAnswerFollowUpSource(
             citationId,
             answerId
           )

--- a/packages/headless/src/features/analytics/analytics-utils.ts
+++ b/packages/headless/src/features/analytics/analytics-utils.ts
@@ -26,6 +26,7 @@ import type {AnalyticsClient} from 'coveo.analytics/dist/definitions/client/anal
 import type {SearchEventResponse} from 'coveo.analytics/dist/definitions/events.js';
 import type {
   DocumentIdentifier,
+  PartialCitationInformation,
   PartialDocumentInformation,
 } from 'coveo.analytics/dist/definitions/searchPage/searchPageEvents.js';
 import type {Logger} from 'pino';
@@ -632,13 +633,26 @@ export const partialRecommendationInformation = (
   return buildPartialDocumentInformation(result, resultIndex, state);
 };
 
-export const partialCitationInformation = (
+export const partialDocumentInformationFromCitation = (
   citation: GeneratedAnswerCitation,
   state: Partial<SearchAppState>
 ): PartialDocumentInformation => {
   return {
     sourceName: getCitationSourceName(citation),
     documentPosition: 1,
+    documentTitle: citation.title,
+    documentUri: citation.uri,
+    documentUrl: citation.clickUri,
+    queryPipeline: state.pipeline || getPipelineInitialState(),
+  };
+};
+
+export const partialFollowupCitationInformation = (
+  citation: GeneratedAnswerCitation,
+  state: Partial<SearchAppState>
+): PartialCitationInformation => {
+  return {
+    sourceName: getCitationSourceName(citation),
     documentTitle: citation.title,
     documentUri: citation.uri,
     documentUrl: citation.clickUri,
@@ -810,7 +824,7 @@ export const analyticsEventItemMetadataForCitations = (
   state: Partial<SearchAppState>
 ): ItemMetaData => {
   const identifier = citationDocumentIdentifier(citation);
-  const information = partialCitationInformation(citation, state);
+  const information = partialDocumentInformationFromCitation(citation, state);
   return {
     uniqueFieldName: identifier.contentIdKey,
     uniqueFieldValue: identifier.contentIdValue,

--- a/packages/headless/src/features/attached-results/attached-results-analytics-actions.ts
+++ b/packages/headless/src/features/attached-results/attached-results-analytics-actions.ts
@@ -7,7 +7,7 @@ import {
   citationDocumentIdentifier,
   documentIdentifier,
   makeInsightAnalyticsActionFactory,
-  partialCitationInformation,
+  partialDocumentInformationFromCitation,
   partialDocumentInformation,
   validateResultPayload,
 } from '../analytics/analytics-utils.js';
@@ -83,7 +83,7 @@ export const logCitationDocumentAttach = (citation: GeneratedAnswerCitation) =>
         documentId: citationDocumentIdentifier(citation),
       };
       return client.logGeneratedAnswerCitationDocumentAttach(
-        partialCitationInformation(citation, state),
+        partialDocumentInformationFromCitation(citation, state),
         citationPayload,
         metadata
       );

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.test.ts
@@ -25,6 +25,7 @@ import {
   logGeneratedAnswerStreamEnd,
   logHoverCitation,
   logLikeGeneratedAnswer,
+  logOpenGeneratedAnswerFollowupSource,
   logOpenGeneratedAnswerSource,
   logRetryGeneratedAnswer,
 } from './generated-answer-analytics-actions.js';
@@ -38,6 +39,9 @@ const mockMakeRetryGeneratedAnswer = vi.fn(() => ({
   log: mockLogFunction,
 }));
 const mockMakeGeneratedAnswerCitationClick = vi.fn((..._args) => ({
+  log: mockLogFunction,
+}));
+const mockMakeGeneratedAnswerFollowupOpenSource = vi.fn((..._args) => ({
   log: mockLogFunction,
 }));
 const mockMakeGeneratedAnswerSourceHover = vi.fn(() => ({
@@ -158,6 +162,8 @@ describe('generated answer analytics actions', () => {
           mockMakeRetryGeneratedAnswer as unknown as typeof this.makeRetryGeneratedAnswer;
         this.makeGeneratedAnswerCitationClick =
           mockMakeGeneratedAnswerCitationClick as unknown as typeof this.makeGeneratedAnswerCitationClick;
+        this.makeGeneratedAnswerFollowupOpenSource =
+          mockMakeGeneratedAnswerFollowupOpenSource as unknown as typeof this.makeGeneratedAnswerFollowupOpenSource;
         this.makeGeneratedAnswerSourceHover =
           mockMakeGeneratedAnswerSourceHover as unknown as typeof this.makeGeneratedAnswerSourceHover;
         this.makeGeneratedAnswerOpenInlineLink =
@@ -278,6 +284,29 @@ describe('generated answer analytics actions', () => {
         generativeQuestionAnsweringId: exampleProvidedAnswerId,
         citationId: exampleCitation.id,
         documentId: exampleDocumentId,
+        conversationId: exampleConversationId,
+      });
+      expect(mockLogFunction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log #logOpenGeneratedAnswerFollowupSource with the right payload', async () => {
+      setConversationIdInState();
+
+      await logOpenGeneratedAnswerFollowupSource(
+        exampleCitation.id,
+        exampleProvidedAnswerId
+      )()(engine.dispatch, () => engine.state, {} as ThunkExtraArguments);
+
+      expect(mockMakeGeneratedAnswerFollowupOpenSource).toHaveBeenCalledTimes(
+        1
+      );
+      expect(
+        mockMakeGeneratedAnswerFollowupOpenSource.mock.calls[0][0]
+      ).toStrictEqual({
+        ...expectedCitationDocumentInfo,
+        generativeQuestionAnsweringId: exampleProvidedAnswerId,
+        citationId: exampleCitation.id,
+        permanentId: exampleCitation.permanentid,
         conversationId: exampleConversationId,
       });
       expect(mockLogFunction).toHaveBeenCalledTimes(1);

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.test.ts
@@ -25,7 +25,7 @@ import {
   logGeneratedAnswerStreamEnd,
   logHoverCitation,
   logLikeGeneratedAnswer,
-  logOpenGeneratedAnswerFollowupSource,
+  logOpenGeneratedAnswerFollowUpSource,
   logOpenGeneratedAnswerSource,
   logRetryGeneratedAnswer,
 } from './generated-answer-analytics-actions.js';
@@ -289,10 +289,10 @@ describe('generated answer analytics actions', () => {
       expect(mockLogFunction).toHaveBeenCalledTimes(1);
     });
 
-    it('should log #logOpenGeneratedAnswerFollowupSource with the right payload', async () => {
+    it('should log #logOpenGeneratedAnswerFollowUpSource with the right payload', async () => {
       setConversationIdInState();
 
-      await logOpenGeneratedAnswerFollowupSource(
+      await logOpenGeneratedAnswerFollowUpSource(
         exampleCitation.id,
         exampleProvidedAnswerId
       )()(engine.dispatch, () => engine.state, {} as ThunkExtraArguments);

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.test.ts
@@ -303,7 +303,11 @@ describe('generated answer analytics actions', () => {
       expect(
         mockMakeGeneratedAnswerFollowupOpenSource.mock.calls[0][0]
       ).toStrictEqual({
-        ...expectedCitationDocumentInfo,
+        sourceName: expectedCitationDocumentInfo.sourceName,
+        documentTitle: expectedCitationDocumentInfo.documentTitle,
+        documentUri: expectedCitationDocumentInfo.documentUri,
+        documentUrl: expectedCitationDocumentInfo.documentUrl,
+        queryPipeline: expectedCitationDocumentInfo.queryPipeline,
         generativeQuestionAnsweringId: exampleProvidedAnswerId,
         citationId: exampleCitation.id,
         permanentId: exampleCitation.permanentid,

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
@@ -457,18 +457,22 @@ export function logCopyGeneratedAnswer(answerId?: string): CustomAction {
   });
 }
 
-export function logOpenGeneratedAnswerFollowupSource(
+export function logOpenGeneratedAnswerFollowUpSource(
   citationId: string,
   answerId: string
 ): CustomAction {
   return makeAnalyticsAction({
-    prefix: 'analytics/generatedAnswer/openFollowupAnswerSource',
+    prefix: 'analytics/generatedAnswer/openFollowUpAnswerSource',
     __legacy__getBuilder: (client, state) => {
       const citation = citationSourceSelector(state, citationId);
       if (!citation) {
         return null;
       }
-      const conversationId = selectFollowUpAnswersConversationId(state) ?? '';
+      const conversationId = selectFollowUpAnswersConversationId(state);
+
+      if (!conversationId) {
+        return null;
+      }
 
       return client.makeGeneratedAnswerFollowupOpenSource({
         ...partialFollowupCitationInformation(citation, state),
@@ -496,7 +500,7 @@ export const generatedAnswerAnalyticsClient = {
   logGeneratedAnswerOpenInlineLink,
   logHoverCitation,
   logOpenGeneratedAnswerSource,
-  logOpenGeneratedAnswerFollowupSource,
+  logOpenGeneratedAnswerFollowUpSource,
   logRetryGeneratedAnswer,
   logGeneratedAnswerExpand,
   logGeneratedAnswerCollapse,

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
@@ -456,6 +456,30 @@ export function logCopyGeneratedAnswer(answerId?: string): CustomAction {
   });
 }
 
+export function logOpenGeneratedAnswerFollowupSource(
+  citationId: string,
+  answerId: string
+): CustomAction {
+  return makeAnalyticsAction({
+    prefix: 'analytics/generatedAnswer/openFollowupAnswerSource',
+    __legacy__getBuilder: (client, state) => {
+      const citation = citationSourceSelector(state, citationId);
+      if (!citation) {
+        return null;
+      }
+      const conversationId = selectFollowUpAnswersConversationId(state) ?? '';
+
+      return client.makeGeneratedAnswerFollowupOpenSource({
+        ...partialCitationInformation(citation, state),
+        generativeQuestionAnsweringId: answerId,
+        citationId: citation.id,
+        permanentId: citation.permanentid,
+        conversationId,
+      });
+    },
+  });
+}
+
 export const retryGeneratedAnswer = (): SearchAction => ({
   actionCause: SearchPageEvents.retryGeneratedAnswer,
 });
@@ -471,6 +495,7 @@ export const generatedAnswerAnalyticsClient = {
   logGeneratedAnswerOpenInlineLink,
   logHoverCitation,
   logOpenGeneratedAnswerSource,
+  logOpenGeneratedAnswerFollowupSource,
   logRetryGeneratedAnswer,
   logGeneratedAnswerExpand,
   logGeneratedAnswerCollapse,

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
@@ -4,7 +4,8 @@ import {
   citationDocumentIdentifier,
   type LegacySearchAction,
   makeAnalyticsAction,
-  partialCitationInformation,
+  partialDocumentInformationFromCitation,
+  partialFollowupCitationInformation,
 } from '../analytics/analytics-utils.js';
 import {SearchPageEvents} from '../analytics/search-action-cause.js';
 import type {SearchAction} from '../search/search-actions.js';
@@ -68,7 +69,7 @@ export function logOpenGeneratedAnswerSource(
       const conversationId = selectFollowUpAnswersConversationId(state);
 
       return client.makeGeneratedAnswerCitationClick(
-        partialCitationInformation(citation, state),
+        partialDocumentInformationFromCitation(citation, state),
         {
           generativeQuestionAnsweringId: resolvedAnswerId,
           citationId: citation.id,
@@ -470,7 +471,7 @@ export function logOpenGeneratedAnswerFollowupSource(
       const conversationId = selectFollowUpAnswersConversationId(state) ?? '';
 
       return client.makeGeneratedAnswerFollowupOpenSource({
-        ...partialCitationInformation(citation, state),
+        ...partialFollowupCitationInformation(citation, state),
         generativeQuestionAnsweringId: answerId,
         citationId: citation.id,
         permanentId: citation.permanentid,

--- a/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
@@ -3,7 +3,7 @@ import {
   citationDocumentIdentifier,
   type InsightAction,
   makeInsightAnalyticsActionFactory,
-  partialCitationInformation,
+  partialDocumentInformationFromCitation,
 } from '../analytics/analytics-utils.js';
 import {SearchPageEvents} from '../analytics/search-action-cause.js';
 import {getCaseContextAnalyticsMetadata} from '../case-context/case-context-state.js';
@@ -41,7 +41,7 @@ export const logOpenGeneratedAnswerSource = (
           return null;
         }
         return client.logGeneratedAnswerCitationClick(
-          partialCitationInformation(citation, state),
+          partialDocumentInformationFromCitation(citation, state),
           {
             generativeQuestionAnsweringId,
             citationId: citation.id,


### PR DESCRIPTION
### SFINT-6801

Implemented the new `openFollowupAnswerSource` UA event. Triggered when a user clicks on a follow-up citation.
RFC available in the Jira.

In short, a click on a follow-up citation cannot be represented by a UA click event as it is no longer linked to the original search and the corresponding results. So it becomes a custom UA event, with all the metadata still available to know which document was clicked on.

The click on the citations of the first/top/head answer remains the same.

Top Answer:

`CLICK`:
<img width="956" height="390" alt="Screen Shot 2026-06-10 at 3 41 43 PM" src="https://github.com/user-attachments/assets/39c279cd-d033-4d7a-8b91-2ca1e8392d70" />


Follow-up Answer:

`CUSTOM`:
<img width="891" height="376" alt="Screen Shot 2026-06-10 at 3 42 35 PM" src="https://github.com/user-attachments/assets/30791f2a-47cd-4df6-86a2-dcd2af28b25e" />