### PR TITLE
chore(atomic-a11y): manual audit for WCAG 2.1.4 Character Key Shortcuts (Level A)

### DIFF
--- a/packages/atomic-a11y/a11y/a11y-overrides.json
+++ b/packages/atomic-a11y/a11y/a11y-overrides.json
@@ -132,6 +132,11 @@
       "criterion": "1.3.3",
       "conformance": "not-applicable",
       "reason": "Atomic is a component library that renders interactive UI widgets, not instructional content. Components do not provide textual instructions that reference shape, color, size, visual location, or sound. All controls use programmatic accessible names (aria-label, text content, input labels)."
+    },
+    {
+      "criterion": "2.1.4",
+      "conformance": "not-applicable",
+      "reason": "No Atomic component implements character-only keyboard shortcuts. All keyboard handlers respond exclusively to standard navigation keys (Escape, Enter, Tab, Arrow keys, Home, End, Space) which are exempt from this criterion."
     }
   ]
 }


### PR DESCRIPTION
[KIT-5826](https://coveord.atlassian.net/browse/KIT-5826)

**Reference:** [Understanding SC 2.1.4 Character Key Shortcuts](https://www.w3.org/WAI/WCAG22/Understanding/character-key-shortcuts.html)

## Problem
WCAG 2.1.4 Character Key Shortcuts (Level A) was marked "Does Not Support" in the Atomic VPAT because no manual audit coverage existed.

## Solution
Manually audited all Atomic component keyboard handlers for character-only shortcut compliance.

All surfaces are **not applicable** — no component implements character-only keyboard shortcuts. All keyboard event handlers respond exclusively to standard navigation keys:
- Escape (close modals, popovers, dropdowns)
- Enter/Space (activate buttons, submit forms)
- Arrow keys (navigate tabs, facets, suggestions)
- Home/End (jump to first/last item)
- Tab (standard browser focus navigation)

No single-character shortcuts (letters, numbers, punctuation, symbols) are implemented anywhere in the codebase.

Criterion 2.1.4 now reports "Not Applicable" in the OpenACR.

[KIT-5826]: https://coveord.atlassian.net/browse/KIT-5826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ