### PR TITLE
feat(samples): integrate @a2ui/react renderer in generative-react sample

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1024,10 +1024,10 @@ importers:
         version: 1.60.0
       '@salesforce/eslint-config-lwc':
         specifier: 3.7.2
-        version: 3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)
+        version: 3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)
       '@salesforce/sfdx-lwc-jest':
         specifier: 6.0.0
-        version: 6.0.0(@types/node@24.12.4)(eslint@8.57.1)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))(typescript@6.0.3)
+        version: 6.0.0(@types/node@25.9.2)(eslint@8.57.1)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))(typescript@6.0.3)
       '@types/wait-on':
         specifier: 5.3.4
         version: 5.3.4
@@ -1048,7 +1048,7 @@ importers:
         version: 3.1.3
       jest:
         specifier: 'catalog:'
-        version: 30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+        version: 30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1066,7 +1066,7 @@ importers:
         version: 2.2.6(prettier@3.8.3)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@24.12.4)(typescript@6.0.3)
+        version: 10.9.2(@types/node@25.9.2)(typescript@6.0.3)
       wait-on:
         specifier: 9.0.10
         version: 9.0.10
@@ -1609,6 +1609,12 @@ importers:
 
   samples/thermidor/generative-react:
     dependencies:
+      '@a2ui/react':
+        specifier: ^0.10.1
+        version: 0.10.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      '@a2ui/web_core':
+        specifier: ^0.10.1
+        version: 0.10.3
       '@coveo/thermidor':
         specifier: workspace:*
         version: link:../../../packages/thermidor
@@ -1696,6 +1702,22 @@ packages:
     peerDependenciesMeta:
       '@75lb/nature':
         optional: true
+
+  '@a2ui/markdown-it@0.0.4':
+    resolution: {integrity: sha512-uaYNywdiHDH4i//pHpyckFnApvOshiUNT2Xl8awceNjL1XAX/gqtki9GRUJQ26RE7id2+aPNgOy1W6mXNBxriQ==}
+    peerDependencies:
+      '@a2ui/web_core': ^0.9.2
+
+  '@a2ui/react@0.10.1':
+    resolution: {integrity: sha512-m7rBhOKA2PNwrD9Q7kaJn+l2u0WLAmd/n0RmaUNkTRdzCTcSfEbcet5sbCHGpT7xu4TSp+ABWfowG+mcL7HAnQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: 19.2.7
+      react-dom: 19.2.7
+      zod: ^3.25.76
+
+  '@a2ui/web_core@0.10.3':
+    resolution: {integrity: sha512-B0+zhC1gac4vweqrWxcW1tlmdspMuZl8YzNXSrza3ppayoFYcJblMuvu8g8+6l++aycNQK5D4WaBX85KVvVx+g==}
 
   '@actions/github@9.1.1':
     resolution: {integrity: sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==}
@@ -5841,6 +5863,9 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@preact/signals-core@1.14.3':
+    resolution: {integrity: sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw==}
+
   '@prettier-apex/apex-ast-serializer-darwin-arm64@2.2.6':
     resolution: {integrity: sha512-XzrGnEVQq/JH/rKPktpdL8/agocjDCnSrY4MuHxMs5V3OnV/4MJdMHp0frQhqOjbhnUIjewypX5XWcVi0xqRBQ==}
     cpu: [arm64]
@@ -8676,6 +8701,10 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   co-body@6.2.0:
     resolution: {integrity: sha512-Kbpv2Yd1NdL1V/V4cwLVxraHDV6K8ayohr2rmH0J87Er8+zJjcTa6dAn9QMPC9CRgU8+aNajKbSf1TzDB1yKPA==}
     engines: {node: '>=8.0.0'}
@@ -9086,6 +9115,9 @@ packages:
 
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
@@ -15647,6 +15679,29 @@ snapshots:
       lodash: 4.18.1
       typical: 7.3.0
 
+  '@a2ui/markdown-it@0.0.4(@a2ui/web_core@0.10.3)':
+    dependencies:
+      '@a2ui/web_core': 0.10.3
+      dompurify: 3.4.5
+      markdown-it: 14.2.0
+
+  '@a2ui/react@0.10.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)':
+    dependencies:
+      '@a2ui/markdown-it': 0.0.4(@a2ui/web_core@0.10.3)
+      '@a2ui/web_core': 0.10.3
+      clsx: 2.1.1
+      markdown-it: 14.2.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      zod: 4.4.3
+
+  '@a2ui/web_core@0.10.3':
+    dependencies:
+      '@preact/signals-core': 1.14.3
+      date-fns: 4.4.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+
   '@actions/github@9.1.1':
     dependencies:
       '@actions/http-client': 3.0.2
@@ -18661,7 +18716,7 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -18675,7 +18730,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -18730,6 +18785,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))':
     dependencies:
@@ -19305,33 +19361,33 @@ snapshots:
       globals: 13.24.0
       minimatch: 9.0.9
 
-  '@lwc/jest-preset@16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@lwc/jest-preset@16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))':
     dependencies:
       '@lwc/compiler': 7.1.2
       '@lwc/engine-dom': 7.1.2
       '@lwc/engine-server': 7.1.2
-      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
+      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
       '@lwc/synthetic-shadow': 7.1.2
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
     transitivePeerDependencies:
       - supports-color
 
-  '@lwc/jest-resolver@16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@lwc/jest-resolver@16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))':
     dependencies:
       '@lwc/jest-shared': 16.0.0
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
 
-  '@lwc/jest-serializer@16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@lwc/jest-serializer@16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))':
     dependencies:
       '@lwc/jest-shared': 16.0.0
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       pretty-format: 29.7.0
 
   '@lwc/jest-shared@16.0.0': {}
 
-  '@lwc/jest-transformer@16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@lwc/jest-transformer@16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.29.7)
@@ -19342,7 +19398,7 @@ snapshots:
       '@lwc/compiler': 7.1.2
       '@lwc/jest-shared': 16.0.0
       babel-preset-jest: 29.6.3(@babel/core@7.29.7)
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       magic-string: 0.30.21
       semver: 7.8.4
     transitivePeerDependencies:
@@ -20307,6 +20363,8 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@preact/signals-core@1.14.3': {}
+
   '@prettier-apex/apex-ast-serializer-darwin-arm64@2.2.6':
     optional: true
 
@@ -20900,7 +20958,7 @@ snapshots:
     dependencies:
       postcss: 8.5.15
 
-  '@salesforce/eslint-config-lwc@3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)':
+  '@salesforce/eslint-config-lwc@3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)':
     dependencies:
       '@babel/core': 7.24.9
       '@babel/eslint-parser': 7.24.8(@babel/core@7.24.9)(eslint@8.57.1)
@@ -20908,7 +20966,7 @@ snapshots:
       '@salesforce/eslint-plugin-lightning': 1.0.1(eslint@8.57.1)
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)
-      eslint-plugin-jest: 29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3)
+      eslint-plugin-jest: 29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))(typescript@6.0.3)
       eslint-restricted-globals: 0.2.0
       semver: 7.8.4
     transitivePeerDependencies:
@@ -20918,21 +20976,21 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  '@salesforce/sfdx-lwc-jest@6.0.0(@types/node@24.12.4)(eslint@8.57.1)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))(typescript@6.0.3)':
+  '@salesforce/sfdx-lwc-jest@6.0.0(@types/node@25.9.2)(eslint@8.57.1)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@lwc/compiler': 7.1.2
       '@lwc/engine-dom': 7.1.2
       '@lwc/engine-server': 7.1.2
-      '@lwc/jest-preset': 16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
-      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))
+      '@lwc/jest-preset': 16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
+      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))
       '@lwc/module-resolver': 7.1.2
       '@lwc/synthetic-shadow': 7.1.2
       '@lwc/wire-service': 7.1.2
       '@salesforce/wire-service-jest-util': 4.1.4(@lwc/engine-dom@7.1.2)(eslint@8.57.1)(typescript@6.0.3)
       fast-glob: 3.3.3
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-environment-jsdom: 29.7.0(patch_hash=b419a992476c3323e67ee6c86f3f9ecf6f4f073127cb572aa9af3b9c6550751d)
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -22007,13 +22065,13 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
+  '@vitest/browser-playwright@4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
-      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
-      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
-      playwright: 1.60.0
+      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      playwright: 1.61.0-alpha-1778188671000
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.2)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@24.12.4)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -22033,6 +22091,34 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/browser-playwright@4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
+    dependencies:
+      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      playwright: 1.61.0-alpha-1778188671000
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@types/node@25.9.2)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser-playwright@4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
+    dependencies:
+      '@vitest/browser': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      playwright: 1.61.0-alpha-1778188671000
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@types/node@25.9.2)(@vitest/browser-playwright@4.1.7)(jsdom@20.0.3)(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
 
   '@vitest/browser@4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
@@ -23357,6 +23443,8 @@ snapshots:
 
   clone@1.0.4: {}
 
+  clsx@2.1.1: {}
+
   co-body@6.2.0:
     dependencies:
       '@hapi/bourne': 3.0.0
@@ -23580,13 +23668,13 @@ snapshots:
       - encoding
       - react-native
 
-  create-jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+  create-jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -23852,6 +23940,8 @@ snapshots:
       is-data-view: 1.0.2
 
   dataloader@1.4.0: {}
+
+  date-fns@4.4.0: {}
 
   dateformat@4.6.3: {}
 
@@ -24411,12 +24501,12 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3):
+  eslint-plugin-jest@29.15.2(eslint@8.57.1)(jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/utils': 8.60.1(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
     optionalDependencies:
-      jest: 30.3.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest: 30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -26051,16 +26141,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+  jest-cli@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      create-jest: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -26088,6 +26178,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   jest-cli@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
@@ -26108,38 +26199,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.7)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 24.12.4
-      ts-node: 10.9.2(@types/node@24.12.4)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+  jest-config@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 29.7.0
@@ -26165,7 +26225,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.9.2
-      ts-node: 10.9.2(@types/node@24.12.4)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@25.9.2)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -26201,6 +26261,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+    optional: true
 
   jest-config@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
     dependencies:
@@ -26233,6 +26294,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+    optional: true
 
   jest-config@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
@@ -26768,12 +26830,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+  jest@29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-cli: 29.7.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -26792,6 +26854,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   jest@30.3.0(@types/node@25.9.2)(ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3)):
     dependencies:
@@ -31103,6 +31166,7 @@ snapshots:
       typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optional: true
 
   ts-node@10.9.2(@types/node@25.9.2)(typescript@6.0.3):
     dependencies:
@@ -31121,7 +31185,6 @@ snapshots:
       typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optional: true
 
   ts-simple-type@2.0.0-next.0: {}
 
@@ -31719,7 +31782,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4
-      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - msw
@@ -31748,7 +31811,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.2
-      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.14(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - msw
@@ -31777,7 +31840,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.2
-      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(playwright@1.61.0-alpha-1778188671000)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(less@4.6.4)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - msw
@@ -32343,6 +32406,10 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -116,6 +116,7 @@ minimumReleaseAgeExclude:
   - react-dom
   - react-router
   - '@react-router/*'
+  - '@a2ui/*'
 
 # Allow using the shell emulator for all commands, which is required for some commands to work properly on Windows.
 # https://pnpm.io/cli/run#shellemulator

--- a/samples/thermidor/generative-react/package.json
+++ b/samples/thermidor/generative-react/package.json
@@ -13,6 +13,8 @@
     "e2e:watch": "playwright test --ui"
   },
   "dependencies": {
+    "@a2ui/react": "^0.10.1",
+    "@a2ui/web_core": "^0.10.1",
     "@coveo/thermidor": "workspace:*",
     "marked": "^15.0.0",
     "react": "catalog:",

--- a/samples/thermidor/generative-react/src/a2ui/SurfaceRenderer/SurfaceRenderer.tsx
+++ b/samples/thermidor/generative-react/src/a2ui/SurfaceRenderer/SurfaceRenderer.tsx
@@ -24,6 +24,19 @@ export interface SurfaceRendererProps {
   onAction?: (text: string, type: string) => void;
 }
 
+interface RealEntry {
+  type: 'real';
+  surface: ParsedSurface;
+}
+
+interface SkeletonEntry {
+  type: 'skeleton';
+  surfaceId: string;
+  componentType: string;
+}
+
+type RenderItem = RealEntry | SkeletonEntry;
+
 export function SurfaceRenderer({surfaces, onAction}: SurfaceRendererProps) {
   const allParsed = useMemo(() => {
     const result: ParsedSurface[] = [];
@@ -33,43 +46,57 @@ export function SurfaceRenderer({surfaces, onAction}: SurfaceRendererProps) {
     return result;
   }, [surfaces]);
 
-  const {customSurfaces, standardSurfaces, skeletons} = useMemo(() => {
-    const custom: ParsedSurface[] = [];
-    const standard: ParsedSurface[] = [];
-    const skel: ParsedSurface[] = [];
+  const renderItems = useMemo(() => {
+    const skeletons: ParsedSurface[] = [];
+    const real: ParsedSurface[] = [];
 
     for (const s of allParsed) {
       const props = s.componentProps as Record<string, unknown>;
-      const isLoading =
-        s.surfaceId.startsWith('skeleton-') || props.isLoading === true;
-
-      if (isLoading && CUSTOM_COMPONENTS.has(s.componentType)) {
-        skel.push(s);
-      } else if (CUSTOM_COMPONENTS.has(s.componentType)) {
-        custom.push(s);
+      if (s.surfaceId.startsWith('skeleton-') || props.isLoading === true) {
+        skeletons.push(s);
       } else if (s.componentType) {
-        standard.push(s);
+        real.push(s);
       }
     }
 
-    return {
-      customSurfaces: custom,
-      standardSurfaces: standard,
-      skeletons: skel,
-    };
+    const dedupedIds = new Set<string>();
+    const dedupedReal: ParsedSurface[] = [];
+    for (const s of real) {
+      if (!dedupedIds.has(s.surfaceId)) {
+        dedupedIds.add(s.surfaceId);
+        dedupedReal.push(s);
+      }
+    }
+
+    const realComponentTypes = new Set(dedupedReal.map((s) => s.componentType));
+
+    const items: RenderItem[] = [];
+
+    const dedupedSkeletonTypes = new Set<string>();
+    for (const s of skeletons) {
+      if (
+        !realComponentTypes.has(s.componentType) &&
+        !dedupedSkeletonTypes.has(s.componentType)
+      ) {
+        dedupedSkeletonTypes.add(s.componentType);
+        items.push({
+          type: 'skeleton',
+          surfaceId: s.surfaceId,
+          componentType: s.componentType,
+        });
+      }
+    }
+
+    for (const s of dedupedReal) {
+      items.push({type: 'real', surface: s});
+    }
+
+    return items;
   }, [allParsed]);
 
-  if (
-    customSurfaces.length === 0 &&
-    standardSurfaces.length === 0 &&
-    skeletons.length === 0
-  ) {
+  if (renderItems.length === 0) {
     return null;
   }
-
-  const realComponentTypes = new Set(
-    customSurfaces.map((s) => s.componentType)
-  );
 
   const handleA2UIAction = onAction
     ? (event: A2UIActionEvent) => {
@@ -82,28 +109,37 @@ export function SurfaceRenderer({surfaces, onAction}: SurfaceRendererProps) {
 
   return (
     <div className={styles.container}>
-      {skeletons
-        .filter((s) => !realComponentTypes.has(s.componentType))
-        .map((s) => (
-          <A2UISkeleton key={s.surfaceId} componentType={s.componentType} />
-        ))}
-      {customSurfaces.map((surface) => (
-        <CustomSurfaceComponent
-          key={surface.surfaceId}
-          surface={surface}
-          allSurfaces={allParsed}
-          onAction={onAction}
-        />
-      ))}
-      {standardSurfaces.map((surface) => (
-        <A2UIViewer
-          key={surface.surfaceId}
-          root={surface.rootId}
-          components={surface.components}
-          data={surface.data}
-          onAction={handleA2UIAction}
-        />
-      ))}
+      {renderItems.map((item) => {
+        if (item.type === 'skeleton') {
+          return (
+            <A2UISkeleton
+              key={item.surfaceId}
+              componentType={item.componentType}
+            />
+          );
+        }
+
+        if (CUSTOM_COMPONENTS.has(item.surface.componentType)) {
+          return (
+            <CustomSurfaceComponent
+              key={item.surface.surfaceId}
+              surface={item.surface}
+              allSurfaces={allParsed}
+              onAction={onAction}
+            />
+          );
+        }
+
+        return (
+          <A2UIViewer
+            key={item.surface.surfaceId}
+            root={item.surface.rootId}
+            components={item.surface.components}
+            data={item.surface.data}
+            onAction={handleA2UIAction}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/samples/thermidor/generative-react/src/a2ui/SurfaceRenderer/SurfaceRenderer.tsx
+++ b/samples/thermidor/generative-react/src/a2ui/SurfaceRenderer/SurfaceRenderer.tsx
@@ -1,4 +1,5 @@
 import {useMemo} from 'react';
+import {A2UIViewer, type A2UIActionEvent} from '@a2ui/react/v0_8';
 import {A2UIProductCarousel} from '../ProductCarousel/ProductCarousel.js';
 import {A2UIBundleDisplay} from '../BundleDisplay/BundleDisplay.js';
 import {A2UINextActionsBar} from '../NextActionsBar/NextActionsBar.js';
@@ -10,7 +11,7 @@ import styles from './SurfaceRenderer.module.css';
 
 type A2UISurface = Record<string, unknown>;
 
-const KNOWN_COMPONENTS = new Set([
+const CUSTOM_COMPONENTS = new Set([
   'ProductCarousel',
   'BundleDisplay',
   'NextActionsBar',
@@ -23,19 +24,6 @@ export interface SurfaceRendererProps {
   onAction?: (text: string, type: string) => void;
 }
 
-interface RenderEntry {
-  type: 'real';
-  surface: ParsedSurface;
-}
-
-interface SkeletonEntry {
-  type: 'skeleton';
-  surfaceId: string;
-  componentType: string;
-}
-
-type RenderItem = RenderEntry | SkeletonEntry;
-
 export function SurfaceRenderer({surfaces, onAction}: SurfaceRendererProps) {
   const allParsed = useMemo(() => {
     const result: ParsedSurface[] = [];
@@ -45,93 +33,92 @@ export function SurfaceRenderer({surfaces, onAction}: SurfaceRendererProps) {
     return result;
   }, [surfaces]);
 
-  const renderItems = useMemo(() => {
-    const known = allParsed.filter((s) =>
-      KNOWN_COMPONENTS.has(s.componentType)
-    );
+  const {customSurfaces, standardSurfaces, skeletons} = useMemo(() => {
+    const custom: ParsedSurface[] = [];
+    const standard: ParsedSurface[] = [];
+    const skel: ParsedSurface[] = [];
 
-    const skeletons: ParsedSurface[] = [];
-    const real: ParsedSurface[] = [];
-
-    for (const s of known) {
+    for (const s of allParsed) {
       const props = s.componentProps as Record<string, unknown>;
-      if (s.surfaceId.startsWith('skeleton-') || props.isLoading === true) {
-        skeletons.push(s);
-      } else {
-        real.push(s);
+      const isLoading =
+        s.surfaceId.startsWith('skeleton-') || props.isLoading === true;
+
+      if (isLoading && CUSTOM_COMPONENTS.has(s.componentType)) {
+        skel.push(s);
+      } else if (CUSTOM_COMPONENTS.has(s.componentType)) {
+        custom.push(s);
+      } else if (s.componentType) {
+        standard.push(s);
       }
     }
 
-    const dedupedIds = new Set<string>();
-    const dedupedReal: ParsedSurface[] = [];
-    for (const s of real) {
-      if (dedupedIds.has(s.surfaceId)) continue;
-      dedupedIds.add(s.surfaceId);
-      dedupedReal.push(s);
-    }
-
-    const realComponentTypes = new Set(dedupedReal.map((s) => s.componentType));
-
-    const items: RenderItem[] = [];
-
-    const dedupedSkeletonTypes = new Set<string>();
-    for (const s of skeletons) {
-      if (realComponentTypes.has(s.componentType)) continue;
-      if (dedupedSkeletonTypes.has(s.componentType)) continue;
-      dedupedSkeletonTypes.add(s.componentType);
-      items.push({
-        type: 'skeleton',
-        surfaceId: s.surfaceId,
-        componentType: s.componentType,
-      });
-    }
-
-    for (const s of dedupedReal) {
-      items.push({type: 'real', surface: s});
-    }
-
-    return items;
+    return {
+      customSurfaces: custom,
+      standardSurfaces: standard,
+      skeletons: skel,
+    };
   }, [allParsed]);
 
-  if (renderItems.length === 0) {
+  if (
+    customSurfaces.length === 0 &&
+    standardSurfaces.length === 0 &&
+    skeletons.length === 0
+  ) {
     return null;
   }
 
+  const realComponentTypes = new Set(
+    customSurfaces.map((s) => s.componentType)
+  );
+
+  const handleA2UIAction = onAction
+    ? (event: A2UIActionEvent) => {
+        const text = (event.context?.text as string) ?? event.actionName ?? '';
+        const type =
+          (event.context?.type as string) ?? event.actionName ?? 'action';
+        onAction(text, type);
+      }
+    : undefined;
+
   return (
     <div className={styles.container}>
-      {renderItems.map((item) => {
-        if (item.type === 'skeleton') {
-          return (
-            <A2UISkeleton
-              key={item.surfaceId}
-              componentType={item.componentType}
-            />
-          );
-        }
-        return (
-          <A2UISurfaceComponent
-            key={item.surface.surfaceId}
-            surface={item.surface}
-            allSurfaces={allParsed}
-            onAction={onAction}
-          />
-        );
-      })}
+      {skeletons
+        .filter((s) => !realComponentTypes.has(s.componentType))
+        .map((s) => (
+          <A2UISkeleton key={s.surfaceId} componentType={s.componentType} />
+        ))}
+      {customSurfaces.map((surface) => (
+        <CustomSurfaceComponent
+          key={surface.surfaceId}
+          surface={surface}
+          allSurfaces={allParsed}
+          onAction={onAction}
+        />
+      ))}
+      {standardSurfaces.map((surface) => (
+        <A2UIViewer
+          key={surface.surfaceId}
+          root={surface.rootId}
+          components={surface.components}
+          data={surface.data}
+          onAction={handleA2UIAction}
+        />
+      ))}
     </div>
   );
 }
 
-interface A2UISurfaceComponentProps {
+interface CustomSurfaceComponentProps {
   surface: ParsedSurface;
   allSurfaces: ParsedSurface[];
   onAction?: (text: string, type: string) => void;
 }
 
-function A2UISurfaceComponent({
+function CustomSurfaceComponent({
   surface,
   allSurfaces,
   onAction,
-}: A2UISurfaceComponentProps) {
+}: CustomSurfaceComponentProps) {
   switch (surface.componentType) {
     case 'ProductCarousel':
       return <A2UIProductCarousel surface={surface} />;

--- a/samples/thermidor/generative-react/src/a2ui/types.ts
+++ b/samples/thermidor/generative-react/src/a2ui/types.ts
@@ -61,6 +61,7 @@ export interface ParsedSurface {
   rootId: string;
   componentType: string;
   componentProps: Record<string, unknown>;
+  components: ComponentEntry[];
   data: Record<string, unknown>;
 }
 
@@ -81,6 +82,7 @@ export function parseSurfaceSnapshot(
       rootId: string;
       componentType: string;
       componentProps: Record<string, unknown>;
+      components: ComponentEntry[];
       data: Record<string, unknown>;
     }
   >();
@@ -93,6 +95,7 @@ export function parseSurfaceSnapshot(
           rootId: root,
           componentType: '',
           componentProps: {},
+          components: [],
           data: {},
         });
       }
@@ -101,14 +104,17 @@ export function parseSurfaceSnapshot(
     if ('surfaceUpdate' in op) {
       const {surfaceId, components} = op.surfaceUpdate;
       const entry = surfaces.get(surfaceId);
-      if (entry && components.length > 0) {
-        const rootComponent = components[0].component;
-        const [type, props] = Object.entries(rootComponent)[0] ?? [
-          'Unknown',
-          {},
-        ];
-        entry.componentType = type;
-        entry.componentProps = props as Record<string, unknown>;
+      if (entry) {
+        entry.components = components;
+        if (components.length > 0) {
+          const rootComponent = components[0].component;
+          const [type, props] = Object.entries(rootComponent)[0] ?? [
+            'Unknown',
+            {},
+          ];
+          entry.componentType = type;
+          entry.componentProps = props as Record<string, unknown>;
+        }
       }
     }
 
@@ -128,6 +134,7 @@ export function parseSurfaceSnapshot(
     rootId: entry.rootId,
     componentType: entry.componentType,
     componentProps: entry.componentProps,
+    components: entry.components,
     data: entry.data,
   }));
 }


### PR DESCRIPTION
## Summary

Integrates the official [`@a2ui/react`](https://github.com/a2ui-project/a2ui/tree/main/renderers/react) renderer into `samples/thermidor/generative-react` using the v0.8 protocol.

## Changes

- Added `@a2ui/react` and `@a2ui/web_core` as dependencies
- Rewrote `SurfaceRenderer` with a hybrid rendering strategy:
  - **Custom domain components** (`ProductCarousel`, `BundleDisplay`, `ComparisonTable`, `ComparisonSummary`, `NextActionsBar`) → rendered via the existing switch
  - **Standard A2UI catalog components** (`Text`, `Button`, `Card`, `Row`, `Column`, `Image`, etc.) → delegated to `A2UIViewer` from `@a2ui/react/v0_8`
- Updated `ParsedSurface` type to expose both the extracted `componentType`/`componentProps` and the raw `components[]` array
- Added `@a2ui/*` to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`

## Current limitation

The backend currently sends only custom component types that are not part of the A2UI standard catalog. As a result, `A2UIViewer` won't render anything today — all surfaces hit the custom path.

The library integration is future-proofing for when the backend starts composing UIs using standard A2UI components (or a mix of both). If the plan is to eventually emit standard component trees (using `Card`, `Row`, `Text`, `Image`, `Button` to compose a product carousel instead of a single opaque `ProductCarousel` type), the `@a2ui/react` dependency makes sense.

## Protocol note

The thermidor backend emits v0.8-format messages (`beginRendering`, `surfaceUpdate`, `dataModelUpdate`). The explicit import from `@a2ui/react/v0_8` reflects this choice. Switching to v0.9 (`createSurface`, `updateComponents`, `updateDataModel`) will require a server-side change.

## Bundle size impact

|            | JS (minified) | JS (gzip)  | CSS       |
| ---------- | ------------- | ---------- | --------- |
| **Before** | 372.09 kB     | 110.70 kB  | 20.13 kB  |
| **After**  | 538.60 kB     | 171.18 kB  | 20.13 kB  |
| **Delta**  | +166.51 kB    | +60.48 kB  | —         |

The increase comes from `@a2ui/react` and `@a2ui/web_core` which include the full v0.8 component catalog (Text, Button, Card, Row, Column, Image, etc.), the message processor, and the data binding engine. This is the cost of the standard renderer — it will be amortized as custom components are migrated to standard A2UI catalog types.
