### PR TITLE
KIT-5822 ci(atomic-a11y): ignore volatile fields from openACR check

### DIFF
--- a/packages/atomic-a11y/scripts/check-openacr-drift.mjs
+++ b/packages/atomic-a11y/scripts/check-openacr-drift.mjs
@@ -7,8 +7,9 @@
  */
 import {existsSync, readFileSync} from 'node:fs';
 import {resolve} from 'node:path';
+import {isDeepStrictEqual} from 'node:util';
+import {parse} from 'yaml';
 import {transformJsonToOpenAcr} from '../dist/index.js';
-import {formatWithOxfmt} from './format-with-oxfmt.mjs';
 
 const PKG_ROOT = resolve(import.meta.dirname, '..');
 const REPO_ROOT = resolve(PKG_ROOT, '../..');
@@ -34,26 +35,29 @@ await transformJsonToOpenAcr({
   inputFile: INPUT_REPORT,
   outputFile: GENERATED_OPENACR,
 });
-// Format the same way the committed file is formatted (see update-openacr /
-// json-to-openacr), otherwise the comparison would flag formatting differences.
-formatWithOxfmt(GENERATED_OPENACR);
 
-const VOLATILE_PATTERNS = [
-  /^(\s*report_date:).*$/m,
-  /^(\s*last_modified_date:).*$/m,
-  /^(\s+version:).*$/m,
-];
-function normalize(yaml) {
-  return VOLATILE_PATTERNS.reduce(
-    (acc, pattern) => acc.replace(pattern, '$1 <normalized>'),
-    yaml
-  );
+// Compare the parsed documents, not the serialized text, so formatting (quote
+// style, line wrapping, key order) is irrelevant. Some fields are regenerated
+// from the environment rather than from a11y results and must be ignored:
+//   - report_date / last_modified_date -> change every day
+//   - product.version                  -> changes on every Atomic release
+function stripVolatile(report) {
+  delete report.report_date;
+  delete report.last_modified_date;
+  if (report.product) {
+    delete report.product.version;
+  }
+  return report;
 }
 
-const committed = readFileSync(COMMITTED_OPENACR, 'utf-8');
-const generated = readFileSync(GENERATED_OPENACR, 'utf-8');
+const committed = stripVolatile(
+  parse(readFileSync(COMMITTED_OPENACR, 'utf-8'))
+);
+const generated = stripVolatile(
+  parse(readFileSync(GENERATED_OPENACR, 'utf-8'))
+);
 
-if (normalize(committed) === normalize(generated)) {
+if (isDeepStrictEqual(committed, generated)) {
   console.log('✅ openacr.yaml is up to date.');
   process.exit(0);
 }
@@ -70,7 +74,7 @@ conformance, or component coverage changed.
 
 To update, run:
 
-  pnpm --filter @coveo/atomic-a11y a11y:update-openacr --run-id=${runId}
+  pnpm exec turbo run a11y:update-openacr --filter=@coveo/atomic-a11y -- --run-id=${runId}
 
 Then review the changes and commit the updated openacr.yaml.
 

--- a/packages/atomic-a11y/scripts/check-openacr-drift.mjs
+++ b/packages/atomic-a11y/scripts/check-openacr-drift.mjs
@@ -38,15 +38,14 @@ await transformJsonToOpenAcr({
 // json-to-openacr), otherwise the comparison would flag formatting differences.
 formatWithOxfmt(GENERATED_OPENACR);
 
-// `report_date` and `last_modified_date` are regenerated to the current date on
-// every run, so a raw comparison would fail daily even with no conformance
-// change. Neutralize those volatile fields (value and quote style) before
-// comparing so the check only reacts to real conformance/coverage changes.
-const VOLATILE_FIELDS = ['report_date', 'last_modified_date'];
+const VOLATILE_PATTERNS = [
+  /^(\s*report_date:).*$/m,
+  /^(\s*last_modified_date:).*$/m,
+  /^(\s+version:).*$/m,
+];
 function normalize(yaml) {
-  return VOLATILE_FIELDS.reduce(
-    (acc, field) =>
-      acc.replace(new RegExp(`^(\\s*${field}:).*$`, 'm'), '$1 <normalized>'),
+  return VOLATILE_PATTERNS.reduce(
+    (acc, pattern) => acc.replace(pattern, '$1 <normalized>'),
     yaml
   );
 }


### PR DESCRIPTION
Jira: https://coveord.atlassian.net/browse/KIT-5822

The OpenACR drift check failed on changes unrelated to accessibility conformance — `report_date`/`last_modified_date` (change daily) and `product.version` (changes on every Atomic release).

This compares the **parsed** OpenACR documents and ignores those volatile fields, so the check only fails on real conformance/coverage changes. Comparing parsed data instead of raw text also makes it robust to formatting (quote style, wrapping, key order).

**Tested:** version/date drift passes; a real conformance change and a top-level schema `version` change are still detected.