### PR TITLE
feat(ci): add workflow to deploy PR commits to CDN

### DIFF
--- a/.github/workflows/pr-cdn-deploy.yml
+++ b/.github/workflows/pr-cdn-deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy PR to CDN (commits/)
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-cdn:
+    name: Build CDN
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: ./.github/actions/build-cdn
+        with:
+          commit-sha: ${{ github.sha }}
+
+  commit-artifact-upload:
+    name: Upload commit artifacts to S3
+    needs: build-cdn
+    runs-on: ubuntu-latest
+    environment: 'Prerelease (CDN)'
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: ./.github/actions/setup
+        with:
+          skip-build: 'true'
+          load-cache: 'false'
+      - name: Trigger commit artifact upload on ui-kit-cd
+        run: node ./scripts/deploy/trigger-commit-upload.mjs
+        env:
+          GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
+          CHANNELS: ''


### PR DESCRIPTION
## Problem

Currently, only commits merged to `main` are deployed to the `commits/` folder on the CDN. There is no way to deploy the current state of a PR for testing purposes without merging first.

## Solution

Add a `workflow_dispatch` workflow (`pr-cdn-deploy.yml`) that can be triggered manually from any PR branch. It:
1. Builds CDN artifacts using the branch head commit SHA
2. Triggers the same `deploy-commit` dispatch to `ui-kit-cd`
3. Deploys to `commits/<sha>/` without updating any channel pointer

**Usage:** Actions → "Deploy PR to CDN (commits/)" → "Run workflow" → select the PR branch → Run.