### PR TITLE
chore(headless): Point the agent answer and follow-up endpoints to the `v1` API instead of `preview` for the GA release

### DIFF
--- a/.changeset/proud-geese-show.md
+++ b/.changeset/proud-geese-show.md
@@ -1,5 +1,5 @@
 ---
-"@coveo/headless": patch
+"@coveo/headless": minor
 ---
 
 Point the agent answer and follow-up endpoints to the `v1` API instead of `preview` for the GA release.

--- a/.changeset/proud-geese-show.md
+++ b/.changeset/proud-geese-show.md
@@ -1,0 +1,5 @@
+---
+"@coveo/headless": patch
+---
+
+Point the agent answer and follow-up endpoints to the `v1` API instead of `preview` for the GA release.

--- a/packages/headless/src/api/knowledge/answer-generation/agents/endpoint-url-builder.test.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/endpoint-url-builder.test.ts
@@ -33,7 +33,7 @@ describe('buildBaseAnswerGenerationUrl', () => {
     );
 
     expect(url).toBe(
-      `https://my-test-org.org.coveo.com/api/preview/organizations/${organizationId}/agents/${agentId}`
+      `https://my-test-org.org.coveo.com/api/v1/organizations/${organizationId}/agents/${agentId}`
     );
     expect(mockedGetOrganizationEndpoint).toHaveBeenCalledWith(
       organizationId,

--- a/packages/headless/src/api/knowledge/answer-generation/agents/endpoint-url-builder.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/endpoint-url-builder.ts
@@ -15,6 +15,6 @@ export const buildBaseAnswerGenerationUrl = (
   if (!platformEndpoint || !organizationId || !trimmedAgentId) {
     throw new Error('Missing required parameters for answer endpoint');
   }
-  const basePath = `/api/preview/organizations/${organizationId}/agents`;
+  const basePath = `/api/v1/organizations/${organizationId}/agents`;
   return `${platformEndpoint}${basePath}/${trimmedAgentId}`;
 };

--- a/packages/platform-mock-api/src/agent/mock.ts
+++ b/packages/platform-mock-api/src/agent/mock.ts
@@ -14,7 +14,7 @@ export class MockAgentApi implements MockApi {
       () => HttpResponse<DefaultBodyType>
     >(
       'POST',
-      `${basePath}/api/preview/organizations/:orgId/agents/:agentId/answer`,
+      `${basePath}/api/v1/organizations/:orgId/agents/:agentId/answer`,
       headAnswerResponse,
       (response) => response()
     );
@@ -23,7 +23,7 @@ export class MockAgentApi implements MockApi {
       () => HttpResponse<DefaultBodyType>
     >(
       'POST',
-      `${basePath}/api/preview/organizations/:orgId/agents/:agentId/follow-up`,
+      `${basePath}/api/v1/organizations/:orgId/agents/:agentId/follow-up`,
       followUpAnswerResponse,
       (response) => response()
     );


### PR DESCRIPTION
## [SFINT-6839](https://coveord.atlassian.net/browse/SFINT-6839)

Endpoints updated from `preview` to `v1`

https://github.com/user-attachments/assets/41c948fe-fa28-421f-8c07-7fb821896102



[SFINT-6839]: https://coveord.atlassian.net/browse/SFINT-6839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ