### PR TITLE
feat: implement conditional chromatic snapshotting based on ci vars

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: read
 
+env:
+  CHROMATIC_ALL: ${{ vars.CHROMATIC_ALL }}
+
 jobs:
   release:
     concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: read
 
+env:
+  CHROMATIC_ALL: ${{ vars.CHROMATIC_ALL }}
+
 jobs:
   pr-report:
     if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/') }}

--- a/packages/atomic/.storybook/main.ts
+++ b/packages/atomic/.storybook/main.ts
@@ -170,6 +170,10 @@ const config: StorybookConfig = {
     name: '@storybook/web-components-vite',
     options: {},
   },
+  env: (config) => ({
+    ...config,
+    CHROMATIC_ALL: process.env.CHROMATIC_ALL ?? '',
+  }),
   async viteFinal(config, {configType}) {
     const {default: tailwindcss} = await import('@tailwindcss/vite');
     const version = getPackageVersion();

--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -97,7 +97,7 @@ const preview: Preview = {
         textColor: '#282829',
       }),
     },
-    chromatic: {disableSnapshot: true},
+    chromatic: {disableSnapshot: import.meta.env.CHROMATIC_ALL !== 'true'},
   },
   beforeEach({canvasElement, canvas}) {
     Object.assign(canvas, {...within(canvasElement)});

--- a/packages/atomic/.storybook/vite-env.d.ts
+++ b/packages/atomic/.storybook/vite-env.d.ts
@@ -5,6 +5,10 @@ declare module '*.css' {
   export default content;
 }
 
+interface ImportMetaEnv {
+  readonly CHROMATIC_ALL: string
+}
+
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }

--- a/packages/atomic/turbo.json
+++ b/packages/atomic/turbo.json
@@ -39,7 +39,8 @@
         "CHROMATIC_PROJECT_TOKEN",
         "CHROMATIC_SHA",
         "CHROMATIC_BRANCH",
-        "CHROMATIC_SLUG"
+        "CHROMATIC_SLUG",
+        "CHROMATIC_ALL"
       ]
     },
     "build:cem": {

--- a/packages/atomic/turbo.json
+++ b/packages/atomic/turbo.json
@@ -30,7 +30,7 @@
     "build:storybook": {
       "dependsOn": ["^build", "pre:storybook"],
       "outputs": ["./dist-storybook/**"],
-      "env": ["STORYBOOK_INVOKED_BY"]
+      "env": ["STORYBOOK_INVOKED_BY", "CHROMATIC_ALL"]
     },
     "chromatic": {
       "dependsOn": [],


### PR DESCRIPTION
To allow an easy/no-code opt-out, I use a GitHub variable (global to the repo) to enable/disable snapshots on all stories.
(per-story params still take precedence)