### PR TITLE
chore(atomic-a11y): manual audit for WCAG 2.1.2 No Keyboard Trap (Level A)

### DIFF
--- a/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
@@ -12,7 +12,7 @@
     },
     "1.4.11-non-text-contrast": {
       "conformance": "partial",
-      "remarks": "Numeric facet input border uses border-neutral (#e5e8e8) at 1.23:1 contrast against white, failing the 3:1 requirement. Rating stars (active #f6ce3c at 1.52:1, inactive #e5e8e8 at 1.23:1) also fail — stars are the only way sighted users identify the rating value. Users with low vision cannot perceive these UI boundaries and graphical indicators, making it difficult to identify form fields or understand rating values."
+      "remarks": "Numeric facet input border uses border-neutral (#e5e8e8) at 1.23:1 contrast against white, failing the 3:1 requirement. Rating stars (active #f6ce3c at 1.52:1, inactive #e5e8e8 at 1.23:1) also fail \u2014 stars are the only way sighted users identify the rating value. Users with low vision cannot perceive these UI boundaries and graphical indicators, making it difficult to identify form fields or understand rating values."
     },
     "3.3.1-error-identification": {
       "conformance": "pass"
@@ -31,6 +31,9 @@
     "2.4.3-focus-order": {
       "conformance": "fail",
       "remarks": "Focus escapes commerce refine-modal when tabbing, due to broken focus trap. See KIT-5811. All non-modal components pass (search box, facets, breadbox, pager, sort dropdown, products-per-page, product list, load-more)."
+    },
+    "2.1.2-no-keyboard-trap": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
@@ -25,6 +25,9 @@
     "2.4.3-focus-order": {
       "conformance": "fail",
       "remarks": "Focus escapes insight refine-modal and smart-snippet-feedback-modal when tabbing, due to broken focus trap. See KIT-5811. All non-modal components pass (search box, facets, pager, tabs)."
+    },
+    "2.1.2-no-keyboard-trap": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
@@ -17,6 +17,9 @@
     "2.4.3-focus-order": {
       "conformance": "fail",
       "remarks": "Focus escapes ipx-modal and ipx-refine-modal when tabbing, due to broken focus trap. See KIT-5811. Tab component passes."
+    },
+    "2.1.2-no-keyboard-trap": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
@@ -12,6 +12,9 @@
     "1.4.10-reflow": {
       "conformance": "pass"
     },
-    "2.4.3-focus-order": "pass"
+    "2.4.3-focus-order": "pass",
+    "2.1.2-no-keyboard-trap": {
+      "conformance": "pass"
+    }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-search.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-search.json
@@ -6,14 +6,14 @@
     },
     "2.4.6-headings-and-labels": {
       "conformance": "fail",
-      "remarks": "atomic-tab-manager renders a tablist with aria-label=\"tab-area\" — a non-descriptive technical placeholder. Screen reader users navigating by landmark or tab group hear \"tab-area\" instead of a meaningful description of the tab purpose (e.g., \"Content type tabs\"), making it difficult to understand the interface structure."
+      "remarks": "atomic-tab-manager renders a tablist with aria-label=\"tab-area\" \u2014 a non-descriptive technical placeholder. Screen reader users navigating by landmark or tab group hear \"tab-area\" instead of a meaningful description of the tab purpose (e.g., \"Content type tabs\"), making it difficult to understand the interface structure."
     },
     "2.5.2-pointer-cancellation": {
       "conformance": "pass"
     },
     "1.4.11-non-text-contrast": {
       "conformance": "partial",
-      "remarks": "Numeric facet input border uses border-neutral (#e5e8e8) at 1.23:1 contrast against white, failing the 3:1 requirement. Rating stars (active #f6ce3c at 1.52:1, inactive #e5e8e8 at 1.23:1) also fail — stars are the only way sighted users identify the rating value. Refine-toggle switch OFF state track uses bg-neutral at 1.23:1. Users with low vision cannot perceive these UI boundaries and graphical indicators, making it difficult to identify form fields, understand rating values, or determine toggle state."
+      "remarks": "Numeric facet input border uses border-neutral (#e5e8e8) at 1.23:1 contrast against white, failing the 3:1 requirement. Rating stars (active #f6ce3c at 1.52:1, inactive #e5e8e8 at 1.23:1) also fail \u2014 stars are the only way sighted users identify the rating value. Refine-toggle switch OFF state track uses bg-neutral at 1.23:1. Users with low vision cannot perceive these UI boundaries and graphical indicators, making it difficult to identify form fields, understand rating values, or determine toggle state."
     },
     "3.3.1-error-identification": {
       "conformance": "pass"
@@ -32,6 +32,9 @@
     "2.4.3-focus-order": {
       "conformance": "fail",
       "remarks": "Focus escapes modal dialogs (refine-modal, quickview-modal, smart-snippet-feedback-modal) and popover when tabbing, due to broken focus trap (undefined scope in atomic-focus-trap). See KIT-5811. All non-modal components pass (search box, facets, pager, sort dropdown, results-per-page, tabs, segmented facet, result list, load-more, smart snippet)."
+    },
+    "2.1.2-no-keyboard-trap": {
+      "conformance": "pass"
     }
   }
 }


### PR DESCRIPTION
[KIT-5784](https://coveord.atlassian.net/browse/KIT-5784)

**Reference:** [Understanding SC 2.1.2 No Keyboard Trap](https://www.w3.org/WAI/WCAG22/Understanding/no-keyboard-trap.html)

## Problem
WCAG 2.1.2 No Keyboard Trap (Level A) was marked "Does Not Support" in the Atomic VPAT because no manual audit coverage existed.

## Solution
Manually audited all Atomic component surfaces for keyboard trap compliance.

All surfaces **pass** — no component traps keyboard focus:
- All non-modal components (search box, facets, pager, sort dropdown, breadbox, tabs, result lists, load-more) allow free Tab/Shift+Tab navigation in and out
- Modal dialogs (refine-modal, quickview, feedback) support Escape key to close
- The known focus trap bug (KIT-5811) causes focus to *escape* modals rather than being *contained* — this is the opposite of a keyboard trap and a 2.4.3 Focus Order issue, not a 2.1.2 violation
- Popover components (facet search, date picker) close on Escape and return focus to trigger
- No embedded content formats (plugins, applets) that could trap focus

Criterion 2.1.2 now reports "Supports" in the OpenACR.

[KIT-5784]: https://coveord.atlassian.net/browse/KIT-5784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ