### PR TITLE
feat(quantic): make the quanticGeneratedAnswerFollowUpInput expandable

### DIFF
--- a/.changeset/better-jobs-thank.md
+++ b/.changeset/better-jobs-thank.md
@@ -1,0 +1,5 @@
+---
+"@coveo/quantic": patch
+---
+
+Made the quanticGeneratedAnswerFollowUpInput expandable

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/__tests__/quanticGeneratedAnswerFollowUpInput.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/__tests__/quanticGeneratedAnswerFollowUpInput.test.js
@@ -12,7 +12,7 @@ jest.mock(
   {virtual: true}
 );
 jest.mock('c/quanticUtils', () => ({
-  keys: {ENTER: 'Enter'},
+  keys: {ENTER: 'Enter', ESC: 'Escape'},
 }));
 
 const selectors = {
@@ -214,6 +214,21 @@ describe('c-quantic-generated-answer-follow-up-input', () => {
       await flushPromises();
 
       expect(expander.dataset.replicatedValue).toBeUndefined();
+    });
+
+    it('should collapse the textarea when the Escape key is pressed', async () => {
+      const element = createTestComponent();
+      await flushPromises();
+
+      const textarea = element.shadowRoot.querySelector(selectors.textarea);
+      textarea.blur = jest.fn();
+      textarea.dispatchEvent(new CustomEvent('focus'));
+      await flushPromises();
+
+      textarea.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+      await flushPromises();
+
+      expect(textarea.blur).toHaveBeenCalled();
     });
   });
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/__tests__/quanticGeneratedAnswerFollowUpInput.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/__tests__/quanticGeneratedAnswerFollowUpInput.test.js
@@ -16,10 +16,13 @@ jest.mock('c/quanticUtils', () => ({
 }));
 
 const selectors = {
-  input: 'lightning-input',
+  textarea: 'textarea',
   submitButton: 'lightning-button-icon',
-  inputContainer: '.follow-up-input__input-container',
+  container: '.follow-up-input__container',
+  expander: '.follow-up-input__expander',
 };
+
+const expandedClass = 'follow-up-input__expander--expanded';
 
 const createTestComponent = buildCreateTestComponent(
   QuanticGeneratedAnswerFollowUpInput,
@@ -31,17 +34,14 @@ describe('c-quantic-generated-answer-follow-up-input', () => {
     cleanup();
   });
 
-  it('should render the input and submit button', async () => {
+  it('should render the textarea and submit button', async () => {
     const element = createTestComponent();
     await flushPromises();
 
-    const input = element.shadowRoot.querySelector(selectors.input);
-    const submitButton = element.shadowRoot.querySelector(
-      selectors.submitButton
-    );
-
-    expect(input).not.toBeNull();
-    expect(submitButton).not.toBeNull();
+    expect(element.shadowRoot.querySelector(selectors.textarea)).not.toBeNull();
+    expect(
+      element.shadowRoot.querySelector(selectors.submitButton)
+    ).not.toBeNull();
   });
 
   describe('submitting a follow up', () => {
@@ -52,9 +52,9 @@ describe('c-quantic-generated-answer-follow-up-input', () => {
       const handler = jest.fn();
       element.addEventListener('quantic__submitfollowup', handler);
 
-      const input = element.shadowRoot.querySelector(selectors.input);
-      input.value = 'follow up question';
-      input.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
+      const textarea = element.shadowRoot.querySelector(selectors.textarea);
+      textarea.value = 'follow up question';
+      textarea.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
 
       expect(handler).toHaveBeenCalledTimes(1);
       expect(handler.mock.calls[0][0].detail.value).toBe('follow up question');
@@ -67,29 +67,40 @@ describe('c-quantic-generated-answer-follow-up-input', () => {
       const handler = jest.fn();
       element.addEventListener('quantic__submitfollowup', handler);
 
-      const input = element.shadowRoot.querySelector(selectors.input);
-      input.value = 'another question';
+      const textarea = element.shadowRoot.querySelector(selectors.textarea);
+      textarea.value = 'another question';
 
-      const submitButton = element.shadowRoot.querySelector(
-        selectors.submitButton
-      );
-      submitButton.click();
+      element.shadowRoot.querySelector(selectors.submitButton).click();
 
       expect(handler).toHaveBeenCalledTimes(1);
       expect(handler.mock.calls[0][0].detail.value).toBe('another question');
     });
 
-    it('should clear the input and blur it after a successful submit', async () => {
+    it('should clear the textarea after a successful submit', async () => {
       const element = createTestComponent();
       await flushPromises();
 
-      const input = element.shadowRoot.querySelector(selectors.input);
-      input.value = 'a question';
-      input.blur = jest.fn();
+      const textarea = element.shadowRoot.querySelector(selectors.textarea);
+      textarea.value = 'a question';
+      textarea.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
 
-      input.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
+      expect(textarea.value).toBe('');
+    });
 
-      expect(input.value).toBe('');
+    it('should collapse after a successful submit', async () => {
+      const element = createTestComponent();
+      await flushPromises();
+
+      const textarea = element.shadowRoot.querySelector(selectors.textarea);
+      textarea.dispatchEvent(new CustomEvent('focus'));
+      await flushPromises();
+
+      textarea.value = 'a question';
+      textarea.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
+      await flushPromises();
+
+      const expander = element.shadowRoot.querySelector(selectors.expander);
+      expect(expander.classList).not.toContain(expandedClass);
     });
   });
 
@@ -101,9 +112,9 @@ describe('c-quantic-generated-answer-follow-up-input', () => {
       const handler = jest.fn();
       element.addEventListener('quantic__submitfollowup', handler);
 
-      const input = element.shadowRoot.querySelector(selectors.input);
-      input.value = 'a question';
-      input.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
+      const textarea = element.shadowRoot.querySelector(selectors.textarea);
+      textarea.value = 'a question';
+      textarea.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
 
       expect(handler).not.toHaveBeenCalled();
     });
@@ -115,9 +126,9 @@ describe('c-quantic-generated-answer-follow-up-input', () => {
       const handler = jest.fn();
       element.addEventListener('quantic__submitfollowup', handler);
 
-      const input = element.shadowRoot.querySelector(selectors.input);
-      input.value = '   ';
-      input.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
+      const textarea = element.shadowRoot.querySelector(selectors.textarea);
+      textarea.value = '   ';
+      textarea.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
 
       expect(handler).not.toHaveBeenCalled();
     });
@@ -129,52 +140,80 @@ describe('c-quantic-generated-answer-follow-up-input', () => {
       const handler = jest.fn();
       element.addEventListener('quantic__submitfollowup', handler);
 
-      const input = element.shadowRoot.querySelector(selectors.input);
-      input.value = '';
-
-      const submitButton = element.shadowRoot.querySelector(
-        selectors.submitButton
-      );
-      submitButton.click();
+      const textarea = element.shadowRoot.querySelector(selectors.textarea);
+      textarea.value = '';
+      element.shadowRoot.querySelector(selectors.submitButton).click();
 
       expect(handler).not.toHaveBeenCalled();
     });
   });
 
-  describe('focus and blur CSS class toggling', () => {
-    it('should add the focused class when the input is focused', async () => {
+  describe('expandable input behaviour', () => {
+    it('should expand and add focused class on focus', async () => {
       const element = createTestComponent();
       await flushPromises();
 
-      const input = element.shadowRoot.querySelector(selectors.input);
-      input.dispatchEvent(new CustomEvent('focus'));
+      const textarea = element.shadowRoot.querySelector(selectors.textarea);
+      textarea.dispatchEvent(new CustomEvent('focus'));
       await flushPromises();
 
-      const container = element.shadowRoot.querySelector(
-        selectors.inputContainer
-      );
+      const expander = element.shadowRoot.querySelector(selectors.expander);
+      const container = element.shadowRoot.querySelector(selectors.container);
+      expect(expander.classList).toContain(expandedClass);
       expect(container.classList).toContain(
-        'follow-up-input__input-container--focused'
+        'follow-up-input__container--focused'
       );
     });
 
-    it('should remove the focused class when the input is blurred', async () => {
+    it('should collapse and remove focused class on blur', async () => {
       const element = createTestComponent();
       await flushPromises();
 
-      const input = element.shadowRoot.querySelector(selectors.input);
-      input.dispatchEvent(new CustomEvent('focus'));
+      const textarea = element.shadowRoot.querySelector(selectors.textarea);
+      textarea.dispatchEvent(new CustomEvent('focus'));
       await flushPromises();
 
-      input.dispatchEvent(new CustomEvent('blur'));
+      textarea.dispatchEvent(new CustomEvent('blur'));
       await flushPromises();
 
-      const container = element.shadowRoot.querySelector(
-        selectors.inputContainer
-      );
+      const expander = element.shadowRoot.querySelector(selectors.expander);
+      const container = element.shadowRoot.querySelector(selectors.container);
+      expect(expander.classList).not.toContain(expandedClass);
       expect(container.classList).not.toContain(
-        'follow-up-input__input-container--focused'
+        'follow-up-input__container--focused'
       );
+    });
+
+    it('should sync replica text on input', async () => {
+      const element = createTestComponent();
+      await flushPromises();
+
+      const textarea = element.shadowRoot.querySelector(selectors.textarea);
+      const expander = element.shadowRoot.querySelector(selectors.expander);
+
+      textarea.value = 'multi\nline\ntext';
+      textarea.dispatchEvent(new CustomEvent('input'));
+      await flushPromises();
+
+      expect(expander.dataset.replicatedValue).toBe('multi\nline\ntext');
+    });
+
+    it('should clear replica text after submit', async () => {
+      const element = createTestComponent();
+      await flushPromises();
+
+      const textarea = element.shadowRoot.querySelector(selectors.textarea);
+      const expander = element.shadowRoot.querySelector(selectors.expander);
+
+      textarea.value = 'some text';
+      textarea.dispatchEvent(new CustomEvent('input'));
+      await flushPromises();
+      expect(expander.dataset.replicatedValue).toBe('some text');
+
+      textarea.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
+      await flushPromises();
+
+      expect(expander.dataset.replicatedValue).toBeUndefined();
     });
   });
 });

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.css
@@ -61,5 +61,5 @@
   position: absolute;
   right: 0.25rem;
   bottom: 0.25rem;
-  z-index: 11;
+  z-index: 15;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.css
@@ -1,17 +1,69 @@
-:host {
-  --slds-c-input-shadow: none;
+/* Container: pin single-line height so layout doesn't jump when expander goes absolute */
+.follow-up-input__container {
+  min-height: calc(2.5rem + 2px);
 }
 
-.follow-up-input__input {
-  border: none;
-  box-shadow: none;
-  outline: none;
-  width: 100%;
-  --slds-c-input-color-border: transparent;
-  --slds-c-input-shadow-focus: transparent;
-  --slds-c-input-spacing-border: 0px;
-}
-
-.follow-up-input__input-container.follow-up-input__input-container--focused {
+.follow-up-input__container--focused {
   border-color: var(--lwc-brandAccessible, #0176d3);
+}
+
+/* Expander: CSS grid trick — textarea and ::after share the same cell */
+.follow-up-input__expander {
+  display: grid;
+  overflow: hidden;
+  margin-right: 2.5rem;
+}
+
+.follow-up-input__expander::after {
+  content: attr(data-replicated-value) ' ';
+  visibility: hidden;
+}
+
+.follow-up-input__expander::after,
+.follow-up-input__textarea {
+  grid-area: 1 / 1 / 2 / 2;
+  resize: none;
+  overflow: hidden;
+  white-space: nowrap;
+  border: none;
+  outline: none;
+  background: transparent;
+  padding: 0.5rem 0.75rem;
+  font: inherit;
+  min-height: 2.5rem;
+}
+
+/* Expanded: absolute, anchored at bottom so it grows upward */
+.follow-up-input__expander--expanded {
+  position: absolute;
+  bottom: -1px;
+  left: -1px;
+  right: -1px;
+  z-index: 10;
+  overflow: visible;
+  margin-right: 0;
+  background-color: var(--lwc-colorBackground, #fff);
+  border: 1px solid var(--lwc-brandAccessible, #0176d3);
+  border-radius: 0.25rem;
+}
+
+.follow-up-input__expander--expanded::after,
+.follow-up-input__expander--expanded .follow-up-input__textarea {
+  white-space: pre-wrap;
+  overflow-y: auto;
+  max-height: 8rem;
+  padding-right: 2.5rem;
+  scrollbar-width: none;
+}
+
+.follow-up-input__expander--expanded .follow-up-input__textarea::-webkit-scrollbar {
+  display: none;
+}
+
+/* Submit button: stays above the expander overlay */
+.follow-up-input__submit-button {
+  position: absolute;
+  right: 0.25rem;
+  bottom: 0.25rem;
+  z-index: 11;
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.css
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.css
@@ -1,4 +1,3 @@
-/* Container: pin single-line height so layout doesn't jump when expander goes absolute */
 .follow-up-input__container {
   min-height: calc(2.5rem + 2px);
 }
@@ -7,7 +6,6 @@
   border-color: var(--lwc-brandAccessible, #0176d3);
 }
 
-/* Expander: CSS grid trick — textarea and ::after share the same cell */
 .follow-up-input__expander {
   display: grid;
   overflow: hidden;
@@ -33,7 +31,6 @@
   min-height: 2.5rem;
 }
 
-/* Expanded: absolute, anchored at bottom so it grows upward */
 .follow-up-input__expander--expanded {
   position: absolute;
   bottom: -1px;
@@ -60,7 +57,6 @@
   display: none;
 }
 
-/* Submit button: stays above the expander overlay */
 .follow-up-input__submit-button {
   position: absolute;
   right: 0.25rem;

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.html
@@ -1,23 +1,24 @@
 <template>
   <div class={inputContainerClasses}>
-    <lightning-input
-      class="slds-col slds-grow follow-up-input__input"
-      type="text" 
-      variant="label-hidden" 
-      label={labels.askFollowUp}
-      placeholder={labels.askFollowUp}
-      name="ask-followup"
-      lwc:ref="askFollowUpInput"
-      onfocus={handleFocus}
-      onblur={handleBlur}
-      onkeydown={handleKeyDown}
-    ></lightning-input>
+    <div class="follow-up-input__expander slds-grow" lwc:ref="expander">
+      <textarea
+        class="follow-up-input__textarea"
+        lwc:ref="askFollowUpInput"
+        rows="1"
+        placeholder={labels.askFollowUp}
+        aria-label={labels.askFollowUp}
+        onfocus={handleFocus}
+        onblur={handleBlur}
+        oninput={handleInput}
+        onkeydown={handleKeyDown}
+      ></textarea>
+    </div>
     <lightning-button-icon
       disabled={submitButtonDisabled}
       onclick={handleSubmitFollowUp}
       icon-name="utility:arrowup"
       variant="brand"
-      class="slds-col slds-grow-none slds-align_absolute-center"
+      class="follow-up-input__submit-button"
       name="submit-follow-up"
       title={labels.submitFollowUp}
       aria-label={labels.submitFollowUp}

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.js
@@ -39,6 +39,8 @@ export default class QuanticGeneratedAnswerFollowUpInput extends LightningElemen
     }
 
     if (event.key === keys.ESC) {
+      event.stopPropagation();
+      event.preventDefault();
       this.refs.askFollowUpInput.blur();
     }
   }

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.js
@@ -33,7 +33,7 @@ export default class QuanticGeneratedAnswerFollowUpInput extends LightningElemen
       return;
     }
 
-    if (event.key === keys.ENTER) {
+    if (event.key === keys.ENTER && !event.shiftKey) {
       event.preventDefault();
       this.handleSubmitFollowUp();
     }
@@ -48,14 +48,46 @@ export default class QuanticGeneratedAnswerFollowUpInput extends LightningElemen
     }
     this.sendSubmitFollowUpEvent();
     this.refs.askFollowUpInput.value = '';
+    this.syncTextWithReplica();
+    this.collapse();
   }
 
   handleFocus() {
     this._focused = true;
+    this.syncTextWithReplica();
+    this.expand();
   }
 
   handleBlur() {
     this._focused = false;
+    this.collapse();
+  }
+
+  handleInput() {
+    this.expand();
+    this.syncTextWithReplica();
+  }
+
+  /**
+   * Syncs the textarea value with the expander's replicated value for seamless CSS transitions.
+   */
+  syncTextWithReplica() {
+    const expander = this.refs.expander;
+    if (expander) {
+      expander.dataset.replicatedValue = this.refs.askFollowUpInput.value;
+    }
+  }
+
+  expand() {
+    this.refs.expander?.classList.add('follow-up-input__expander--expanded');
+  }
+
+  collapse() {
+    const expander = this.refs.expander;
+    if (expander) {
+      expander.classList.remove('follow-up-input__expander--expanded');
+      delete expander.dataset.replicatedValue;
+    }
   }
 
   /**
@@ -74,6 +106,6 @@ export default class QuanticGeneratedAnswerFollowUpInput extends LightningElemen
   }
 
   get inputContainerClasses() {
-    return `follow-up-input__input-container slds-box slds-grid slds-box_xx-small ${this._focused ? 'follow-up-input__input-container--focused' : ''}`;
+    return `follow-up-input__container slds-is-relative slds-grid slds-box slds-p-around_none ${this._focused ? 'follow-up-input__container--focused' : ''}`;
   }
 }

--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswerFollowUpInput/quanticGeneratedAnswerFollowUpInput.js
@@ -37,6 +37,10 @@ export default class QuanticGeneratedAnswerFollowUpInput extends LightningElemen
       event.preventDefault();
       this.handleSubmitFollowUp();
     }
+
+    if (event.key === keys.ESC) {
+      this.refs.askFollowUpInput.blur();
+    }
   }
 
   handleSubmitFollowUp() {


### PR DESCRIPTION
[SFINT-6790](https://coveord.atlassian.net/browse/SFINT-6790)

## IN THIS PR:
- Made QuanticGeneratedAnswerFollowUpInput expandable
  
- Replaced the single-line lightning-input with a native <textarea> that expands as the user enters multi-line text, matching the behaviour of atomic-ask-follow-up-input.
  
### How it works
  
  Uses the same CSS grid replica trick as atomic: a hidden ::after pseudo-element mirrors the textarea content via data-replicated-value, sharing the same grid cell. This drives the container's
  height automatically. On focus, the expander becomes `position: absolute; bottom: -1px` so it grows upward without shifting page layout.
  
### Result:

- expandable search input for the followup in quantic
- covered with unit tests
- all acceptance criterias met
- parity with atomic's behaviour

## DEMO:

https://github.com/user-attachments/assets/c5d931aa-3663-4736-bdbd-3e84d153fe89

## TESTS:
<img width="913" height="409" alt="image" src="https://github.com/user-attachments/assets/d2916a92-1669-4418-b6ed-3a7eb40767b8" />




[SFINT-6790]: https://coveord.atlassian.net/browse/SFINT-6790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ