### PR TITLE
feat(create-ui): resolve catalog: and workspace:* deps in scaffolded samples

### DIFF
--- a/packages/create-ui/package.json
+++ b/packages/create-ui/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "minimist": "1.2.8",
-    "tar": "7.5.16"
+    "tar": "7.5.16",
+    "yaml": "catalog:"
   },
   "devDependencies": {
     "@types/minimist": "1.2.5",

--- a/packages/create-ui/src/index.ts
+++ b/packages/create-ui/src/index.ts
@@ -7,6 +7,7 @@ import {fileURLToPath} from 'node:url';
 import {argv} from 'node:process';
 import {downloadTemplate} from './download.js';
 import {dirExists, isEmptyOrMissing} from './fs-utils.js';
+import {resolveSampleDependencies} from './resolve-deps.js';
 import {finalizeProject, installDependencies} from './setup.js';
 import {getTemplate, getTemplates, type Template} from './templates.js';
 import {formatError, getPackageManager, log} from './utils.js';
@@ -62,7 +63,7 @@ export function parseArgs(rawArgs: string[]): CliArgs {
   };
 }
 
-/** Downloads, finalizes, and installs the chosen template. */
+/** Downloads, resolves, finalizes, and installs the chosen template. */
 export async function scaffold(
   template: Template,
   projectName: string
@@ -78,10 +79,8 @@ export async function scaffold(
       destDir: tempDir,
     });
 
-    // TODO: (KIT-5842): resolve monorepo-only dependency protocols (catalog:,
-    // workspace:*) in the sample's package.json so it installs standalone.
-    // The download step already extracts the support files resolution needs.
-    // https://coveord.atlassian.net/browse/KIT-5842
+    log.step('Resolving dependencies…');
+    await resolveSampleDependencies({sampleDir, treeRoot: tempDir});
 
     log.step(`Creating project in ${targetDir}…`);
     await finalizeProject({sampleDir, targetDir, projectName});

--- a/packages/create-ui/src/resolve-deps.test.ts
+++ b/packages/create-ui/src/resolve-deps.test.ts
@@ -1,0 +1,131 @@
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {
+  parseCatalogs,
+  resolveDependencyMap,
+  resolvePackageJson,
+  resolveSampleDependencies,
+  type ResolutionContext,
+} from './resolve-deps.js';
+
+const ctx: ResolutionContext = {
+  catalog: {vite: '8.0.14', react: '19.2.7'},
+  catalogs: {react18: {react: '18.3.1'}},
+  workspaceVersions: {
+    '@coveo/headless': '3.40.0',
+    '@coveo/auth': '2.1.9',
+  },
+};
+
+describe('parseCatalogs', () => {
+  it('parses default and named catalogs, defaulting to empty objects', () => {
+    const yaml = [
+      'catalog:',
+      '  vite: 8.0.14',
+      '  react: 19.2.7',
+      'catalogs:',
+      '  react18:',
+      '    react: 18.3.1',
+    ].join('\n');
+    const {catalog, catalogs} = parseCatalogs(yaml);
+    expect(catalog.vite).toBe('8.0.14');
+    expect(catalogs.react18.react).toBe('18.3.1');
+    expect(parseCatalogs('packages:\n  - a\n')).toEqual({
+      catalog: {},
+      catalogs: {},
+    });
+  });
+});
+
+describe('resolveDependencyMap', () => {
+  it('resolves catalog references (default and named) to caret ranges', () => {
+    expect(resolveDependencyMap({vite: 'catalog:'}, ctx)).toEqual({
+      vite: '^8.0.14',
+    });
+    expect(resolveDependencyMap({react: 'catalog:react18'}, ctx)).toEqual({
+      react: '^18.3.1',
+    });
+  });
+
+  it('resolves workspace protocols and leaves concrete versions untouched', () => {
+    expect(
+      resolveDependencyMap(
+        {'@coveo/headless': 'workspace:*', '@coveo/auth': 'workspace:^'},
+        ctx
+      )
+    ).toEqual({'@coveo/headless': '^3.40.0', '@coveo/auth': '^2.1.9'});
+    expect(resolveDependencyMap({express: '5.2.1'}, ctx)).toEqual({
+      express: '5.2.1',
+    });
+  });
+
+  it('throws when a catalog or workspace reference cannot be resolved', () => {
+    expect(() => resolveDependencyMap({unknown: 'catalog:'}, ctx)).toThrow(
+      /Cannot resolve "unknown"/
+    );
+    expect(() =>
+      resolveDependencyMap({'@coveo/missing': 'workspace:*'}, ctx)
+    ).toThrow(/Cannot resolve "@coveo\/missing"/);
+  });
+});
+
+describe('resolvePackageJson', () => {
+  it('resolves across all dependency fields', () => {
+    const resolved = resolvePackageJson(
+      {
+        name: 'x',
+        dependencies: {'@coveo/headless': 'workspace:*', react: 'catalog:'},
+        devDependencies: {vite: 'catalog:'},
+      },
+      ctx
+    );
+    expect(resolved.dependencies).toEqual({
+      '@coveo/headless': '^3.40.0',
+      react: '^19.2.7',
+    });
+    expect(resolved.devDependencies).toEqual({vite: '^8.0.14'});
+  });
+});
+
+describe('resolveSampleDependencies (IO)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'create-ui-resolve-'));
+  });
+  afterEach(async () => {
+    await rm(dir, {recursive: true, force: true});
+  });
+
+  it('rewrites the sample package.json from the extracted tree', async () => {
+    await writeFile(
+      join(dir, 'pnpm-workspace.yaml'),
+      'catalog:\n  vite: 8.0.14\n'
+    );
+    await mkdir(join(dir, 'packages/headless'), {recursive: true});
+    await writeFile(
+      join(dir, 'packages/headless/package.json'),
+      JSON.stringify({name: '@coveo/headless', version: '3.40.0'})
+    );
+    const sampleDir = join(dir, 'samples/headless/search-react');
+    await mkdir(sampleDir, {recursive: true});
+    await writeFile(
+      join(sampleDir, 'package.json'),
+      JSON.stringify({
+        name: '@samples/headless-search-react',
+        dependencies: {'@coveo/headless': 'workspace:*'},
+        devDependencies: {vite: 'catalog:'},
+      })
+    );
+
+    await resolveSampleDependencies({sampleDir, treeRoot: dir});
+
+    const pkg = JSON.parse(
+      await readFile(join(sampleDir, 'package.json'), 'utf8')
+    );
+    expect(pkg.dependencies['@coveo/headless']).toBe('^3.40.0');
+    expect(pkg.devDependencies.vite).toBe('^8.0.14');
+  });
+});

--- a/packages/create-ui/src/resolve-deps.ts
+++ b/packages/create-ui/src/resolve-deps.ts
@@ -1,0 +1,177 @@
+/**
+ * Resolves monorepo-only dependency protocols in a scaffolded sample's
+ * package.json so it can be installed outside the workspace:
+ *   - `catalog:` / `catalog:<name>` -> a concrete version from the catalog
+ *     block(s) of `pnpm-workspace.yaml`
+ *   - `workspace:` (any form) for a monorepo package -> a caret range built
+ *     from that package's own version in the tarball
+ *
+ * Unlike `flatten-catalog.mjs` (which runs `pnpm list` inside the monorepo),
+ * this reads versions from the downloaded tarball, so it works on a user's
+ * machine. Throws if any protocol cannot be resolved (never emits a broken
+ * package.json).
+ */
+
+import {readdir, readFile, writeFile} from 'node:fs/promises';
+import {join} from 'node:path';
+import {parse as parseYaml} from 'yaml';
+import type {PackageJson} from './types.js';
+
+export interface ResolutionContext {
+  /** Default catalog: dependency name -> version. */
+  catalog: Record<string, string>;
+  /** Named catalogs: catalogName -> (dependency name -> version). */
+  catalogs: Record<string, Record<string, string>>;
+  /** Monorepo package name -> version (for workspace: resolution). */
+  workspaceVersions: Record<string, string>;
+}
+
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+] as const;
+
+/** Adds a caret to a bare version; leaves existing ranges untouched. */
+function toCaretRange(version: string): string {
+  return /^\d/.test(version) ? `^${version}` : version;
+}
+
+/** Parses the catalog and catalogs blocks from pnpm-workspace.yaml content. */
+export function parseCatalogs(workspaceYaml: string): {
+  catalog: Record<string, string>;
+  catalogs: Record<string, Record<string, string>>;
+} {
+  const doc = (parseYaml(workspaceYaml) ?? {}) as {
+    catalog?: Record<string, string>;
+    catalogs?: Record<string, Record<string, string>>;
+  };
+  return {
+    catalog: doc.catalog ?? {},
+    catalogs: doc.catalogs ?? {},
+  };
+}
+
+function resolveCatalogReference(
+  name: string,
+  spec: string,
+  ctx: ResolutionContext
+): string {
+  // `catalog:` uses the default catalog; `catalog:foo` uses a named catalog.
+  const named = spec.slice('catalog:'.length).trim();
+  const table = named ? ctx.catalogs[named] : ctx.catalog;
+  const version = table?.[name];
+  if (!version) {
+    throw new Error(
+      `Cannot resolve "${name}": "${spec}" not found in ${
+        named ? `catalog "${named}"` : 'the default catalog'
+      } of pnpm-workspace.yaml.`
+    );
+  }
+  return toCaretRange(version);
+}
+
+function resolveWorkspaceReference(
+  name: string,
+  ctx: ResolutionContext
+): string {
+  const version = ctx.workspaceVersions[name];
+  if (!version) {
+    throw new Error(
+      `Cannot resolve "${name}": workspace dependency has no known published version in the monorepo.`
+    );
+  }
+  return toCaretRange(version);
+}
+
+/** Resolves all protocol references in a single dependency map. */
+export function resolveDependencyMap(
+  deps: Record<string, string>,
+  ctx: ResolutionContext
+): Record<string, string> {
+  const resolved: Record<string, string> = {};
+  for (const [name, spec] of Object.entries(deps)) {
+    if (spec.startsWith('catalog:')) {
+      resolved[name] = resolveCatalogReference(name, spec, ctx);
+    } else if (spec.startsWith('workspace:')) {
+      resolved[name] = resolveWorkspaceReference(name, ctx);
+    } else {
+      resolved[name] = spec;
+    }
+  }
+  return resolved;
+}
+
+/** Returns a new package.json with all protocol references resolved. */
+export function resolvePackageJson(
+  pkg: PackageJson,
+  ctx: ResolutionContext
+): PackageJson {
+  const next: PackageJson = {...pkg};
+  for (const field of DEPENDENCY_FIELDS) {
+    const deps = pkg[field];
+    if (deps) {
+      next[field] = resolveDependencyMap(deps, ctx);
+    }
+  }
+  return next;
+}
+
+/** Reads every `packages/<dir>/package.json`, indexed by package name. */
+async function readWorkspaceVersions(
+  treeRoot: string
+): Promise<Record<string, string>> {
+  const packagesDir = join(treeRoot, 'packages');
+  const versions: Record<string, string> = {};
+  let entries: string[] = [];
+  try {
+    entries = await readdir(packagesDir);
+  } catch {
+    return versions;
+  }
+  for (const dir of entries) {
+    try {
+      const raw = await readFile(
+        join(packagesDir, dir, 'package.json'),
+        'utf8'
+      );
+      const pkg = JSON.parse(raw) as PackageJson;
+      if (pkg.name && pkg.version) {
+        versions[pkg.name] = pkg.version;
+      }
+    } catch {
+      // Not every directory has a package.json; skip it.
+    }
+  }
+  return versions;
+}
+
+/**
+ * Resolves the sample's package.json in place using the catalog and package
+ * versions from the extracted tarball tree (`treeRoot` contains
+ * pnpm-workspace.yaml and the packages directory).
+ */
+export async function resolveSampleDependencies(options: {
+  sampleDir: string;
+  treeRoot: string;
+}): Promise<void> {
+  const {sampleDir, treeRoot} = options;
+
+  const workspaceYaml = await readFile(
+    join(treeRoot, 'pnpm-workspace.yaml'),
+    'utf8'
+  );
+  const {catalog, catalogs} = parseCatalogs(workspaceYaml);
+  const workspaceVersions = await readWorkspaceVersions(treeRoot);
+
+  const pkgPath = join(sampleDir, 'package.json');
+  const pkg = JSON.parse(await readFile(pkgPath, 'utf8')) as PackageJson;
+  const resolved = resolvePackageJson(pkg, {
+    catalog,
+    catalogs,
+    workspaceVersions,
+  });
+
+  await writeFile(pkgPath, `${JSON.stringify(resolved, null, 2)}\n`);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -804,6 +804,9 @@ importers:
       tar:
         specifier: 7.5.16
         version: 7.5.16
+      yaml:
+        specifier: 'catalog:'
+        version: 2.9.0
     devDependencies:
       '@types/minimist':
         specifier: 1.2.5


### PR DESCRIPTION
## What (stacked on #7845)

Adds dependency resolution to the scaffolding engine. A sample's `package.json` in the monorepo uses protocols that won't install standalone, so we rewrite them in place using versions read from the downloaded tarball — no monorepo checkout needed:

- `catalog:` / `catalog:<name>` → a concrete version from the catalog block(s) of `pnpm-workspace.yaml`
- `workspace:` (any form) for a monorepo package → a caret range built from that package's own version in the tarball

The resolver throws if any protocol can't be resolved, so we never emit a broken `package.json`.

## Why a separate PR

Split out of #7845 to keep the engine PR focused and this logic easy to review. #7845 leaves a `TODO` (KIT-5842) in the scaffold flow and already extracts the support files this step consumes (`pnpm-workspace.yaml` + each `packages/*/package.json`); this PR wires `resolveSampleDependencies` in and restores the `yaml` dependency used to parse the workspace file.

## Verification

- `tsc --noEmit` clean
- 25 unit tests (6 new in `resolve-deps.test.ts`: default/named catalog refs, `workspace:*` protocols, the unresolved-reference throw paths, and the end-to-end package.json rewrite)
- `oxlint` and `knip` clean

## Base

Stacked on #7845 (2/3) — merge that first.

[KIT-5842](https://coveord.atlassian.net/browse/KIT-5842) | Epic: [KIT-5452](https://coveord.atlassian.net/browse/KIT-5452)


[KIT-5842]: https://coveord.atlassian.net/browse/KIT-5842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ