### PR TITLE
chore(atomic-a11y): manual audit for WCAG 3.2.2 On Input (Level A)

### DIFF
--- a/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-commerce.json
@@ -40,6 +40,9 @@
     },
     "1.3.2-meaningful-sequence": {
       "conformance": "pass"
+    },
+    "3.2.2-on-input": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-insight.json
@@ -34,6 +34,9 @@
     },
     "1.3.2-meaningful-sequence": {
       "conformance": "pass"
+    },
+    "3.2.2-on-input": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-ipx.json
@@ -26,6 +26,9 @@
     },
     "1.3.2-meaningful-sequence": {
       "conformance": "pass"
+    },
+    "3.2.2-on-input": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-recommendations.json
@@ -21,6 +21,9 @@
     },
     "1.3.2-meaningful-sequence": {
       "conformance": "pass"
+    },
+    "3.2.2-on-input": {
+      "conformance": "pass"
     }
   }
 }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-search.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-search.json
@@ -41,6 +41,9 @@
     },
     "1.3.2-meaningful-sequence": {
       "conformance": "pass"
+    },
+    "3.2.2-on-input": {
+      "conformance": "pass"
     }
   }
 }


### PR DESCRIPTION
[KIT-5790](https://coveord.atlassian.net/browse/KIT-5790)

**Reference:** [Understanding SC 3.2.2 On Input](https://www.w3.org/WAI/WCAG22/Understanding/on-input.html)

## Problem
WCAG 3.2.2 On Input (Level A) was marked "Does Not Support" in the Atomic VPAT because no manual audit coverage existed.

## Solution
Manually audited all Atomic component surfaces for on-input compliance.

All surfaces **pass** — no component causes a change of context when its setting is changed:
- Sort dropdowns: selecting a sort option updates results in place, no navigation
- Results/products per page: changing value updates count in place
- Facets (all variants): toggling filters updates results in place
- Search boxes: only trigger navigation on explicit submit (Enter key or button click), never on input change
- Radio buttons: changing selection updates local state only

Criterion 3.2.2 now reports "Supports" in the OpenACR.

[KIT-5790]: https://coveord.atlassian.net/browse/KIT-5790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ