### PR TITLE
fix(headless): added guard to prevent reacting to events from aborted agents

### DIFF
--- a/.changeset/seven-rings-like.md
+++ b/.changeset/seven-rings-like.md
@@ -1,0 +1,5 @@
+---
+"@coveo/headless": patch
+---
+
+added guard to prevent reacting to events from aborted agents

--- a/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/answer-agent-runner.test.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/answer-agent-runner.test.ts
@@ -155,6 +155,16 @@ describe('createAnswerRunner', () => {
     expect(abortRunMock).toHaveBeenCalledTimes(1);
   });
 
+  it('sets isRunning to false on the agent when abortRun is called', async () => {
+    const runner = buildRunner();
+
+    await runner.run(state, dispatch, navigatorProvider);
+    mockAgent.isRunning = true;
+    runner.abortRun();
+
+    expect(mockAgent.isRunning).toBe(false);
+  });
+
   it('dispatches the loading state when a run starts', async () => {
     const runner = buildRunner();
 

--- a/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/answer-agent-runner.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/answer-agent-runner.ts
@@ -29,7 +29,10 @@ export const createAnswerRunner = () => {
   let currentAgent: AnswerAgent | undefined;
 
   const abortRun = () => {
-    currentAgent?.abortRun();
+    if (currentAgent) {
+      currentAgent.isRunning = false;
+      currentAgent.abortRun();
+    }
     currentAgent = undefined;
   };
 

--- a/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/head-answer-strategy.test.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/head-answer-strategy.test.ts
@@ -54,6 +54,7 @@ describe('createHeadAnswerStrategy', () => {
   it('dispatches a new generation step start when a step starts', () => {
     strategy.onStepStartedEvent!({
       event: {stepName: 'searching', timestamp: 123},
+      agent: {isRunning: true},
     } as any);
 
     expect(dispatch).toHaveBeenCalledWith(
@@ -66,6 +67,7 @@ describe('createHeadAnswerStrategy', () => {
 
     strategy.onStepFinishedEvent!({
       event: {stepName: 'answering'},
+      agent: {isRunning: true},
     } as any);
 
     expect(dispatch).toHaveBeenCalledWith(
@@ -76,7 +78,10 @@ describe('createHeadAnswerStrategy', () => {
   });
 
   it('appends incoming text deltas to the answer message', () => {
-    strategy.onTextMessageContentEvent!({event: {delta: 'Hello'}} as any);
+    strategy.onTextMessageContentEvent!({
+      event: {delta: 'Hello'},
+      agent: {isRunning: true},
+    } as any);
 
     expect(dispatch).toHaveBeenCalledWith(updateMessage({textDelta: 'Hello'}));
   });
@@ -91,6 +96,7 @@ describe('createHeadAnswerStrategy', () => {
           conversationToken: 'token-123',
         },
       },
+      agent: {isRunning: true},
     } as any);
 
     expect(dispatch).toHaveBeenCalledWith(
@@ -119,6 +125,7 @@ describe('createHeadAnswerStrategy', () => {
         name: 'citations',
         value: {citations},
       },
+      agent: {isRunning: true},
     } as any);
 
     expect(dispatch).toHaveBeenCalledWith(updateCitations({citations}));
@@ -130,6 +137,7 @@ describe('createHeadAnswerStrategy', () => {
         message: 'Something went wrong',
         code: 'KNOWLEDGE:SSE_MAX_DURATION_EXCEEDED',
       },
+      agent: {isRunning: true},
     } as any);
 
     expect(dispatch).toHaveBeenCalledWith(
@@ -163,6 +171,7 @@ describe('createHeadAnswerStrategy', () => {
         },
         threadId: 'thread-007',
       },
+      agent: {isRunning: true},
     } as any);
 
     expect(dispatch).toHaveBeenNthCalledWith(1, setIsAnswerGenerated(true));
@@ -196,6 +205,7 @@ describe('createHeadAnswerStrategy', () => {
         },
         threadId: 'thread-007',
       },
+      agent: {isRunning: true},
     } as any);
 
     expect(dispatch).toHaveBeenNthCalledWith(1, setIsAnswerGenerated(false));
@@ -204,5 +214,72 @@ describe('createHeadAnswerStrategy', () => {
     expect(streamEndSpy).toHaveBeenCalledWith(false, 'run-001', undefined);
     expect(dispatch).toHaveBeenNthCalledWith(4, streamEndAction);
     expect(dispatch).toHaveBeenNthCalledWith(5, responseLinkedAction);
+  });
+
+  describe('when agent.isRunning is false', () => {
+    const stoppedAgent = {isRunning: false};
+
+    it('does not dispatch on step started', () => {
+      strategy.onStepStartedEvent!({
+        event: {stepName: 'searching', timestamp: 123},
+        agent: stoppedAgent,
+      } as any);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch on step finished', () => {
+      strategy.onStepFinishedEvent!({
+        event: {stepName: 'answering', timestamp: 456},
+        agent: stoppedAgent,
+      } as any);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch on text message content', () => {
+      strategy.onTextMessageContentEvent!({
+        event: {delta: 'Hello'},
+        agent: stoppedAgent,
+      } as any);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch on custom event', () => {
+      strategy.onCustomEvent!({
+        event: {
+          name: 'header',
+          value: {contentFormat: 'text/markdown'},
+        },
+        agent: stoppedAgent,
+      } as any);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch on run error', () => {
+      strategy.onRunErrorEvent!({
+        event: {
+          message: 'Something went wrong',
+          code: 'KNOWLEDGE:SSE_MAX_DURATION_EXCEEDED',
+        },
+        agent: stoppedAgent,
+      } as any);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch on run finished', () => {
+      strategy.onRunFinishedEvent!({
+        event: {
+          result: {completionReason: 'ANSWERED'},
+          threadId: 'thread-007',
+        },
+        agent: stoppedAgent,
+      } as any);
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/head-answer-strategy.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/head-answer-strategy.ts
@@ -46,7 +46,7 @@ export const createHeadAnswerStrategy = (
       dispatch(clearFollowUpAnswersConversationToken());
     },
     onStepStartedEvent: ({event, agent}) => {
-      if (!agent.isRunning) {
+      if (agent.isRunning === false) {
         return;
       }
       dispatch(
@@ -57,7 +57,7 @@ export const createHeadAnswerStrategy = (
       );
     },
     onStepFinishedEvent: ({event, agent}) => {
-      if (!agent.isRunning) {
+      if (agent.isRunning === false) {
         return;
       }
       dispatch(
@@ -68,7 +68,7 @@ export const createHeadAnswerStrategy = (
       );
     },
     onTextMessageContentEvent: ({event, agent}) => {
-      if (!agent.isRunning) {
+      if (agent.isRunning === false) {
         return;
       }
       if (event.delta.length > 0) {
@@ -77,7 +77,7 @@ export const createHeadAnswerStrategy = (
       dispatch(updateMessage({textDelta: event.delta}));
     },
     onCustomEvent: ({event, agent}) => {
-      if (!agent.isRunning) {
+      if (agent.isRunning === false) {
         return;
       }
       const {name, value} = event;
@@ -103,7 +103,7 @@ export const createHeadAnswerStrategy = (
       }
     },
     onRunErrorEvent: ({event, agent}) => {
-      if (!agent.isRunning) {
+      if (agent.isRunning === false) {
         return;
       }
       const mappedCode = mapRunErrorCode(event.code);
@@ -115,7 +115,7 @@ export const createHeadAnswerStrategy = (
       );
     },
     onRunFinishedEvent: ({event, agent}) => {
-      if (!agent.isRunning) {
+      if (agent.isRunning === false) {
         return;
       }
       const answerGenerated = event.result?.completionReason === 'ANSWERED';

--- a/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/head-answer-strategy.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/head-answer-strategy.ts
@@ -45,7 +45,10 @@ export const createHeadAnswerStrategy = (
       dispatch(setFollowUpAnswersConversationId(event.threadId));
       dispatch(clearFollowUpAnswersConversationToken());
     },
-    onStepStartedEvent: ({event}) => {
+    onStepStartedEvent: ({event, agent}) => {
+      if (!agent.isRunning) {
+        return;
+      }
       dispatch(
         startStep({
           name: event.stepName as GenerationStepName,
@@ -53,7 +56,10 @@ export const createHeadAnswerStrategy = (
         })
       );
     },
-    onStepFinishedEvent: ({event}) => {
+    onStepFinishedEvent: ({event, agent}) => {
+      if (!agent.isRunning) {
+        return;
+      }
       dispatch(
         finishStep({
           name: event.stepName as GenerationStepName,
@@ -61,13 +67,19 @@ export const createHeadAnswerStrategy = (
         })
       );
     },
-    onTextMessageContentEvent: ({event}) => {
+    onTextMessageContentEvent: ({event, agent}) => {
+      if (!agent.isRunning) {
+        return;
+      }
       if (event.delta.length > 0) {
         answerHasText = true;
       }
       dispatch(updateMessage({textDelta: event.delta}));
     },
-    onCustomEvent: ({event}) => {
+    onCustomEvent: ({event, agent}) => {
+      if (!agent.isRunning) {
+        return;
+      }
       const {name, value} = event;
       switch (name) {
         case 'header': {
@@ -90,7 +102,10 @@ export const createHeadAnswerStrategy = (
         }
       }
     },
-    onRunErrorEvent: ({event}) => {
+    onRunErrorEvent: ({event, agent}) => {
+      if (!agent.isRunning) {
+        return;
+      }
       const mappedCode = mapRunErrorCode(event.code);
       dispatch(
         updateError({
@@ -99,7 +114,10 @@ export const createHeadAnswerStrategy = (
         })
       );
     },
-    onRunFinishedEvent: ({event}) => {
+    onRunFinishedEvent: ({event, agent}) => {
+      if (!agent.isRunning) {
+        return;
+      }
       const answerGenerated = event.result?.completionReason === 'ANSWERED';
       const answerTextIsEmpty = answerGenerated ? !answerHasText : undefined;
       dispatch(setIsAnswerGenerated(answerGenerated));


### PR DESCRIPTION
## [SFINT-6830](https://coveord.atlassian.net/browse/SFINT-6830)

## Problem

In Salesforce (Quantic), AbortController is not always available. When a new query is triggered while the head answer agent is still streaming, abortRun() fails to actually stop event processing and the stream continues dispatching actions to the store.

## Solution

Use the agent.isRunning flag as a cancellation mechanism:

- The agent runner sets `agent.isRunning = true` when calling `agent.runAgent()`.
- when calling the `abortRun` method of the agent runner, we set `agent.isRunning = false`
- Each event handler has access to the `agent` so it checks `agent.isRunning` and returns early if false.

This ensures events arriving after an abort are silently dropped, regardless of whether the underlying network request was actually cancelled.



[SFINT-6830]: https://coveord.atlassian.net/browse/SFINT-6830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ