### PR TITLE
ci(atomic-a11y): run OpenACR validation and VPAT generation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,6 +473,9 @@ jobs:
       - name: 'Merge a11y shard reports'
         run: pnpm run a11y:merge-shards -- ../atomic/reports/a11y-report.json
         working-directory: packages/atomic-a11y
+      - name: 'Generate and validate OpenACR/VPAT'
+        run: pnpm a11y:vpat
+        working-directory: packages/atomic-a11y
       - name: 'Upload merged a11y report'
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## Problem

The OpenACR schema validation (`validate-openacr.mjs`) only runs locally via `pnpm a11y:vpat`. If a PR introduces invalid conformance data, CI won't catch it.

## Solution

Add a `Generate and validate OpenACR/VPAT` step in the CI workflow after merging a11y shard reports. This runs the full pipeline: build → json-to-openacr → validate against GSA schema → generate VPAT markdown.

Fails CI if the generated OpenACR YAML does not conform to the [official GSA schema](https://github.com/GSA/openacr/blob/main/schema/openacr-0.1.0.json).