### PR TITLE
refactor(create-ui): remove default .gitignore creation

### DIFF
--- a/packages/create-ui/src/setup.test.ts
+++ b/packages/create-ui/src/setup.test.ts
@@ -49,7 +49,7 @@ describe('finalizeProject (IO)', () => {
     }
   }
 
-  it('rewrites package.json, adds .gitignore, and moves to the target', async () => {
+  it('rewrites package.json and moves to the target', async () => {
     const sampleDir = join(dir, 'extracted');
     await mkdir(sampleDir, {recursive: true});
     await writeFile(
@@ -61,7 +61,6 @@ describe('finalizeProject (IO)', () => {
     await finalizeProject({sampleDir, targetDir, projectName: 'my-app'});
 
     expect(await exists(sampleDir)).toBe(false);
-    expect(await exists(join(targetDir, '.gitignore'))).toBe(true);
     const pkg = JSON.parse(
       await readFile(join(targetDir, 'package.json'), 'utf8')
     );

--- a/packages/create-ui/src/setup.ts
+++ b/packages/create-ui/src/setup.ts
@@ -1,16 +1,13 @@
 /**
  * Finalizes a scaffolded project: renames the package, removes monorepo-only
- * fields, ensures a .gitignore, moves it into place, and installs dependencies.
+ * fields, moves it into place, and installs dependencies.
  */
 
 import {spawnSync} from 'node:child_process';
 import {cp, readFile, rm, writeFile} from 'node:fs/promises';
 import {basename, join} from 'node:path';
-import {pathExists} from './fs-utils.js';
 import type {PackageJson} from './types.js';
 import {getPackageManager} from './utils.js';
-
-const DEFAULT_GITIGNORE = ['node_modules', 'dist', '.DS_Store'].join('\n');
 
 /**
  * Turns a project name or path into a valid npm package name (lowercase,
@@ -64,10 +61,6 @@ export async function finalizeProject(options: {
     pkgPath,
     `${JSON.stringify(finalizePackageJson(pkg, projectName), null, 2)}\n`
   );
-
-  if (!(await pathExists(join(sampleDir, '.gitignore')))) {
-    await writeFile(join(sampleDir, '.gitignore'), `${DEFAULT_GITIGNORE}\n`);
-  }
 
   // Copy out of the temp extraction tree into the user's target directory.
   if (sampleDir !== targetDir) {


### PR DESCRIPTION
The CLI doesn'\''t create a git repo, so generating a fallback `.gitignore` is unnecessary complexity. Samples should ship their own when they'\''re scaffold-ready.

Removes the `DEFAULT_GITIGNORE` constant and the conditional write from `finalizeProject`.

[KIT-5452](https://coveord.atlassian.net/browse/KIT-5452)

[KIT-5452]: https://coveord.atlassian.net/browse/KIT-5452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ