### PR TITLE
chore(atomic-a11y): manual audit for WCAG 3.2.1 On Focus (Level A)

### DIFF
--- a/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
@@ -34,6 +34,9 @@
     },
     "2.1.2-no-keyboard-trap": {
       "conformance": "pass"
+    },
+    "3.2.1-on-focus": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
@@ -28,6 +28,9 @@
     },
     "2.1.2-no-keyboard-trap": {
       "conformance": "pass"
+    },
+    "3.2.1-on-focus": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
@@ -20,6 +20,9 @@
     },
     "2.1.2-no-keyboard-trap": {
       "conformance": "pass"
+    },
+    "3.2.1-on-focus": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
@@ -15,6 +15,9 @@
     "2.4.3-focus-order": "pass",
     "2.1.2-no-keyboard-trap": {
       "conformance": "pass"
+    },
+    "3.2.1-on-focus": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-search.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-search.json
@@ -35,6 +35,9 @@
     },
     "2.1.2-no-keyboard-trap": {
       "conformance": "pass"
+    },
+    "3.2.1-on-focus": {
+      "conformance": "pass"
     }
   }
 }


### PR DESCRIPTION
[KIT-5825](https://coveord.atlassian.net/browse/KIT-5825)

**Reference:** [Understanding SC 3.2.1 On Focus](https://www.w3.org/WAI/WCAG22/Understanding/on-focus.html)

## Problem
WCAG 3.2.1 On Focus (Level A) was marked "Does Not Support" in the Atomic VPAT because no manual audit coverage existed.

## Solution
Manually audited all Atomic component surfaces for on-focus compliance.

All surfaces **pass** — no component initiates a change of context when receiving focus:
- Search box focus opens suggestion list (content change, not context change)
- Tab/facet focus does not trigger navigation or form submission
- Popover trigger focus does not auto-open the popover (requires activation)
- No component moves focus to another element on receiving focus
- No new windows or pages are launched on focus

Criterion 3.2.1 now reports "Supports" in the OpenACR.

[KIT-5825]: https://coveord.atlassian.net/browse/KIT-5825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ