### PR TITLE
yolo/chromatic all

### DIFF
--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -97,7 +97,7 @@ const preview: Preview = {
         textColor: '#282829',
       }),
     },
-    chromatic: {disableSnapshot: true},
+    chromatic: {disableSnapshot: false},
   },
   beforeEach({canvasElement, canvas}) {
     Object.assign(canvas, {...within(canvasElement)});

--- a/packages/atomic/src/components/search/atomic-result-html/atomic-result-html.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-html/atomic-result-html.new.stories.tsx
@@ -4,7 +4,25 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInResultList} from '@/storybook-utils/search/result-list-wrapper';
 import {wrapInResultTemplate} from '@/storybook-utils/search/result-template-wrapper';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import '@/src/components/search/atomic-result-html/atomic-result-html.js';
+
+const searchApiHarness = new MockSearchApi();
+
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...response,
+  results: response.results.slice(0, 1).map((r) => ({
+    ...r,
+    excerpt: '<div>Some <b>HTML</b> content</div>',
+    title: '<h2>HTML Title <em>with emphasis</em></h2>',
+    raw: {
+      ...r.raw,
+      custom_html_field: '<p>Custom <strong>HTML</strong> field</p>',
+    },
+  })),
+  totalCount: 1,
+  totalCountFiltered: 1,
+}));
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-html',
@@ -12,24 +30,7 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const {decorator: searchInterfaceDecorator, play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-    search: {
-      preprocessSearchResponseMiddleware: (res) => {
-        res.body.results.forEach((r) => {
-          r.excerpt = '<div>Some <b>HTML</b> content</div>';
-          r.title = '<h2>HTML Title <em>with emphasis</em></h2>';
-          r.raw.custom_html_field = '<p>Custom <strong>HTML</strong> field</p>';
-        });
-        return res;
-      },
-    },
-  },
+  includeCodeRoot: false,
 });
 
 const {decorator: resultListDecorator} = wrapInResultList(undefined, false);
@@ -48,12 +49,18 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {
+      handlers: [...searchApiHarness.handlers],
+    },
     actions: {
       handles: events,
     },
   },
   args,
   argTypes,
+  beforeEach: async () => {
+    searchApiHarness.clearAll();
+  },
 
   play,
 };

--- a/packages/atomic/src/components/search/atomic-result-number/atomic-result-number.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-number/atomic-result-number.new.stories.tsx
@@ -6,10 +6,26 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInResultList} from '@/storybook-utils/search/result-list-wrapper';
 import {wrapInResultTemplate} from '@/storybook-utils/search/result-template-wrapper';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import '@/src/components/search/atomic-format-currency/atomic-format-currency.js';
 import '@/src/components/search/atomic-format-number/atomic-format-number.js';
 import '@/src/components/search/atomic-format-unit/atomic-format-unit.js';
 import '@/src/components/search/atomic-result-number/atomic-result-number.js';
+
+const searchApiHarness = new MockSearchApi();
+
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...response,
+  results: response.results.slice(0, 1).map((r) => ({
+    ...r,
+    raw: {
+      ...r.raw,
+      size: 1234567,
+    },
+  })),
+  totalCount: 1,
+  totalCountFiltered: 1,
+}));
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-number',
@@ -17,15 +33,6 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const {decorator: searchInterfaceDecorator, play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.fieldsToInclude = [...parsed.fieldsToInclude, 'size'];
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-  },
   includeCodeRoot: false,
 });
 const {decorator: resultListDecorator} = wrapInResultList('list', false);
@@ -44,12 +51,18 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {
+      handlers: [...searchApiHarness.handlers],
+    },
     actions: {
       handles: events,
     },
   },
   args,
   argTypes,
+  beforeEach: async () => {
+    searchApiHarness.clearAll();
+  },
   play,
 };
 

--- a/packages/atomic/src/components/search/atomic-result-rating/atomic-result-rating.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-rating/atomic-result-rating.new.stories.tsx
@@ -4,7 +4,23 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInResultList} from '@/storybook-utils/search/result-list-wrapper';
 import {wrapInResultTemplate} from '@/storybook-utils/search/result-template-wrapper';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import '@/src/components/search/atomic-result-rating/atomic-result-rating.js';
+
+const searchApiHarness = new MockSearchApi();
+
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...response,
+  results: response.results.slice(0, 1).map((r) => ({
+    ...r,
+    raw: {
+      ...r.raw,
+      snrating: 3.5,
+    },
+  })),
+  totalCount: 1,
+  totalCountFiltered: 1,
+}));
 
 const CircleIcon =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="currentColor"/></svg>';
@@ -15,16 +31,7 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const {decorator: searchInterfaceDecorator, play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.aq = '@snrating';
-      parsed.fieldsToInclude = [...parsed.fieldsToInclude, 'snrating'];
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-  },
+  includeCodeRoot: false,
 });
 
 const {decorator: resultListDecorator} = wrapInResultList(undefined, false);
@@ -43,12 +50,18 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {
+      handlers: [...searchApiHarness.handlers],
+    },
     actions: {
       handles: events,
     },
   },
   args,
   argTypes,
+  beforeEach: async () => {
+    searchApiHarness.clearAll();
+  },
 
   play,
 };

--- a/packages/atomic/src/components/search/atomic-result-text/atomic-result-text.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-text/atomic-result-text.new.stories.tsx
@@ -4,7 +4,33 @@ import {parameters} from '@/storybook-utils/common/common-meta-parameters';
 import {wrapInResultList} from '@/storybook-utils/search/result-list-wrapper';
 import {wrapInResultTemplate} from '@/storybook-utils/search/result-template-wrapper';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
+import {MockSearchApi} from '@/storybook-utils/api/search/mock';
 import '@/src/components/search/atomic-result-text/atomic-result-text.js';
+
+const searchApiHarness = new MockSearchApi();
+
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...response,
+  results: response.results.slice(0, 1).map((r) => ({
+    ...r,
+    excerpt: 'Bonobo the great ape',
+    title: 'Bonobo the great ape',
+    firstSentences: 'Bonobo the great ape',
+    printableUri: 'https://example.com/bonobo',
+    raw: {
+      ...r.raw,
+      author: 'Bonobo',
+      summary: 'Bonobo the great ape',
+    },
+    excerptHighlights: [{offset: 0, length: 6}],
+    titleHighlights: [{offset: 0, length: 6}],
+    firstSentencesHighlights: [{offset: 0, length: 6}],
+    printableUriHighlights: [{offset: 20, length: 6}],
+    summaryHighlights: [{offset: 0, length: 6}],
+  })),
+  totalCount: 1,
+  totalCountFiltered: 1,
+}));
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-text',
@@ -12,32 +38,7 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const {decorator: searchInterfaceDecorator, play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-    search: {
-      preprocessSearchResponseMiddleware: (res) => {
-        res.body.results.forEach((r) => {
-          r.excerpt = 'Bonobo the great ape';
-          r.title = 'Bonobo the great ape';
-          r.firstSentences = 'Bonobo the great ape';
-          r.printableUri = 'https://example.com/bonobo';
-          r.raw.author = 'Bonobo';
-          r.raw.summary = 'Bonobo the great ape';
-          r.excerptHighlights = [{offset: 0, length: 6}];
-          r.titleHighlights = [{offset: 0, length: 6}];
-          r.firstSentencesHighlights = [{offset: 0, length: 6}];
-          r.printableUriHighlights = [{offset: 20, length: 6}];
-          r.summaryHighlights = [{offset: 0, length: 6}];
-        });
-        return res;
-      },
-    },
-  },
+  includeCodeRoot: false,
 });
 
 const {decorator: resultListDecorator} = wrapInResultList(undefined, false);
@@ -56,12 +57,18 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     chromatic: {disableSnapshot: true},
+    msw: {
+      handlers: [...searchApiHarness.handlers],
+    },
     actions: {
       handles: events,
     },
   },
   args,
   argTypes,
+  beforeEach: async () => {
+    searchApiHarness.clearAll();
+  },
 
   play,
 };


### PR DESCRIPTION
- **refactor: migrate atomic result component stories to use MockSearchApi instead of request/response middleware**
- **pull the lever kronk**
