### PR TITLE
chore(atomic-a11y): manual audit for WCAG 2.4.1 Bypass Blocks (Level A)

### DIFF
--- a/packages/atomic-a11y/a11y/a11y-overrides.json
+++ b/packages/atomic-a11y/a11y/a11y-overrides.json
@@ -122,6 +122,11 @@
       "criterion": "2.5.7",
       "conformance": "not-applicable",
       "reason": "No Atomic component implements custom dragging movements. Scrollable containers use native CSS overflow (user-agent scrolling, exempt per 2.5.7) with arrow button alternatives. Modal touchmove listeners only prevent background scrolling."
+    },
+    {
+      "criterion": "2.4.1",
+      "conformance": "not-applicable",
+      "reason": "Bypass blocks is a page-level concern for the consuming application. Atomic is a component library providing individual widgets, not complete web pages with repeated navigation blocks. Components provide proper semantic structure (nav landmarks, aside, header/footer, role=region) that enables consuming apps to satisfy this criterion."
     }
   ]
 }


### PR DESCRIPTION
[KIT-5785](https://coveord.atlassian.net/browse/KIT-5785)

**Reference:** [Understanding SC 2.4.1 Bypass Blocks](https://www.w3.org/WAI/WCAG22/Understanding/bypass-blocks.html)

## Problem
WCAG 2.4.1 Bypass Blocks (Level A) was marked "Does Not Support" in the Atomic VPAT because no manual audit coverage existed.

## Solution
Manually audited all Atomic component surfaces for bypass blocks compliance.

All surfaces are **not applicable** — WCAG 2.4.1 requires "a mechanism to bypass blocks of content that are repeated on multiple web pages." Atomic is a component library providing individual widgets, not complete web pages with repeated navigation blocks. The bypass blocks concern is a page-level responsibility of the consuming application.

However, Atomic does provide proper semantic structure that enables consuming apps to meet this criterion:
- `<nav aria-label="pagination">` landmark for pager navigation
- `<aside>` landmarks for smart snippets and generated answers
- `<header>` / `<footer>` for modal structure
- `role="region"` with labels for carousels and IPX body
- CSS grid layout sections with distinct named areas

Criterion 2.4.1 now reports "Not Applicable" in the OpenACR.

[KIT-5785]: https://coveord.atlassian.net/browse/KIT-5785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ