### PR TITLE
fix(atomic): remove flaky baseline comparison in status-message a11y test

### DIFF
--- a/packages/atomic/storybook-utils/a11y/status-message.ts
+++ b/packages/atomic/storybook-utils/a11y/status-message.ts
@@ -124,18 +124,6 @@ export async function testStatusMessageA11y(
   const timeout = options.timeout ?? 5000;
 
   try {
-    let baselineTexts: Set<string> = new Set();
-
-    await step('Capture baseline live region content', async () => {
-      const liveRegions = findLiveRegions(canvasElement);
-      for (const region of liveRegions) {
-        const text = region.textContent?.trim() ?? '';
-        if (text.length > 0) {
-          baselineTexts.add(text);
-        }
-      }
-    });
-
     await step(
       'Trigger action that should produce a status message',
       async () => {
@@ -153,8 +141,7 @@ export async function testStatusMessageA11y(
             const populatedRegions = liveRegions.filter((region) => {
               if (region.getAttribute('aria-hidden') === 'true') return false;
               const text = region.textContent?.trim() ?? '';
-              if (text.length === 0) return false;
-              return !baselineTexts.has(text);
+              return text.length > 0;
             });
 
             expect(populatedRegions.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Problem

The `testStatusMessageA11y` helper in storybook-utils captures a "baseline" of live region text before `triggerAction`, then expects *new* text to appear. In stories where `play()` already triggers the search (e.g. `atomic-query-summary`), the status message may already be present when the baseline is captured — causing the `!baselineTexts.has(text)` filter to reject it and the `populatedRegions.length > 0` assertion to fail intermittently.

Example failure: https://github.com/coveo/ui-kit/actions/runs/28021973634/job/82941110541

## Solution

Removed the baseline capture step. The test now simply waits for a live region containing the expected text to exist. The `expectedText` parameter already validates correctness — the baseline comparison was an unnecessary layer that introduced a timing-dependent race condition.