### PR TITLE
chore(atomic-a11y): manual audit for WCAG 1.3.3 Sensory Characteristics (Level A)

### DIFF
--- a/packages/atomic-a11y/a11y/a11y-overrides.json
+++ b/packages/atomic-a11y/a11y/a11y-overrides.json
@@ -127,6 +127,11 @@
       "criterion": "2.4.1",
       "conformance": "not-applicable",
       "reason": "Bypass blocks is a page-level concern for the consuming application. Atomic is a component library providing individual widgets, not complete web pages with repeated navigation blocks. Components provide proper semantic structure (nav landmarks, aside, header/footer, role=region) that enables consuming apps to satisfy this criterion."
+    },
+    {
+      "criterion": "1.3.3",
+      "conformance": "not-applicable",
+      "reason": "Atomic is a component library that renders interactive UI widgets, not instructional content. Components do not provide textual instructions that reference shape, color, size, visual location, or sound. All controls use programmatic accessible names (aria-label, text content, input labels)."
     }
   ]
 }


### PR DESCRIPTION
[KIT-5783](https://coveord.atlassian.net/browse/KIT-5783)

**Reference:** [Understanding SC 1.3.3 Sensory Characteristics](https://www.w3.org/WAI/WCAG22/Understanding/sensory-characteristics.html)

## Problem
WCAG 1.3.3 Sensory Characteristics (Level A) was marked "Does Not Support" in the Atomic VPAT because no manual audit coverage existed.

## Solution
Manually audited all Atomic component surfaces for sensory characteristics compliance.

All surfaces are **not applicable** — Atomic is a component library that renders interactive UI widgets, not instructional content. The criterion requires that "instructions provided for understanding and operating content do not rely solely on sensory characteristics." Atomic components:
- Do not provide textual instructions that reference shape, color, size, visual location, or sound
- Use programmatic accessible names (aria-label, text content, input labels) for all controls
- Contain no user-facing guidance like "click the round button" or "use the control on the right"
- All i18n strings are descriptive labels, not positional/sensory instructions

Criterion 1.3.3 now reports "Not Applicable" in the OpenACR.

[KIT-5783]: https://coveord.atlassian.net/browse/KIT-5783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ