### PR TITLE
docs: rework samples README with MSW testing requirement

### DIFF
--- a/samples/CONTRIBUTING.md
+++ b/samples/CONTRIBUTING.md
@@ -1,94 +1,243 @@
-# UI-KIT Samples
+# Contributing to UI-Kit Samples
 
-This guide outlines the conventions and best practices for creating and maintaining samples in the ui-kit repository.
+This guide outlines the conventions and requirements for creating and maintaining samples in the ui-kit repository.
 
-## Overview
+## Dual Purpose: Samples & Scaffolding Starters
 
-The UI-Kit samples are organized into three main entry points that represent the primary ways developers interact with the UI-Kit:
+Every sample in this directory serves two roles:
+
+1. **Living documentation** — Demonstrates correct usage of Coveo libraries.
+2. **Scaffolding template** — Used by `npm create @coveo/ui` to bootstrap new projects.
+
+This means every sample must be **self-contained, zero-config, and runnable out of the box** without any Coveo platform credentials or OAuth setup.
+
+## Sample Requirements
+
+Every sample **must** have:
+
+| Requirement                          | Details                                                                                                                                                |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Pre-configured credentials**       | Use the `searchuisamples` demo organization with the embedded public sample access token. No OAuth flow, no `.env` file, no user-provided credentials. |
+| **`pnpm install && pnpm dev` works** | A developer should be able to clone and run the sample with no additional setup. New samples must use a `dev` script.                                  |
+| **README.md**                        | Purpose, prerequisites, how to run, key features demonstrated.                                                                                         |
+| **Playwright smoke tests with MSW**  | At least one test verifying the sample loads and renders expected content, using `@coveo/platform-mock-api` for deterministic responses.               |
+| **Minimal configuration**            | No custom styling, no complex initialization. Use vanilla fields that work with the sample org.                                                        |
+| **Single purpose**                   | Each sample focuses on one library + framework combination.                                                                                            |
+
+## Directory Structure
 
 ```
 samples/
-├── atomic/
-│   └── ...
-├── headless/
-│   └── ...
-└── headless-ssr/
-    └── ...
+├── atomic/           # @coveo/atomic and @coveo/atomic-react samples
+├── headless/         # @coveo/headless client-side rendering samples
+└── headless-ssr/     # @coveo/headless server-side rendering samples
 ```
 
-- **`atomic/`** - Samples using Atomic components in every form
-- **`headless/`** - Samples using headless controllers for custom UI implementations
-- **`headless-ssr/`** - Samples demonstrating server-side rendering with headless controllers
-
 ## Naming Convention
-
-All samples follow this standardized folder and package naming pattern:
 
 **Folder pattern:**
 
 ```
-<entry-point-folder>/<subpackage-name>-<framework>-<optional-details>
+<category>/<use-case>[-<framework>][-<variant>]
 ```
 
-**Package pattern (in `package.json`):**
+**Examples:**
+
+- `headless/search-vite` — Vanilla headless search (JS + Vite)
+- `headless/commerce-react` — Headless commerce with React
+- `headless-ssr/commerce-nextjs` — Headless SSR commerce with Next.js
+- `headless-ssr/commerce-nextjs-v4` — Variant for Headless V4 preview
+- `atomic/search-commerce-angular` — Combined search + commerce in Angular
+
+**Package name in `package.json`:**
 
 ```
-@samples/<entry-point>/<subpackage>-<framework>-<optional-details>
+@samples/<category>-<use-case>[-<framework>][-<variant>]
 ```
 
-### Examples:
+### Guidelines
 
-- Folder: `atomic/commerce-angular`
-
-  Package: `@samples/atomic/commerce-angular`
-
-- Folder: `headless-ssr/search-nextjs`
-
-  Package: `@samples/headless-ssr-search-nextjs`
-
-- Folder: `atomic/search-react-vite`
-
-  Package: `@samples/atomic/search-react-vite`
-
-### Guidelines:
-
-- Use **kebab-case** for all folder and package names
-- **Subpackage names**: `commerce`, `search`, `insight`, etc.
-- **Framework names**: `react`, `angular`, `vuejs`, `nextjs`, `stencil`, etc.
-- **Optional details**: `vite`, `app-router`, etc.
-- Package name must exactly match the folder structure under `samples/`
+- Use **kebab-case** for all names
+- **Use cases**: `search`, `commerce`, `search-commerce` (combined)
+- **Framework names**: `react`, `angular`, `nextjs`, `vuejs`
+- **Variant suffixes**: `-v4`, `-app-router`, etc. for alternative implementations
+- Vanilla (no-framework) samples use `-vite` as the framework suffix (e.g., `search-vite`)
 
 ## Creating a New Sample
 
-### 1. Choose the Correct Entry Point
+### 1. Choose the correct category
 
-Determine which entry point best fits your sample:
+- **`atomic/`** — Uses `@coveo/atomic` or `@coveo/atomic-react` components
+- **`headless/`** — Uses `@coveo/headless` controllers with client-side rendering
+- **`headless-ssr/`** — Uses `@coveo/headless-react` or similar with server-side rendering
 
-- **`atomic/`** - If using pre-built UI components from `@coveo/atomic`
-- **`headless/`** - If building custom UI with headless controllers from `@coveo/headless`
-- **`headless-ssr/`** - If implementing server-side rendering with headless
+### 2. Use sample credentials
 
-### 2. Create a README.md
+All samples connect to the `searchuisamples` organization using the public sample access token. No authentication flow, no environment variables to configure.
 
-Every sample must include a README.md with:
+```typescript
+// Headless Search — uses embedded sample token
+import {getSampleSearchEngineConfiguration} from '@coveo/headless';
 
-- **Purpose**: Brief description of what the sample demonstrates
-- **Prerequisites**: Required tools, versions, or accounts
-- **Key Features**: Highlighted functionality or components used
-- **Running**: How to start and use the sample
+// Headless Commerce — uses explicit public sample token
+import {buildCommerceEngine} from '@coveo/headless/commerce';
+// accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457', organizationId: 'searchuisamples'
+```
 
-### 3. Add Smoke Tests
+### 3. Write a README.md
 
-Include basic tests to verify the sample works correctly:
+Include:
 
-- Use Playwright
-- Have at least one test that verifies the sample loads and renders
+- **Purpose** — One-liner on what the sample demonstrates
+- **Template name** — The scaffolding template identifier
+- **Prerequisites** — Node version, pnpm
+- **Running** — `pnpm install && pnpm dev`
+- **Key features** — What components/controllers are showcased
 
-## Sample Principles
+### 4. Add Playwright smoke tests with `@coveo/platform-mock-api`
 
-- **Minimalism**: Include only files necessary for the demonstration
-- **Single Purpose**: Focus on one specific use case or functionality
-- **Avoid Redundancy**: Don't try to showcase every possible feature
-- **Clear Intent**: Make the sample's purpose immediately obvious
-- **Well-commented**: Explain complex logic or configuration
-- **Idiomatic**: Use framework and library best practices
+Every sample must include Playwright tests that use the internal `@coveo/platform-mock-api` package (at `packages/platform-mock-api`) and `@msw/playwright` for network mocking. This ensures tests are:
+
+- **Deterministic** — No flakiness from live API calls
+- **Fast** — No network latency
+- **CI-friendly** — No dependency on external services
+
+```typescript
+// e2e/fixtures.ts
+import {test as base, expect} from '@playwright/test';
+import {defineNetworkFixture, type NetworkFixture} from '@msw/playwright';
+import {MockSearchApi} from '@coveo/platform-mock-api';
+
+interface Fixtures {
+  network: NetworkFixture;
+}
+
+export const searchApi = new MockSearchApi();
+
+export const test = base.extend<Fixtures>({
+  network: [
+    async ({context}, use) => {
+      const network = defineNetworkFixture({
+        context,
+        handlers: [...searchApi.handlers],
+      });
+      await network.enable();
+      await use(network);
+      await network.disable();
+    },
+    {auto: true},
+  ],
+});
+
+export {expect};
+```
+
+```typescript
+// e2e/smoke.spec.ts
+import {test, expect} from './fixtures.js';
+
+test('sample loads and renders results', async ({page}) => {
+  await page.goto('/');
+  await expect(page.locator('#search-box input')).toBeVisible();
+  await expect(page.locator('#result-list .result-item').first()).toBeVisible();
+});
+```
+
+Required devDependencies:
+
+```json
+{
+  "devDependencies": {
+    "@playwright/test": "catalog:",
+    "@coveo/platform-mock-api": "workspace:*",
+    "@msw/playwright": "catalog:",
+    "msw": "catalog:"
+  }
+}
+```
+
+> **Note:** `@msw/playwright` and `msw` must be added to the pnpm catalog (`pnpm-workspace.yaml`) if not already present.
+
+### 5. Keep it minimal
+
+- Include only files necessary for the demonstration
+- No custom CSS themes or complex layouts
+- No advanced configuration beyond what works with the sample org
+- Use default/vanilla field values
+
+## What Belongs in a Sample
+
+### Headless Search
+
+At minimum: search box, result list, pager. Should also include facets and sort for a more complete demonstration.
+
+### Headless Commerce
+
+- 1 search page
+- 1+ product listing pages
+- 1 recommendations section
+
+### Atomic Search
+
+Include every relevant component with minimal configuration. Use fields available in the `searchuisamples` organization.
+
+### Atomic Commerce
+
+- 1 search page
+- 2 product listing pages
+- 1 recommendations page
+
+## Framework Version Support
+
+Officially support **current and immediate previous major versions** of Angular, React, and Next.js.
+
+## Relationship to Scaffolding
+
+When a developer runs:
+
+```bash
+npm create @coveo/ui my-project -- --template headless-search
+```
+
+The CLI clones the corresponding sample as their project starter. This is why samples must be:
+
+- **Zero-config** — Works immediately after `npm install`
+- **Self-contained** — No dependencies on the monorepo structure at runtime
+- **Tested** — Smoke tests give confidence the template works
+
+## Standard Script Contract
+
+CI discovers samples through Turbo tasks, so scripts must follow this contract. Adding a sample that respects it requires **no CI changes**.
+
+| Script  | Required | Command           | Purpose                                                 |
+| ------- | -------- | ----------------- | ------------------------------------------------------- |
+| `dev`   | yes      | start dev server  | Local development and the scaffolded starter experience |
+| `build` | yes      | production build  | Built by the `build`/`affected` pipeline                |
+| `e2e`   | yes      | `playwright test` | Run by the single affected-driven `samples-e2e` CI job  |
+| `test`  | optional | `vitest run`      | Unit tests; run by `turbo test --affected` when present |
+
+Rules:
+
+- Playwright tests go under the **`e2e`** script (never `test`). `test` is reserved for unit tests so the two CI lanes stay separate.
+- **Atomic-React exception:** samples that consume `@coveo/atomic-react` assets may add a `build:assets` step (copying `dist/assets`, `dist/lang`, `dist/themes`) and call it from a `predev`/`build` hook. This is the only permitted deviation from the standard scripts.
+
+## How Samples Are Tested in CI
+
+- **Build & unit tests** are already affected-driven: `turbo build --affected` and `turbo test --affected` pick up any sample automatically.
+- **E2E** runs through a single `samples-e2e` job that executes `turbo run e2e --affected` inside the Playwright container. Because a sample that depends on `@coveo/headless` or `@coveo/atomic` is automatically marked affected when those libraries change, a library change that breaks a sample is caught immediately — and adding a new sample needs **zero** CI edits.
+
+## Testing Locally
+
+From the sample directory:
+
+```bash
+pnpm install
+pnpm dev             # Verify it runs
+pnpm e2e             # Verify Playwright tests pass
+```
+
+From the monorepo root, linting must also pass:
+
+```bash
+pnpm run lint:check
+```

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,57 +1,69 @@
 # Coveo UI-Kit Samples
 
-This directory contains code samples demonstrating how to use Coveo's UI-Kit in various frameworks and implementation patterns. These samples are designed to help developers quickly understand and implement Coveo search and commerce experiences.
+This directory contains code samples demonstrating how to use Coveo's UI-Kit libraries in various frameworks and implementation patterns.
+
+**These samples serve a dual purpose:**
+
+1. **Samples** — Living documentation showing how to use Coveo libraries correctly.
+2. **Scaffolding starters** — The source templates for `npm create @coveo/ui`, giving developers a working project in seconds.
+
+Because of this dual role, every sample must be **self-contained, runnable out of the box, and tested**. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full requirements.
 
 ## 📚 Sample Categories
 
-The samples are organized into three main categories based on the Coveo libraries they use:
+Samples are organized by the Coveo library they use:
 
 ### [Atomic Samples](./atomic/)
 
-Samples using `@coveo/atomic` or `@coveo/atomic-react` components for pre-built, customizable search and commerce interfaces.
+Pre-built, customizable search and commerce components from `@coveo/atomic` and `@coveo/atomic-react`.
 
-| Sample                                                       | Description                                                                  | Framework            | Use Case          |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------------- | -------------------- | ----------------- |
-| [search-commerce-angular](./atomic/search-commerce-angular/) | Search and commerce interfaces with Atomic components in Angular             | Angular              | Search & Commerce |
-| [search-commerce-react](./atomic/search-commerce-react/)     | Multiple search and commerce interface examples with Atomic React components | React + Vite         | Search & Commerce |
-| [search-nextjs](./atomic/search-nextjs/)                     | Atomic React with Next.js App Router                                         | Next.js (App Router) | Search            |
-| [search-vuejs](./atomic/search-vuejs/)                       | Atomic components integrated with Vue.js                                     | Vue.js + Vite        | Search            |
+| Sample                                                       | Description                          | Framework     | Use Case          |
+| ------------------------------------------------------------ | ------------------------------------ | ------------- | ----------------- |
+| [search-commerce-angular](./atomic/search-commerce-angular/) | Atomic components in Angular         | Angular       | Search & Commerce |
+| [search-commerce-react](./atomic/search-commerce-react/)     | Atomic React components              | React (Vite)  | Search & Commerce |
+| [search-nextjs](./atomic/search-nextjs/)                     | Atomic React with Next.js App Router | Next.js       | Search            |
+| [search-vuejs](./atomic/search-vuejs/)                       | Atomic components with Vue.js        | Vue.js (Vite) | Search            |
 
 ### [Headless Samples](./headless/)
 
-Samples using `@coveo/headless` controllers to build fully custom search and commerce interfaces.
+Fully custom UIs built with `@coveo/headless` controllers (client-side rendering).
 
-| Sample                                       | Description                                                   | Framework | Use Case |
-| -------------------------------------------- | ------------------------------------------------------------- | --------- | -------- |
-| [commerce-react](./headless/commerce-react/) | Custom commerce interface using Headless commerce controllers | React     | Commerce |
-| [search-react](./headless/search-react/)     | Custom search interface using Headless search controllers     | React     | Search   |
+| Sample                                       | Description                          | Framework    | Use Case |
+| -------------------------------------------- | ------------------------------------ | ------------ | -------- |
+| [search-react](./headless/search-react/)     | Custom search interface with React   | React (Vite) | Search   |
+| [commerce-react](./headless/commerce-react/) | Custom commerce interface with React | React (Vite) | Commerce |
 
 ### [Headless SSR Samples](./headless-ssr/)
 
-Samples demonstrating server-side rendering (SSR) with Headless controllers for improved performance and SEO.
+Server-side rendering with Headless controllers for improved performance and SEO.
 
-| Sample                                                         | Description                                                  | Framework            | Use Case |
-| -------------------------------------------------------------- | ------------------------------------------------------------ | -------------------- | -------- |
-| [commerce-express](./headless-ssr/commerce-express/)           | Generic SSR implementation with Express server               | Express + TypeScript | Commerce |
-| [commerce-nextjs](./headless-ssr/commerce-nextjs/)             | Commerce SSR with Next.js App Router (current version)       | Next.js (App Router) | Commerce |
-| [commerce-nextjs-v4](./headless-ssr/commerce-nextjs-v4/)       | Commerce SSR with Next.js App Router (preview - Headless V4) | Next.js (App Router) | Commerce |
-| [commerce-react-router](./headless-ssr/commerce-react-router/) | Commerce SSR with React Router                               | React Router         | Commerce |
-| [search-nextjs](./headless-ssr/search-nextjs/)                 | Search SSR example with Next.js App Router                   | Next.js (App Router) | Search   |
+| Sample                                                         | Description                          | Framework    | Use Case |
+| -------------------------------------------------------------- | ------------------------------------ | ------------ | -------- |
+| [commerce-nextjs](./headless-ssr/commerce-nextjs/)             | Commerce SSR with Next.js App Router | Next.js      | Commerce |
+| [commerce-nextjs-v4](./headless-ssr/commerce-nextjs-v4/)       | Commerce SSR (Headless V4 preview)   | Next.js      | Commerce |
+| [search-nextjs](./headless-ssr/search-nextjs/)                 | Search SSR with Next.js App Router   | Next.js      | Search   |
+| [commerce-express](./headless-ssr/commerce-express/)           | Generic SSR with Express server      | Express      | Commerce |
+| [commerce-react-router](./headless-ssr/commerce-react-router/) | Commerce SSR with React Router       | React Router | Commerce |
 
 ## 🚀 Quick Start
 
-Each sample includes its own README with specific setup instructions. Generally, to run any sample:
+Every sample can be run standalone:
 
 ```bash
-# Navigate to the sample directory
 cd samples/<category>/<sample-name>
-
-# Install dependencies
-npm install
-
-# Run the development server
-npm run dev
+pnpm install
+pnpm dev  # or check the sample's README for the correct start command
 ```
+
+No platform credentials are needed — all samples use the `searchuisamples` demo organization with a pre-configured public access token.
+
+## 💡 Choosing the Right Approach
+
+**Atomic** — Use when you want pre-built, customizable components with minimal code. Best for rapid implementation.
+
+**Headless** — Use when you need full control over the UI or are integrating with an existing design system.
+
+**Headless SSR** — Use when SEO or initial page load performance is a priority.
 
 ## 📖 Documentation
 
@@ -59,32 +71,8 @@ npm run dev
 - [Coveo Headless Documentation](https://docs.coveo.com/en/headless/)
 - [Coveo for Commerce Documentation](https://docs.coveo.com/en/coveo-for-commerce/)
 
-## 🛠️ Contributing
-
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines on creating and maintaining samples.
-
-## 💡 Choosing the Right Sample
-
-**Use Atomic samples when:**
-
-- You want pre-built, customizable components
-- You need a quick implementation with minimal custom code
-- You prefer declarative component configuration
-
-**Use Headless samples when:**
-
-- You need complete control over the UI and behavior
-- You want to build a custom design system
-- You're integrating with an existing component library
-
-**Use Headless SSR samples when:**
-
-- SEO is a priority
-- You need improved initial page load performance
-- You want server-side rendering capabilities
-
 ## 🔗 Related Resources
 
 - [Main Repository README](../README.md)
+- [Contributing Guide](./CONTRIBUTING.md)
 - [Coveo Developer Portal](https://docs.coveo.com/)
-- [Coveo Community](https://connect.coveo.com/)


### PR DESCRIPTION
## Problem
The samples README and CONTRIBUTING guide are outdated and don't reflect:
- The dual purpose of samples (documentation + scaffolding starters)
- The requirement to use `@coveo/platform-mock-api` + `@msw/playwright` for Playwright tests
- The updated naming conventions and directory structure

Inspired by #7554 but updated to reference the new internal `@coveo/platform-mock-api` package.

## Solution
Rewrote both `samples/README.md` and `samples/CONTRIBUTING.md`:
- Clarifies dual purpose (samples + scaffolding starters)
- Adds MSW testing requirement with code examples using `@coveo/platform-mock-api`
- Documents the fixtures pattern with `@msw/playwright` + `defineNetworkFixture`
- Updated sample tables to include the new headless/search and headless/commerce samples
- Simplified naming conventions
- Added scaffolding relationship explanation