### PR TITLE
fix(atomic): Custom no message error slot being displayed before answer generates

### DIFF
--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts
@@ -292,9 +292,11 @@ describe('atomic-generated-answer', () => {
     const renderGeneratedAnswerWithCustomMessage = async ({
       props = {},
       generatedAnswerState = {},
+      searchStatusState = {},
     }: {
       props?: Partial<AtomicGeneratedAnswer>;
       generatedAnswerState?: Partial<GeneratedAnswerState>;
+      searchStatusState?: {hasError?: boolean; firstSearchExecuted?: boolean};
     } = {}) => {
       mockedGeneratedAnswer = buildFakeGeneratedAnswer({
         answer: undefined,
@@ -309,6 +311,7 @@ describe('atomic-generated-answer', () => {
         firstSearchExecuted: true,
         isLoading: false,
         hasResults: true,
+        ...searchStatusState,
       });
 
       mockedTabManager = buildFakeTabManager({
@@ -460,6 +463,13 @@ describe('atomic-generated-answer', () => {
       expect(generatedContainer).toContainElement(
         customMessageSlot as HTMLElement
       );
+    });
+
+    it('should not render the custom no-answer message before first search is executed', async () => {
+      const {container} = await renderGeneratedAnswerWithCustomMessage({
+        searchStatusState: {firstSearchExecuted: false},
+      });
+      expect(container).not.toBeInTheDocument();
     });
   });
 

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
@@ -419,6 +419,7 @@ export class AtomicGeneratedAnswer
 
     if (this.hasNoAnswerGenerated) {
       if (
+        this.searchStatusState?.firstSearchExecuted &&
         this.generatedAnswerState?.cannotAnswer &&
         this.hasCustomNoAnswerMessage
       ) {


### PR DESCRIPTION
[SFINT-6835](https://coveord.atlassian.net/browse/SFINT-6835)

[SFINT-6835]: https://coveord.atlassian.net/browse/SFINT-6835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ