### PR TITLE
fix(atomic): prevent focus from escaping modal dialogs

### DIFF
--- a/.changeset/fix-modal-focus-trap-scope.md
+++ b/.changeset/fix-modal-focus-trap-scope.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": patch
+---
+
+Fixed focus escaping modal dialogs by ensuring `atomic-focus-trap` always receives a valid `scope` element. When no explicit scope is provided to `atomic-modal`, it now defaults to the interface element or `document.body` instead of `undefined`.

--- a/packages/atomic/src/components/common/atomic-focus-trap/atomic-focus-trap.ts
+++ b/packages/atomic/src/components/common/atomic-focus-trap/atomic-focus-trap.ts
@@ -145,23 +145,13 @@ export class AtomicFocusTrap extends LightDomMixin(LitElement) {
   }
 
   private onFocusChanged = (e: FocusEvent) => {
-    const elementIsPartOfHost = (focusedElement: Element | ShadowRoot) =>
-      isAncestorOf(this, focusedElement);
-
-    const elementIsPartOfScope = (focusedElement: Element | ShadowRoot) =>
-      isAncestorOf(this.scope, focusedElement);
-
     if (!e.target || !this.active) {
       return;
     }
 
     const focusedElement = getFocusedElement();
 
-    if (
-      focusedElement &&
-      (elementIsPartOfHost(focusedElement) ||
-        !elementIsPartOfScope(focusedElement))
-    ) {
+    if (focusedElement && isAncestorOf(this, focusedElement)) {
       return;
     }
 

--- a/packages/atomic/src/components/common/atomic-modal/atomic-modal.ts
+++ b/packages/atomic/src/components/common/atomic-modal/atomic-modal.ts
@@ -175,7 +175,9 @@ export class AtomicModal
               .source=${this.source}
               .container=${this.container ?? this}
               ${ref(this.focusTrap)}
-              .scope=${this.scope}
+              .scope=${this.scope ??
+              this.bindings?.interfaceElement ??
+              document.body}
             >
               ${this.renderContent()}
             </atomic-focus-trap>


### PR DESCRIPTION
[KIT-5811](https://coveord.atlassian.net/browse/KIT-5811)

## Problem
Focus escapes modal dialogs when pressing Tab. Two issues in the focus trap mechanism:

1. **`atomic-modal` passes `undefined` as scope to `atomic-focus-trap`** — most modal callers (quickview, feedback, generated-answer) never set `scope` on `atomic-modal`. When Lit binds `.scope=${undefined}`, it overrides the focus-trap's default of `document.body`. This breaks `hideSiblingsRecursively()` which uses `scope` to know when to stop walking up the DOM to set `aria-hidden` on siblings.

2. **`atomic-focus-trap.onFocusChanged` had flawed logic** — the handler only redirected focus for elements *inside* the scope but *outside* the trap. Elements *outside* the scope (like nav links above the search interface) were ignored, allowing focus to permanently escape to the page behind the modal.

## Solution

**`atomic-modal.ts`**: Added a fallback for the scope binding:
```
.scope=${this.scope ?? this.bindings?.interfaceElement ?? document.body}
```
This ensures `hideSiblingsRecursively()` always has a valid boundary to stop at when setting `aria-hidden` on sibling elements.

**`atomic-focus-trap.ts`**: Simplified the `onFocusChanged` handler to redirect focus back into the trap whenever it lands on *any* element that is not a descendant of the trap — regardless of whether that element is inside or outside the scope. This matches the WAI-ARIA APG dialog pattern requirement that focus must remain trapped within the modal.

Before: focus would escape after tabbing through all elements and never come back.
After: focus cycles through Close → Keywords highlight → Toggle keywords → Next → Previous → Remove highlights → Iframe → Next quickview → (wraps back) → Close.

[KIT-5811]: https://coveord.atlassian.net/browse/KIT-5811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ