### PR TITLE
fix(samples): make headless React sample tsconfigs self-contained [KIT-5829]

### DIFF
--- a/samples/headless/commerce-react/tsconfig.json
+++ b/samples/headless/commerce-react/tsconfig.json
@@ -1,15 +1,18 @@
 {
-  "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "module": "Node16",
     "moduleResolution": "Node16",
     "noEmit": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": true
   },
   "include": ["src"]
 }

--- a/samples/headless/search-react/tsconfig.json
+++ b/samples/headless/search-react/tsconfig.json
@@ -1,13 +1,15 @@
 {
-  "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
     "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "strict": true
   },
   "include": ["src", "server"]
 }


### PR DESCRIPTION
## What

Inline the compiler options in `samples/headless/search-react/tsconfig.json` and `samples/headless/commerce-react/tsconfig.json`, dropping the monorepo-relative `extends: "../../../tsconfig.json"`.

## Why

That `extends` points at the monorepo root config, which does not exist once the sample is scaffolded into a standalone project. Vite 8 (oxc/rolldown) loads the tsconfig per file, follows the broken `extends`, and fails:

```
[TSCONFIG_ERROR] Failed to load tsconfig for 'src/index.tsx': Tsconfig not found
```

This breaks both `dev` and `build` for any project scaffolded from these samples. Making the tsconfig self-contained is a prerequisite for the samples to be scaffold-ready.

## Verification

- Both samples still build inside the monorepo (`pnpm --filter @samples/headless-search-react build`, `@samples/headless-commerce-react build`).
- A project scaffolded from each sample runs `dev`/`build` standalone with no Tsconfig error.

---

[KIT-5829](https://coveord.atlassian.net/browse/KIT-5829) | Epic: [KIT-5452](https://coveord.atlassian.net/browse/KIT-5452)

[KIT-5829]: https://coveord.atlassian.net/browse/KIT-5829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIT-5452]: https://coveord.atlassian.net/browse/KIT-5452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ