### PR TITLE
feat(create-ui): zero-config scaffolding CLI [KIT-5830]

### DIFF
--- a/.changeset/create-ui-initial.md
+++ b/.changeset/create-ui-initial.md
@@ -1,0 +1,12 @@
+---
+"@coveo/create-ui": minor
+---
+
+feat(create-ui): add zero-config scaffolding CLI
+
+`npm create @coveo/ui <project-name> --template <template-name>` scaffolds a
+Coveo UI project by downloading an official sample, resolving its
+`catalog:`/`workspace:*` dependencies to concrete versions, and installing.
+Runs with no credentials against the sample organization. Headless search and
+commerce (React) templates are available first; Atomic and vanilla templates
+follow as their samples become scaffold-ready.

--- a/packages/create-ui/README.md
+++ b/packages/create-ui/README.md
@@ -1,0 +1,46 @@
+# @coveo/create-ui
+
+Scaffold a Coveo UI project (Atomic or Headless) from the official
+[ui-kit samples](https://github.com/coveo/ui-kit/tree/main/samples). Every
+template runs with **zero configuration** against the sample organization — no
+credentials, API keys, or search tokens required.
+
+## Usage
+
+```sh
+npm create @coveo/ui@latest my-app --template headless-search-react
+```
+
+Or run without arguments for an interactive prompt:
+
+```sh
+npm create @coveo/ui@latest
+```
+
+`pnpm` is also supported:
+
+```sh
+pnpm create @coveo/ui my-app --template headless-search-react
+```
+
+### Options
+
+| Option            | Description                                          |
+| ----------------- | ---------------------------------------------------- |
+| `<project-name>`  | Directory to create the project in.                  |
+| `--template <id>` | Template to scaffold (skips the interactive prompt). |
+| `-h`, `--help`    | Show usage and the list of available templates.      |
+
+## Templates
+
+Run `npm create @coveo/ui --help` for the current list. Templates encode the
+library, use case, and framework (e.g. `headless-search-react`). Additional
+Atomic and vanilla templates are added as their samples become scaffold-ready.
+
+## How it works
+
+The CLI downloads the matching sample directory from the `coveo/ui-kit` `main`
+branch (via GitHub tarball), rewrites the sample's `package.json` so its
+monorepo-only `catalog:` and `workspace:*` dependencies resolve to concrete
+published versions, renames the project, and installs dependencies with the
+package manager you invoked it with.

--- a/packages/create-ui/package.json
+++ b/packages/create-ui/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@coveo/create-ui",
+  "version": "0.0.0",
+  "description": "Scaffold a Coveo UI project (Atomic or Headless) from the official samples.",
+  "keywords": [
+    "atomic",
+    "coveo",
+    "create",
+    "headless",
+    "scaffold",
+    "template"
+  ],
+  "license": "Apache-2.0",
+  "author": "Coveo",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/coveo/ui-kit.git",
+    "directory": "packages/create-ui"
+  },
+  "bin": {
+    "create-ui": "./dist/index.js"
+  },
+  "files": [
+    "dist/"
+  ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node ./dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "node ../../utils/ci/rm-rf.mjs dist",
+    "lint": "prettier --check ."
+  },
+  "dependencies": {
+    "@inquirer/prompts": "8.5.2",
+    "minimist": "1.2.8",
+    "tar": "7.5.16",
+    "yaml": "catalog:"
+  },
+  "devDependencies": {
+    "@types/minimist": "1.2.5",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": "^20.9.0 || ^22.11.0 || ^24.11.0"
+  }
+}

--- a/packages/create-ui/src/download.test.ts
+++ b/packages/create-ui/src/download.test.ts
@@ -1,0 +1,136 @@
+import {createReadStream} from 'node:fs';
+import {mkdir, mkdtemp, rm, writeFile, access} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, join} from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {create} from 'tar';
+import {extractSampleFromTarball, fetchWithRetry} from './download.js';
+
+const ROOT = 'ui-kit-deadbeef';
+
+/** Files placed inside the fixture tarball (paths relative to the repo root). */
+const FIXTURE_FILES = [
+  'pnpm-workspace.yaml',
+  'packages/headless/package.json',
+  'packages/atomic/package.json',
+  // unrelated package file that must NOT be extracted (only package.json)
+  'packages/atomic/src/index.ts',
+  // the target sample
+  'samples/headless/search-react/package.json',
+  'samples/headless/search-react/src/main.tsx',
+  // a different sample that must NOT be extracted
+  'samples/headless/commerce-react/package.json',
+];
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('extractSampleFromTarball', () => {
+  let workDir: string;
+  let tarballPath: string;
+  let destDir: string;
+
+  beforeEach(async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'create-ui-test-'));
+    const srcDir = join(workDir, 'src');
+    // Build the fixture tree under `<srcDir>/ui-kit-deadbeef/...`
+    for (const file of FIXTURE_FILES) {
+      const full = join(srcDir, ROOT, file);
+      await mkdir(dirname(full), {recursive: true});
+      await writeFile(full, `// ${file}\n`);
+    }
+    tarballPath = join(workDir, 'fixture.tar.gz');
+    await create({gzip: true, cwd: srcDir, file: tarballPath}, [ROOT]);
+    destDir = join(workDir, 'out');
+  });
+
+  afterEach(async () => {
+    await rm(workDir, {recursive: true, force: true});
+  });
+
+  it('extracts the sample dir, strips the root prefix, and returns its path', async () => {
+    const sampleDir = await extractSampleFromTarball(
+      createReadStream(tarballPath),
+      {samplePath: 'samples/headless/search-react', destDir}
+    );
+
+    expect(sampleDir).toBe(join(destDir, 'samples/headless/search-react'));
+    expect(await exists(join(sampleDir, 'package.json'))).toBe(true);
+    expect(await exists(join(sampleDir, 'src/main.tsx'))).toBe(true);
+  });
+
+  it('extracts support files (pnpm-workspace.yaml + packages/*/package.json)', async () => {
+    await extractSampleFromTarball(createReadStream(tarballPath), {
+      samplePath: 'samples/headless/search-react',
+      destDir,
+    });
+
+    expect(await exists(join(destDir, 'pnpm-workspace.yaml'))).toBe(true);
+    expect(await exists(join(destDir, 'packages/headless/package.json'))).toBe(
+      true
+    );
+    expect(await exists(join(destDir, 'packages/atomic/package.json'))).toBe(
+      true
+    );
+  });
+
+  it('does not extract other samples or non-package files', async () => {
+    await extractSampleFromTarball(createReadStream(tarballPath), {
+      samplePath: 'samples/headless/search-react',
+      destDir,
+    });
+
+    expect(await exists(join(destDir, 'samples/headless/commerce-react'))).toBe(
+      false
+    );
+    expect(await exists(join(destDir, 'packages/atomic/src'))).toBe(false);
+  });
+});
+
+describe('fetchWithRetry', () => {
+  it('returns the response on the first successful attempt', async () => {
+    const ok = {ok: true, body: {}} as unknown as Response;
+    const fetchImpl = vi.fn().mockResolvedValue(ok);
+    const result = await fetchWithRetry('http://x', {fetchImpl});
+    expect(result).toBe(ok);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries once after a network failure', async () => {
+    const ok = {ok: true, body: {}} as unknown as Response;
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce(ok);
+    const result = await fetchWithRetry('http://x', {fetchImpl});
+    expect(result).toBe(ok);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws a clear error after exhausting retries', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('ECONNRESET'));
+    await expect(
+      fetchWithRetry('http://x', {retries: 1, fetchImpl})
+    ).rejects.toThrow(/Failed to download the sample/);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a non-ok response as a failure', async () => {
+    const notFound = {
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as unknown as Response;
+    const fetchImpl = vi.fn().mockResolvedValue(notFound);
+    await expect(
+      fetchWithRetry('http://x', {retries: 0, fetchImpl})
+    ).rejects.toThrow(/404 Not Found/);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/create-ui/src/download.ts
+++ b/packages/create-ui/src/download.ts
@@ -1,0 +1,116 @@
+/**
+ * Downloads a sample from the `coveo/ui-kit` monorepo as a GitHub tarball and
+ * extracts only the files needed to scaffold a project:
+ *   - the sample directory (`samples/<library>/<folder>/`)
+ *   - `pnpm-workspace.yaml` (catalog versions, used by dependency resolution)
+ *   - every `packages/<name>/package.json` (workspace protocol versions)
+ *
+ * The whole-monorepo tarball is large; v1 streams it and extracts selectively.
+ * Optimizing the download size is a known follow-up.
+ */
+
+import {mkdir} from 'node:fs/promises';
+import {join} from 'node:path';
+import {Readable} from 'node:stream';
+import {pipeline} from 'node:stream/promises';
+import {extract} from 'tar';
+
+const TARBALL_BASE = 'https://codeload.github.com/coveo/ui-kit/tar.gz';
+
+type FetchImpl = typeof fetch;
+
+/**
+ * Fetches a URL with one retry on failure, throwing a single clear error if all
+ * attempts fail. `fetchImpl` is injectable for testing.
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: {retries?: number; fetchImpl?: FetchImpl} = {}
+): Promise<Response> {
+  const retries = options.retries ?? 1;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const response = await fetchImpl(url);
+      if (response.ok && response.body) {
+        return response;
+      }
+      lastError = new Error(`${response.status} ${response.statusText}`);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  const reason =
+    lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(
+    `Failed to download the sample from ${url} (${reason}). Check your network connection and try again.`
+  );
+}
+
+/** Files outside the sample dir that resolution needs from the tarball. */
+function isSupportFile(relPath: string): boolean {
+  return (
+    relPath === 'pnpm-workspace.yaml' ||
+    /^packages\/[^/]+\/package\.json$/.test(relPath)
+  );
+}
+
+/**
+ * Extracts the sample (and support files) from a gzipped tar stream into
+ * `destDir`. The GitHub tarball wraps everything in a top-level
+ * `ui-kit-<sha>/` directory, which is stripped. Returns the absolute path to
+ * the extracted sample directory.
+ */
+export async function extractSampleFromTarball(
+  source: Readable,
+  options: {samplePath: string; destDir: string}
+): Promise<string> {
+  const {samplePath, destDir} = options;
+  await mkdir(destDir, {recursive: true});
+
+  const extractor = extract({
+    cwd: destDir,
+    // Drop the leading `ui-kit-<sha>/` path component.
+    strip: 1,
+    filter: (path: string) => {
+      // `path` is the original archive path, e.g.
+      // `ui-kit-<sha>/samples/headless/search-react/package.json`.
+      const rel = path.split('/').slice(1).join('/').replace(/\/$/, '');
+      if (!rel) {
+        return false;
+      }
+      if (isSupportFile(rel)) {
+        return true;
+      }
+      return rel === samplePath || rel.startsWith(`${samplePath}/`);
+    },
+  });
+
+  await pipeline(source, extractor);
+  return join(destDir, samplePath);
+}
+
+/**
+ * Downloads the given ref's tarball and extracts the sample into `destDir`.
+ */
+export async function downloadTemplate(options: {
+  samplePath: string;
+  destDir: string;
+  ref?: string;
+}): Promise<string> {
+  const ref = options.ref ?? 'main';
+  const url = `${TARBALL_BASE}/${ref}`;
+
+  const response = await fetchWithRetry(url);
+
+  const nodeStream = Readable.fromWeb(
+    response.body as Parameters<typeof Readable.fromWeb>[0]
+  );
+  return extractSampleFromTarball(nodeStream, {
+    samplePath: options.samplePath,
+    destDir: options.destDir,
+  });
+}

--- a/packages/create-ui/src/e2e.test.ts
+++ b/packages/create-ui/src/e2e.test.ts
@@ -1,0 +1,99 @@
+/**
+ * End-to-end smoke test: packages the LOCAL repo's sample into a tarball (the
+ * same shape GitHub serves), runs the full create-ui pipeline
+ * (extract -> resolve -> finalize -> install), and builds the result.
+ *
+ * Using a local tarball keeps the test deterministic and offline — it validates
+ * the current working tree's samples rather than whatever is on `main`.
+ *
+ * Install- and build-heavy, so it is excluded from the default unit run:
+ *
+ *   E2E=1 pnpm --filter @coveo/create-ui test
+ */
+
+import {createReadStream} from 'node:fs';
+import {access, cp, mkdir, mkdtemp, readdir, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join, resolve} from 'node:path';
+import {spawnSync} from 'node:child_process';
+import {afterAll, beforeAll, describe, expect, it} from 'vitest';
+import {create} from 'tar';
+import {extractSampleFromTarball} from './download.js';
+import {resolveSampleDependencies} from './resolve-deps.js';
+import {finalizeProject, installDependencies} from './setup.js';
+import {getTemplate} from './templates.js';
+
+const RUN_E2E = Boolean(process.env.E2E);
+const REPO_ROOT = resolve(process.cwd(), '../..');
+const ROOT = 'ui-kit-e2e';
+
+/** Builds a GitHub-shaped tarball containing only what scaffolding needs. */
+async function buildLocalTarball(
+  samplePath: string,
+  workDir: string
+): Promise<string> {
+  const stage = join(workDir, 'stage');
+  const rootDir = join(stage, ROOT);
+
+  await cp(join(REPO_ROOT, samplePath), join(rootDir, samplePath), {
+    recursive: true,
+  });
+  await cp(
+    join(REPO_ROOT, 'pnpm-workspace.yaml'),
+    join(rootDir, 'pnpm-workspace.yaml')
+  );
+
+  // Copy each packages/<name>/package.json for workspace: resolution.
+  const packagesDir = join(REPO_ROOT, 'packages');
+  for (const dir of await readdir(packagesDir)) {
+    const src = join(packagesDir, dir, 'package.json');
+    try {
+      await access(src);
+    } catch {
+      continue;
+    }
+    await mkdir(join(rootDir, 'packages', dir), {recursive: true});
+    await cp(src, join(rootDir, 'packages', dir, 'package.json'));
+  }
+
+  const tarball = join(workDir, 'local.tar.gz');
+  await create({gzip: true, cwd: stage, file: tarball}, [ROOT]);
+  return tarball;
+}
+
+describe.skipIf(!RUN_E2E)('create-ui e2e (local tarball)', () => {
+  let workDir: string;
+
+  beforeAll(async () => {
+    workDir = await mkdtemp(join(tmpdir(), 'create-ui-e2e-'));
+  });
+
+  afterAll(async () => {
+    await rm(workDir, {recursive: true, force: true});
+  });
+
+  it('scaffolds, installs, and builds headless-search-react', async () => {
+    const template = getTemplate('headless-search-react')!;
+    const tarball = await buildLocalTarball(template.path, workDir);
+
+    const treeRoot = join(workDir, 'tree');
+    const sampleDir = await extractSampleFromTarball(
+      createReadStream(tarball),
+      {samplePath: template.path, destDir: treeRoot}
+    );
+    await resolveSampleDependencies({sampleDir, treeRoot});
+
+    const targetDir = join(workDir, 'my-app');
+    await finalizeProject({sampleDir, targetDir, projectName: 'my-app'});
+
+    expect(installDependencies(targetDir, 'npm')).toBe(true);
+
+    const build = spawnSync('npm', ['run', 'build'], {
+      cwd: targetDir,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+    expect(build.status).toBe(0);
+    await expect(access(join(targetDir, 'dist'))).resolves.toBeUndefined();
+  }, 300_000);
+});

--- a/packages/create-ui/src/index.test.ts
+++ b/packages/create-ui/src/index.test.ts
@@ -1,0 +1,69 @@
+import {describe, expect, it, vi} from 'vitest';
+import {main, parseArgs} from './index.js';
+import {availableTemplates, getTemplate, templates} from './templates.js';
+
+describe('templates', () => {
+  it('exposes the eight canonical templates', () => {
+    expect(templates).toHaveLength(8);
+  });
+
+  it('maps template names to monorepo sample paths', () => {
+    expect(getTemplate('headless-search-react')?.path).toBe(
+      'samples/headless/search-react'
+    );
+    expect(getTemplate('atomic-search')?.path).toBe(
+      'samples/atomic/search-vite'
+    );
+  });
+
+  it('returns only available templates from availableTemplates()', () => {
+    const names = availableTemplates().map((t) => t.name);
+    expect(names).toContain('headless-search-react');
+    expect(names).toContain('headless-commerce-react');
+    expect(names).not.toContain('atomic-search');
+  });
+
+  it('returns undefined for an unknown template', () => {
+    expect(getTemplate('does-not-exist')).toBeUndefined();
+  });
+});
+
+describe('parseArgs', () => {
+  it('reads the project name as the first positional', () => {
+    expect(parseArgs(['my-app']).projectName).toBe('my-app');
+  });
+
+  it('reads the --template flag', () => {
+    expect(
+      parseArgs(['my-app', '--template', 'headless-search-react']).template
+    ).toBe('headless-search-react');
+  });
+
+  it('supports -h/--help', () => {
+    expect(parseArgs(['--help']).help).toBe(true);
+    expect(parseArgs(['-h']).help).toBe(true);
+    expect(parseArgs([]).help).toBe(false);
+  });
+});
+
+describe('main (no-prompt paths)', () => {
+  it('returns 0 for --help', async () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    expect(await main(['--help'])).toBe(0);
+    spy.mockRestore();
+  });
+
+  it('returns 1 for an unknown template without prompting', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(await main(['my-app', '--template', 'nope'])).toBe(1);
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('returns 1 for a not-yet-available template', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(await main(['my-app', '--template', 'atomic-search'])).toBe(1);
+    errSpy.mockRestore();
+  });
+});

--- a/packages/create-ui/src/index.ts
+++ b/packages/create-ui/src/index.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+import minimist from 'minimist';
+import {mkdtemp, rm, readdir, access} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {argv} from 'node:process';
+import {downloadTemplate} from './download.js';
+import {promptProjectName, selectTemplate} from './prompt.js';
+import {resolveSampleDependencies} from './resolve-deps.js';
+import {finalizeProject, installDependencies} from './setup.js';
+import {availableTemplates, getTemplate, type Template} from './templates.js';
+import {detectPackageManager, log} from './utils.js';
+
+const HELP = `
+Usage: npm create @coveo/ui <project-name> [options]
+
+Scaffold a Coveo UI project from the official samples. Runs with zero
+configuration against the sample organization — no credentials required.
+
+Options:
+  --template <name>   Template to scaffold (skips the interactive prompt)
+  -h, --help          Show this help
+
+Available templates:
+${availableTemplates()
+  .map((t) => `  ${t.name.padEnd(26)} ${t.description}`)
+  .join('\n')}
+
+Example:
+  npm create @coveo/ui my-app --template headless-search-react
+`;
+
+export interface CliArgs {
+  projectName?: string;
+  template?: string;
+  help: boolean;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const parsed = minimist(argv, {
+    string: ['template'],
+    boolean: ['help'],
+    alias: {h: 'help'},
+  });
+  return {
+    projectName: parsed._[0],
+    template: parsed.template,
+    help: Boolean(parsed.help),
+  };
+}
+
+async function isEmptyOrMissing(dir: string): Promise<boolean> {
+  try {
+    await access(dir);
+  } catch {
+    return true; // missing
+  }
+  const entries = await readdir(dir);
+  return entries.length === 0;
+}
+
+/** Downloads, resolves, finalizes, and installs the chosen template. */
+export async function scaffold(
+  template: Template,
+  projectName: string
+): Promise<void> {
+  const targetDir = resolve(process.cwd(), projectName);
+  const tempDir = await mkdtemp(join(tmpdir(), 'create-ui-'));
+
+  try {
+    log.step(`Downloading the "${template.name}" template…`);
+    const sampleDir = await downloadTemplate({
+      samplePath: template.path,
+      destDir: tempDir,
+    });
+
+    log.step('Resolving dependencies…');
+    await resolveSampleDependencies({sampleDir, treeRoot: tempDir});
+
+    log.step(`Creating project in ${targetDir}…`);
+    await finalizeProject({sampleDir, targetDir, projectName});
+  } catch (error) {
+    // Remove any partially-created target directory (it was empty/missing
+    // before scaffolding started, so this is safe).
+    await rm(targetDir, {recursive: true, force: true});
+    throw error;
+  } finally {
+    await rm(tempDir, {recursive: true, force: true});
+  }
+
+  const pm = detectPackageManager();
+  log.step(`Installing dependencies with ${pm}…`);
+  const installed = installDependencies(targetDir, pm);
+
+  log.step('Done!');
+  log.info(`\n  cd ${projectName}`);
+  if (!installed) {
+    log.warn(`Dependency installation failed — run "${pm} install" manually.`);
+  }
+  log.info(`  ${pm} run dev\n`);
+}
+
+export async function main(argv: string[]): Promise<number> {
+  const args = parseArgs(argv);
+
+  if (args.help) {
+    log.info(HELP);
+    return 0;
+  }
+
+  // Resolve the template: explicit --template (validated) or interactive select.
+  let template: Template;
+  if (args.template !== undefined) {
+    const found = getTemplate(args.template);
+    if (!found) {
+      log.error(`Unknown template "${args.template}".`);
+      log.info(
+        `\nAvailable templates:\n${availableTemplates()
+          .map((t) => `  ${t.name}`)
+          .join('\n')}`
+      );
+      return 1;
+    }
+    if (!found.available) {
+      log.error(`Template "${args.template}" is not available yet.`);
+      return 1;
+    }
+    template = found;
+  } else {
+    template = await selectTemplate();
+  }
+
+  // Resolve the project name: positional arg or interactive input.
+  const projectName = args.projectName ?? (await promptProjectName());
+
+  const targetDir = resolve(process.cwd(), projectName);
+  if (!(await isEmptyOrMissing(targetDir))) {
+    log.error(
+      `Target directory "${projectName}" already exists and is not empty.`
+    );
+    return 1;
+  }
+
+  await scaffold(template, projectName);
+  return 0;
+}
+
+const isDirectRun =
+  argv[1] !== undefined && fileURLToPath(import.meta.url) === argv[1];
+
+if (isDirectRun) {
+  main(argv.slice(2)).then(
+    (code) => process.exit(code),
+    (error) => {
+      // A user pressing Ctrl-C during a prompt should exit quietly.
+      if (error instanceof Error && error.name === 'ExitPromptError') {
+        log.info('\nAborted.');
+        process.exit(130);
+      }
+      log.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  );
+}

--- a/packages/create-ui/src/prompt.test.ts
+++ b/packages/create-ui/src/prompt.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from 'vitest';
+import {buildTemplateChoices} from './prompt.js';
+import type {Template} from './templates.js';
+
+const sample: Template[] = [
+  {
+    name: 'headless-search-react',
+    library: 'headless',
+    description: 'Headless search UI (React)',
+    path: 'samples/headless/search-react',
+    available: true,
+  },
+  {
+    name: 'atomic-search',
+    library: 'atomic',
+    description: 'Atomic search UI (vanilla + Vite)',
+    path: 'samples/atomic/search-vite',
+    available: true,
+  },
+];
+
+describe('buildTemplateChoices', () => {
+  it('builds labelled choices keyed by template name', () => {
+    const choices = buildTemplateChoices(sample);
+    expect(choices).toEqual([
+      {
+        name: 'Headless — Headless search UI (React)',
+        value: 'headless-search-react',
+        description: 'Headless search UI (React)',
+      },
+      {
+        name: 'Atomic — Atomic search UI (vanilla + Vite)',
+        value: 'atomic-search',
+        description: 'Atomic search UI (vanilla + Vite)',
+      },
+    ]);
+  });
+
+  it('defaults to the available templates', () => {
+    const values = buildTemplateChoices().map((c) => c.value);
+    expect(values).toContain('headless-search-react');
+    expect(values).not.toContain('atomic-search');
+  });
+});

--- a/packages/create-ui/src/prompt.ts
+++ b/packages/create-ui/src/prompt.ts
@@ -1,0 +1,56 @@
+/**
+ * Interactive prompts shown when arguments are omitted. The interactive calls
+ * are thin wrappers around @inquirer/prompts; the choice-building logic is kept
+ * pure so it can be unit-tested without a TTY.
+ */
+
+import {input, select} from '@inquirer/prompts';
+import {availableTemplates, type Library, type Template} from './templates.js';
+
+const LIBRARY_LABELS: Record<Library, string> = {
+  atomic: 'Atomic',
+  headless: 'Headless',
+};
+
+export interface TemplateChoice {
+  name: string;
+  value: string;
+  description: string;
+}
+
+/**
+ * Pure: builds the select choices from the available templates, prefixing each
+ * with its library label so options read e.g. "Headless — search (React)".
+ */
+export function buildTemplateChoices(
+  templates: Template[] = availableTemplates()
+): TemplateChoice[] {
+  return templates.map((t) => ({
+    name: `${LIBRARY_LABELS[t.library]} — ${t.description}`,
+    value: t.name,
+    description: t.description,
+  }));
+}
+
+/** Prompts the user to pick a template from the available list. */
+export async function selectTemplate(): Promise<Template> {
+  const choices = buildTemplateChoices();
+  const value = await select({
+    message: 'Which template would you like to use?',
+    choices,
+  });
+  // Safe: `value` is one of the available template names.
+  return availableTemplates().find((t) => t.name === value)!;
+}
+
+/** Prompts for a project name, defaulting to a sensible value. */
+export async function promptProjectName(
+  defaultName = 'my-coveo-app'
+): Promise<string> {
+  return input({
+    message: 'Project name:',
+    default: defaultName,
+    validate: (value) =>
+      value.trim().length > 0 ? true : 'Please enter a project name.',
+  });
+}

--- a/packages/create-ui/src/resolve-deps.test.ts
+++ b/packages/create-ui/src/resolve-deps.test.ts
@@ -1,0 +1,143 @@
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {
+  parseCatalogs,
+  resolveDependencyMap,
+  resolvePackageJson,
+  resolveSampleDependencies,
+  type ResolutionContext,
+} from './resolve-deps.js';
+
+const ctx: ResolutionContext = {
+  catalog: {vite: '8.0.14', react: '19.2.7'},
+  catalogs: {react18: {react: '18.3.1'}},
+  workspaceVersions: {
+    '@coveo/headless': '3.40.0',
+    '@coveo/auth': '2.1.9',
+  },
+};
+
+describe('parseCatalogs', () => {
+  it('parses the default catalog and named catalogs', () => {
+    const yaml = [
+      'catalog:',
+      '  vite: 8.0.14',
+      '  react: 19.2.7',
+      'catalogs:',
+      '  react18:',
+      '    react: 18.3.1',
+    ].join('\n');
+    const {catalog, catalogs} = parseCatalogs(yaml);
+    expect(catalog.vite).toBe('8.0.14');
+    expect(catalogs.react18.react).toBe('18.3.1');
+  });
+
+  it('returns empty objects when no catalog is present', () => {
+    expect(parseCatalogs('packages:\n  - a\n')).toEqual({
+      catalog: {},
+      catalogs: {},
+    });
+  });
+});
+
+describe('resolveDependencyMap', () => {
+  it('resolves catalog: to a caret range from the default catalog', () => {
+    expect(resolveDependencyMap({vite: 'catalog:'}, ctx)).toEqual({
+      vite: '^8.0.14',
+    });
+  });
+
+  it('resolves catalog:<name> from a named catalog', () => {
+    expect(resolveDependencyMap({react: 'catalog:react18'}, ctx)).toEqual({
+      react: '^18.3.1',
+    });
+  });
+
+  it('resolves workspace: protocols to a caret range from the package version', () => {
+    expect(
+      resolveDependencyMap(
+        {'@coveo/headless': 'workspace:*', '@coveo/auth': 'workspace:^'},
+        ctx
+      )
+    ).toEqual({'@coveo/headless': '^3.40.0', '@coveo/auth': '^2.1.9'});
+  });
+
+  it('leaves concrete versions untouched', () => {
+    expect(resolveDependencyMap({express: '5.2.1'}, ctx)).toEqual({
+      express: '5.2.1',
+    });
+  });
+
+  it('throws when a catalog reference cannot be resolved', () => {
+    expect(() => resolveDependencyMap({unknown: 'catalog:'}, ctx)).toThrow(
+      /Cannot resolve "unknown"/
+    );
+  });
+
+  it('throws when a workspace dependency has no known version', () => {
+    expect(() =>
+      resolveDependencyMap({'@coveo/missing': 'workspace:*'}, ctx)
+    ).toThrow(/Cannot resolve "@coveo\/missing"/);
+  });
+});
+
+describe('resolvePackageJson', () => {
+  it('resolves across all dependency fields', () => {
+    const resolved = resolvePackageJson(
+      {
+        name: 'x',
+        dependencies: {'@coveo/headless': 'workspace:*', react: 'catalog:'},
+        devDependencies: {vite: 'catalog:'},
+      },
+      ctx
+    );
+    expect(resolved.dependencies).toEqual({
+      '@coveo/headless': '^3.40.0',
+      react: '^19.2.7',
+    });
+    expect(resolved.devDependencies).toEqual({vite: '^8.0.14'});
+  });
+});
+
+describe('resolveSampleDependencies (IO)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'create-ui-resolve-'));
+  });
+  afterEach(async () => {
+    await rm(dir, {recursive: true, force: true});
+  });
+
+  it('rewrites the sample package.json from the extracted tree', async () => {
+    await writeFile(
+      join(dir, 'pnpm-workspace.yaml'),
+      'catalog:\n  vite: 8.0.14\n'
+    );
+    await mkdir(join(dir, 'packages/headless'), {recursive: true});
+    await writeFile(
+      join(dir, 'packages/headless/package.json'),
+      JSON.stringify({name: '@coveo/headless', version: '3.40.0'})
+    );
+    const sampleDir = join(dir, 'samples/headless/search-react');
+    await mkdir(sampleDir, {recursive: true});
+    await writeFile(
+      join(sampleDir, 'package.json'),
+      JSON.stringify({
+        name: '@samples/headless-search-react',
+        dependencies: {'@coveo/headless': 'workspace:*'},
+        devDependencies: {vite: 'catalog:'},
+      })
+    );
+
+    await resolveSampleDependencies({sampleDir, treeRoot: dir});
+
+    const pkg = JSON.parse(
+      await readFile(join(sampleDir, 'package.json'), 'utf8')
+    );
+    expect(pkg.dependencies['@coveo/headless']).toBe('^3.40.0');
+    expect(pkg.devDependencies.vite).toBe('^8.0.14');
+  });
+});

--- a/packages/create-ui/src/resolve-deps.ts
+++ b/packages/create-ui/src/resolve-deps.ts
@@ -1,0 +1,186 @@
+/**
+ * Resolves monorepo-only dependency protocols in a scaffolded sample's
+ * package.json so it can be installed outside the workspace:
+ *   - `catalog:` / `catalog:<name>` -> a concrete version from the catalog
+ *     block(s) of `pnpm-workspace.yaml`
+ *   - `workspace:` (any form) for a monorepo package -> a caret range built
+ *     from that package's own version in the tarball
+ *
+ * Unlike `flatten-catalog.mjs` (which runs `pnpm list` inside the monorepo),
+ * this reads versions from the downloaded tarball, so it works on a user's
+ * machine. Throws if any protocol cannot be resolved (never emits a broken
+ * package.json).
+ */
+
+import {readdir, readFile, writeFile} from 'node:fs/promises';
+import {join} from 'node:path';
+import {parse as parseYaml} from 'yaml';
+
+interface PackageJson {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+export interface ResolutionContext {
+  /** Default catalog: dependency name -> version. */
+  catalog: Record<string, string>;
+  /** Named catalogs: catalogName -> (dependency name -> version). */
+  catalogs: Record<string, Record<string, string>>;
+  /** Monorepo package name -> version (for workspace: resolution). */
+  workspaceVersions: Record<string, string>;
+}
+
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+] as const;
+
+/** Adds a caret to a bare version; leaves existing ranges untouched. */
+function toCaretRange(version: string): string {
+  return /^\d/.test(version) ? `^${version}` : version;
+}
+
+/** Parses the catalog and catalogs blocks from pnpm-workspace.yaml content. */
+export function parseCatalogs(workspaceYaml: string): {
+  catalog: Record<string, string>;
+  catalogs: Record<string, Record<string, string>>;
+} {
+  const doc = (parseYaml(workspaceYaml) ?? {}) as {
+    catalog?: Record<string, string>;
+    catalogs?: Record<string, Record<string, string>>;
+  };
+  return {
+    catalog: doc.catalog ?? {},
+    catalogs: doc.catalogs ?? {},
+  };
+}
+
+function resolveCatalogReference(
+  name: string,
+  spec: string,
+  ctx: ResolutionContext
+): string {
+  // `catalog:` uses the default catalog; `catalog:foo` uses a named catalog.
+  const named = spec.slice('catalog:'.length).trim();
+  const table = named ? ctx.catalogs[named] : ctx.catalog;
+  const version = table?.[name];
+  if (!version) {
+    throw new Error(
+      `Cannot resolve "${name}": "${spec}" not found in ${
+        named ? `catalog "${named}"` : 'the default catalog'
+      } of pnpm-workspace.yaml.`
+    );
+  }
+  return toCaretRange(version);
+}
+
+function resolveWorkspaceReference(
+  name: string,
+  ctx: ResolutionContext
+): string {
+  const version = ctx.workspaceVersions[name];
+  if (!version) {
+    throw new Error(
+      `Cannot resolve "${name}": workspace dependency has no known published version in the monorepo.`
+    );
+  }
+  return toCaretRange(version);
+}
+
+/** Pure: resolves all protocol references in a single dependency map. */
+export function resolveDependencyMap(
+  deps: Record<string, string>,
+  ctx: ResolutionContext
+): Record<string, string> {
+  const resolved: Record<string, string> = {};
+  for (const [name, spec] of Object.entries(deps)) {
+    if (spec.startsWith('catalog:')) {
+      resolved[name] = resolveCatalogReference(name, spec, ctx);
+    } else if (spec.startsWith('workspace:')) {
+      resolved[name] = resolveWorkspaceReference(name, ctx);
+    } else {
+      resolved[name] = spec;
+    }
+  }
+  return resolved;
+}
+
+/** Pure: returns a new package.json with all protocol references resolved. */
+export function resolvePackageJson(
+  pkg: PackageJson,
+  ctx: ResolutionContext
+): PackageJson {
+  const next: PackageJson = {...pkg};
+  for (const field of DEPENDENCY_FIELDS) {
+    const deps = pkg[field];
+    if (deps) {
+      next[field] = resolveDependencyMap(deps, ctx);
+    }
+  }
+  return next;
+}
+
+/** Reads every `packages/<dir>/package.json`, indexed by package name. */
+async function readWorkspaceVersions(
+  treeRoot: string
+): Promise<Record<string, string>> {
+  const packagesDir = join(treeRoot, 'packages');
+  const versions: Record<string, string> = {};
+  let entries: string[] = [];
+  try {
+    entries = await readdir(packagesDir);
+  } catch {
+    return versions;
+  }
+  for (const dir of entries) {
+    try {
+      const raw = await readFile(
+        join(packagesDir, dir, 'package.json'),
+        'utf8'
+      );
+      const pkg = JSON.parse(raw) as PackageJson;
+      if (pkg.name && pkg.version) {
+        versions[pkg.name] = pkg.version;
+      }
+    } catch {
+      // Not every directory has a package.json; skip it.
+    }
+  }
+  return versions;
+}
+
+/**
+ * Resolves the sample's package.json in place using the catalog and package
+ * versions from the extracted tarball tree (`treeRoot` contains
+ * pnpm-workspace.yaml and the packages directory).
+ */
+export async function resolveSampleDependencies(options: {
+  sampleDir: string;
+  treeRoot: string;
+}): Promise<void> {
+  const {sampleDir, treeRoot} = options;
+
+  const workspaceYaml = await readFile(
+    join(treeRoot, 'pnpm-workspace.yaml'),
+    'utf8'
+  );
+  const {catalog, catalogs} = parseCatalogs(workspaceYaml);
+  const workspaceVersions = await readWorkspaceVersions(treeRoot);
+
+  const pkgPath = join(sampleDir, 'package.json');
+  const pkg = JSON.parse(await readFile(pkgPath, 'utf8')) as PackageJson;
+  const resolved = resolvePackageJson(pkg, {
+    catalog,
+    catalogs,
+    workspaceVersions,
+  });
+
+  await writeFile(pkgPath, `${JSON.stringify(resolved, null, 2)}\n`);
+}

--- a/packages/create-ui/src/setup.test.ts
+++ b/packages/create-ui/src/setup.test.ts
@@ -1,0 +1,103 @@
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {
+  finalizePackageJson,
+  finalizeProject,
+  installCommand,
+  toPackageName,
+} from './setup.js';
+
+describe('toPackageName', () => {
+  it('lowercases and uses the final path segment', () => {
+    expect(toPackageName('My-App')).toBe('my-app');
+    expect(toPackageName('some/path/My App')).toBe('my-app');
+  });
+});
+
+describe('finalizePackageJson', () => {
+  it('renames the package and strips the private flag', () => {
+    const result = finalizePackageJson(
+      {name: '@samples/headless-search-react', private: true, foo: 'bar'},
+      'my-app'
+    );
+    expect(result.name).toBe('my-app');
+    expect(result.private).toBeUndefined();
+    expect(result.version).toBe('0.1.0');
+    expect(result.foo).toBe('bar');
+  });
+});
+
+describe('installCommand', () => {
+  it('builds the install command per package manager', () => {
+    expect(installCommand('npm')).toEqual({command: 'npm', args: ['install']});
+    expect(installCommand('pnpm')).toEqual({
+      command: 'pnpm',
+      args: ['install'],
+    });
+  });
+});
+
+describe('finalizeProject (IO)', () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'create-ui-setup-'));
+  });
+  afterEach(async () => {
+    await rm(dir, {recursive: true, force: true});
+  });
+
+  async function exists(p: string): Promise<boolean> {
+    try {
+      await access(p);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  it('rewrites package.json, adds .gitignore, and moves to the target', async () => {
+    const sampleDir = join(dir, 'extracted');
+    await mkdir(sampleDir, {recursive: true});
+    await writeFile(
+      join(sampleDir, 'package.json'),
+      JSON.stringify({name: '@samples/x', private: true})
+    );
+    const targetDir = join(dir, 'my-app');
+
+    await finalizeProject({sampleDir, targetDir, projectName: 'my-app'});
+
+    expect(await exists(sampleDir)).toBe(false);
+    expect(await exists(join(targetDir, '.gitignore'))).toBe(true);
+    const pkg = JSON.parse(
+      await readFile(join(targetDir, 'package.json'), 'utf8')
+    );
+    expect(pkg.name).toBe('my-app');
+    expect(pkg.private).toBeUndefined();
+  });
+
+  it('keeps an existing .gitignore', async () => {
+    const sampleDir = join(dir, 'extracted2');
+    await mkdir(sampleDir, {recursive: true});
+    await writeFile(
+      join(sampleDir, 'package.json'),
+      JSON.stringify({name: '@samples/x'})
+    );
+    await writeFile(join(sampleDir, '.gitignore'), 'custom\n');
+    const targetDir = join(dir, 'app2');
+
+    await finalizeProject({sampleDir, targetDir, projectName: 'app2'});
+
+    expect(await readFile(join(targetDir, '.gitignore'), 'utf8')).toBe(
+      'custom\n'
+    );
+  });
+});

--- a/packages/create-ui/src/setup.ts
+++ b/packages/create-ui/src/setup.ts
@@ -1,0 +1,104 @@
+/**
+ * Finalizes a scaffolded project: renames the package, removes monorepo-only
+ * fields, ensures a .gitignore, moves it into place, and installs dependencies.
+ */
+
+import {spawnSync} from 'node:child_process';
+import {cp, readFile, rm, writeFile, access} from 'node:fs/promises';
+import {basename, join} from 'node:path';
+import type {PackageManager} from './utils.js';
+
+interface PackageJson {
+  name?: string;
+  private?: boolean;
+  version?: string;
+  [key: string]: unknown;
+}
+
+const DEFAULT_GITIGNORE = ['node_modules', 'dist', '.DS_Store', ''].join('\n');
+
+/**
+ * Turns a project name or path into a valid npm package name (lowercase,
+ * spaces collapsed to dashes). Uses the final path segment.
+ */
+export function toPackageName(projectName: string): string {
+  return basename(projectName)
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9._-]/g, '');
+}
+
+/**
+ * Pure: returns a new package.json renamed for the user's project, with the
+ * monorepo-only `private` flag removed and the version reset.
+ */
+export function finalizePackageJson(
+  pkg: PackageJson,
+  projectName: string
+): PackageJson {
+  const next: PackageJson = {...pkg, name: toPackageName(projectName)};
+  delete next.private;
+  next.version = '0.1.0';
+  return next;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Returns the install command for the detected package manager. */
+export function installCommand(pm: PackageManager): {
+  command: string;
+  args: string[];
+} {
+  return {command: pm, args: ['install']};
+}
+
+/**
+ * Finalizes the extracted sample into the target project directory:
+ * rewrites package.json, ensures a .gitignore, and copies it into place.
+ */
+export async function finalizeProject(options: {
+  sampleDir: string;
+  targetDir: string;
+  projectName: string;
+}): Promise<void> {
+  const {sampleDir, targetDir, projectName} = options;
+
+  const pkgPath = join(sampleDir, 'package.json');
+  const pkg = JSON.parse(await readFile(pkgPath, 'utf8')) as PackageJson;
+  await writeFile(
+    pkgPath,
+    `${JSON.stringify(finalizePackageJson(pkg, projectName), null, 2)}\n`
+  );
+
+  if (!(await exists(join(sampleDir, '.gitignore')))) {
+    await writeFile(join(sampleDir, '.gitignore'), `${DEFAULT_GITIGNORE}\n`);
+  }
+
+  // Copy out of the temp extraction tree into the user's target directory.
+  if (sampleDir !== targetDir) {
+    await cp(sampleDir, targetDir, {recursive: true});
+    await rm(sampleDir, {recursive: true, force: true});
+  }
+}
+
+/** Runs `<pm> install` in the target directory. Returns true on success. */
+export function installDependencies(
+  targetDir: string,
+  pm: PackageManager
+): boolean {
+  const {command, args} = installCommand(pm);
+  const result = spawnSync(command, args, {
+    cwd: targetDir,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+  return result.status === 0;
+}

--- a/packages/create-ui/src/templates.ts
+++ b/packages/create-ui/src/templates.ts
@@ -1,0 +1,96 @@
+/**
+ * Canonical scaffolding templates.
+ *
+ * Each template maps a CLI-facing name to a sample directory in the
+ * `coveo/ui-kit` monorepo. The `--template` name drops the framework token for
+ * vanilla samples (e.g. `atomic-search` -> `samples/atomic/search-vite`); this
+ * map holds the real folder path used for tarball extraction.
+ *
+ * `available` gates whether a template is shown/usable. Samples that are not yet
+ * scaffold-ready (e.g. those still coupled to the monorepo) are flagged
+ * `false` until their sample story lands.
+ *
+ * See `samples/CONTRIBUTING.md` for the naming convention.
+ */
+
+export type Library = 'atomic' | 'headless';
+
+export interface Template {
+  /** CLI-facing template name passed to `--template`. */
+  name: string;
+  /** Library the template is built on, used for grouping in prompts. */
+  library: Library;
+  /** Human-readable description shown in interactive selection. */
+  description: string;
+  /** Sample directory in the monorepo, relative to the repo root. */
+  path: string;
+  /** Whether the template is scaffold-ready and selectable. */
+  available: boolean;
+}
+
+export const templates: Template[] = [
+  {
+    name: 'atomic-search',
+    library: 'atomic',
+    description: 'Atomic search UI (vanilla + Vite)',
+    path: 'samples/atomic/search-vite',
+    available: false,
+  },
+  {
+    name: 'atomic-commerce',
+    library: 'atomic',
+    description: 'Atomic commerce UI (vanilla + Vite)',
+    path: 'samples/atomic/commerce-vite',
+    available: false,
+  },
+  {
+    name: 'atomic-search-react',
+    library: 'atomic',
+    description: 'Atomic search UI (React)',
+    path: 'samples/atomic/search-react',
+    available: false,
+  },
+  {
+    name: 'atomic-commerce-react',
+    library: 'atomic',
+    description: 'Atomic commerce UI (React)',
+    path: 'samples/atomic/commerce-react',
+    available: false,
+  },
+  {
+    name: 'headless-search',
+    library: 'headless',
+    description: 'Headless search UI (vanilla + Vite)',
+    path: 'samples/headless/search-vite',
+    available: false,
+  },
+  {
+    name: 'headless-commerce',
+    library: 'headless',
+    description: 'Headless commerce UI (vanilla + Vite)',
+    path: 'samples/headless/commerce-vite',
+    available: false,
+  },
+  {
+    name: 'headless-search-react',
+    library: 'headless',
+    description: 'Headless search UI (React)',
+    path: 'samples/headless/search-react',
+    available: true,
+  },
+  {
+    name: 'headless-commerce-react',
+    library: 'headless',
+    description: 'Headless commerce UI (React)',
+    path: 'samples/headless/commerce-react',
+    available: true,
+  },
+];
+
+export function getTemplate(name: string): Template | undefined {
+  return templates.find((t) => t.name === name);
+}
+
+export function availableTemplates(): Template[] {
+  return templates.filter((t) => t.available);
+}

--- a/packages/create-ui/src/utils.test.ts
+++ b/packages/create-ui/src/utils.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from 'vitest';
+import {detectPackageManager} from './utils.js';
+
+describe('detectPackageManager', () => {
+  it('detects pnpm from the user agent', () => {
+    expect(detectPackageManager('pnpm/9.0.0 npm/? node/v20.0.0')).toBe('pnpm');
+  });
+
+  it('detects npm from the user agent', () => {
+    expect(detectPackageManager('npm/10.0.0 node/v20.0.0')).toBe('npm');
+  });
+
+  it('falls back to npm for yarn or unknown agents', () => {
+    expect(detectPackageManager('yarn/1.22.0 npm/? node/v20.0.0')).toBe('npm');
+    expect(detectPackageManager('')).toBe('npm');
+  });
+
+  it('falls back to npm when no user agent is set in the environment', () => {
+    const previous = process.env.npm_config_user_agent;
+    delete process.env.npm_config_user_agent;
+    try {
+      expect(detectPackageManager()).toBe('npm');
+    } finally {
+      if (previous !== undefined) {
+        process.env.npm_config_user_agent = previous;
+      }
+    }
+  });
+});

--- a/packages/create-ui/src/utils.ts
+++ b/packages/create-ui/src/utils.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared helpers: logging and package-manager detection.
+ */
+
+export type PackageManager = 'npm' | 'pnpm';
+
+/**
+ * Detects the package manager the user invoked `create` with, via the
+ * `npm_config_user_agent` environment variable that npm/pnpm/yarn set.
+ * Only npm and pnpm are supported; anything else falls back to npm.
+ */
+export function detectPackageManager(
+  userAgent: string | undefined = process.env.npm_config_user_agent
+): PackageManager {
+  if (!userAgent) {
+    return 'npm';
+  }
+  const name = userAgent.split(' ')[0]?.split('/')[0];
+  return name === 'pnpm' ? 'pnpm' : 'npm';
+}
+
+export const log = {
+  info(message: string): void {
+    console.log(message);
+  },
+  step(message: string): void {
+    console.log(`\n${message}`);
+  },
+  success(message: string): void {
+    console.log(`✓ ${message}`);
+  },
+  warn(message: string): void {
+    console.warn(`⚠ ${message}`);
+  },
+  error(message: string): void {
+    console.error(`✗ ${message}`);
+  },
+};

--- a/packages/create-ui/tsconfig.json
+++ b/packages/create-ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "isolatedModules": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/create-ui/vitest.config.ts
+++ b/packages/create-ui/vitest.config.ts
@@ -1,0 +1,8 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,6 +793,34 @@ importers:
         specifier: 'catalog:'
         version: 3.0.0
 
+  packages/create-ui:
+    dependencies:
+      '@inquirer/prompts':
+        specifier: 8.5.2
+        version: 8.5.2(@types/node@24.12.4)
+      minimist:
+        specifier: 1.2.8
+        version: 1.2.8
+      tar:
+        specifier: 7.5.16
+        version: 7.5.16
+      yaml:
+        specifier: 'catalog:'
+        version: 2.9.0
+    devDependencies:
+      '@types/minimist':
+        specifier: 1.2.5
+        version: 1.2.5
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.4
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@types/node@24.12.4)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+
   packages/documentation:
     devDependencies:
       typedoc:
@@ -966,10 +994,10 @@ importers:
         version: 1.60.0
       '@salesforce/eslint-config-lwc':
         specifier: 3.7.2
-        version: 3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)
+        version: 3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)
       '@salesforce/sfdx-lwc-jest':
         specifier: 6.0.0
-        version: 6.0.0(@types/node@24.12.4)(eslint@8.57.1)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))(typescript@6.0.3)
+        version: 6.0.0(@types/node@25.9.2)(eslint@8.57.1)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))(typescript@6.0.3)
       '@types/wait-on':
         specifier: 5.3.4
         version: 5.3.4
@@ -990,7 +1018,7 @@ importers:
         version: 3.1.3
       jest:
         specifier: 'catalog:'
-        version: 30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+        version: 30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1008,7 +1036,7 @@ importers:
         version: 2.2.6(prettier@3.8.3)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@24.12.4)(typescript@6.0.3)
+        version: 10.9.2(@types/node@25.9.2)(typescript@6.0.3)
       wait-on:
         specifier: 9.0.10
         version: 9.0.10
@@ -3876,9 +3904,22 @@ packages:
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
 
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
   '@inquirer/checkbox@4.3.2':
     resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/checkbox@5.2.1':
+    resolution: {integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -3903,6 +3944,15 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/core@10.3.2':
     resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
     engines: {node: '>=18'}
@@ -3921,9 +3971,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/editor@4.2.23':
     resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.2.2':
+    resolution: {integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -3939,9 +4007,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/expand@5.1.1':
+    resolution: {integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.3':
+    resolution: {integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -3956,9 +4042,22 @@ packages:
     resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
 
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
   '@inquirer/input@4.3.1':
     resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/input@5.1.2':
+    resolution: {integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -3974,9 +4073,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/number@4.1.1':
+    resolution: {integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/password@4.0.23':
     resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.1.1':
+    resolution: {integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -3992,9 +4109,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/prompts@8.5.2':
+    resolution: {integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/rawlist@4.1.11':
     resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.3.1':
+    resolution: {integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -4010,9 +4145,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/search@4.2.1':
+    resolution: {integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/select@4.4.2':
     resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.2.1':
+    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -4031,6 +4184,15 @@ packages:
   '@inquirer/type@4.0.5':
     resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -14201,8 +14363,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.15:
-    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -18166,6 +18328,8 @@ snapshots:
 
   '@inquirer/ansi@2.0.5': {}
 
+  '@inquirer/ansi@2.0.7': {}
+
   '@inquirer/checkbox@4.3.2(@types/node@24.12.4)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -18185,6 +18349,15 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.9.2
+
+  '@inquirer/checkbox@5.2.1(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.12.4)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
 
   '@inquirer/confirm@5.1.21(@types/node@24.12.4)':
     dependencies:
@@ -18214,6 +18387,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.2
     optional: true
+
+  '@inquirer/confirm@6.1.1(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.12.4)
+      '@inquirer/type': 4.0.7(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
 
   '@inquirer/core@10.3.2(@types/node@24.12.4)':
     dependencies:
@@ -18266,6 +18446,18 @@ snapshots:
       '@types/node': 25.9.2
     optional: true
 
+  '@inquirer/core@11.2.1(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.12.4)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 24.12.4
+
   '@inquirer/editor@4.2.23(@types/node@24.12.4)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@24.12.4)
@@ -18281,6 +18473,14 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@25.9.2)
     optionalDependencies:
       '@types/node': 25.9.2
+
+  '@inquirer/editor@5.2.2(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.12.4)
+      '@inquirer/external-editor': 3.0.3(@types/node@24.12.4)
+      '@inquirer/type': 4.0.7(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
 
   '@inquirer/expand@4.0.23(@types/node@24.12.4)':
     dependencies:
@@ -18298,6 +18498,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.2
 
+  '@inquirer/expand@5.1.1(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.12.4)
+      '@inquirer/type': 4.0.7(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
+
   '@inquirer/external-editor@1.0.3(@types/node@24.12.4)':
     dependencies:
       chardet: 2.1.1
@@ -18312,9 +18519,18 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.2
 
+  '@inquirer/external-editor@3.0.3(@types/node@24.12.4)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 24.12.4
+
   '@inquirer/figures@1.0.15': {}
 
   '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/figures@2.0.7': {}
 
   '@inquirer/input@4.3.1(@types/node@24.12.4)':
     dependencies:
@@ -18330,6 +18546,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.2
 
+  '@inquirer/input@5.1.2(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.12.4)
+      '@inquirer/type': 4.0.7(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
+
   '@inquirer/number@3.0.23(@types/node@24.12.4)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@24.12.4)
@@ -18343,6 +18566,13 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@25.9.2)
     optionalDependencies:
       '@types/node': 25.9.2
+
+  '@inquirer/number@4.1.1(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.12.4)
+      '@inquirer/type': 4.0.7(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
 
   '@inquirer/password@4.0.23(@types/node@24.12.4)':
     dependencies:
@@ -18359,6 +18589,14 @@ snapshots:
       '@inquirer/type': 3.0.10(@types/node@25.9.2)
     optionalDependencies:
       '@types/node': 25.9.2
+
+  '@inquirer/password@5.1.1(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.12.4)
+      '@inquirer/type': 4.0.7(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
 
   '@inquirer/prompts@7.10.1(@types/node@24.12.4)':
     dependencies:
@@ -18390,6 +18628,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.2
 
+  '@inquirer/prompts@8.5.2(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/checkbox': 5.2.1(@types/node@24.12.4)
+      '@inquirer/confirm': 6.1.1(@types/node@24.12.4)
+      '@inquirer/editor': 5.2.2(@types/node@24.12.4)
+      '@inquirer/expand': 5.1.1(@types/node@24.12.4)
+      '@inquirer/input': 5.1.2(@types/node@24.12.4)
+      '@inquirer/number': 4.1.1(@types/node@24.12.4)
+      '@inquirer/password': 5.1.1(@types/node@24.12.4)
+      '@inquirer/rawlist': 5.3.1(@types/node@24.12.4)
+      '@inquirer/search': 4.2.1(@types/node@24.12.4)
+      '@inquirer/select': 5.2.1(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
+
   '@inquirer/rawlist@4.1.11(@types/node@24.12.4)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@24.12.4)
@@ -18405,6 +18658,13 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.9.2
+
+  '@inquirer/rawlist@5.3.1(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.12.4)
+      '@inquirer/type': 4.0.7(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
 
   '@inquirer/search@3.2.2(@types/node@24.12.4)':
     dependencies:
@@ -18423,6 +18683,14 @@ snapshots:
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.9.2
+
+  '@inquirer/search@4.2.1(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@24.12.4)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
 
   '@inquirer/select@4.4.2(@types/node@24.12.4)':
     dependencies:
@@ -18444,6 +18712,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.2
 
+  '@inquirer/select@5.2.1(@types/node@24.12.4)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@24.12.4)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@24.12.4)
+    optionalDependencies:
+      '@types/node': 24.12.4
+
   '@inquirer/type@3.0.10(@types/node@24.12.4)':
     optionalDependencies:
       '@types/node': 24.12.4
@@ -18460,6 +18737,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.2
     optional: true
+
+  '@inquirer/type@4.0.7(@types/node@24.12.4)':
+    optionalDependencies:
+      '@types/node': 24.12.4
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -18504,7 +18785,7 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -18518,7 +18799,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -18573,6 +18854,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))':
     dependencies:
@@ -19148,33 +19430,33 @@ snapshots:
       globals: 13.24.0
       minimatch: 9.0.9
 
-  '@lwc/jest-preset@16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@lwc/jest-preset@16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))':
     dependencies:
       '@lwc/compiler': 7.1.2
       '@lwc/engine-dom': 7.1.2
       '@lwc/engine-server': 7.1.2
-      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
+      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
       '@lwc/synthetic-shadow': 7.1.2
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
     transitivePeerDependencies:
       - supports-color
 
-  '@lwc/jest-resolver@16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@lwc/jest-resolver@16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))':
     dependencies:
       '@lwc/jest-shared': 16.0.0
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
 
-  '@lwc/jest-serializer@16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@lwc/jest-serializer@16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))':
     dependencies:
       '@lwc/jest-shared': 16.0.0
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       pretty-format: 29.7.0
 
   '@lwc/jest-shared@16.0.0': {}
 
-  '@lwc/jest-transformer@16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@lwc/jest-transformer@16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.29.7)
@@ -19185,7 +19467,7 @@ snapshots:
       '@lwc/compiler': 7.1.2
       '@lwc/jest-shared': 16.0.0
       babel-preset-jest: 29.6.3(@babel/core@7.29.7)
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       magic-string: 0.30.21
       semver: 7.8.2
     transitivePeerDependencies:
@@ -20730,7 +21012,7 @@ snapshots:
     dependencies:
       postcss: 8.5.15
 
-  '@salesforce/eslint-config-lwc@3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)':
+  '@salesforce/eslint-config-lwc@3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)':
     dependencies:
       '@babel/core': 7.24.9
       '@babel/eslint-parser': 7.24.8(@babel/core@7.24.9)(eslint@8.57.1)
@@ -20738,7 +21020,7 @@ snapshots:
       '@salesforce/eslint-plugin-lightning': 1.0.1(eslint@8.57.1)
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)
-      eslint-plugin-jest: 29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3)
+      eslint-plugin-jest: 29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))(typescript@6.0.3)
       eslint-restricted-globals: 0.2.0
       semver: 7.8.2
     transitivePeerDependencies:
@@ -20748,21 +21030,21 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  '@salesforce/sfdx-lwc-jest@6.0.0(@types/node@24.12.4)(eslint@8.57.1)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))(typescript@6.0.3)':
+  '@salesforce/sfdx-lwc-jest@6.0.0(@types/node@25.9.2)(eslint@8.57.1)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@lwc/compiler': 7.1.2
       '@lwc/engine-dom': 7.1.2
       '@lwc/engine-server': 7.1.2
-      '@lwc/jest-preset': 16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
+      '@lwc/jest-preset': 16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
       '@lwc/module-resolver': 7.1.2
       '@lwc/synthetic-shadow': 7.1.2
       '@lwc/wire-service': 7.1.2
       '@salesforce/wire-service-jest-util': 4.1.4(@lwc/engine-dom@7.1.2)(eslint@8.57.1)(typescript@6.0.3)
       fast-glob: 3.3.3
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-environment-jsdom: 29.7.0(patch_hash=b419a992476c3323e67ee6c86f3f9ecf6f4f073127cb572aa9af3b9c6550751d)
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -21837,13 +22119,13 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
+  '@vitest/browser-playwright@4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
-      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
-      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
-      playwright: 1.60.0
+      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      playwright: 1.61.0-alpha-1778188671000
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.2)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@24.12.4)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -21863,6 +22145,34 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/browser-playwright@4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
+    dependencies:
+      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      playwright: 1.61.0-alpha-1778188671000
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@types/node@25.9.2)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser-playwright@4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
+    dependencies:
+      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      playwright: 1.61.0-alpha-1778188671000
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@types/node@25.9.2)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
 
   '@vitest/browser@4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
@@ -23410,13 +23720,13 @@ snapshots:
       - encoding
       - react-native
 
-  create-jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+  create-jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -24236,12 +24546,12 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3):
+  eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/utils': 8.60.1(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
     optionalDependencies:
-      jest: 30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -25870,16 +26180,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+  jest-cli@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      create-jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -25907,6 +26217,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   jest-cli@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
@@ -25927,38 +26238,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.7)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 24.12.4
-      ts-node: 10.9.2(@types/node@24.12.4)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+  jest-config@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 29.7.0
@@ -25984,7 +26264,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.9.2
-      ts-node: 10.9.2(@types/node@24.12.4)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@25.9.2)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -26020,6 +26300,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+    optional: true
 
   jest-config@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
     dependencies:
@@ -26052,6 +26333,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+    optional: true
 
   jest-config@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
@@ -26587,12 +26869,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+  jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-cli: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -26611,6 +26893,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
@@ -28289,7 +28572,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.8.2
-      tar: 7.5.15
+      tar: 7.5.16
       tinyglobby: 0.2.17
       undici: 6.26.0
       which: 6.0.1
@@ -28786,7 +29069,7 @@ snapshots:
       promise-retry: 2.0.1
       sigstore: 4.1.1
       ssri: 13.0.1
-      tar: 7.5.15
+      tar: 7.5.16
     transitivePeerDependencies:
       - supports-color
 
@@ -30702,7 +30985,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.15:
+  tar@7.5.16:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -30921,6 +31204,7 @@ snapshots:
       typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optional: true
 
   ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3):
     dependencies:
@@ -30939,7 +31223,6 @@ snapshots:
       typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optional: true
 
   ts-simple-type@2.0.0-next.0: {}
 
@@ -31537,7 +31820,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4
-      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - msw
@@ -31566,7 +31849,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.2
-      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - msw
@@ -31595,7 +31878,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.2
-      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,7 @@ packages:
   - packages/shopify
   - packages/create-atomic-template
   - packages/create-atomic
+  - packages/create-ui
   - packages/create-atomic-component
   - packages/create-atomic-component/template/src/components/sample-component
   - packages/create-atomic-component-project


### PR DESCRIPTION
## What

New `@coveo/create-ui` package — a zero-config scaffolding CLI:

```sh
npm create @coveo/ui my-app --template headless-search-react
```

Downloads a sample from the `coveo/ui-kit` `main` branch (GitHub tarball), resolves its monorepo-only dependency protocols to concrete versions, renames the project, and installs.

## Why

Getting started with Atomic/Headless required platform credentials and there was no Headless scaffolding. This delivers the RFC's "samples are the scaffolding" entry point.

## How it works

| Module | Responsibility |
| --- | --- |
| `templates.ts` | Template → sample-path map, with `available` gating |
| `download.ts` | Tarball fetch (1 retry) + selective extraction |
| `resolve-deps.ts` | `catalog:` / `workspace:*` → concrete `^versions` from the tarball |
| `setup.ts` | rename, strip `private`, `.gitignore`, move, install (npm/pnpm) |
| `prompt.ts` | interactive template + project-name selection |
| `index.ts` | arg parsing, `--help`, orchestration, graceful Ctrl-C |

## Scope / notes

- Only scaffold-ready templates are enabled (`headless-search-react`, `headless-commerce-react`); Atomic/vanilla templates flip on as their samples land.
- Always pulls `main` (no version pinning — intended tradeoff).
- The full e2e (scaffold → install → build) depends on the self-contained sample tsconfigs in [KIT-5829](https://coveord.atlassian.net/browse/KIT-5829).

## Verification

- 38 unit tests; gated e2e (`E2E=1`) scaffolds + installs + builds `headless-search-react` from a local tarball.
- `tsc` build clean; changeset included (minor).

---

[KIT-5830](https://coveord.atlassian.net/browse/KIT-5830) | Epic: [KIT-5452](https://coveord.atlassian.net/browse/KIT-5452)

[KIT-5829]: https://coveord.atlassian.net/browse/KIT-5829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ