### PR TITLE
fix(atomic): WCAG 1.4.11 non-text contrast fixes (switch, input, rating)

### DIFF
--- a/.changeset/fix-input-border-contrast.md
+++ b/.changeset/fix-input-border-contrast.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": patch
+---
+
+Increased `input-primary` border contrast from 1.23:1 to 5.56:1 to meet WCAG 1.4.11 Non-text Contrast (3:1 minimum).

--- a/.changeset/fix-rating-stars-contrast.md
+++ b/.changeset/fix-rating-stars-contrast.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": patch
+---
+
+Increased default rating star icon contrast to meet WCAG 1.4.11 Non-text Contrast (3:1 minimum). Active stars changed from #f6ce3c (1.52:1) to #b88600 (3.26:1). Inactive stars changed from #e5e8e8 (1.23:1) to #626971 (5.56:1).

--- a/.changeset/fix-switch-off-contrast.md
+++ b/.changeset/fix-switch-off-contrast.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": patch
+---
+
+Increased switch OFF state track contrast from 1.23:1 to 5.56:1 to meet WCAG 1.4.11 Non-text Contrast (3:1 minimum).

--- a/packages/atomic-a11y/a11y/reports/manual-audit-common.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-common.json
@@ -6,8 +6,8 @@
       "status": "complete",
       "wcag22Criteria": {
         "1.4.11-non-text-contrast": {
-          "conformance": "partial",
-          "remarks": "Input border uses border-neutral (#e5e8e8) at 1.23:1 vs white, failing 3:1 for the input boundary. Focus indicator passes at 4.94:1. See KIT-5807."
+          "conformance": "pass",
+          "remarks": "Input border uses border-neutral-dark (#626971) at 5.56:1 vs white, passing 3:1. Focus indicator passes at 4.94:1."
         }
       }
     }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-common.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-common.json
@@ -19,8 +19,8 @@
       "status": "complete",
       "wcag22Criteria": {
         "1.4.11-non-text-contrast": {
-          "conformance": "partial",
-          "remarks": "Contains a switch component. OFF state track uses bg-neutral (#e5e8e8) at 1.23:1 vs white, failing 3:1. ON state passes with primary bg at 4.94:1. See KIT-5806."
+          "conformance": "pass",
+          "remarks": "Switch OFF state track uses bg-neutral-dark (#626971) at 5.56:1 vs white. ON state uses primary bg at 4.94:1. Both pass 3:1."
         }
       }
     }

--- a/packages/atomic-a11y/a11y/reports/manual-audit-common.json
+++ b/packages/atomic-a11y/a11y/reports/manual-audit-common.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "atomic-facet-number-input",
+    "category": "common",
+    "manual": {
+      "status": "complete",
+      "wcag22Criteria": {
+        "1.4.11-non-text-contrast": {
+          "conformance": "partial",
+          "remarks": "Input border uses border-neutral (#e5e8e8) at 1.23:1 vs white, failing 3:1 for the input boundary. Focus indicator passes at 4.94:1. See KIT-5807."
+        }
+      }
+    }
+  },
+  {
+    "name": "atomic-refine-toggle",
+    "category": "common",
+    "manual": {
+      "status": "complete",
+      "wcag22Criteria": {
+        "1.4.11-non-text-contrast": {
+          "conformance": "partial",
+          "remarks": "Contains a switch component. OFF state track uses bg-neutral (#e5e8e8) at 1.23:1 vs white, failing 3:1. ON state passes with primary bg at 4.94:1. See KIT-5806."
+        }
+      }
+    }
+  }
+]

--- a/packages/atomic/src/components/common/switch.spec.ts
+++ b/packages/atomic/src/components/common/switch.spec.ts
@@ -58,10 +58,10 @@ describe('#renderSwitch', () => {
     expect(button).toHaveAttribute('aria-checked', 'true');
   });
 
-  it('should apply bg-neutral class to container when unchecked', async () => {
+  it('should apply bg-neutral-dark class to container when unchecked', async () => {
     const element = await renderComponent({checked: false});
     const container = locators(element).container;
-    expect(container).toHaveClass('bg-neutral');
+    expect(container).toHaveClass('bg-neutral-dark');
     expect(container).not.toHaveClass('bg-primary');
   });
 
@@ -69,7 +69,7 @@ describe('#renderSwitch', () => {
     const element = await renderComponent({checked: true});
     const container = locators(element).container;
     expect(container).toHaveClass('bg-primary');
-    expect(container).not.toHaveClass('bg-neutral');
+    expect(container).not.toHaveClass('bg-neutral-dark');
   });
 
   it('should apply ml-6 class to handle when checked', async () => {

--- a/packages/atomic/src/components/common/switch.ts
+++ b/packages/atomic/src/components/common/switch.ts
@@ -17,7 +17,7 @@ export const renderSwitch: FunctionalComponent<SwitchProps> = ({props}) => {
   const containerClasses = tw({
     'w-12 h-6 p-1 rounded-full': true,
     'bg-primary': props.checked,
-    'bg-neutral': !props.checked,
+    'bg-neutral-dark': !props.checked,
   });
 
   const handleClasses = tw({

--- a/packages/atomic/src/utils/coveo.tw.css
+++ b/packages/atomic/src/utils/coveo.tw.css
@@ -74,9 +74,9 @@
 
   --color-rating-icon-inactive: var(
     --atomic-rating-icon-inactive-color,
-    var(--atomic-neutral)
+    var(--atomic-neutral-dark)
   );
-  --color-rating-icon-active: var(--atomic-rating-icon-active-color, #f6ce3c);
+  --color-rating-icon-active: var(--atomic-rating-icon-active-color, #b88600);
 
   --color-rating-icon-outline: var(--atomic-rating-icon-outline-color, none);
 

--- a/packages/atomic/src/utils/tailwind-utilities/components.css
+++ b/packages/atomic/src/utils/tailwind-utilities/components.css
@@ -5,7 +5,7 @@
 
 @layer components {
   .input-primary {
-    @apply border-neutral bg-background hover:border-primary-light focus-visible:border-primary focus-visible:ring-ring-primary rounded border focus-visible:ring-2 focus-visible:outline-none;
+    @apply border-neutral-dark bg-background hover:border-primary-light focus-visible:border-primary focus-visible:ring-ring-primary rounded border focus-visible:ring-2 focus-visible:outline-none;
   }
 
   .btn-radio {


### PR DESCRIPTION
[KIT-5843](https://coveord.atlassian.net/browse/KIT-5843)

## Problem
Three components fail WCAG 1.4.11 Non-text Contrast (3:1 minimum):
- **Switch** OFF state track: `bg-neutral` (#e5e8e8) at 1.23:1
- **Input** border: `border-neutral` (#e5e8e8) at 1.23:1
- **Rating stars**: active #f6ce3c at 1.52:1, inactive #e5e8e8 at 1.23:1

## Solution
- Switch: changed OFF track to `bg-neutral-dark` (#626971, 5.56:1)
- Input: changed border to `border-neutral-dark` (#626971, 5.56:1)
- Rating active: #f6ce3c → #b88600 (3.26:1); inactive: `neutral` → `neutral-dark` (5.56:1)

Supersedes #7777, #7778, #7779.

[KIT-5843]: https://coveord.atlassian.net/browse/KIT-5843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ