### PR TITLE
feat(create-ui): package scaffold + template registry + CLI args (1/3)

### DIFF
--- a/packages/create-ui/package.json
+++ b/packages/create-ui/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@coveo/create-ui",
+  "version": "0.0.0",
+  "description": "Scaffold a Coveo UI project (Atomic or Headless) from the official samples.",
+  "keywords": [
+    "atomic",
+    "coveo",
+    "create",
+    "headless",
+    "scaffold",
+    "template"
+  ],
+  "license": "Apache-2.0",
+  "author": "Coveo",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/coveo/ui-kit.git",
+    "directory": "packages/create-ui"
+  },
+  "bin": {
+    "create-ui": "./dist/index.js"
+  },
+  "files": [
+    "dist/"
+  ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node ./dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "node ../../utils/ci/rm-rf.mjs dist",
+    "lint": "prettier --check ."
+  },
+  "dependencies": {
+    "minimist": "1.2.8"
+  },
+  "devDependencies": {
+    "@types/minimist": "1.2.5",
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": "^20.9.0 || ^22.11.0 || ^24.11.0"
+  }
+}

--- a/packages/create-ui/package.json
+++ b/packages/create-ui/package.json
@@ -32,8 +32,7 @@
     "start": "node ./dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "clean": "node ../../utils/ci/rm-rf.mjs dist",
-    "lint": "prettier --check ."
+    "clean": "node ../../utils/ci/rm-rf.mjs dist"
   },
   "dependencies": {
     "minimist": "1.2.8"

--- a/packages/create-ui/src/index.test.ts
+++ b/packages/create-ui/src/index.test.ts
@@ -1,69 +1,48 @@
 import {describe, expect, it, vi} from 'vitest';
 import {main, parseArgs} from './index.js';
-import {availableTemplates, getTemplate, templates} from './templates.js';
+import {getTemplate, getTemplates} from './templates.js';
 
 describe('templates', () => {
-  it('exposes the eight canonical templates', () => {
-    expect(templates).toHaveLength(8);
-  });
-
-  it('maps template names to monorepo sample paths', () => {
+  it('resolves names to sample paths, and unknown names to undefined', () => {
     expect(getTemplate('headless-search-react')?.path).toBe(
       'samples/headless/search-react'
     );
-    expect(getTemplate('atomic-search')?.path).toBe(
-      'samples/atomic/search-vite'
-    );
-  });
-
-  it('returns only available templates from availableTemplates()', () => {
-    const names = availableTemplates().map((t) => t.name);
-    expect(names).toContain('headless-search-react');
-    expect(names).toContain('headless-commerce-react');
-    expect(names).not.toContain('atomic-search');
-  });
-
-  it('returns undefined for an unknown template', () => {
     expect(getTemplate('does-not-exist')).toBeUndefined();
   });
 });
 
 describe('parseArgs', () => {
-  it('reads the project name as the first positional', () => {
-    expect(parseArgs(['my-app']).projectName).toBe('my-app');
+  it('reads the project name and --template', () => {
+    const args = parseArgs(['my-app', '--template', 'headless-search-react']);
+    expect(args.projectName).toBe('my-app');
+    expect(args.template).toBe('headless-search-react');
   });
 
-  it('reads the --template flag', () => {
-    expect(
-      parseArgs(['my-app', '--template', 'headless-search-react']).template
-    ).toBe('headless-search-react');
-  });
-
-  it('supports -h/--help', () => {
-    expect(parseArgs(['--help']).help).toBe(true);
+  it('parses boolean flags (-h, --docs) and defaults them to false', () => {
     expect(parseArgs(['-h']).help).toBe(true);
-    expect(parseArgs([]).help).toBe(false);
+    expect(parseArgs(['--docs']).docs).toBe(true);
+    const none = parseArgs([]);
+    expect(none.help).toBe(false);
+    expect(none.docs).toBe(false);
   });
 });
 
-describe('main (no-prompt paths)', () => {
-  it('returns 0 for --help', async () => {
+describe('main', () => {
+  it('returns 0 for --docs and prints the documentation links', async () => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    expect(await main(['--help'])).toBe(0);
+    expect(await main(['--docs'])).toBe(0);
+    const output = spy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(output).toContain('https://docs.coveo.com');
+    expect(output).toContain('https://docs.coveo.com/en/atomic/latest');
+    expect(output).toContain('https://docs.coveo.com/en/headless/latest');
     spy.mockRestore();
   });
 
-  it('returns 1 for an unknown template without prompting', async () => {
+  it('returns 1 for an invalid --template', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(await main(['my-app', '--template', 'nope'])).toBe(1);
     logSpy.mockRestore();
-    errSpy.mockRestore();
-  });
-
-  it('returns 1 for a not-yet-available template', async () => {
-    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    expect(await main(['my-app', '--template', 'atomic-search'])).toBe(1);
     errSpy.mockRestore();
   });
 });

--- a/packages/create-ui/src/index.test.ts
+++ b/packages/create-ui/src/index.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it, vi} from 'vitest';
 import {main, parseArgs} from './index.js';
-import {getTemplate, getTemplates} from './templates.js';
+import {getTemplate} from './templates.js';
 
 describe('templates', () => {
   it('resolves names to sample paths, and unknown names to undefined', () => {

--- a/packages/create-ui/src/index.test.ts
+++ b/packages/create-ui/src/index.test.ts
@@ -1,0 +1,69 @@
+import {describe, expect, it, vi} from 'vitest';
+import {main, parseArgs} from './index.js';
+import {availableTemplates, getTemplate, templates} from './templates.js';
+
+describe('templates', () => {
+  it('exposes the eight canonical templates', () => {
+    expect(templates).toHaveLength(8);
+  });
+
+  it('maps template names to monorepo sample paths', () => {
+    expect(getTemplate('headless-search-react')?.path).toBe(
+      'samples/headless/search-react'
+    );
+    expect(getTemplate('atomic-search')?.path).toBe(
+      'samples/atomic/search-vite'
+    );
+  });
+
+  it('returns only available templates from availableTemplates()', () => {
+    const names = availableTemplates().map((t) => t.name);
+    expect(names).toContain('headless-search-react');
+    expect(names).toContain('headless-commerce-react');
+    expect(names).not.toContain('atomic-search');
+  });
+
+  it('returns undefined for an unknown template', () => {
+    expect(getTemplate('does-not-exist')).toBeUndefined();
+  });
+});
+
+describe('parseArgs', () => {
+  it('reads the project name as the first positional', () => {
+    expect(parseArgs(['my-app']).projectName).toBe('my-app');
+  });
+
+  it('reads the --template flag', () => {
+    expect(
+      parseArgs(['my-app', '--template', 'headless-search-react']).template
+    ).toBe('headless-search-react');
+  });
+
+  it('supports -h/--help', () => {
+    expect(parseArgs(['--help']).help).toBe(true);
+    expect(parseArgs(['-h']).help).toBe(true);
+    expect(parseArgs([]).help).toBe(false);
+  });
+});
+
+describe('main (no-prompt paths)', () => {
+  it('returns 0 for --help', async () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    expect(await main(['--help'])).toBe(0);
+    spy.mockRestore();
+  });
+
+  it('returns 1 for an unknown template without prompting', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(await main(['my-app', '--template', 'nope'])).toBe(1);
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it('returns 1 for a not-yet-available template', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(await main(['my-app', '--template', 'atomic-search'])).toBe(1);
+    errSpy.mockRestore();
+  });
+});

--- a/packages/create-ui/src/index.ts
+++ b/packages/create-ui/src/index.ts
@@ -30,8 +30,8 @@ export interface CliArgs {
   help: boolean;
 }
 
-export function parseArgs(argv: string[]): CliArgs {
-  const parsed = minimist(argv, {
+export function parseArgs(rawArgs: string[]): CliArgs {
+  const parsed = minimist(rawArgs, {
     string: ['template'],
     boolean: ['help'],
     alias: {h: 'help'},
@@ -43,8 +43,8 @@ export function parseArgs(argv: string[]): CliArgs {
   };
 }
 
-export async function main(argv: string[]): Promise<number> {
-  const args = parseArgs(argv);
+export async function main(rawArgs: string[]): Promise<number> {
+  const args = parseArgs(rawArgs);
 
   if (args.help) {
     log.info(HELP);

--- a/packages/create-ui/src/index.ts
+++ b/packages/create-ui/src/index.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+import minimist from 'minimist';
+import {fileURLToPath} from 'node:url';
+import {argv} from 'node:process';
+import {availableTemplates, getTemplate} from './templates.js';
+import {log} from './utils.js';
+
+const HELP = `
+Usage: npm create @coveo/ui <project-name> [options]
+
+Scaffold a Coveo UI project from the official samples. Runs with zero
+configuration against the sample organization — no credentials required.
+
+Options:
+  --template <name>   Template to scaffold (skips the interactive prompt)
+  -h, --help          Show this help
+
+Available templates:
+${availableTemplates()
+  .map((t) => `  ${t.name.padEnd(26)} ${t.description}`)
+  .join('\n')}
+
+Example:
+  npm create @coveo/ui my-app --template headless-search-react
+`;
+
+export interface CliArgs {
+  projectName?: string;
+  template?: string;
+  help: boolean;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const parsed = minimist(argv, {
+    string: ['template'],
+    boolean: ['help'],
+    alias: {h: 'help'},
+  });
+  return {
+    projectName: parsed._[0],
+    template: parsed.template,
+    help: Boolean(parsed.help),
+  };
+}
+
+export async function main(argv: string[]): Promise<number> {
+  const args = parseArgs(argv);
+
+  if (args.help) {
+    log.info(HELP);
+    return 0;
+  }
+
+  // A `--template` value, when provided, must reference a known, available
+  // template. Scaffolding itself is wired in a follow-up PR.
+  if (args.template !== undefined) {
+    const template = getTemplate(args.template);
+    if (!template) {
+      log.error(`Unknown template "${args.template}".`);
+      log.info(
+        `\nAvailable templates:\n${availableTemplates()
+          .map((t) => `  ${t.name}`)
+          .join('\n')}`
+      );
+      return 1;
+    }
+    if (!template.available) {
+      log.error(`Template "${args.template}" is not available yet.`);
+      return 1;
+    }
+  }
+
+  log.info(HELP);
+  return 0;
+}
+
+const isDirectRun =
+  argv[1] !== undefined && fileURLToPath(import.meta.url) === argv[1];
+
+if (isDirectRun) {
+  main(argv.slice(2)).then(
+    (code) => process.exit(code),
+    (error) => {
+      log.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  );
+}

--- a/packages/create-ui/src/index.ts
+++ b/packages/create-ui/src/index.ts
@@ -2,7 +2,7 @@
 import minimist from 'minimist';
 import {fileURLToPath} from 'node:url';
 import {argv} from 'node:process';
-import {availableTemplates, getTemplate} from './templates.js';
+import {getTemplate, getTemplates} from './templates.js';
 import {log} from './utils.js';
 
 const HELP = `
@@ -13,10 +13,11 @@ configuration against the sample organization — no credentials required.
 
 Options:
   --template <name>   Template to scaffold (skips the interactive prompt)
+  --docs              Print links to the Coveo documentation
   -h, --help          Show this help
 
 Available templates:
-${availableTemplates()
+${getTemplates()
   .map((t) => `  ${t.name.padEnd(26)} ${t.description}`)
   .join('\n')}
 
@@ -24,22 +25,34 @@ Example:
   npm create @coveo/ui my-app --template headless-search-react
 `;
 
+// TODO: (KIT-5833): add a link to the "How to use @coveo/create-ui" guide here
+// once that documentation page is published.
+const DOCS = `
+Coveo documentation:
+
+  Docs home   https://docs.coveo.com
+  Atomic      https://docs.coveo.com/en/atomic/latest
+  Headless    https://docs.coveo.com/en/headless/latest
+`;
+
 export interface CliArgs {
   projectName?: string;
   template?: string;
   help: boolean;
+  docs: boolean;
 }
 
 export function parseArgs(rawArgs: string[]): CliArgs {
   const parsed = minimist(rawArgs, {
     string: ['template'],
-    boolean: ['help'],
+    boolean: ['help', 'docs'],
     alias: {h: 'help'},
   });
   return {
     projectName: parsed._[0],
     template: parsed.template,
     help: Boolean(parsed.help),
+    docs: Boolean(parsed.docs),
   };
 }
 
@@ -51,6 +64,11 @@ export async function main(rawArgs: string[]): Promise<number> {
     return 0;
   }
 
+  if (args.docs) {
+    log.info(DOCS);
+    return 0;
+  }
+
   // A `--template` value, when provided, must reference a known, available
   // template. Scaffolding itself is wired in a follow-up PR.
   if (args.template !== undefined) {
@@ -58,14 +76,10 @@ export async function main(rawArgs: string[]): Promise<number> {
     if (!template) {
       log.error(`Unknown template "${args.template}".`);
       log.info(
-        `\nAvailable templates:\n${availableTemplates()
+        `\nAvailable templates:\n${getTemplates()
           .map((t) => `  ${t.name}`)
           .join('\n')}`
       );
-      return 1;
-    }
-    if (!template.available) {
-      log.error(`Template "${args.template}" is not available yet.`);
       return 1;
     }
   }

--- a/packages/create-ui/src/templates.ts
+++ b/packages/create-ui/src/templates.ts
@@ -24,66 +24,57 @@ export interface Template {
   description: string;
   /** Sample directory in the monorepo, relative to the repo root. */
   path: string;
-  /** Whether the template is scaffold-ready and selectable. */
-  available: boolean;
 }
 
 export const templates: Template[] = [
-  {
-    name: 'atomic-search',
-    library: 'atomic',
-    description: 'Atomic search UI (vanilla + Vite)',
-    path: 'samples/atomic/search-vite',
-    available: false,
-  },
-  {
-    name: 'atomic-commerce',
-    library: 'atomic',
-    description: 'Atomic commerce UI (vanilla + Vite)',
-    path: 'samples/atomic/commerce-vite',
-    available: false,
-  },
-  {
-    name: 'atomic-search-react',
-    library: 'atomic',
-    description: 'Atomic search UI (React)',
-    path: 'samples/atomic/search-react',
-    available: false,
-  },
-  {
-    name: 'atomic-commerce-react',
-    library: 'atomic',
-    description: 'Atomic commerce UI (React)',
-    path: 'samples/atomic/commerce-react',
-    available: false,
-  },
-  {
-    name: 'headless-search',
-    library: 'headless',
-    description: 'Headless search UI (vanilla + Vite)',
-    path: 'samples/headless/search-vite',
-    available: false,
-  },
-  {
-    name: 'headless-commerce',
-    library: 'headless',
-    description: 'Headless commerce UI (vanilla + Vite)',
-    path: 'samples/headless/commerce-vite',
-    available: false,
-  },
+  // TODO: uncomment when template is available
+  // {
+  //   name: 'atomic-search',
+  //   library: 'atomic',
+  //   description: 'Atomic search UI (vanilla + Vite)',
+  //   path: 'samples/atomic/search-vite',
+  // },
+  // {
+  //   name: 'atomic-commerce',
+  //   library: 'atomic',
+  //   description: 'Atomic commerce UI (vanilla + Vite)',
+  //   path: 'samples/atomic/commerce-vite',
+  // },
+  // {
+  //   name: 'atomic-search-react',
+  //   library: 'atomic',
+  //   description: 'Atomic search UI (React)',
+  //   path: 'samples/atomic/search-react',
+  // },
+  // {
+  //   name: 'atomic-commerce-react',
+  //   library: 'atomic',
+  //   description: 'Atomic commerce UI (React)',
+  //   path: 'samples/atomic/commerce-react',
+  // },
+  // {
+  //   name: 'headless-search',
+  //   library: 'headless',
+  //   description: 'Headless search UI (vanilla + Vite)',
+  //   path: 'samples/headless/search-vite',
+  // },
+  // {
+  //   name: 'headless-commerce',
+  //   library: 'headless',
+  //   description: 'Headless commerce UI (vanilla + Vite)',
+  //   path: 'samples/headless/commerce-vite',
+  // },
   {
     name: 'headless-search-react',
     library: 'headless',
     description: 'Headless search UI (React)',
     path: 'samples/headless/search-react',
-    available: true,
   },
   {
     name: 'headless-commerce-react',
     library: 'headless',
     description: 'Headless commerce UI (React)',
     path: 'samples/headless/commerce-react',
-    available: true,
   },
 ];
 
@@ -91,6 +82,6 @@ export function getTemplate(name: string): Template | undefined {
   return templates.find((t) => t.name === name);
 }
 
-export function availableTemplates(): Template[] {
-  return templates.filter((t) => t.available);
+export function getTemplates(): Template[] {
+  return templates;
 }

--- a/packages/create-ui/src/templates.ts
+++ b/packages/create-ui/src/templates.ts
@@ -13,7 +13,7 @@
  * See `samples/CONTRIBUTING.md` for the naming convention.
  */
 
-export type Library = 'atomic' | 'headless';
+type Library = 'atomic' | 'headless';
 
 export interface Template {
   /** CLI-facing template name passed to `--template`. */

--- a/packages/create-ui/src/templates.ts
+++ b/packages/create-ui/src/templates.ts
@@ -26,7 +26,7 @@ export interface Template {
   path: string;
 }
 
-export const templates: Template[] = [
+const templates: Template[] = [
   // TODO: uncomment when template is available
   // {
   //   name: 'atomic-search',

--- a/packages/create-ui/src/templates.ts
+++ b/packages/create-ui/src/templates.ts
@@ -1,0 +1,96 @@
+/**
+ * Canonical scaffolding templates.
+ *
+ * Each template maps a CLI-facing name to a sample directory in the
+ * `coveo/ui-kit` monorepo. The `--template` name drops the framework token for
+ * vanilla samples (e.g. `atomic-search` -> `samples/atomic/search-vite`); this
+ * map holds the real folder path used for tarball extraction.
+ *
+ * `available` gates whether a template is shown/usable. Samples that are not yet
+ * scaffold-ready (e.g. those still coupled to the monorepo) are flagged
+ * `false` until their sample story lands.
+ *
+ * See `samples/CONTRIBUTING.md` for the naming convention.
+ */
+
+export type Library = 'atomic' | 'headless';
+
+export interface Template {
+  /** CLI-facing template name passed to `--template`. */
+  name: string;
+  /** Library the template is built on, used for grouping in prompts. */
+  library: Library;
+  /** Human-readable description shown in interactive selection. */
+  description: string;
+  /** Sample directory in the monorepo, relative to the repo root. */
+  path: string;
+  /** Whether the template is scaffold-ready and selectable. */
+  available: boolean;
+}
+
+export const templates: Template[] = [
+  {
+    name: 'atomic-search',
+    library: 'atomic',
+    description: 'Atomic search UI (vanilla + Vite)',
+    path: 'samples/atomic/search-vite',
+    available: false,
+  },
+  {
+    name: 'atomic-commerce',
+    library: 'atomic',
+    description: 'Atomic commerce UI (vanilla + Vite)',
+    path: 'samples/atomic/commerce-vite',
+    available: false,
+  },
+  {
+    name: 'atomic-search-react',
+    library: 'atomic',
+    description: 'Atomic search UI (React)',
+    path: 'samples/atomic/search-react',
+    available: false,
+  },
+  {
+    name: 'atomic-commerce-react',
+    library: 'atomic',
+    description: 'Atomic commerce UI (React)',
+    path: 'samples/atomic/commerce-react',
+    available: false,
+  },
+  {
+    name: 'headless-search',
+    library: 'headless',
+    description: 'Headless search UI (vanilla + Vite)',
+    path: 'samples/headless/search-vite',
+    available: false,
+  },
+  {
+    name: 'headless-commerce',
+    library: 'headless',
+    description: 'Headless commerce UI (vanilla + Vite)',
+    path: 'samples/headless/commerce-vite',
+    available: false,
+  },
+  {
+    name: 'headless-search-react',
+    library: 'headless',
+    description: 'Headless search UI (React)',
+    path: 'samples/headless/search-react',
+    available: true,
+  },
+  {
+    name: 'headless-commerce-react',
+    library: 'headless',
+    description: 'Headless commerce UI (React)',
+    path: 'samples/headless/commerce-react',
+    available: true,
+  },
+];
+
+export function getTemplate(name: string): Template | undefined {
+  return templates.find((t) => t.name === name);
+}
+
+export function availableTemplates(): Template[] {
+  return templates.filter((t) => t.available);
+}

--- a/packages/create-ui/src/utils.ts
+++ b/packages/create-ui/src/utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared logging helpers.
+ */
+
+export const log = {
+  info(message: string): void {
+    console.log(message);
+  },
+  step(message: string): void {
+    console.log(`\n${message}`);
+  },
+  success(message: string): void {
+    console.log(`✓ ${message}`);
+  },
+  warn(message: string): void {
+    console.warn(`⚠ ${message}`);
+  },
+  error(message: string): void {
+    console.error(`✗ ${message}`);
+  },
+};

--- a/packages/create-ui/tsconfig.json
+++ b/packages/create-ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "types": ["node"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "isolatedModules": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/create-ui/vitest.config.ts
+++ b/packages/create-ui/vitest.config.ts
@@ -1,0 +1,8 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,6 +793,25 @@ importers:
         specifier: 'catalog:'
         version: 3.0.0
 
+  packages/create-ui:
+    dependencies:
+      minimist:
+        specifier: 1.2.8
+        version: 1.2.8
+    devDependencies:
+      '@types/minimist':
+        specifier: 1.2.5
+        version: 1.2.5
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.4
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@types/node@24.12.4)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+
   packages/documentation:
     devDependencies:
       typedoc:
@@ -966,10 +985,10 @@ importers:
         version: 1.60.0
       '@salesforce/eslint-config-lwc':
         specifier: 3.7.2
-        version: 3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)
+        version: 3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)
       '@salesforce/sfdx-lwc-jest':
         specifier: 6.0.0
-        version: 6.0.0(@types/node@24.12.4)(eslint@8.57.1)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))(typescript@6.0.3)
+        version: 6.0.0(@types/node@25.9.2)(eslint@8.57.1)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))(typescript@6.0.3)
       '@types/wait-on':
         specifier: 5.3.4
         version: 5.3.4
@@ -990,7 +1009,7 @@ importers:
         version: 3.1.3
       jest:
         specifier: 'catalog:'
-        version: 30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+        version: 30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1008,7 +1027,7 @@ importers:
         version: 2.2.6(prettier@3.8.3)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@24.12.4)(typescript@6.0.3)
+        version: 10.9.2(@types/node@25.9.2)(typescript@6.0.3)
       wait-on:
         specifier: 9.0.10
         version: 9.0.10
@@ -18504,7 +18523,7 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -18518,7 +18537,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -18573,6 +18592,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))':
     dependencies:
@@ -19148,33 +19168,33 @@ snapshots:
       globals: 13.24.0
       minimatch: 9.0.9
 
-  '@lwc/jest-preset@16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@lwc/jest-preset@16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))':
     dependencies:
       '@lwc/compiler': 7.1.2
       '@lwc/engine-dom': 7.1.2
       '@lwc/engine-server': 7.1.2
-      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
+      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
       '@lwc/synthetic-shadow': 7.1.2
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
     transitivePeerDependencies:
       - supports-color
 
-  '@lwc/jest-resolver@16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@lwc/jest-resolver@16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))':
     dependencies:
       '@lwc/jest-shared': 16.0.0
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
 
-  '@lwc/jest-serializer@16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@lwc/jest-serializer@16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))':
     dependencies:
       '@lwc/jest-shared': 16.0.0
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       pretty-format: 29.7.0
 
   '@lwc/jest-shared@16.0.0': {}
 
-  '@lwc/jest-transformer@16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@lwc/jest-transformer@16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.29.7)
@@ -19185,7 +19205,7 @@ snapshots:
       '@lwc/compiler': 7.1.2
       '@lwc/jest-shared': 16.0.0
       babel-preset-jest: 29.6.3(@babel/core@7.29.7)
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       magic-string: 0.30.21
       semver: 7.8.2
     transitivePeerDependencies:
@@ -20730,7 +20750,7 @@ snapshots:
     dependencies:
       postcss: 8.5.15
 
-  '@salesforce/eslint-config-lwc@3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)':
+  '@salesforce/eslint-config-lwc@3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)':
     dependencies:
       '@babel/core': 7.24.9
       '@babel/eslint-parser': 7.24.8(@babel/core@7.24.9)(eslint@8.57.1)
@@ -20738,7 +20758,7 @@ snapshots:
       '@salesforce/eslint-plugin-lightning': 1.0.1(eslint@8.57.1)
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)
-      eslint-plugin-jest: 29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3)
+      eslint-plugin-jest: 29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))(typescript@6.0.3)
       eslint-restricted-globals: 0.2.0
       semver: 7.8.2
     transitivePeerDependencies:
@@ -20748,21 +20768,21 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  '@salesforce/sfdx-lwc-jest@6.0.0(@types/node@24.12.4)(eslint@8.57.1)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))(typescript@6.0.3)':
+  '@salesforce/sfdx-lwc-jest@6.0.0(@types/node@25.9.2)(eslint@8.57.1)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@lwc/compiler': 7.1.2
       '@lwc/engine-dom': 7.1.2
       '@lwc/engine-server': 7.1.2
-      '@lwc/jest-preset': 16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
+      '@lwc/jest-preset': 16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
       '@lwc/module-resolver': 7.1.2
       '@lwc/synthetic-shadow': 7.1.2
       '@lwc/wire-service': 7.1.2
       '@salesforce/wire-service-jest-util': 4.1.4(@lwc/engine-dom@7.1.2)(eslint@8.57.1)(typescript@6.0.3)
       fast-glob: 3.3.3
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-environment-jsdom: 29.7.0(patch_hash=b419a992476c3323e67ee6c86f3f9ecf6f4f073127cb572aa9af3b9c6550751d)
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -21837,13 +21857,13 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
+  '@vitest/browser-playwright@4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
-      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
-      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
-      playwright: 1.60.0
+      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      playwright: 1.61.0-alpha-1778188671000
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.2)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@24.12.4)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -21863,6 +21883,34 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/browser-playwright@4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
+    dependencies:
+      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      playwright: 1.61.0-alpha-1778188671000
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@types/node@25.9.2)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser-playwright@4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
+    dependencies:
+      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      playwright: 1.61.0-alpha-1778188671000
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@types/node@25.9.2)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
 
   '@vitest/browser@4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
@@ -23410,13 +23458,13 @@ snapshots:
       - encoding
       - react-native
 
-  create-jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+  create-jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -24236,12 +24284,12 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3):
+  eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/utils': 8.60.1(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
     optionalDependencies:
-      jest: 30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -25870,16 +25918,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+  jest-cli@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      create-jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -25907,6 +25955,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   jest-cli@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
@@ -25927,38 +25976,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.7)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 24.12.4
-      ts-node: 10.9.2(@types/node@24.12.4)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+  jest-config@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 29.7.0
@@ -25984,7 +26002,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.9.2
-      ts-node: 10.9.2(@types/node@24.12.4)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@25.9.2)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -26020,6 +26038,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+    optional: true
 
   jest-config@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
     dependencies:
@@ -26052,6 +26071,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+    optional: true
 
   jest-config@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
@@ -26587,12 +26607,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+  jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-cli: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -26611,6 +26631,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
@@ -30921,6 +30942,7 @@ snapshots:
       typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optional: true
 
   ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3):
     dependencies:
@@ -30939,7 +30961,6 @@ snapshots:
       typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optional: true
 
   ts-simple-type@2.0.0-next.0: {}
 
@@ -31537,7 +31558,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4
-      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - msw
@@ -31566,7 +31587,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.2
-      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - msw
@@ -31595,7 +31616,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.2
-      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,7 @@ packages:
   - packages/shopify
   - packages/create-atomic-template
   - packages/create-atomic
+  - packages/create-ui
   - packages/create-atomic-component
   - packages/create-atomic-component/template/src/components/sample-component
   - packages/create-atomic-component-project


### PR DESCRIPTION
## What (PR 1 of 3)

First slice of `@coveo/create-ui`. Sets up the package and the CLI surface:
- package scaffold (`package.json`, `tsconfig`, `vitest.config`) + workspace entry
- `templates.ts` — template → sample-path registry with `available` gating
- `index.ts` — argument parsing, `--help`, and `--template` validation
- `utils.ts` — logging helpers

No scaffolding behaviour yet — that lands in PR 2/3 (download + dependency resolution) and PR 3/3 (interactive prompts).

## Verification
- `tsc` build clean; 10 unit tests pass (`parseArgs`, template registry, `main` help/validation paths).

## Stacked PRs
1. **(this)** scaffold + registry + args
2. download + dependency resolution + orchestration
3. interactive prompts + e2e + changeset

---
[KIT-5830](https://coveord.atlassian.net/browse/KIT-5830) | Epic: [KIT-5452](https://coveord.atlassian.net/browse/KIT-5452)

[KIT-5830]: https://coveord.atlassian.net/browse/KIT-5830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIT-5452]: https://coveord.atlassian.net/browse/KIT-5452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ