### PR TITLE
doc: make generated answer component docs more generic

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.mdx
@@ -11,7 +11,7 @@ import {AtomicDocTemplate} from '../../../../storybook-utils/documentation/atomi
   className="AtomicInsightGeneratedAnswer"
 >
 
-The `atomic-insight-generated-answer` component uses Coveo Machine Learning (Coveo ML) models to automatically generate an answer to a query executed by the user within an Insight Panel context. For more information, see [About Relevance Generative Answering (RGA)](https://docs.coveo.com/en/n9de0370/).
+The `atomic-insight-generated-answer` component uses Coveo Machine Learning (Coveo ML) models to automatically generate an answer to a query executed by the user within an Insight Panel context.
 
 ```html
 <atomic-insight-interface>

--- a/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.ts
@@ -35,7 +35,6 @@ import atomicInsightGeneratedAnswerStyles from './atomic-insight-generated-answe
 
 /**
  * The `atomic-insight-generated-answer` component uses Coveo Machine Learning (Coveo ML) models to automatically generate an answer to a query executed by the user.
- * For more information, see [About Relevance Generative Answering (RGA)](https://docs.coveo.com/en/n9de0370/)
  *
  * @slot no-answer-message - Lets you pass a custom sorry message when no answer is generated.
  *

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.mdx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.mdx
@@ -11,7 +11,7 @@ import {AtomicDocTemplate} from '../../../../storybook-utils/documentation/atomi
   className="AtomicGeneratedAnswer"
 >
 
-The `atomic-generated-answer` component uses Coveo Machine Learning (Coveo ML) models to automatically generate an answer to a query executed by the user. For more information, see [About Relevance Generative Answering (RGA)](https://docs.coveo.com/en/n9de0370/).
+The `atomic-generated-answer` component uses Coveo Machine Learning (Coveo ML) models to automatically generate an answer to a query executed by the user.
 
 ```html
 <atomic-search-interface>

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
@@ -84,7 +84,6 @@ const FOLLOW_UP_INPUT_EXPORT_PARTS = [
 
 /**
  * The `atomic-generated-answer` component uses Coveo Machine Learning (Coveo ML) models to automatically generate an answer to a query executed by the user.
- * For more information, see [About Relevance Generative Answering (RGA)](https://docs.coveo.com/en/n9de0370/)
  *
  * @slot no-answer-message - Lets you pass a custom sorry message when no answer is generated.
  *


### PR DESCRIPTION
https://coveord.atlassian.net/browse/DOC-19768

Since the component can now be used both for RGA and the search agent (and others might come), this PR makes its description more generic, like the Quantic one.