### PR TITLE
fix(atomic): re-open dialog in testDialogA11y to stabilize axe check

### DIFF
--- a/packages/atomic/storybook-utils/a11y/dialog.ts
+++ b/packages/atomic/storybook-utils/a11y/dialog.ts
@@ -130,6 +130,20 @@ export async function testDialogA11y(
         );
       }
     );
+
+    // Re-open the dialog so the addon-a11y afterEach hook runs axe on a
+    // stable, fully-visible DOM. Without this, axe may catch the close
+    // animation mid-flight and report spurious color-contrast violations.
+    await step('Re-open dialog for axe evaluation', async () => {
+      await userEvent.click(trigger);
+      await waitFor(
+        async () => {
+          const d = await root.findByShadowRole('dialog', {}, {timeout: 5000});
+          expect(d).toBeInTheDocument();
+        },
+        {timeout: 8000}
+      );
+    });
   } catch (error) {
     status = 'failed';
     throw error;


### PR DESCRIPTION
## Problem

The `atomic-smart-snippet-feedback-modal` `A11yDialog` story intermittently reports a spurious `color-contrast` violation (WCAG 1.4.3).

**Root cause:** `testDialogA11y` closes the modal via Escape at the end of its assertions. The `@storybook/addon-a11y` `afterEach` hook then runs axe-core immediately without calling `waitForAnimations()`. Axe evaluates the DOM while the close animation is in flight (opacity 1 → 0), computing incorrect foreground/background color pairs and flagging a contrast violation that does not exist (`#626971` on white = 5.56:1, well above the 4.5:1 threshold).

## Solution

After validating focus-return (the last assertion), re-open the dialog via the trigger button so the DOM is in a stable, fully-visible state when axe runs. This fixes the flake for all components using `testDialogA11y`.