### PR TITLE
refactor(thermidor): Remove unnecessary exports of internal factories

### DIFF
--- a/packages/thermidor/src/core/interface/cart/cart-selectors.test.ts
+++ b/packages/thermidor/src/core/interface/cart/cart-selectors.test.ts
@@ -1,10 +1,10 @@
 import {describe, expect, it} from 'vitest';
-import {createCartSelectors} from '@/src/core/internal/cart/cart-selectors.js';
+import {getOrCreateCartSelectors} from '@/src/core/internal/cart/cart-selectors.js';
 
 const TEST_ID = 'test-interface';
 
-describe('cart selectors', () => {
-  const selectors = createCartSelectors(TEST_ID);
+describe('getOrCreateCartSelectors', () => {
+  const selectors = getOrCreateCartSelectors(TEST_ID);
 
   it('should return empty items when slice is not adopted', () => {
     const state = {};

--- a/packages/thermidor/src/core/interface/cart/cart-selectors.ts
+++ b/packages/thermidor/src/core/interface/cart/cart-selectors.ts
@@ -1,4 +1,1 @@
-export {
-  createCartSelectors,
-  getOrCreateCartSelectors,
-} from '@/src/core/internal/cart/cart-selectors.js';
+export {getOrCreateCartSelectors} from '@/src/core/internal/cart/cart-selectors.js';

--- a/packages/thermidor/src/core/interface/result-list/result-list-selectors.ts
+++ b/packages/thermidor/src/core/interface/result-list/result-list-selectors.ts
@@ -10,7 +10,4 @@ export const getResults = (interfaceId: string = 'default') => {
   return getOrCreateResultsSelectors(interfaceId).getResults;
 };
 
-export {
-  createResultsSelectors,
-  getOrCreateResultsSelectors,
-} from '@/src/core/internal/result-list/result-list-selectors.js';
+export {getOrCreateResultsSelectors} from '@/src/core/internal/result-list/result-list-selectors.js';

--- a/packages/thermidor/src/core/interface/search-box/search-box-selectors.ts
+++ b/packages/thermidor/src/core/interface/search-box/search-box-selectors.ts
@@ -14,7 +14,4 @@ export const getQuery = createMemoizedStateSelector(
   (searchBox) => searchBox.query
 );
 
-export {
-  createSearchBoxSelectors,
-  getOrCreateSearchBoxSelectors,
-} from '@/src/core/internal/search-box/search-box-selectors.js';
+export {getOrCreateSearchBoxSelectors} from '@/src/core/internal/search-box/search-box-selectors.js';

--- a/packages/thermidor/src/core/internal/api/search/commerce-search-thunk-slice.ts
+++ b/packages/thermidor/src/core/internal/api/search/commerce-search-thunk-slice.ts
@@ -56,7 +56,7 @@ export function getOrCreateCommerceSearchEndpointSlice(
   return sliceCache.get(interfaceId)!;
 }
 
-export function createCommerceSearchEndpointSelectors(interfaceId: string) {
+function createCommerceSearchEndpointSelectors(interfaceId: string) {
   const sliceSelector = createSelectSlice(
     interfaceId,
     'commerceSearchEndpoint',

--- a/packages/thermidor/src/core/internal/api/search/search-thunk-slice.ts
+++ b/packages/thermidor/src/core/internal/api/search/search-thunk-slice.ts
@@ -52,7 +52,7 @@ export function getOrCreateSearchEndpointSlice(
   return sliceCache.get(interfaceId)!;
 }
 
-export function createSearchEndpointSelectors(interfaceId: string) {
+function createSearchEndpointSelectors(interfaceId: string) {
   const sliceSelector = createSelectSlice(
     interfaceId,
     'searchEndpoint',

--- a/packages/thermidor/src/core/internal/cart/cart-actions.ts
+++ b/packages/thermidor/src/core/internal/cart/cart-actions.ts
@@ -1,7 +1,7 @@
 import {createAction} from '@reduxjs/toolkit';
 import type {CartItem} from '@/src/core/interface/cart/cart-types.js';
 
-export function createCartActions(interfaceId: string) {
+function createCartActions(interfaceId: string) {
   return {
     setItems: createAction<CartItem[]>(`${interfaceId}/cart/setItems`),
     updateItemQuantity: createAction<CartItem>(

--- a/packages/thermidor/src/core/internal/cart/cart-selectors.ts
+++ b/packages/thermidor/src/core/internal/cart/cart-selectors.ts
@@ -2,7 +2,7 @@ import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-s
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
 import {initialCartState} from './cart-slice.js';
 
-export function createCartSelectors(interfaceId: string) {
+function createCartSelectors(interfaceId: string) {
   const sliceSelector = createSelectSlice(
     interfaceId,
     'cart',

--- a/packages/thermidor/src/core/internal/cart/cart-slice.test.ts
+++ b/packages/thermidor/src/core/internal/cart/cart-slice.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from 'vitest';
-import {createCartSlice, initialCartState} from './cart-slice.js';
+import {getOrCreateCartSlice, initialCartState} from './cart-slice.js';
 import {getOrCreateCartActions} from './cart-actions.js';
 import type {CartItem} from '@/src/core/interface/cart/cart-types.js';
 
@@ -14,7 +14,7 @@ const item = (overrides: Partial<CartItem> = {}): CartItem => ({
 });
 
 describe('cartSlice', () => {
-  const slice = createCartSlice(TEST_ID);
+  const slice = getOrCreateCartSlice(TEST_ID);
   const actions = getOrCreateCartActions(TEST_ID);
 
   describe('setItems', () => {

--- a/packages/thermidor/src/core/internal/cart/cart-slice.ts
+++ b/packages/thermidor/src/core/internal/cart/cart-slice.ts
@@ -12,7 +12,7 @@ export const initialCartState: CartState = {
 const cartKey = (item: CartItem) =>
   `${item.productId},${item.name},${item.price}`;
 
-export function createCartSlice(interfaceId: string) {
+function createCartSlice(interfaceId: string) {
   const actions = getOrCreateCartActions(interfaceId);
   return createSlice({
     name: `${interfaceId}/cart`,

--- a/packages/thermidor/src/core/internal/facets/facets-actions.ts
+++ b/packages/thermidor/src/core/internal/facets/facets-actions.ts
@@ -1,7 +1,7 @@
 import {createAction} from '@reduxjs/toolkit';
 import type {CoveoFacetResponse} from '@/src/core/interface/api/search/search-types.js';
 
-export function createFacetsActions(interfaceId: string) {
+function createFacetsActions(interfaceId: string) {
   return {
     updateFromResponse: createAction<CoveoFacetResponse[] | undefined>(
       `${interfaceId}/facets/updateFromResponse`

--- a/packages/thermidor/src/core/internal/facets/facets-selectors.ts
+++ b/packages/thermidor/src/core/internal/facets/facets-selectors.ts
@@ -3,7 +3,7 @@ import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
 import {initialFacetsState} from './facets-slice.js';
 import type {FacetsState} from '@/src/core/interface/facets/facets-types.js';
 
-export function createFacetsSelectors(interfaceId: string) {
+function createFacetsSelectors(interfaceId: string) {
   const sliceSelector = createSelectSlice(
     interfaceId,
     'facets',

--- a/packages/thermidor/src/core/internal/facets/facets-slice.test.ts
+++ b/packages/thermidor/src/core/internal/facets/facets-slice.test.ts
@@ -8,33 +8,13 @@ import {
   getOrCreateFacetsSlice,
   initialFacetsState,
 } from './facets-slice.js';
-import {
-  createFacetsActions,
-  getOrCreateFacetsActions,
-} from './facets-actions.js';
+import {getOrCreateFacetsActions} from './facets-actions.js';
 import {
   createFacetsSelectors,
   getOrCreateFacetsSelectors,
 } from './facets-selectors.js';
 import type {FacetsState} from '@/src/core/interface/facets/facets-types.js';
 import type {CoveoFacetResponse} from '@/src/core/interface/api/search/search-types.js';
-
-describe('createFacetsActions', () => {
-  it('should create actions scoped to the interfaceId', () => {
-    const actions = createFacetsActions('search');
-    expect(actions.updateFromResponse.type).toBe(
-      'search/facets/updateFromResponse'
-    );
-  });
-
-  it('should create different actions for different interfaceIds', () => {
-    const actionsA = createFacetsActions('interfaceA');
-    const actionsB = createFacetsActions('interfaceB');
-    expect(actionsA.updateFromResponse.type).not.toBe(
-      actionsB.updateFromResponse.type
-    );
-  });
-});
 
 describe('getOrCreateFacetsActions', () => {
   it('should return the same instance for the same interfaceId', () => {

--- a/packages/thermidor/src/core/internal/facets/facets-slice.test.ts
+++ b/packages/thermidor/src/core/internal/facets/facets-slice.test.ts
@@ -3,11 +3,7 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import {
-  createFacetsSlice,
-  getOrCreateFacetsSlice,
-  initialFacetsState,
-} from './facets-slice.js';
+import {getOrCreateFacetsSlice, initialFacetsState} from './facets-slice.js';
 import {getOrCreateFacetsActions} from './facets-actions.js';
 import {
   createFacetsSelectors,
@@ -30,19 +26,19 @@ describe('getOrCreateFacetsActions', () => {
   });
 });
 
-describe('createFacetsSlice', () => {
+describe('getOrCreateFacetsSlice', () => {
   it('should have empty object as initial state', () => {
     expect(initialFacetsState).toEqual({});
   });
 
   it('should create a slice with scoped name', () => {
-    const slice = createFacetsSlice('myInterface');
+    const slice = getOrCreateFacetsSlice('myInterface');
     expect(slice.name).toBe('myInterface/facets');
   });
 
   it('should update facet values from response', () => {
     const actions = getOrCreateFacetsActions('test-response');
-    const slice = createFacetsSlice('test-response');
+    const slice = getOrCreateFacetsSlice('test-response');
 
     const stateWithFacet: FacetsState = {
       category: {
@@ -77,7 +73,7 @@ describe('createFacetsSlice', () => {
 
   it('should not modify state when response is undefined', () => {
     const actions = getOrCreateFacetsActions('test-undefined');
-    const slice = createFacetsSlice('test-undefined');
+    const slice = getOrCreateFacetsSlice('test-undefined');
 
     const stateWithFacet: FacetsState = {
       category: {
@@ -98,7 +94,7 @@ describe('createFacetsSlice', () => {
 
   it('should ignore response facets that do not exist in state', () => {
     const actions = getOrCreateFacetsActions('test-missing');
-    const slice = createFacetsSlice('test-missing');
+    const slice = getOrCreateFacetsSlice('test-missing');
 
     const response: CoveoFacetResponse[] = [
       {
@@ -118,7 +114,7 @@ describe('createFacetsSlice', () => {
 
   it('should maintain state immutability', () => {
     const actions = getOrCreateFacetsActions('test-immutable');
-    const slice = createFacetsSlice('test-immutable');
+    const slice = getOrCreateFacetsSlice('test-immutable');
 
     const original: FacetsState = {
       category: {
@@ -140,9 +136,7 @@ describe('createFacetsSlice', () => {
     slice.reducer(original, actions.updateFromResponse(response));
     expect(original.category.values).toEqual([]);
   });
-});
 
-describe('getOrCreateFacetsSlice', () => {
   it('should return the same instance for the same interfaceId', () => {
     const a = getOrCreateFacetsSlice('cached-facet-slice');
     const b = getOrCreateFacetsSlice('cached-facet-slice');
@@ -156,7 +150,7 @@ describe('getOrCreateFacetsSlice', () => {
   });
 });
 
-describe('createFacetsSelectors', () => {
+describe('getOrCreateFacetsSelectors', () => {
   it('should build facets request from state', () => {
     const selectors = createFacetsSelectors('myFacets');
     const state = {
@@ -194,9 +188,7 @@ describe('createFacetsSelectors', () => {
     const state = {};
     expect(selectors.buildFacetsRequest(state)).toEqual([]);
   });
-});
 
-describe('getOrCreateFacetsSelectors', () => {
   it('should return the same instance for the same interfaceId', () => {
     const a = getOrCreateFacetsSelectors('cached-facet-sel');
     const b = getOrCreateFacetsSelectors('cached-facet-sel');

--- a/packages/thermidor/src/core/internal/facets/facets-slice.test.ts
+++ b/packages/thermidor/src/core/internal/facets/facets-slice.test.ts
@@ -5,10 +5,7 @@
 import {describe, it, expect} from 'vitest';
 import {getOrCreateFacetsSlice, initialFacetsState} from './facets-slice.js';
 import {getOrCreateFacetsActions} from './facets-actions.js';
-import {
-  createFacetsSelectors,
-  getOrCreateFacetsSelectors,
-} from './facets-selectors.js';
+import {getOrCreateFacetsSelectors} from './facets-selectors.js';
 import type {FacetsState} from '@/src/core/interface/facets/facets-types.js';
 import type {CoveoFacetResponse} from '@/src/core/interface/api/search/search-types.js';
 
@@ -152,7 +149,7 @@ describe('getOrCreateFacetsSlice', () => {
 
 describe('getOrCreateFacetsSelectors', () => {
   it('should build facets request from state', () => {
-    const selectors = createFacetsSelectors('myFacets');
+    const selectors = getOrCreateFacetsSelectors('myFacets');
     const state = {
       'myFacets/facets': {
         category: {
@@ -178,13 +175,13 @@ describe('getOrCreateFacetsSelectors', () => {
   });
 
   it('should return empty array when no facets exist', () => {
-    const selectors = createFacetsSelectors('emptyFacets');
+    const selectors = getOrCreateFacetsSelectors('emptyFacets');
     const state = {'emptyFacets/facets': {} as FacetsState};
     expect(selectors.buildFacetsRequest(state)).toEqual([]);
   });
 
   it('should return initial state when slice is not present', () => {
-    const selectors = createFacetsSelectors('missing');
+    const selectors = getOrCreateFacetsSelectors('missing');
     const state = {};
     expect(selectors.buildFacetsRequest(state)).toEqual([]);
   });

--- a/packages/thermidor/src/core/internal/facets/facets-slice.ts
+++ b/packages/thermidor/src/core/internal/facets/facets-slice.ts
@@ -5,7 +5,7 @@ import {getOrCreateHydrateFromSnapshotAction} from '@/src/core/interface/generat
 
 export const initialFacetsState: FacetsState = {};
 
-export function createFacetsSlice(interfaceId: string) {
+function createFacetsSlice(interfaceId: string) {
   const actions = getOrCreateFacetsActions(interfaceId);
   const hydrateAction = getOrCreateHydrateFromSnapshotAction(interfaceId);
 

--- a/packages/thermidor/src/core/internal/generative/generative-actions.ts
+++ b/packages/thermidor/src/core/internal/generative/generative-actions.ts
@@ -5,7 +5,7 @@ import type {
   TurnStatus,
 } from '@/src/core/interface/generative/generative-types.js';
 
-export function createGenerativeActions(interfaceId: string) {
+function createGenerativeActions(interfaceId: string) {
   const prefix = `${interfaceId}/generative`;
   return {
     createTurn: createAction<{id: string; prompt: string; status: TurnStatus}>(

--- a/packages/thermidor/src/core/internal/generative/generative-selectors.ts
+++ b/packages/thermidor/src/core/internal/generative/generative-selectors.ts
@@ -3,7 +3,7 @@ import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
 import {initialGenerativeState} from './generative-slice.js';
 import type {Turn} from '@/src/core/interface/generative/generative-types.js';
 
-export function createGenerativeSelectors(interfaceId: string) {
+function createGenerativeSelectors(interfaceId: string) {
   const sliceSelector = createSelectSlice(
     interfaceId,
     'generative',

--- a/packages/thermidor/src/core/internal/generative/generative-slice.ts
+++ b/packages/thermidor/src/core/internal/generative/generative-slice.ts
@@ -7,7 +7,7 @@ export const initialGenerativeState: GenerativeState = {
   activeTurnId: undefined,
 };
 
-export function createGenerativeSlice(interfaceId: string) {
+function createGenerativeSlice(interfaceId: string) {
   const actions = getOrCreateGenerativeActions(interfaceId);
 
   return createSlice({

--- a/packages/thermidor/src/core/internal/pagination/pagination-actions.ts
+++ b/packages/thermidor/src/core/internal/pagination/pagination-actions.ts
@@ -1,6 +1,6 @@
 import {createAction} from '@reduxjs/toolkit';
 
-export function createPaginationActions(interfaceId: string) {
+function createPaginationActions(interfaceId: string) {
   return {
     setFirstResult: createAction<number>(
       `${interfaceId}/pagination/setFirstResult`

--- a/packages/thermidor/src/core/internal/pagination/pagination-selectors.ts
+++ b/packages/thermidor/src/core/internal/pagination/pagination-selectors.ts
@@ -2,7 +2,7 @@ import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-s
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
 import {initialPaginationState} from './pagination-slice.js';
 
-export function createPaginationSelectors(interfaceId: string) {
+function createPaginationSelectors(interfaceId: string) {
   const sliceSelector = createSelectSlice(
     interfaceId,
     'pagination',

--- a/packages/thermidor/src/core/internal/pagination/pagination-slice.test.ts
+++ b/packages/thermidor/src/core/internal/pagination/pagination-slice.test.ts
@@ -4,10 +4,7 @@ import {
   initialPaginationState,
 } from './pagination-slice.js';
 import {getOrCreatePaginationActions} from './pagination-actions.js';
-import {
-  createPaginationSelectors,
-  getOrCreatePaginationSelectors,
-} from './pagination-selectors.js';
+import {getOrCreatePaginationSelectors} from './pagination-selectors.js';
 
 describe('getOrCreatePaginationActions', () => {
   it('should return the same instance for the same interface ID', () => {
@@ -121,7 +118,7 @@ describe('getOrCreatePaginationSlice', () => {
 
 describe('getOrCreatePaginationSelectors', () => {
   it('should read firstResult from scoped state', () => {
-    const selectors = createPaginationSelectors('sel-test');
+    const selectors = getOrCreatePaginationSelectors('sel-test');
     const state = {
       'sel-test/pagination': {firstResult: 30, pageSize: 10, totalCount: 100},
     };
@@ -130,7 +127,7 @@ describe('getOrCreatePaginationSelectors', () => {
   });
 
   it('should read pageSize from scoped state', () => {
-    const selectors = createPaginationSelectors('sel-test-2');
+    const selectors = getOrCreatePaginationSelectors('sel-test-2');
     const state = {
       'sel-test-2/pagination': {firstResult: 0, pageSize: 25, totalCount: 50},
     };
@@ -139,7 +136,7 @@ describe('getOrCreatePaginationSelectors', () => {
   });
 
   it('should read totalCount from scoped state', () => {
-    const selectors = createPaginationSelectors('sel-test-3');
+    const selectors = getOrCreatePaginationSelectors('sel-test-3');
     const state = {
       'sel-test-3/pagination': {firstResult: 0, pageSize: 10, totalCount: 200},
     };
@@ -148,7 +145,7 @@ describe('getOrCreatePaginationSelectors', () => {
   });
 
   it('should fall back to initial state when slice is not present', () => {
-    const selectors = createPaginationSelectors('missing-slice');
+    const selectors = getOrCreatePaginationSelectors('missing-slice');
     const state = {};
 
     expect(selectors.getFirstResult(state)).toBe(0);

--- a/packages/thermidor/src/core/internal/pagination/pagination-slice.test.ts
+++ b/packages/thermidor/src/core/internal/pagination/pagination-slice.test.ts
@@ -4,35 +4,11 @@ import {
   getOrCreatePaginationSlice,
   initialPaginationState,
 } from './pagination-slice.js';
-import {
-  createPaginationActions,
-  getOrCreatePaginationActions,
-} from './pagination-actions.js';
+import {getOrCreatePaginationActions} from './pagination-actions.js';
 import {
   createPaginationSelectors,
   getOrCreatePaginationSelectors,
 } from './pagination-selectors.js';
-
-describe('createPaginationActions', () => {
-  it('should create actions scoped to the interface ID', () => {
-    const actions = createPaginationActions('search-1');
-
-    expect(actions.setFirstResult.type).toBe(
-      'search-1/pagination/setFirstResult'
-    );
-    expect(actions.setPageSize.type).toBe('search-1/pagination/setPageSize');
-    expect(actions.setTotalCount.type).toBe(
-      'search-1/pagination/setTotalCount'
-    );
-  });
-
-  it('should create distinct actions for different interface IDs', () => {
-    const actionsA = createPaginationActions('interface-a');
-    const actionsB = createPaginationActions('interface-b');
-
-    expect(actionsA.setFirstResult.type).not.toBe(actionsB.setFirstResult.type);
-  });
-});
 
 describe('getOrCreatePaginationActions', () => {
   it('should return the same instance for the same interface ID', () => {

--- a/packages/thermidor/src/core/internal/pagination/pagination-slice.test.ts
+++ b/packages/thermidor/src/core/internal/pagination/pagination-slice.test.ts
@@ -1,6 +1,5 @@
 import {describe, it, expect} from 'vitest';
 import {
-  createPaginationSlice,
   getOrCreatePaginationSlice,
   initialPaginationState,
 } from './pagination-slice.js';
@@ -26,7 +25,7 @@ describe('getOrCreatePaginationActions', () => {
   });
 });
 
-describe('createPaginationSlice', () => {
+describe('getOrCreatePaginationSlice', () => {
   it('should have the correct initial state', () => {
     expect(initialPaginationState).toEqual({
       firstResult: 0,
@@ -36,13 +35,13 @@ describe('createPaginationSlice', () => {
   });
 
   it('should create a slice with scoped name', () => {
-    const slice = createPaginationSlice('search-1');
+    const slice = getOrCreatePaginationSlice('search-1');
 
     expect(slice.name).toBe('search-1/pagination');
   });
 
   it('should handle setFirstResult', () => {
-    const slice = createPaginationSlice('test-1');
+    const slice = getOrCreatePaginationSlice('test-1');
     const actions = getOrCreatePaginationActions('test-1');
 
     const state = slice.reducer(
@@ -56,7 +55,7 @@ describe('createPaginationSlice', () => {
   });
 
   it('should handle setPageSize', () => {
-    const slice = createPaginationSlice('test-2');
+    const slice = getOrCreatePaginationSlice('test-2');
     const actions = getOrCreatePaginationActions('test-2');
 
     const state = slice.reducer(
@@ -70,7 +69,7 @@ describe('createPaginationSlice', () => {
   });
 
   it('should handle setTotalCount', () => {
-    const slice = createPaginationSlice('test-3');
+    const slice = getOrCreatePaginationSlice('test-3');
     const actions = getOrCreatePaginationActions('test-3');
 
     const state = slice.reducer(
@@ -84,7 +83,7 @@ describe('createPaginationSlice', () => {
   });
 
   it('should not respond to actions from a different interface', () => {
-    const slice = createPaginationSlice('iface-x');
+    const slice = getOrCreatePaginationSlice('iface-x');
     const otherActions = getOrCreatePaginationActions('iface-y');
 
     const state = slice.reducer(
@@ -96,7 +95,7 @@ describe('createPaginationSlice', () => {
   });
 
   it('should maintain state immutability', () => {
-    const slice = createPaginationSlice('immut-test');
+    const slice = getOrCreatePaginationSlice('immut-test');
     const actions = getOrCreatePaginationActions('immut-test');
     const original = {...initialPaginationState};
 
@@ -104,9 +103,7 @@ describe('createPaginationSlice', () => {
 
     expect(original.firstResult).toBe(0);
   });
-});
 
-describe('getOrCreatePaginationSlice', () => {
   it('should return the same slice instance for the same interface ID', () => {
     const a = getOrCreatePaginationSlice('cached-slice-test');
     const b = getOrCreatePaginationSlice('cached-slice-test');
@@ -122,7 +119,7 @@ describe('getOrCreatePaginationSlice', () => {
   });
 });
 
-describe('createPaginationSelectors', () => {
+describe('getOrCreatePaginationSelectors', () => {
   it('should read firstResult from scoped state', () => {
     const selectors = createPaginationSelectors('sel-test');
     const state = {
@@ -158,9 +155,7 @@ describe('createPaginationSelectors', () => {
     expect(selectors.getPageSize(state)).toBe(10);
     expect(selectors.getTotalCount(state)).toBe(0);
   });
-});
 
-describe('getOrCreatePaginationSelectors', () => {
   it('should return the same instance for the same interface ID', () => {
     const a = getOrCreatePaginationSelectors('cached-sel-test');
     const b = getOrCreatePaginationSelectors('cached-sel-test');

--- a/packages/thermidor/src/core/internal/pagination/pagination-slice.ts
+++ b/packages/thermidor/src/core/internal/pagination/pagination-slice.ts
@@ -14,7 +14,7 @@ export const initialPaginationState: PaginationState = {
   totalCount: 0,
 };
 
-export function createPaginationSlice(interfaceId: string) {
+function createPaginationSlice(interfaceId: string) {
   const actions = getOrCreatePaginationActions(interfaceId);
   const hydrateAction = getOrCreateHydrateFromSnapshotAction(interfaceId);
 

--- a/packages/thermidor/src/core/internal/product-list/product-list-actions.ts
+++ b/packages/thermidor/src/core/internal/product-list/product-list-actions.ts
@@ -1,6 +1,6 @@
 import {createAction} from '@reduxjs/toolkit';
 
-export function createProductListActions(interfaceId: string) {
+function createProductListActions(interfaceId: string) {
   return {
     setProductsFromResponse: createAction<unknown[]>(
       `${interfaceId}/products/setProductsFromResponse`

--- a/packages/thermidor/src/core/internal/product-list/product-list-selectors.ts
+++ b/packages/thermidor/src/core/internal/product-list/product-list-selectors.ts
@@ -3,7 +3,7 @@ import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
 import {initialProductListState} from './product-list-slice.js';
 import type {Product} from '@/src/core/interface/product-list/product-list-types.js';
 
-export function createProductListSelectors(interfaceId: string) {
+function createProductListSelectors(interfaceId: string) {
   const sliceSelector = createSelectSlice(
     interfaceId,
     'products',

--- a/packages/thermidor/src/core/internal/product-list/product-list-slice.ts
+++ b/packages/thermidor/src/core/internal/product-list/product-list-slice.ts
@@ -41,7 +41,7 @@ function mapProduct(raw: Record<string, unknown>): Product {
   };
 }
 
-export function createProductListSlice(interfaceId: string) {
+function createProductListSlice(interfaceId: string) {
   const actions = getOrCreateProductListActions(interfaceId);
   const hydrateAction = getOrCreateHydrateFromSnapshotAction(interfaceId);
 

--- a/packages/thermidor/src/core/internal/query-correction/query-correction-actions.ts
+++ b/packages/thermidor/src/core/internal/query-correction/query-correction-actions.ts
@@ -5,7 +5,7 @@ export interface QueryCorrection {
   originalQuery: string;
 }
 
-export function createQueryCorrectionActions(interfaceId: string) {
+function createQueryCorrectionActions(interfaceId: string) {
   return {
     setQueryCorrection: createAction<QueryCorrection | null>(
       `${interfaceId}/queryCorrection/setQueryCorrection`

--- a/packages/thermidor/src/core/internal/query-correction/query-correction-slice.ts
+++ b/packages/thermidor/src/core/internal/query-correction/query-correction-slice.ts
@@ -10,7 +10,7 @@ export const initialQueryCorrectionState: QueryCorrectionState = {
   correction: null,
 };
 
-export function createQueryCorrectionSlice(interfaceId: string) {
+function createQueryCorrectionSlice(interfaceId: string) {
   const actions = getOrCreateQueryCorrectionActions(interfaceId);
 
   return createSlice({

--- a/packages/thermidor/src/core/internal/result-list/result-list-actions.ts
+++ b/packages/thermidor/src/core/internal/result-list/result-list-actions.ts
@@ -1,7 +1,7 @@
 import {createAction} from '@reduxjs/toolkit';
 import type {CoveoSearchResult} from '@/src/core/interface/api/search/search-types.js';
 
-export function createResultsActions(interfaceId: string) {
+function createResultsActions(interfaceId: string) {
   return {
     setResultsFromResponse: createAction<CoveoSearchResult[]>(
       `${interfaceId}/results/setResultsFromResponse`

--- a/packages/thermidor/src/core/internal/result-list/result-list-selectors.ts
+++ b/packages/thermidor/src/core/internal/result-list/result-list-selectors.ts
@@ -2,7 +2,7 @@ import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-s
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
 import {initialResultListState} from './result-list-slice.js';
 
-export function createResultsSelectors(interfaceId: string) {
+function createResultsSelectors(interfaceId: string) {
   const sliceSelector = createSelectSlice(
     interfaceId,
     'results',

--- a/packages/thermidor/src/core/internal/result-list/result-list-slice.test.ts
+++ b/packages/thermidor/src/core/internal/result-list/result-list-slice.test.ts
@@ -4,10 +4,7 @@ import {
   getOrCreateResultsSlice,
   initialResultListState,
 } from './result-list-slice.js';
-import {
-  createResultsActions,
-  getOrCreateResultsActions,
-} from './result-list-actions.js';
+import {getOrCreateResultsActions} from './result-list-actions.js';
 import {
   createResultsSelectors,
   getOrCreateResultsSelectors,
@@ -33,25 +30,6 @@ describe('initialResultListState', () => {
     expect(initialResultListState).toEqual({
       results: [],
     });
-  });
-});
-
-describe('createResultsActions', () => {
-  it('should create actions scoped to the given interfaceId', () => {
-    const actions = createResultsActions('search-1');
-
-    expect(actions.setResultsFromResponse.type).toBe(
-      'search-1/results/setResultsFromResponse'
-    );
-  });
-
-  it('should create independent actions for different interfaceIds', () => {
-    const actions1 = createResultsActions('interface-a');
-    const actions2 = createResultsActions('interface-b');
-
-    expect(actions1.setResultsFromResponse.type).not.toBe(
-      actions2.setResultsFromResponse.type
-    );
   });
 });
 

--- a/packages/thermidor/src/core/internal/result-list/result-list-slice.test.ts
+++ b/packages/thermidor/src/core/internal/result-list/result-list-slice.test.ts
@@ -1,6 +1,5 @@
 import {describe, it, expect} from 'vitest';
 import {
-  createResultsSlice,
   getOrCreateResultsSlice,
   initialResultListState,
 } from './result-list-slice.js';
@@ -49,15 +48,15 @@ describe('getOrCreateResultsActions', () => {
   });
 });
 
-describe('createResultsSlice', () => {
+describe('getOrCreateResultsSlice', () => {
   it('should create a slice scoped to the interfaceId', () => {
-    const slice = createResultsSlice('my-interface');
+    const slice = getOrCreateResultsSlice('my-interface');
 
     expect(slice.name).toBe('my-interface/results');
   });
 
   it('should handle setResultsFromResponse action', () => {
-    const slice = createResultsSlice('test');
+    const slice = getOrCreateResultsSlice('test');
     const actions = getOrCreateResultsActions('test');
 
     const coveoResults: CoveoSearchResult[] = [
@@ -78,7 +77,7 @@ describe('createResultsSlice', () => {
   });
 
   it('should map CoveoSearchResult fields correctly', () => {
-    const slice = createResultsSlice('map-test');
+    const slice = getOrCreateResultsSlice('map-test');
     const actions = getOrCreateResultsActions('map-test');
 
     const coveoResult = mockCoveoResult({
@@ -110,7 +109,7 @@ describe('createResultsSlice', () => {
   });
 
   it('should replace previous results completely', () => {
-    const slice = createResultsSlice('replace-test');
+    const slice = getOrCreateResultsSlice('replace-test');
     const actions = getOrCreateResultsActions('replace-test');
 
     const oldState = {
@@ -140,7 +139,7 @@ describe('createResultsSlice', () => {
   });
 
   it('should not respond to actions from a different interfaceId', () => {
-    const slice = createResultsSlice('slice-a');
+    const slice = getOrCreateResultsSlice('slice-a');
     const actionsB = getOrCreateResultsActions('slice-b');
 
     const state = slice.reducer(
@@ -150,9 +149,7 @@ describe('createResultsSlice', () => {
 
     expect(state.results).toEqual([]);
   });
-});
 
-describe('getOrCreateResultsSlice', () => {
   it('should return the same reference for the same interfaceId', () => {
     const first = getOrCreateResultsSlice('cached-slice');
     const second = getOrCreateResultsSlice('cached-slice');

--- a/packages/thermidor/src/core/internal/result-list/result-list-slice.test.ts
+++ b/packages/thermidor/src/core/internal/result-list/result-list-slice.test.ts
@@ -4,10 +4,7 @@ import {
   initialResultListState,
 } from './result-list-slice.js';
 import {getOrCreateResultsActions} from './result-list-actions.js';
-import {
-  createResultsSelectors,
-  getOrCreateResultsSelectors,
-} from './result-list-selectors.js';
+import {getOrCreateResultsSelectors} from './result-list-selectors.js';
 import type {CoveoSearchResult} from '@/src/core/interface/api/search/search-types.js';
 
 const mockCoveoResult = (
@@ -165,9 +162,9 @@ describe('getOrCreateResultsSlice', () => {
   });
 });
 
-describe('createResultsSelectors', () => {
+describe('getOrCreateResultsSelectors', () => {
   it('should return initial results when slice is not in state', () => {
-    const selectors = createResultsSelectors('sel-test');
+    const selectors = getOrCreateResultsSelectors('sel-test');
     const state = {};
 
     const results = selectors.getResults(state);
@@ -176,7 +173,7 @@ describe('createResultsSelectors', () => {
   });
 
   it('should return results from scoped state', () => {
-    const selectors = createResultsSelectors('sel-test-2');
+    const selectors = getOrCreateResultsSelectors('sel-test-2');
     const mockResults = [
       {
         uniqueId: '1',
@@ -195,9 +192,7 @@ describe('createResultsSelectors', () => {
 
     expect(results).toEqual(mockResults);
   });
-});
 
-describe('getOrCreateResultsSelectors', () => {
   it('should return the same reference for the same interfaceId', () => {
     const first = getOrCreateResultsSelectors('cached-sel');
     const second = getOrCreateResultsSelectors('cached-sel');

--- a/packages/thermidor/src/core/internal/result-list/result-list-slice.ts
+++ b/packages/thermidor/src/core/internal/result-list/result-list-slice.ts
@@ -20,7 +20,7 @@ function mapResult(result: Record<string, unknown>) {
   };
 }
 
-export function createResultsSlice(interfaceId: string) {
+function createResultsSlice(interfaceId: string) {
   const actions = getOrCreateResultsActions(interfaceId);
   const hydrateAction = getOrCreateHydrateFromSnapshotAction(interfaceId);
 

--- a/packages/thermidor/src/core/internal/search-box/search-box-actions.ts
+++ b/packages/thermidor/src/core/internal/search-box/search-box-actions.ts
@@ -1,6 +1,6 @@
 import {createAction} from '@reduxjs/toolkit';
 
-export function createSearchBoxActions(interfaceId: string) {
+function createSearchBoxActions(interfaceId: string) {
   return {
     setQuery: createAction<string>(`${interfaceId}/searchBox/setQuery`),
   };

--- a/packages/thermidor/src/core/internal/search-box/search-box-selectors.ts
+++ b/packages/thermidor/src/core/internal/search-box/search-box-selectors.ts
@@ -2,7 +2,7 @@ import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-s
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
 import {initialSearchBoxState} from './search-box-slice.js';
 
-export function createSearchBoxSelectors(interfaceId: string) {
+function createSearchBoxSelectors(interfaceId: string) {
   const sliceSelector = createSelectSlice(
     interfaceId,
     'searchBox',

--- a/packages/thermidor/src/core/internal/search-box/search-box-slice.test.ts
+++ b/packages/thermidor/src/core/internal/search-box/search-box-slice.test.ts
@@ -8,27 +8,11 @@ import {
   getOrCreateSearchBoxSlice,
   initialSearchBoxState,
 } from './search-box-slice.js';
-import {
-  createSearchBoxActions,
-  getOrCreateSearchBoxActions,
-} from './search-box-actions.js';
+import {getOrCreateSearchBoxActions} from './search-box-actions.js';
 import {
   createSearchBoxSelectors,
   getOrCreateSearchBoxSelectors,
 } from './search-box-selectors.js';
-
-describe('createSearchBoxActions', () => {
-  it('should create actions scoped to the interfaceId', () => {
-    const actions = createSearchBoxActions('search');
-    expect(actions.setQuery.type).toBe('search/searchBox/setQuery');
-  });
-
-  it('should create different actions for different interfaceIds', () => {
-    const actionsA = createSearchBoxActions('interfaceA');
-    const actionsB = createSearchBoxActions('interfaceB');
-    expect(actionsA.setQuery.type).not.toBe(actionsB.setQuery.type);
-  });
-});
 
 describe('getOrCreateSearchBoxActions', () => {
   it('should return the same instance for the same interfaceId', () => {

--- a/packages/thermidor/src/core/internal/search-box/search-box-slice.test.ts
+++ b/packages/thermidor/src/core/internal/search-box/search-box-slice.test.ts
@@ -4,7 +4,6 @@
 
 import {describe, it, expect} from 'vitest';
 import {
-  createSearchBoxSlice,
   getOrCreateSearchBoxSlice,
   initialSearchBoxState,
 } from './search-box-slice.js';
@@ -28,19 +27,19 @@ describe('getOrCreateSearchBoxActions', () => {
   });
 });
 
-describe('createSearchBoxSlice', () => {
+describe('getOrCreateSearchBoxSlice', () => {
   it('should have correct initial state', () => {
     expect(initialSearchBoxState).toEqual({query: ''});
   });
 
   it('should create a slice with scoped name', () => {
-    const slice = createSearchBoxSlice('myInterface');
+    const slice = getOrCreateSearchBoxSlice('myInterface');
     expect(slice.name).toBe('myInterface/searchBox');
   });
 
   it('should update query via scoped setQuery action', () => {
     const actions = getOrCreateSearchBoxActions('test');
-    const slice = createSearchBoxSlice('test');
+    const slice = getOrCreateSearchBoxSlice('test');
 
     const state = slice.reducer(
       initialSearchBoxState,
@@ -51,7 +50,7 @@ describe('createSearchBoxSlice', () => {
 
   it('should accept empty string', () => {
     const actions = getOrCreateSearchBoxActions('test2');
-    const slice = createSearchBoxSlice('test2');
+    const slice = getOrCreateSearchBoxSlice('test2');
 
     const state = slice.reducer({query: 'existing'}, actions.setQuery(''));
     expect(state.query).toBe('');
@@ -59,15 +58,13 @@ describe('createSearchBoxSlice', () => {
 
   it('should maintain state immutability', () => {
     const actions = getOrCreateSearchBoxActions('test3');
-    const slice = createSearchBoxSlice('test3');
+    const slice = getOrCreateSearchBoxSlice('test3');
 
     const original = {...initialSearchBoxState};
     slice.reducer(original, actions.setQuery('test'));
     expect(original.query).toBe('');
   });
-});
 
-describe('getOrCreateSearchBoxSlice', () => {
   it('should return the same instance for the same interfaceId', () => {
     const a = getOrCreateSearchBoxSlice('cached-slice');
     const b = getOrCreateSearchBoxSlice('cached-slice');

--- a/packages/thermidor/src/core/internal/search-box/search-box-slice.test.ts
+++ b/packages/thermidor/src/core/internal/search-box/search-box-slice.test.ts
@@ -8,10 +8,7 @@ import {
   initialSearchBoxState,
 } from './search-box-slice.js';
 import {getOrCreateSearchBoxActions} from './search-box-actions.js';
-import {
-  createSearchBoxSelectors,
-  getOrCreateSearchBoxSelectors,
-} from './search-box-selectors.js';
+import {getOrCreateSearchBoxSelectors} from './search-box-selectors.js';
 
 describe('getOrCreateSearchBoxActions', () => {
   it('should return the same instance for the same interfaceId', () => {
@@ -78,21 +75,19 @@ describe('getOrCreateSearchBoxSlice', () => {
   });
 });
 
-describe('createSearchBoxSelectors', () => {
+describe('getOrCreateSearchBoxSelectors', () => {
   it('should return getQuery selector scoped to the interfaceId', () => {
-    const selectors = createSearchBoxSelectors('mySearch');
+    const selectors = getOrCreateSearchBoxSelectors('mySearch');
     const state = {'mySearch/searchBox': {query: 'hello'}};
     expect(selectors.getQuery(state)).toBe('hello');
   });
 
   it('should return initial state when slice is not present', () => {
-    const selectors = createSearchBoxSelectors('missing');
+    const selectors = getOrCreateSearchBoxSelectors('missing');
     const state = {};
     expect(selectors.getQuery(state)).toBe('');
   });
-});
 
-describe('getOrCreateSearchBoxSelectors', () => {
   it('should return the same instance for the same interfaceId', () => {
     const a = getOrCreateSearchBoxSelectors('cached-sel');
     const b = getOrCreateSearchBoxSelectors('cached-sel');

--- a/packages/thermidor/src/core/internal/search-box/search-box-slice.ts
+++ b/packages/thermidor/src/core/internal/search-box/search-box-slice.ts
@@ -9,7 +9,7 @@ export const initialSearchBoxState: SearchBoxState = {
   query: '',
 };
 
-export function createSearchBoxSlice(interfaceId: string) {
+function createSearchBoxSlice(interfaceId: string) {
   const actions = getOrCreateSearchBoxActions(interfaceId);
   return createSlice({
     name: `${interfaceId}/searchBox`,

--- a/packages/thermidor/src/core/internal/search-parameters/search-parameters-actions.ts
+++ b/packages/thermidor/src/core/internal/search-parameters/search-parameters-actions.ts
@@ -1,6 +1,6 @@
 import {createAction} from '@reduxjs/toolkit';
 
-export function createSearchParametersActions(interfaceId: string) {
+function createSearchParametersActions(interfaceId: string) {
   return {
     setPipeline: createAction<string>(
       `${interfaceId}/searchParameters/setPipeline`

--- a/packages/thermidor/src/core/internal/search-parameters/search-parameters-selectors.ts
+++ b/packages/thermidor/src/core/internal/search-parameters/search-parameters-selectors.ts
@@ -2,7 +2,7 @@ import {createMemoizedStateSelector} from '@/src/core/interface/utils/memoized-s
 import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
 import {initialSearchParametersState} from './search-parameters-slice.js';
 
-export function createSearchParametersSelectors(interfaceId: string) {
+function createSearchParametersSelectors(interfaceId: string) {
   const sliceSelector = createSelectSlice(
     interfaceId,
     'searchParameters',

--- a/packages/thermidor/src/core/internal/search-parameters/search-parameters-slice.ts
+++ b/packages/thermidor/src/core/internal/search-parameters/search-parameters-slice.ts
@@ -11,7 +11,7 @@ export const initialSearchParametersState: SearchParametersState = {
   cq: '',
 };
 
-export function createSearchParametersSlice(interfaceId: string) {
+function createSearchParametersSlice(interfaceId: string) {
   const actions = getOrCreateSearchParametersActions(interfaceId);
   return createSlice({
     name: `${interfaceId}/searchParameters`,

--- a/packages/thermidor/src/core/internal/sort/sort-actions.ts
+++ b/packages/thermidor/src/core/internal/sort/sort-actions.ts
@@ -1,7 +1,7 @@
 import {createAction} from '@reduxjs/toolkit';
 import type {CommerceSearchSort} from '@/src/api/interface/commerce-search-endpoint/commerce-search-endpoint-types.js';
 
-export function createSortActions(interfaceId: string) {
+function createSortActions(interfaceId: string) {
   return {
     updateFromResponse: createAction<CommerceSearchSort | undefined>(
       `${interfaceId}/sort/updateFromResponse`

--- a/packages/thermidor/src/core/internal/sort/sort-selectors.ts
+++ b/packages/thermidor/src/core/internal/sort/sort-selectors.ts
@@ -3,7 +3,7 @@ import {createSelectSlice} from '@/src/core/interface/utils/select-slice.js';
 import {initialSortState} from './sort-slice.js';
 import type {SortState} from './sort-slice.js';
 
-export function createSortSelectors(interfaceId: string) {
+function createSortSelectors(interfaceId: string) {
   const sliceSelector = createSelectSlice(
     interfaceId,
     'sort',

--- a/packages/thermidor/src/core/internal/sort/sort-slice.ts
+++ b/packages/thermidor/src/core/internal/sort/sort-slice.ts
@@ -12,7 +12,7 @@ export const initialSortState: SortState = {
   availableSorts: [],
 };
 
-export function createSortSlice(interfaceId: string) {
+function createSortSlice(interfaceId: string) {
   const actions = getOrCreateSortActions(interfaceId);
 
   return createSlice({

--- a/packages/thermidor/src/core/internal/triggers/triggers-actions.ts
+++ b/packages/thermidor/src/core/internal/triggers/triggers-actions.ts
@@ -5,7 +5,7 @@ export interface Trigger {
   content: string;
 }
 
-export function createTriggersActions(interfaceId: string) {
+function createTriggersActions(interfaceId: string) {
   return {
     setTriggers: createAction<Trigger[]>(`${interfaceId}/triggers/setTriggers`),
   };

--- a/packages/thermidor/src/core/internal/triggers/triggers-slice.ts
+++ b/packages/thermidor/src/core/internal/triggers/triggers-slice.ts
@@ -7,7 +7,7 @@ export interface TriggersState {
 
 export const initialTriggersState: TriggersState = {triggers: []};
 
-export function createTriggersSlice(interfaceId: string) {
+function createTriggersSlice(interfaceId: string) {
   const actions = getOrCreateTriggersActions(interfaceId);
   return createSlice({
     name: `${interfaceId}/triggers`,


### PR DESCRIPTION
The raw `createXxxActions`, `createXxxSelectors`, and `createXxxSlice` factory functions in packages/thermidor/src/core/internal/ were exported but only consumed within their own files as arguments to SingletonFactory(). The memoized getOrCreateXxx wrappers are the intended public API.

Changes:

- Removed export from 30 internal factory functions (11 actions, 11 slices, 8 selectors)
- Removed 3 re-exports (`createCartSelectors`, `createResultsSelectors`, `createSearchBoxSelectors`) from the interface layer since they had no downstream consumers
- Updated test files to use `getOrCreateXxx` equivalents and merged duplicate describe blocks
- Aligned describe labels with the actual exported function names

Non changes:

- No behaviour changes
- All 342 tests pass unchanged (except the labels/functions).