### PR TITLE
refactor(thermidor): Introduce SingletonFactory to DRY getOrCreate functions

### DIFF
--- a/packages/thermidor/src/core/interface/generative/generative-hydration.ts
+++ b/packages/thermidor/src/core/interface/generative/generative-hydration.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {Engine, getFullEngine} from '@/src/core/interface/engine/engine.js';
 import {STATE_ID} from '@/src/core/interface/utils/symbols.js';
 import type {
@@ -16,23 +17,14 @@ const ACTIVITY_TYPE_TO_ROUTED_USE_CASE: Record<string, RoutedUseCase> = {
   'search-api-response': 'search',
 };
 
-const hydrateActionCache = new Map<
-  string,
-  ReturnType<typeof createHydrateAction>
->();
-
 function createHydrateAction(interfaceId: string) {
   return createAction<Record<string, unknown>>(
     `${interfaceId}/hydrateFromSnapshot`
   );
 }
 
-export function getOrCreateHydrateFromSnapshotAction(interfaceId: string) {
-  if (!hydrateActionCache.has(interfaceId)) {
-    hydrateActionCache.set(interfaceId, createHydrateAction(interfaceId));
-  }
-  return hydrateActionCache.get(interfaceId)!;
-}
+export const getOrCreateHydrateFromSnapshotAction =
+  SingletonFactory(createHydrateAction);
 
 export function createHydrateSubInterface(engine: Engine): HydrateSubInterface {
   const fullEngine = getFullEngine(engine);

--- a/packages/thermidor/src/core/interface/utils/facade-cache.ts
+++ b/packages/thermidor/src/core/interface/utils/facade-cache.ts
@@ -1,5 +1,9 @@
 import type {FullEngine} from '@/src/core/interface/engine/engine.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import type {EndpointStateScope} from './interface-types.js';
+
+const getScopeKey = (scope: EndpointStateScope): string =>
+  scope.composedInterfaceId ?? scope.interfaceId;
 
 export type FacadeFactory<T> = (
   engine: FullEngine,
@@ -10,13 +14,8 @@ export function createFacadeCache<T>(
   engine: FullEngine,
   factory: FacadeFactory<T>
 ) {
-  const cache = new Map<string, T>();
-
-  return (scope: EndpointStateScope): T => {
-    const key = scope.composedInterfaceId ?? scope.interfaceId;
-    if (!cache.has(key)) {
-      cache.set(key, factory(engine, scope));
-    }
-    return cache.get(key) as T;
-  };
+  return SingletonFactory<string, T, EndpointStateScope>(
+    (scope) => factory(engine, scope),
+    getScopeKey
+  );
 }

--- a/packages/thermidor/src/core/internal/api/search/commerce-search-thunk-slice.ts
+++ b/packages/thermidor/src/core/internal/api/search/commerce-search-thunk-slice.ts
@@ -1,6 +1,7 @@
 import {createSlice} from '@reduxjs/toolkit';
 import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-state-selector.js';
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import type {EndpointThunk} from '@/src/core/interface/utils/interface-types.js';
 
 export interface CommerceSearchEndpointThunkState {
@@ -74,18 +75,6 @@ export function createCommerceSearchEndpointSelectors(interfaceId: string) {
   };
 }
 
-const selectorsCache = new Map<
-  string,
-  ReturnType<typeof createCommerceSearchEndpointSelectors>
->();
-export function getOrCreateCommerceSearchEndpointSelectors(
-  interfaceId: string
-) {
-  if (!selectorsCache.has(interfaceId)) {
-    selectorsCache.set(
-      interfaceId,
-      createCommerceSearchEndpointSelectors(interfaceId)
-    );
-  }
-  return selectorsCache.get(interfaceId)!;
-}
+export const getOrCreateCommerceSearchEndpointSelectors = SingletonFactory(
+  createCommerceSearchEndpointSelectors
+);

--- a/packages/thermidor/src/core/internal/api/search/search-thunk-slice.ts
+++ b/packages/thermidor/src/core/internal/api/search/search-thunk-slice.ts
@@ -1,6 +1,7 @@
 import {createSlice} from '@reduxjs/toolkit';
 import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-state-selector.js';
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import type {EndpointThunk} from '@/src/core/interface/utils/interface-types.js';
 
 export interface SearchEndpointThunkState {
@@ -70,13 +71,6 @@ export function createSearchEndpointSelectors(interfaceId: string) {
   };
 }
 
-const selectorsCache = new Map<
-  string,
-  ReturnType<typeof createSearchEndpointSelectors>
->();
-export function getOrCreateSearchEndpointSelectors(interfaceId: string) {
-  if (!selectorsCache.has(interfaceId)) {
-    selectorsCache.set(interfaceId, createSearchEndpointSelectors(interfaceId));
-  }
-  return selectorsCache.get(interfaceId)!;
-}
+export const getOrCreateSearchEndpointSelectors = SingletonFactory(
+  createSearchEndpointSelectors
+);

--- a/packages/thermidor/src/core/internal/cart/cart-actions.ts
+++ b/packages/thermidor/src/core/internal/cart/cart-actions.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import type {CartItem} from '@/src/core/interface/cart/cart-types.js';
 
 export function createCartActions(interfaceId: string) {
@@ -10,10 +11,4 @@ export function createCartActions(interfaceId: string) {
   };
 }
 
-const actionsCache = new Map<string, ReturnType<typeof createCartActions>>();
-export function getOrCreateCartActions(interfaceId: string) {
-  if (!actionsCache.has(interfaceId)) {
-    actionsCache.set(interfaceId, createCartActions(interfaceId));
-  }
-  return actionsCache.get(interfaceId)!;
-}
+export const getOrCreateCartActions = SingletonFactory(createCartActions);

--- a/packages/thermidor/src/core/internal/cart/cart-selectors.ts
+++ b/packages/thermidor/src/core/internal/cart/cart-selectors.ts
@@ -1,5 +1,6 @@
 import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-state-selector.js';
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {initialCartState} from './cart-slice.js';
 
 export function createCartSelectors(interfaceId: string) {
@@ -16,13 +17,4 @@ export function createCartSelectors(interfaceId: string) {
   };
 }
 
-const selectorsCache = new Map<
-  string,
-  ReturnType<typeof createCartSelectors>
->();
-export function getOrCreateCartSelectors(interfaceId: string) {
-  if (!selectorsCache.has(interfaceId)) {
-    selectorsCache.set(interfaceId, createCartSelectors(interfaceId));
-  }
-  return selectorsCache.get(interfaceId)!;
-}
+export const getOrCreateCartSelectors = SingletonFactory(createCartSelectors);

--- a/packages/thermidor/src/core/internal/cart/cart-slice.ts
+++ b/packages/thermidor/src/core/internal/cart/cart-slice.ts
@@ -3,6 +3,7 @@ import type {
   CartItem,
   CartState,
 } from '@/src/core/interface/cart/cart-types.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {getOrCreateCartActions} from './cart-actions.js';
 
 export const initialCartState: CartState = {
@@ -45,10 +46,4 @@ export function createCartSlice(interfaceId: string) {
   });
 }
 
-const sliceCache = new Map<string, ReturnType<typeof createCartSlice>>();
-export function getOrCreateCartSlice(interfaceId: string) {
-  if (!sliceCache.has(interfaceId)) {
-    sliceCache.set(interfaceId, createCartSlice(interfaceId));
-  }
-  return sliceCache.get(interfaceId)!;
-}
+export const getOrCreateCartSlice = SingletonFactory(createCartSlice);

--- a/packages/thermidor/src/core/internal/facets/facets-actions.ts
+++ b/packages/thermidor/src/core/internal/facets/facets-actions.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import type {CoveoFacetResponse} from '@/src/core/interface/api/search/search-types.js';
 
 export function createFacetsActions(interfaceId: string) {
@@ -12,10 +13,4 @@ export function createFacetsActions(interfaceId: string) {
   };
 }
 
-const actionsCache = new Map<string, ReturnType<typeof createFacetsActions>>();
-export function getOrCreateFacetsActions(interfaceId: string) {
-  if (!actionsCache.has(interfaceId)) {
-    actionsCache.set(interfaceId, createFacetsActions(interfaceId));
-  }
-  return actionsCache.get(interfaceId)!;
-}
+export const getOrCreateFacetsActions = SingletonFactory(createFacetsActions);

--- a/packages/thermidor/src/core/internal/facets/facets-selectors.ts
+++ b/packages/thermidor/src/core/internal/facets/facets-selectors.ts
@@ -1,5 +1,6 @@
 import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-state-selector.js';
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {initialFacetsState} from './facets-slice.js';
 import type {FacetsState} from '@/src/core/interface/facets/facets-types.js';
 
@@ -22,13 +23,6 @@ export function createFacetsSelectors(interfaceId: string) {
   };
 }
 
-const selectorsCache = new Map<
-  string,
-  ReturnType<typeof createFacetsSelectors>
->();
-export function getOrCreateFacetsSelectors(interfaceId: string) {
-  if (!selectorsCache.has(interfaceId)) {
-    selectorsCache.set(interfaceId, createFacetsSelectors(interfaceId));
-  }
-  return selectorsCache.get(interfaceId)!;
-}
+export const getOrCreateFacetsSelectors = SingletonFactory(
+  createFacetsSelectors
+);

--- a/packages/thermidor/src/core/internal/facets/facets-slice.ts
+++ b/packages/thermidor/src/core/internal/facets/facets-slice.ts
@@ -1,4 +1,5 @@
 import {createSlice} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import type {FacetsState} from '@/src/core/interface/facets/facets-types.js';
 import {getOrCreateFacetsActions} from './facets-actions.js';
 import {getOrCreateHydrateFromSnapshotAction} from '@/src/core/interface/generative/generative-hydration.js';
@@ -83,10 +84,4 @@ export function createFacetsSlice(interfaceId: string) {
   });
 }
 
-const sliceCache = new Map<string, ReturnType<typeof createFacetsSlice>>();
-export function getOrCreateFacetsSlice(interfaceId: string) {
-  if (!sliceCache.has(interfaceId)) {
-    sliceCache.set(interfaceId, createFacetsSlice(interfaceId));
-  }
-  return sliceCache.get(interfaceId)!;
-}
+export const getOrCreateFacetsSlice = SingletonFactory(createFacetsSlice);

--- a/packages/thermidor/src/core/internal/generative/generative-actions.ts
+++ b/packages/thermidor/src/core/internal/generative/generative-actions.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import type {
   A2UISurface,
   RoutedInterface,
@@ -56,14 +57,6 @@ export function createGenerativeActions(interfaceId: string) {
   };
 }
 
-const actionsCache = new Map<
-  string,
-  ReturnType<typeof createGenerativeActions>
->();
-
-export function getOrCreateGenerativeActions(interfaceId: string) {
-  if (!actionsCache.has(interfaceId)) {
-    actionsCache.set(interfaceId, createGenerativeActions(interfaceId));
-  }
-  return actionsCache.get(interfaceId)!;
-}
+export const getOrCreateGenerativeActions = SingletonFactory(
+  createGenerativeActions
+);

--- a/packages/thermidor/src/core/internal/generative/generative-selectors.ts
+++ b/packages/thermidor/src/core/internal/generative/generative-selectors.ts
@@ -1,5 +1,6 @@
 import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-state-selector.js';
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {initialGenerativeState} from './generative-slice.js';
 import type {Turn} from '@/src/core/interface/generative/generative-types.js';
 
@@ -32,14 +33,6 @@ export function createGenerativeSelectors(interfaceId: string) {
   };
 }
 
-const selectorsCache = new Map<
-  string,
-  ReturnType<typeof createGenerativeSelectors>
->();
-
-export function getOrCreateGenerativeSelectors(interfaceId: string) {
-  if (!selectorsCache.has(interfaceId)) {
-    selectorsCache.set(interfaceId, createGenerativeSelectors(interfaceId));
-  }
-  return selectorsCache.get(interfaceId)!;
-}
+export const getOrCreateGenerativeSelectors = SingletonFactory(
+  createGenerativeSelectors
+);

--- a/packages/thermidor/src/core/internal/generative/generative-slice.ts
+++ b/packages/thermidor/src/core/internal/generative/generative-slice.ts
@@ -1,4 +1,5 @@
 import {createSlice} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import type {GenerativeState} from '@/src/core/interface/generative/generative-types.js';
 import {getOrCreateGenerativeActions} from './generative-actions.js';
 
@@ -122,11 +123,6 @@ export function createGenerativeSlice(interfaceId: string) {
   });
 }
 
-const sliceCache = new Map<string, ReturnType<typeof createGenerativeSlice>>();
-
-export function getOrCreateGenerativeSlice(interfaceId: string) {
-  if (!sliceCache.has(interfaceId)) {
-    sliceCache.set(interfaceId, createGenerativeSlice(interfaceId));
-  }
-  return sliceCache.get(interfaceId)!;
-}
+export const getOrCreateGenerativeSlice = SingletonFactory(
+  createGenerativeSlice
+);

--- a/packages/thermidor/src/core/internal/pagination/pagination-actions.ts
+++ b/packages/thermidor/src/core/internal/pagination/pagination-actions.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 
 export function createPaginationActions(interfaceId: string) {
   return {
@@ -12,13 +13,6 @@ export function createPaginationActions(interfaceId: string) {
   };
 }
 
-const actionsCache = new Map<
-  string,
-  ReturnType<typeof createPaginationActions>
->();
-export function getOrCreatePaginationActions(interfaceId: string) {
-  if (!actionsCache.has(interfaceId)) {
-    actionsCache.set(interfaceId, createPaginationActions(interfaceId));
-  }
-  return actionsCache.get(interfaceId)!;
-}
+export const getOrCreatePaginationActions = SingletonFactory(
+  createPaginationActions
+);

--- a/packages/thermidor/src/core/internal/pagination/pagination-selectors.ts
+++ b/packages/thermidor/src/core/internal/pagination/pagination-selectors.ts
@@ -1,5 +1,6 @@
 import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-state-selector.js';
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {initialPaginationState} from './pagination-slice.js';
 
 export function createPaginationSelectors(interfaceId: string) {
@@ -27,13 +28,6 @@ export function createPaginationSelectors(interfaceId: string) {
   };
 }
 
-const selectorsCache = new Map<
-  string,
-  ReturnType<typeof createPaginationSelectors>
->();
-export function getOrCreatePaginationSelectors(interfaceId: string) {
-  if (!selectorsCache.has(interfaceId)) {
-    selectorsCache.set(interfaceId, createPaginationSelectors(interfaceId));
-  }
-  return selectorsCache.get(interfaceId)!;
-}
+export const getOrCreatePaginationSelectors = SingletonFactory(
+  createPaginationSelectors
+);

--- a/packages/thermidor/src/core/internal/pagination/pagination-slice.ts
+++ b/packages/thermidor/src/core/internal/pagination/pagination-slice.ts
@@ -1,4 +1,5 @@
 import {createSlice} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {getOrCreatePaginationActions} from './pagination-actions.js';
 import {getOrCreateHydrateFromSnapshotAction} from '@/src/core/interface/generative/generative-hydration.js';
 
@@ -62,10 +63,6 @@ export function createPaginationSlice(interfaceId: string) {
   });
 }
 
-const sliceCache = new Map<string, ReturnType<typeof createPaginationSlice>>();
-export function getOrCreatePaginationSlice(interfaceId: string) {
-  if (!sliceCache.has(interfaceId)) {
-    sliceCache.set(interfaceId, createPaginationSlice(interfaceId));
-  }
-  return sliceCache.get(interfaceId)!;
-}
+export const getOrCreatePaginationSlice = SingletonFactory(
+  createPaginationSlice
+);

--- a/packages/thermidor/src/core/internal/product-list/product-list-actions.ts
+++ b/packages/thermidor/src/core/internal/product-list/product-list-actions.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 
 export function createProductListActions(interfaceId: string) {
   return {
@@ -8,13 +9,6 @@ export function createProductListActions(interfaceId: string) {
   };
 }
 
-const actionsCache = new Map<
-  string,
-  ReturnType<typeof createProductListActions>
->();
-export function getOrCreateProductListActions(interfaceId: string) {
-  if (!actionsCache.has(interfaceId)) {
-    actionsCache.set(interfaceId, createProductListActions(interfaceId));
-  }
-  return actionsCache.get(interfaceId)!;
-}
+export const getOrCreateProductListActions = SingletonFactory(
+  createProductListActions
+);

--- a/packages/thermidor/src/core/internal/product-list/product-list-selectors.ts
+++ b/packages/thermidor/src/core/internal/product-list/product-list-selectors.ts
@@ -1,5 +1,6 @@
 import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-state-selector.js';
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {initialProductListState} from './product-list-slice.js';
 import type {Product} from '@/src/core/interface/product-list/product-list-types.js';
 
@@ -18,14 +19,6 @@ export function createProductListSelectors(interfaceId: string) {
   };
 }
 
-const selectorsCache = new Map<
-  string,
-  ReturnType<typeof createProductListSelectors>
->();
-
-export function getOrCreateProductListSelectors(interfaceId: string) {
-  if (!selectorsCache.has(interfaceId)) {
-    selectorsCache.set(interfaceId, createProductListSelectors(interfaceId));
-  }
-  return selectorsCache.get(interfaceId)!;
-}
+export const getOrCreateProductListSelectors = SingletonFactory(
+  createProductListSelectors
+);

--- a/packages/thermidor/src/core/internal/product-list/product-list-slice.ts
+++ b/packages/thermidor/src/core/internal/product-list/product-list-slice.ts
@@ -3,6 +3,7 @@ import type {
   Product,
   ProductListState,
 } from '@/src/core/interface/product-list/product-list-types.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {getOrCreateProductListActions} from './product-list-actions.js';
 import {getOrCreateHydrateFromSnapshotAction} from '@/src/core/interface/generative/generative-hydration.js';
 
@@ -68,10 +69,6 @@ export function createProductListSlice(interfaceId: string) {
   });
 }
 
-const sliceCache = new Map<string, ReturnType<typeof createProductListSlice>>();
-export function getOrCreateProductListSlice(interfaceId: string) {
-  if (!sliceCache.has(interfaceId)) {
-    sliceCache.set(interfaceId, createProductListSlice(interfaceId));
-  }
-  return sliceCache.get(interfaceId)!;
-}
+export const getOrCreateProductListSlice = SingletonFactory(
+  createProductListSlice
+);

--- a/packages/thermidor/src/core/internal/query-correction/query-correction-actions.ts
+++ b/packages/thermidor/src/core/internal/query-correction/query-correction-actions.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 
 export interface QueryCorrection {
   correctedQuery: string;
@@ -13,13 +14,6 @@ export function createQueryCorrectionActions(interfaceId: string) {
   };
 }
 
-const actionsCache = new Map<
-  string,
-  ReturnType<typeof createQueryCorrectionActions>
->();
-export function getOrCreateQueryCorrectionActions(interfaceId: string) {
-  if (!actionsCache.has(interfaceId)) {
-    actionsCache.set(interfaceId, createQueryCorrectionActions(interfaceId));
-  }
-  return actionsCache.get(interfaceId)!;
-}
+export const getOrCreateQueryCorrectionActions = SingletonFactory(
+  createQueryCorrectionActions
+);

--- a/packages/thermidor/src/core/internal/query-correction/query-correction-slice.ts
+++ b/packages/thermidor/src/core/internal/query-correction/query-correction-slice.ts
@@ -1,4 +1,5 @@
 import {createSlice} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {getOrCreateQueryCorrectionActions} from './query-correction-actions.js';
 import type {QueryCorrection} from './query-correction-actions.js';
 
@@ -25,13 +26,6 @@ export function createQueryCorrectionSlice(interfaceId: string) {
   });
 }
 
-const sliceCache = new Map<
-  string,
-  ReturnType<typeof createQueryCorrectionSlice>
->();
-export function getOrCreateQueryCorrectionSlice(interfaceId: string) {
-  if (!sliceCache.has(interfaceId)) {
-    sliceCache.set(interfaceId, createQueryCorrectionSlice(interfaceId));
-  }
-  return sliceCache.get(interfaceId)!;
-}
+export const getOrCreateQueryCorrectionSlice = SingletonFactory(
+  createQueryCorrectionSlice
+);

--- a/packages/thermidor/src/core/internal/result-list/result-list-actions.ts
+++ b/packages/thermidor/src/core/internal/result-list/result-list-actions.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import type {CoveoSearchResult} from '@/src/core/interface/api/search/search-types.js';
 
 export function createResultsActions(interfaceId: string) {
@@ -9,10 +10,4 @@ export function createResultsActions(interfaceId: string) {
   };
 }
 
-const actionsCache = new Map<string, ReturnType<typeof createResultsActions>>();
-export function getOrCreateResultsActions(interfaceId: string) {
-  if (!actionsCache.has(interfaceId)) {
-    actionsCache.set(interfaceId, createResultsActions(interfaceId));
-  }
-  return actionsCache.get(interfaceId)!;
-}
+export const getOrCreateResultsActions = SingletonFactory(createResultsActions);

--- a/packages/thermidor/src/core/internal/result-list/result-list-selectors.ts
+++ b/packages/thermidor/src/core/internal/result-list/result-list-selectors.ts
@@ -1,5 +1,6 @@
 import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-state-selector.js';
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {initialResultListState} from './result-list-slice.js';
 
 export function createResultsSelectors(interfaceId: string) {
@@ -16,13 +17,6 @@ export function createResultsSelectors(interfaceId: string) {
   };
 }
 
-const selectorsCache = new Map<
-  string,
-  ReturnType<typeof createResultsSelectors>
->();
-export function getOrCreateResultsSelectors(interfaceId: string) {
-  if (!selectorsCache.has(interfaceId)) {
-    selectorsCache.set(interfaceId, createResultsSelectors(interfaceId));
-  }
-  return selectorsCache.get(interfaceId)!;
-}
+export const getOrCreateResultsSelectors = SingletonFactory(
+  createResultsSelectors
+);

--- a/packages/thermidor/src/core/internal/result-list/result-list-slice.ts
+++ b/packages/thermidor/src/core/internal/result-list/result-list-slice.ts
@@ -1,4 +1,5 @@
 import {createSlice} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import type {ResultListState} from '@/src/core/interface/result-list/result-list-types.js';
 import {getOrCreateResultsActions} from './result-list-actions.js';
 import {getOrCreateHydrateFromSnapshotAction} from '@/src/core/interface/generative/generative-hydration.js';
@@ -54,10 +55,4 @@ export function createResultsSlice(interfaceId: string) {
   });
 }
 
-const sliceCache = new Map<string, ReturnType<typeof createResultsSlice>>();
-export function getOrCreateResultsSlice(interfaceId: string) {
-  if (!sliceCache.has(interfaceId)) {
-    sliceCache.set(interfaceId, createResultsSlice(interfaceId));
-  }
-  return sliceCache.get(interfaceId)!;
-}
+export const getOrCreateResultsSlice = SingletonFactory(createResultsSlice);

--- a/packages/thermidor/src/core/internal/search-box/search-box-actions.ts
+++ b/packages/thermidor/src/core/internal/search-box/search-box-actions.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 
 export function createSearchBoxActions(interfaceId: string) {
   return {
@@ -6,13 +7,6 @@ export function createSearchBoxActions(interfaceId: string) {
   };
 }
 
-const actionsCache = new Map<
-  string,
-  ReturnType<typeof createSearchBoxActions>
->();
-export function getOrCreateSearchBoxActions(interfaceId: string) {
-  if (!actionsCache.has(interfaceId)) {
-    actionsCache.set(interfaceId, createSearchBoxActions(interfaceId));
-  }
-  return actionsCache.get(interfaceId)!;
-}
+export const getOrCreateSearchBoxActions = SingletonFactory(
+  createSearchBoxActions
+);

--- a/packages/thermidor/src/core/internal/search-box/search-box-selectors.ts
+++ b/packages/thermidor/src/core/internal/search-box/search-box-selectors.ts
@@ -1,5 +1,6 @@
 import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-state-selector.js';
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {initialSearchBoxState} from './search-box-slice.js';
 
 export function createSearchBoxSelectors(interfaceId: string) {
@@ -16,13 +17,6 @@ export function createSearchBoxSelectors(interfaceId: string) {
   };
 }
 
-const selectorsCache = new Map<
-  string,
-  ReturnType<typeof createSearchBoxSelectors>
->();
-export function getOrCreateSearchBoxSelectors(interfaceId: string) {
-  if (!selectorsCache.has(interfaceId)) {
-    selectorsCache.set(interfaceId, createSearchBoxSelectors(interfaceId));
-  }
-  return selectorsCache.get(interfaceId)!;
-}
+export const getOrCreateSearchBoxSelectors = SingletonFactory(
+  createSearchBoxSelectors
+);

--- a/packages/thermidor/src/core/internal/search-box/search-box-slice.ts
+++ b/packages/thermidor/src/core/internal/search-box/search-box-slice.ts
@@ -1,4 +1,5 @@
 import {createSlice} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {getOrCreateSearchBoxActions} from './search-box-actions.js';
 
 export interface SearchBoxState {
@@ -23,10 +24,4 @@ export function createSearchBoxSlice(interfaceId: string) {
   });
 }
 
-const sliceCache = new Map<string, ReturnType<typeof createSearchBoxSlice>>();
-export function getOrCreateSearchBoxSlice(interfaceId: string) {
-  if (!sliceCache.has(interfaceId)) {
-    sliceCache.set(interfaceId, createSearchBoxSlice(interfaceId));
-  }
-  return sliceCache.get(interfaceId)!;
-}
+export const getOrCreateSearchBoxSlice = SingletonFactory(createSearchBoxSlice);

--- a/packages/thermidor/src/core/internal/search-parameters/search-parameters-actions.ts
+++ b/packages/thermidor/src/core/internal/search-parameters/search-parameters-actions.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 
 export function createSearchParametersActions(interfaceId: string) {
   return {
@@ -11,13 +12,6 @@ export function createSearchParametersActions(interfaceId: string) {
   };
 }
 
-const actionsCache = new Map<
-  string,
-  ReturnType<typeof createSearchParametersActions>
->();
-export function getOrCreateSearchParametersActions(interfaceId: string) {
-  if (!actionsCache.has(interfaceId)) {
-    actionsCache.set(interfaceId, createSearchParametersActions(interfaceId));
-  }
-  return actionsCache.get(interfaceId)!;
-}
+export const getOrCreateSearchParametersActions = SingletonFactory(
+  createSearchParametersActions
+);

--- a/packages/thermidor/src/core/internal/search-parameters/search-parameters-selectors.ts
+++ b/packages/thermidor/src/core/internal/search-parameters/search-parameters-selectors.ts
@@ -1,5 +1,6 @@
 import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-state-selector.js';
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {initialSearchParametersState} from './search-parameters-slice.js';
 
 export function createSearchParametersSelectors(interfaceId: string) {
@@ -20,16 +21,6 @@ export function createSearchParametersSelectors(interfaceId: string) {
   };
 }
 
-const selectorsCache = new Map<
-  string,
-  ReturnType<typeof createSearchParametersSelectors>
->();
-export function getOrCreateSearchParametersSelectors(interfaceId: string) {
-  if (!selectorsCache.has(interfaceId)) {
-    selectorsCache.set(
-      interfaceId,
-      createSearchParametersSelectors(interfaceId)
-    );
-  }
-  return selectorsCache.get(interfaceId)!;
-}
+export const getOrCreateSearchParametersSelectors = SingletonFactory(
+  createSearchParametersSelectors
+);

--- a/packages/thermidor/src/core/internal/search-parameters/search-parameters-slice.ts
+++ b/packages/thermidor/src/core/internal/search-parameters/search-parameters-slice.ts
@@ -1,4 +1,5 @@
 import {createSlice} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {getOrCreateSearchParametersActions} from './search-parameters-actions.js';
 
 export interface SearchParametersState {
@@ -28,13 +29,6 @@ export function createSearchParametersSlice(interfaceId: string) {
   });
 }
 
-const sliceCache = new Map<
-  string,
-  ReturnType<typeof createSearchParametersSlice>
->();
-export function getOrCreateSearchParametersSlice(interfaceId: string) {
-  if (!sliceCache.has(interfaceId)) {
-    sliceCache.set(interfaceId, createSearchParametersSlice(interfaceId));
-  }
-  return sliceCache.get(interfaceId)!;
-}
+export const getOrCreateSearchParametersSlice = SingletonFactory(
+  createSearchParametersSlice
+);

--- a/packages/thermidor/src/core/internal/singleton-factory/singleton-factory.test.ts
+++ b/packages/thermidor/src/core/internal/singleton-factory/singleton-factory.test.ts
@@ -1,0 +1,96 @@
+import {describe, it, expect, vi} from 'vitest';
+import {SingletonFactory} from './singleton-factory.js';
+
+describe('SingletonFactory', () => {
+  it('should return a value computed by the factory', () => {
+    const get = SingletonFactory((key: string) => `value-${key}`);
+
+    expect(get('a')).toBe('value-a');
+  });
+
+  it('should return the same reference for the same key', () => {
+    const get = SingletonFactory((key: string) => ({id: key}));
+
+    const first = get('x');
+    const second = get('x');
+
+    expect(first).toBe(second);
+  });
+
+  it('should return different values for different keys', () => {
+    const get = SingletonFactory((key: string) => ({id: key}));
+
+    const a = get('a');
+    const b = get('b');
+
+    expect(a).not.toBe(b);
+    expect(a.id).toBe('a');
+    expect(b.id).toBe('b');
+  });
+
+  it('should call the factory exactly once per key', () => {
+    const factory = vi.fn((key: string) => key.toUpperCase());
+    const get = SingletonFactory(factory);
+
+    get('hello');
+    get('hello');
+    get('hello');
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledWith('hello');
+  });
+
+  describe('with custom keyFn', () => {
+    interface Scope {
+      interfaceId: string;
+      composedInterfaceId?: string;
+    }
+
+    it('should use the derived key for caching', () => {
+      const factory = vi.fn((scope: Scope) => ({scope}));
+      const get = SingletonFactory<string, {scope: Scope}, Scope>(
+        factory,
+        (scope) => scope.composedInterfaceId ?? scope.interfaceId
+      );
+
+      const scope1: Scope = {interfaceId: 'a', composedInterfaceId: 'shared'};
+      const scope2: Scope = {interfaceId: 'b', composedInterfaceId: 'shared'};
+
+      const result1 = get(scope1);
+      const result2 = get(scope2);
+
+      expect(result1).toBe(result2);
+      expect(factory).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass the original argument to the factory', () => {
+      const factory = vi.fn((scope: Scope) => scope.interfaceId);
+      const get = SingletonFactory<string, string, Scope>(
+        factory,
+        (scope) => scope.composedInterfaceId ?? scope.interfaceId
+      );
+
+      const scope: Scope = {
+        interfaceId: 'original',
+        composedInterfaceId: 'key',
+      };
+      get(scope);
+
+      expect(factory).toHaveBeenCalledWith(scope);
+    });
+
+    it('should produce different entries for different derived keys', () => {
+      const factory = vi.fn((scope: Scope) => ({id: scope.interfaceId}));
+      const get = SingletonFactory<string, {id: string}, Scope>(
+        factory,
+        (scope) => scope.interfaceId
+      );
+
+      const a = get({interfaceId: 'x'});
+      const b = get({interfaceId: 'y'});
+
+      expect(a).not.toBe(b);
+      expect(factory).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/thermidor/src/core/internal/singleton-factory/singleton-factory.ts
+++ b/packages/thermidor/src/core/internal/singleton-factory/singleton-factory.ts
@@ -1,0 +1,40 @@
+/**
+ * Creates a memoized function that computes a value once per unique key and
+ * caches it for subsequent calls.
+ *
+ * @typeParam K - The cache key type used to index stored values.
+ * @typeParam V - The type of the cached value.
+ * @typeParam A - The argument type passed to the returned function. Defaults to `K`.
+ *
+ * @param factory - A function that produces a value from the given argument.
+ *   Called at most once per unique key.
+ * @param keyFn - An optional function that derives a cache key from the
+ *   argument. Defaults to identity (i.e., the argument itself is used as the key).
+ * @returns A function with signature `(arg: A) => V` that returns the cached
+ *   value for the derived key, creating it via `factory` on first access.
+ *
+ * @example
+ * // Simple case: argument is the key
+ * const getOrCreateSlice = SingletonFactory(createSlice);
+ * const slice = getOrCreateSlice('my-interface');
+ *
+ * @example
+ * // Custom key derivation from a complex argument
+ * const resolve = SingletonFactory<string, Thunk, Scope>(
+ *   (scope) => createThunk(engine, scope),
+ *   (scope) => scope.composedInterfaceId ?? scope.interfaceId,
+ * );
+ */
+export function SingletonFactory<K, V, A = K>(
+  factory: (arg: A) => V,
+  keyFn: (arg: A) => K = (arg) => arg as unknown as K
+): (arg: A) => V {
+  const cache = new Map<K, V>();
+  return (arg: A): V => {
+    const key = keyFn(arg);
+    if (!cache.has(key)) {
+      cache.set(key, factory(arg));
+    }
+    return cache.get(key) as V;
+  };
+}

--- a/packages/thermidor/src/core/internal/sort/sort-actions.ts
+++ b/packages/thermidor/src/core/internal/sort/sort-actions.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import type {CommerceSearchSort} from '@/src/api/interface/commerce-search-endpoint/commerce-search-endpoint-types.js';
 
 export function createSortActions(interfaceId: string) {
@@ -9,10 +10,4 @@ export function createSortActions(interfaceId: string) {
   };
 }
 
-const actionsCache = new Map<string, ReturnType<typeof createSortActions>>();
-export function getOrCreateSortActions(interfaceId: string) {
-  if (!actionsCache.has(interfaceId)) {
-    actionsCache.set(interfaceId, createSortActions(interfaceId));
-  }
-  return actionsCache.get(interfaceId)!;
-}
+export const getOrCreateSortActions = SingletonFactory(createSortActions);

--- a/packages/thermidor/src/core/internal/sort/sort-selectors.ts
+++ b/packages/thermidor/src/core/internal/sort/sort-selectors.ts
@@ -1,5 +1,6 @@
 import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-state-selector.js';
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {initialSortState} from './sort-slice.js';
 import type {SortState} from './sort-slice.js';
 
@@ -31,13 +32,4 @@ export function createSortSelectors(interfaceId: string) {
   };
 }
 
-const selectorsCache = new Map<
-  string,
-  ReturnType<typeof createSortSelectors>
->();
-export function getOrCreateSortSelectors(interfaceId: string) {
-  if (!selectorsCache.has(interfaceId)) {
-    selectorsCache.set(interfaceId, createSortSelectors(interfaceId));
-  }
-  return selectorsCache.get(interfaceId)!;
-}
+export const getOrCreateSortSelectors = SingletonFactory(createSortSelectors);

--- a/packages/thermidor/src/core/internal/sort/sort-slice.ts
+++ b/packages/thermidor/src/core/internal/sort/sort-slice.ts
@@ -1,4 +1,5 @@
 import {createSlice} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import type {CommerceSearchSortCriterion} from '@/src/api/interface/commerce-search-endpoint/commerce-search-endpoint-types.js';
 import {getOrCreateSortActions} from './sort-actions.js';
 
@@ -32,10 +33,4 @@ export function createSortSlice(interfaceId: string) {
   });
 }
 
-const sliceCache = new Map<string, ReturnType<typeof createSortSlice>>();
-export function getOrCreateSortSlice(interfaceId: string) {
-  if (!sliceCache.has(interfaceId)) {
-    sliceCache.set(interfaceId, createSortSlice(interfaceId));
-  }
-  return sliceCache.get(interfaceId)!;
-}
+export const getOrCreateSortSlice = SingletonFactory(createSortSlice);

--- a/packages/thermidor/src/core/internal/triggers/triggers-actions.ts
+++ b/packages/thermidor/src/core/internal/triggers/triggers-actions.ts
@@ -1,4 +1,5 @@
 import {createAction} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 
 export interface Trigger {
   type: string;
@@ -11,13 +12,6 @@ export function createTriggersActions(interfaceId: string) {
   };
 }
 
-const actionsCache = new Map<
-  string,
-  ReturnType<typeof createTriggersActions>
->();
-export function getOrCreateTriggersActions(interfaceId: string) {
-  if (!actionsCache.has(interfaceId)) {
-    actionsCache.set(interfaceId, createTriggersActions(interfaceId));
-  }
-  return actionsCache.get(interfaceId)!;
-}
+export const getOrCreateTriggersActions = SingletonFactory(
+  createTriggersActions
+);

--- a/packages/thermidor/src/core/internal/triggers/triggers-slice.ts
+++ b/packages/thermidor/src/core/internal/triggers/triggers-slice.ts
@@ -1,4 +1,5 @@
 import {createSlice} from '@reduxjs/toolkit';
+import {SingletonFactory} from '@/src/core/internal/singleton-factory/singleton-factory.js';
 import {getOrCreateTriggersActions, type Trigger} from './triggers-actions.js';
 
 export interface TriggersState {
@@ -21,10 +22,4 @@ export function createTriggersSlice(interfaceId: string) {
   });
 }
 
-const sliceCache = new Map<string, ReturnType<typeof createTriggersSlice>>();
-export function getOrCreateTriggersSlice(interfaceId: string) {
-  if (!sliceCache.has(interfaceId)) {
-    sliceCache.set(interfaceId, createTriggersSlice(interfaceId));
-  }
-  return sliceCache.get(interfaceId)!;
-}
+export const getOrCreateTriggersSlice = SingletonFactory(createTriggersSlice);


### PR DESCRIPTION
While reading through the thermidor code, I found the `has/get/set` repetitive, so I made a generic helper to DRY it out.

Adds a generic `SingletonFactory<K, V, A>` function that wraps a Map with lazy-initialization semantics — call it with an argument, get back the cached value or create it once via the factory.

Refactors 33 instances of the repeated `Map` + has/set/get pattern across `thermidor/src/core/internal/` into one-liner `SingletonFactory(createX)` calls.

Also rewrites `createFacadeCache` to delegate to `SingletonFactory` with a custom `keyFn`.

Changes:

- New: `packages/thermidor/src/core/internal/singleton-factory/singleton-factory.ts`
- Refactored: all *-actions.ts, *-slice.ts, *-selectors.ts files in internal/
- Refactored: facade-cache.ts, generative-hydration.ts, search-thunk-slice.ts, commerce-search-thunk-slice.ts
- Excluding the added test file, this is:
  ```
  159 insertions(+), 323 deletions(-)
  ```

Non changes:
- Not refactored: `getOrCreateSearchEndpointSlice` and `getOrCreateCommerceSearchEndpointSlice`
  - They are two-argument factories that don't fit the `(key) => V` shape.
  - Having arguments that are not part of the cache is an anti-pattern that can break guarantees, but that's out of scope for this PR.

Points of debate:
- I’m not sold on the `SingletonFactory`, I’m happy to take other suggestions

