### PR TITLE
fix(atomic): disable generated answer on init when tab is excluded

### DIFF
--- a/.changeset/fix-generated-answer-tab-initial-load.md
+++ b/.changeset/fix-generated-answer-tab-initial-load.md
@@ -1,0 +1,8 @@
+---
+"@coveo/headless": patch
+"@coveo/atomic": patch
+---
+
+fix(atomic): prevent agentic stream request on initial load when tab is excluded via `tabs-included`/`tabs-excluded`
+
+The `buildCoreGeneratedAnswer` controller now honors `initialState.isEnabled`, and `atomic-generated-answer` passes `isEnabled: false` when the initial active tab is excluded.

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts
@@ -1521,6 +1521,59 @@ describe('atomic-generated-answer', () => {
     });
   });
 
+  describe('initial tab state', () => {
+    it('should pass isEnabled: false to buildGeneratedAnswer when initial tab is excluded', async () => {
+      await renderGeneratedAnswer({
+        props: {tabsExcluded: ['ExcludedTab']},
+        tabManagerState: {activeTab: 'ExcludedTab'},
+        generatedAnswerState: {isVisible: true, answer: 'Test answer'},
+      });
+
+      expect(buildGeneratedAnswer).toHaveBeenCalledWith(
+        mockedEngine,
+        expect.objectContaining({
+          initialState: expect.objectContaining({
+            isEnabled: false,
+          }),
+        })
+      );
+    });
+
+    it('should pass isEnabled: false to buildGeneratedAnswer when initial tab is not in tabsIncluded', async () => {
+      await renderGeneratedAnswer({
+        props: {tabsIncluded: ['IncludedTab']},
+        tabManagerState: {activeTab: 'OtherTab'},
+        generatedAnswerState: {isVisible: true, answer: 'Test answer'},
+      });
+
+      expect(buildGeneratedAnswer).toHaveBeenCalledWith(
+        mockedEngine,
+        expect.objectContaining({
+          initialState: expect.objectContaining({
+            isEnabled: false,
+          }),
+        })
+      );
+    });
+
+    it('should pass isEnabled: true to buildGeneratedAnswer when initial tab is allowed', async () => {
+      await renderGeneratedAnswer({
+        props: {tabsIncluded: ['IncludedTab']},
+        tabManagerState: {activeTab: 'IncludedTab'},
+        generatedAnswerState: {isVisible: true, answer: 'Test answer'},
+      });
+
+      expect(buildGeneratedAnswer).toHaveBeenCalledWith(
+        mockedEngine,
+        expect.objectContaining({
+          initialState: expect.objectContaining({
+            isEnabled: true,
+          }),
+        })
+      );
+    });
+  });
+
   describe('tabsExcluded property', () => {
     it('should render when tabsExcluded is empty', async () => {
       const {container} = await renderGeneratedAnswer({

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
@@ -318,9 +318,17 @@ export class AtomicGeneratedAnswer
       getBindings: () => this.bindings,
     });
 
+    this.tabManager = buildTabManager(this.bindings.engine);
+    this.searchStatus = buildSearchStatus(this.bindings.engine);
+
     this.generatedAnswer = buildGeneratedAnswer(this.bindings.engine, {
       initialState: {
         isVisible: this.controller.data.isVisible,
+        isEnabled: shouldDisplayOnCurrentTab(
+          this.tabsIncluded,
+          this.tabsExcluded,
+          this.tabManager.state.activeTab
+        ),
         responseFormat: {
           contentFormat: ['text/markdown', 'text/plain'],
         },
@@ -333,8 +341,6 @@ export class AtomicGeneratedAnswer
       }),
       fieldsToIncludeInCitations: this.getCitationFields(),
     });
-    this.searchStatus = buildSearchStatus(this.bindings.engine);
-    this.tabManager = buildTabManager(this.bindings.engine);
 
     this.controller.insertFeedbackModal();
 

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.test.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.test.ts
@@ -372,6 +372,18 @@ describe('generated answer', () => {
       });
     });
 
+    describe('when #isEnabled is set', () => {
+      it('should dispatch setIsEnabled action when set to true', () => {
+        initGeneratedAnswer({initialState: {isEnabled: true}});
+        expect(setIsEnabled).toHaveBeenCalledWith(true);
+      });
+
+      it('should dispatch setIsEnabled action when set to false', () => {
+        initGeneratedAnswer({initialState: {isEnabled: false}});
+        expect(setIsEnabled).toHaveBeenCalledWith(false);
+      });
+    });
+
     describe('when #responseFormat is set', () => {
       it('should dispatch updateResponseFormat action', () => {
         const responseFormat: GeneratedResponseFormat = {

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -233,6 +233,10 @@ export function buildCoreGeneratedAnswer(
   if (isVisible !== undefined) {
     dispatch(setIsVisible(isVisible));
   }
+  const isEnabled = props.initialState?.isEnabled;
+  if (isEnabled !== undefined) {
+    dispatch(setIsEnabled(isEnabled));
+  }
   const initialResponseFormat = props.initialState?.responseFormat;
   if (initialResponseFormat) {
     dispatch(updateResponseFormat(initialResponseFormat));

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
@@ -603,6 +603,38 @@ describe('knowledge-generated-answer', () => {
           expect(mockGenerateAnswer).toHaveBeenCalledTimes(1);
         });
       });
+
+      describe('when isEnabled is false', () => {
+        it('should not call generateAnswer', () => {
+          engine.state.generatedAnswer.isEnabled = false;
+          mockSelectAnswerTriggerParams.mockReturnValue({
+            q: 'test query',
+            requestId: 'new-request',
+            cannotAnswer: false,
+            analyticsMode: 'legacy',
+            actionCause: 'searchboxSubmit',
+          });
+
+          listener();
+
+          expect(mockGenerateAnswer).not.toHaveBeenCalled();
+        });
+
+        it('should still reset the answer', () => {
+          engine.state.generatedAnswer.isEnabled = false;
+          mockSelectAnswerTriggerParams.mockReturnValue({
+            q: 'test query',
+            requestId: 'new-request',
+            cannotAnswer: false,
+            analyticsMode: 'legacy',
+            actionCause: 'searchboxSubmit',
+          });
+
+          listener();
+
+          expect(mockResetAnswer).toHaveBeenCalledTimes(1);
+        });
+      });
     });
 
     describe('user interaction scenarios', () => {

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -114,6 +114,10 @@ const subscribeToSearchRequest = (
       lastRequestId = currentRequestId;
       engine.dispatch(resetAnswer());
 
+      if (state.generatedAnswer.isEnabled === false) {
+        return;
+      }
+
       if (triggerParams.q?.length > 0) {
         engine.dispatch(generateAnswer());
       }


### PR DESCRIPTION
## Summary

Prevents the agentic stream request from firing on initial load when the active tab excludes the generated answer via `tabs-included` or `tabs-excluded`.

## Changes

- Build `tabManager` before `generatedAnswer` during initialization so the active tab state is available
- Pass `isEnabled: shouldDisplayOnCurrentTab(...)` in the `initialState` when building the generated answer controller
- Added tests verifying `isEnabled` is correctly set based on initial tab state

## Jira

https://coveord.atlassian.net/browse/KIT-5817