### PR TITLE
fix(atomic): restore focus on next new result after load more

### DIFF
--- a/.changeset/fix-load-more-results-focus.md
+++ b/.changeset/fix-load-more-results-focus.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": patch
+---
+
+Fixed keyboard focus being lost after clicking "Load more" in both `atomic-load-more-results` and `atomic-commerce-load-more-products`. Focus now correctly moves to the first newly-loaded item. The underlying issue was a timing problem in the shared `item-list-common` infrastructure where the focus target was evaluated before the new result element finished rendering its shadow DOM.

--- a/packages/atomic/src/components/common/item-list/item-list-common.spec.ts
+++ b/packages/atomic/src/components/common/item-list/item-list-common.spec.ts
@@ -140,6 +140,40 @@ describe('ItemListCommon', () => {
       expect(getFirstFocusableDescendantMock).not.toHaveBeenCalled();
     });
 
+    it('should defer and set focus target after getUpdateComplete resolves when element initially has no children', async () => {
+      const setTarget = vi.fn();
+      const nextNewItemTarget = {
+        ...baseNextNewItemTarget,
+        setTarget,
+      } as unknown as FocusTargetController;
+      const getCurrentNumberOfItems = vi.fn(() => 0);
+      const itemListCommon = itemListCommonFixture({
+        getCurrentNumberOfItems,
+        nextNewItemTarget,
+      });
+
+      itemListCommon.focusOnNextNewResult();
+
+      const element = document.createElement('div') as HTMLElement & {
+        getUpdateComplete: () => Promise<boolean>;
+      };
+      let resolveUpdate!: (value: boolean) => void;
+      element.getUpdateComplete = () =>
+        new Promise((resolve) => {
+          resolveUpdate = resolve;
+        });
+
+      itemListCommon.setNewResultRef(element, 0);
+
+      expect(setTarget).not.toHaveBeenCalled();
+
+      element.appendChild(document.createElement('button'));
+      resolveUpdate(true);
+      await Promise.resolve();
+
+      expect(setTarget).toHaveBeenCalledOnce();
+    });
+
     describe('when #element has children and #resultIndex is the index of the result to focus', () => {
       let itemListCommon: ItemListCommon;
 

--- a/packages/atomic/src/components/common/item-list/item-list-common.ts
+++ b/packages/atomic/src/components/common/item-list/item-list-common.ts
@@ -77,6 +77,14 @@ export class ItemListCommon {
     }
 
     if (!element.children.length && !element.shadowRoot?.children.length) {
+      const litElement = element as unknown as {
+        getUpdateComplete?(): Promise<boolean>;
+        updateComplete?: Promise<boolean>;
+      };
+      const ready =
+        litElement.getUpdateComplete?.() ?? litElement.updateComplete;
+
+      ready?.then(() => this.setNewResultRef(element, resultIndex));
       return;
     }
 

--- a/packages/atomic/src/components/search/atomic-load-more-results/atomic-load-more-results.spec.ts
+++ b/packages/atomic/src/components/search/atomic-load-more-results/atomic-load-more-results.spec.ts
@@ -42,6 +42,8 @@ describe('atomic-load-more-results', () => {
       isAppLoaded = true,
     } = props;
 
+    const focusOnNextNewResultSpy = vi.fn();
+
     const fakeResults = Array.from({length: numberOfResults}, (_, i) =>
       buildFakeResult({uniqueId: `result-${i}`})
     );
@@ -75,6 +77,9 @@ describe('atomic-load-more-results', () => {
         selector: 'atomic-load-more-results',
         bindings: (bindings) => {
           bindings.engine = mockedEngine;
+          bindings.store.state.resultList = {
+            focusOnNextNewResult: focusOnNextNewResultSpy,
+          } as unknown as (typeof bindings.store.state)['resultList'];
           bindings.store.state.loadingFlags = isAppLoaded
             ? []
             : ['app-loading'];
@@ -86,6 +91,7 @@ describe('atomic-load-more-results', () => {
 
     return {
       element,
+      focusOnNextNewResultSpy,
       get loadMoreButton() {
         return page.getByRole('button');
       },
@@ -241,21 +247,13 @@ describe('atomic-load-more-results', () => {
         expect(fetchMoreResultsSpy).toHaveBeenCalledOnce();
       });
 
-      it('should blur the active element', async () => {
-        const {loadMoreButton} = await renderLoadMoreResults();
-        const blurSpy = vi.fn();
-
-        // Create a fake active element with a blur method
-        const fakeActiveElement = document.createElement('button');
-        fakeActiveElement.blur = blurSpy;
-        Object.defineProperty(document, 'activeElement', {
-          configurable: true,
-          get: () => fakeActiveElement,
-        });
+      it('should call #focusOnNextNewResult', async () => {
+        const {loadMoreButton, focusOnNextNewResultSpy} =
+          await renderLoadMoreResults();
 
         await loadMoreButton.click();
 
-        expect(blurSpy).toHaveBeenCalledOnce();
+        expect(focusOnNextNewResultSpy).toHaveBeenCalledOnce();
       });
     });
   });

--- a/packages/atomic/src/components/search/atomic-load-more-results/atomic-load-more-results.ts
+++ b/packages/atomic/src/components/search/atomic-load-more-results/atomic-load-more-results.ts
@@ -105,10 +105,7 @@ export class AtomicLoadMoreResults
   }
 
   private async onClick() {
-    // TODO KIT-4227: Once the focus mess is resolved, ensure that:
-    // The focus is set on the next new result after loading more results **without scrolling**.
-    //this.bindings.store.state.resultList?.focusOnNextNewResult();
-    (document.activeElement as HTMLElement)?.blur(); // Blur the active element to avoid focus issues, remove when focus mess is resolved.
+    this.bindings.store.state.resultList?.focusOnNextNewResult();
     this.resultList.fetchMoreResults();
   }
 


### PR DESCRIPTION
[KIT-5810](https://coveord.atlassian.net/browse/KIT-5810)

## Problem
After clicking "Load more results" in `atomic-load-more-results`, focus is moved to `<body>` via an explicit `blur()` call. Keyboard users lose their position entirely and must Tab through the entire page to reach the new content.

## Solution
Replaced the `blur()` workaround with `focusOnNextNewResult()`, matching the behavior already implemented in the commerce equivalent (`atomic-commerce-load-more-products`). This moves focus to the first newly-loaded result after clicking "Load more results".

[KIT-5810]: https://coveord.atlassian.net/browse/KIT-5810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ