### PR TITLE
fix(headless): acknowledge server-side query correction when automaticallyCorrectQuery is disabled

### DIFF
--- a/.changeset/fix-server-query-correction.md
+++ b/.changeset/fix-server-query-correction.md
@@ -1,0 +1,7 @@
+---
+'@coveo/headless': patch
+---
+
+fix(headless): acknowledge server-side query correction when automaticallyCorrectQuery is disabled
+
+When a search pipeline overrides `automaticallyCorrect` to `whenNoResults` but the client sets `automaticallyCorrectQuery: false`, headless now correctly updates `state.query.q` to the corrected query returned by the server. This ensures subsequent requests (e.g., facet "Show More") use the corrected query instead of the original uncorrected one, which previously caused facet values to disappear.

--- a/.changeset/fix-server-query-correction.md
+++ b/.changeset/fix-server-query-correction.md
@@ -2,6 +2,6 @@
 '@coveo/headless': patch
 ---
 
-fix(headless): acknowledge server-side query correction when automaticallyCorrectQuery is disabled
+Acknowledge server-side query correction when `automaticallyCorrectQuery` is disabled.
 
 When a search pipeline overrides `automaticallyCorrect` to `whenNoResults` but the client sets `automaticallyCorrectQuery: false`, headless now correctly updates `state.query.q` to the corrected query returned by the server. This ensures subsequent requests (e.g., facet "Show More") use the corrected query instead of the original uncorrected one, which previously caused facet values to disappear.

--- a/packages/headless/src/features/insight-search/insight-search-actions-thunk-processor.ts
+++ b/packages/headless/src/features/insight-search/insight-search-actions-thunk-processor.ts
@@ -113,7 +113,17 @@ export class AsyncInsightSearchThunkProcessor<RejectionType> {
     const {enableDidYouMean, automaticallyCorrectQuery} = state.didYouMean;
     const {results, queryCorrections, queryCorrection} = successResponse;
 
-    if (!enableDidYouMean || !automaticallyCorrectQuery) {
+    if (!enableDidYouMean) {
+      return null;
+    }
+
+    if (!automaticallyCorrectQuery) {
+      if (
+        !isNullOrUndefined(queryCorrection) &&
+        !isNullOrUndefined(queryCorrection.correctedQuery)
+      ) {
+        return this.processNextDidYouMeanAutoCorrection(fetched);
+      }
       return null;
     }
 

--- a/packages/headless/src/features/search/search-actions-thunk-processor.test.ts
+++ b/packages/headless/src/features/search/search-actions-thunk-processor.test.ts
@@ -1,0 +1,165 @@
+import type {Relay} from '@coveo/relay';
+import type {Logger} from 'pino';
+import {type Mock} from 'vitest';
+import type {SearchAPIClient} from '../../api/search/search-api-client.js';
+import {defaultNodeJSNavigatorContextProvider} from '../../app/navigator-context-provider.js';
+import {buildMockResult} from '../../test/mock-result.js';
+import {buildMockSearchRequest} from '../../test/mock-search-request.js';
+import {buildMockSearchResponse} from '../../test/mock-search-response.js';
+import {buildMockSearchState} from '../../test/mock-search-state.js';
+import {getConfigurationInitialState} from '../configuration/configuration-state.js';
+import {updateQuery} from '../query/query-actions.js';
+import type {ExecuteSearchThunkReturn} from './search-actions.js';
+import {AsyncSearchThunkProcessor} from './search-actions-thunk-processor.js';
+
+vi.mock('./search-analytics-actions');
+
+interface AsyncThunkConfig {
+  dispatch: Mock;
+  extra: {
+    analyticsClientMiddleware: Mock;
+    apiClient: {search: Mock};
+    logger: unknown;
+    validatePayload: Mock;
+    preprocessRequest: Mock;
+    relay: unknown;
+    navigatorContext: ReturnType<typeof defaultNodeJSNavigatorContextProvider>;
+  };
+  getState: Mock;
+  rejectWithValue: Mock;
+  analyticsAction: Record<string, unknown>;
+}
+
+describe('AsyncSearchThunkProcessor', () => {
+  let config: AsyncThunkConfig;
+  const results = [buildMockResult()];
+
+  beforeEach(() => {
+    config = {
+      analyticsAction: {},
+      dispatch: vi.fn(),
+      extra: {
+        analyticsClientMiddleware: vi.fn(),
+        apiClient: {search: vi.fn()},
+        logger: vi.fn() as unknown as Logger,
+        validatePayload: vi.fn(),
+        preprocessRequest: vi.fn(),
+        relay: vi.fn() as unknown as Relay,
+        navigatorContext: defaultNodeJSNavigatorContextProvider(),
+      },
+      getState: vi.fn().mockReturnValue({
+        configuration: getConfigurationInitialState(),
+        search: buildMockSearchState({
+          results,
+          response: buildMockSearchResponse({results}),
+        }),
+        didYouMean: {
+          enableDidYouMean: true,
+          automaticallyCorrectQuery: true,
+          queryCorrectionMode: 'next',
+        },
+      }),
+      rejectWithValue: vi.fn(),
+    };
+  });
+
+  describe('when server applies query correction and automaticallyCorrectQuery is false', () => {
+    beforeEach(() => {
+      config.getState = vi.fn().mockReturnValue({
+        configuration: getConfigurationInitialState(),
+        search: buildMockSearchState({
+          results,
+          response: buildMockSearchResponse({results}),
+        }),
+        query: {q: 'hone', enableQuerySyntax: false},
+        didYouMean: {
+          enableDidYouMean: true,
+          automaticallyCorrectQuery: false,
+          queryCorrectionMode: 'next',
+        },
+      });
+    });
+
+    it('should update query state to the corrected query when server returns queryCorrection.correctedQuery', async () => {
+      const processor = new AsyncSearchThunkProcessor<{}>(config as never);
+
+      const responseWithServerCorrection = buildMockSearchResponse({
+        results: [buildMockResult()],
+        queryCorrection: {
+          correctedQuery: 'honeywell',
+          originalQuery: 'hone',
+          corrections: [],
+        },
+      });
+
+      const fetched = {
+        response: {
+          success: responseWithServerCorrection,
+        },
+        duration: 123,
+        queryExecuted: 'hone',
+        requestExecuted: buildMockSearchRequest(),
+      };
+
+      const processed = (await processor.process(
+        fetched
+      )) as ExecuteSearchThunkReturn;
+
+      expect(config.dispatch).toHaveBeenCalledWith(
+        updateQuery({q: 'honeywell'})
+      );
+      expect(processed.queryExecuted).toBe('honeywell');
+      expect(processed.originalQuery).toBe('hone');
+      expect(processed.automaticallyCorrected).toBe(true);
+    });
+
+    it('should not re-fetch from API since the server already corrected', async () => {
+      const processor = new AsyncSearchThunkProcessor<{}>(config as never);
+
+      const responseWithServerCorrection = buildMockSearchResponse({
+        results: [buildMockResult()],
+        queryCorrection: {
+          correctedQuery: 'honeywell',
+          originalQuery: 'hone',
+          corrections: [],
+        },
+      });
+
+      const fetched = {
+        response: {
+          success: responseWithServerCorrection,
+        },
+        duration: 123,
+        queryExecuted: 'hone',
+        requestExecuted: buildMockSearchRequest(),
+      };
+
+      await processor.process(fetched);
+
+      expect(config.extra.apiClient.search).not.toHaveBeenCalled();
+    });
+
+    it('should not update query when server returns empty queryCorrection', async () => {
+      const processor = new AsyncSearchThunkProcessor<{}>(config as never);
+
+      const responseWithNoCorrection = buildMockSearchResponse({
+        results: [buildMockResult()],
+      });
+
+      const fetched = {
+        response: {
+          success: responseWithNoCorrection,
+        },
+        duration: 123,
+        queryExecuted: 'hone',
+        requestExecuted: buildMockSearchRequest(),
+      };
+
+      await processor.process(fetched);
+
+      expect(config.dispatch).not.toHaveBeenCalledWith(
+        updateQuery({q: expect.any(String)})
+      );
+    });
+  });
+});

--- a/packages/headless/src/features/search/search-actions-thunk-processor.ts
+++ b/packages/headless/src/features/search/search-actions-thunk-processor.ts
@@ -172,7 +172,21 @@ export class AsyncSearchThunkProcessor<RejectionType> {
     const {enableDidYouMean, automaticallyCorrectQuery} = state.didYouMean;
     const {results, queryCorrections, queryCorrection} = successResponse;
 
-    if (!enableDidYouMean || !automaticallyCorrectQuery) {
+    if (!enableDidYouMean) {
+      return null;
+    }
+
+    // When the server applied a correction (via pipeline override) but the
+    // client did not request auto-correction, we still need to acknowledge
+    // the corrected query so subsequent requests (e.g., facet Show More)
+    // use the right query.
+    if (!automaticallyCorrectQuery) {
+      if (
+        !isNullOrUndefined(queryCorrection) &&
+        !isNullOrUndefined(queryCorrection.correctedQuery)
+      ) {
+        return this.processModernDidYouMeanAutoCorrection(fetched);
+      }
       return null;
     }
 


### PR DESCRIPTION
[KIT-5824](https://coveord.atlassian.net/browse/KIT-5824)

## Problem

When a search pipeline overrides `automaticallyCorrect` to `whenNoResults` but the headless client has `automaticallyCorrectQuery: false`, clicking "Show More" on a facet causes facet values to disappear.

**Root cause:** The server applies the correction and returns results for the corrected query. Headless displays those results and facets. However, because `automaticallyCorrectQuery` is `false`, headless never updates `state.query.q` to the corrected query. When "Show More" triggers a `fetchFacetValues` request, it uses the original uncorrected query (e.g., `"hone"`) which returns 0 results and empty facets.

## Discussion: is this a product bug or client misconfiguration?

**Argument for client misconfiguration:**
- The customer configured their pipeline to override `automaticallyCorrect` to `whenNoResults`, contradicting their frontend setting of `automaticallyCorrectQuery: false`. These should agree.
- If the customer doesn't want auto-correction, they should remove the pipeline override.

**Argument for product bug (the approach taken here):**
- Once headless accepts and displays corrected results, it has committed to that state. Forgetting the correction on subsequent requests is inconsistent.
- Pipeline rules are managed by admins in the Coveo Admin Console; frontend config by developers. It's normal that these are configured independently. The frontend dev may not know the pipeline contradicts their config.
- `automaticallyCorrectQuery: false` is documented as controlling whether headless *retries* a failed query — not whether it acknowledges a correction the server already applied.
- The fix is minimal (3 lines) and makes headless more resilient to server/client disagreements.

## Solution

In `processQueryCorrectionsOrContinue`, when `automaticallyCorrectQuery` is `false` but the server returned a non-empty `queryCorrection.correctedQuery`, headless now calls `processModernDidYouMeanAutoCorrection` to update `state.query.q` to the corrected query. This ensures subsequent requests use the correct query.

[KIT-5824]: https://coveord.atlassian.net/browse/KIT-5824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ