### PR TITLE
fix(atomic-cdn-smoke): correct commit CDN base URL for smoke tests

### DIFF
--- a/packages/atomic-cdn-smoke/fixtures.ts
+++ b/packages/atomic-cdn-smoke/fixtures.ts
@@ -9,8 +9,11 @@ import {
 import type {HttpHandler} from 'msw';
 
 const COMMIT_SHA = process.env.COMMIT_SHA;
+// Commit builds are published under `atomic/commits/<sha>` (no version segment),
+// while the rolling release lives under `atomic/v3`. The previous commit URL
+// (`atomic/commit/<sha>/v3`) returned 403, causing addStyleTag/addScriptTag to fail.
 const BASE_URL = COMMIT_SHA
-  ? `https://static.cloud.coveo.com/atomic/commit/${COMMIT_SHA}/v3`
+  ? `https://static.cloud.coveo.com/atomic/commits/${COMMIT_SHA}`
   : 'https://static.cloud.coveo.com/atomic/v3';
 const ATOMIC_URL = `${BASE_URL}/atomic.esm.js`;
 const THEME_URL = `${BASE_URL}/themes/coveo.css`;

--- a/packages/atomic-cdn-smoke/fixtures.ts
+++ b/packages/atomic-cdn-smoke/fixtures.ts
@@ -9,9 +9,6 @@ import {
 import type {HttpHandler} from 'msw';
 
 const COMMIT_SHA = process.env.COMMIT_SHA;
-// Commit builds are published under `atomic/commits/<sha>` (no version segment),
-// while the rolling release lives under `atomic/v3`. The previous commit URL
-// (`atomic/commit/<sha>/v3`) returned 403, causing addStyleTag/addScriptTag to fail.
 const BASE_URL = COMMIT_SHA
   ? `https://static.cloud.coveo.com/atomic/commits/${COMMIT_SHA}`
   : 'https://static.cloud.coveo.com/atomic/v3';


### PR DESCRIPTION
## Problem
The Chromatic CDN smoke test (`@coveo/atomic-cdn-smoke`) fails for every release in `ui-kit-cd`'s `update-cdn-pointers` workflow. All four specs (commerce, insight, ipx, search) fail at `fixtures.ts:52` with a bare `Error: page.addStyleTag: Event`, and the Chromatic upload step is skipped as a result.

Root cause: when `COMMIT_SHA` is set, `fixtures.ts` builds the CDN base URL as:

```
https://static.cloud.coveo.com/atomic/commit/<sha>/v3
```

But commit builds are actually published under:

```
https://static.cloud.coveo.com/atomic/commits/<sha>
```

Two mistakes: `commit` (singular) instead of `commits`, and an extra `/v3` segment that does not exist for commit paths. The requests returned **403**, so the injected `<link>`/`<script>` fired `onerror` and Playwright threw `Event`.

Verified with the failing release commit `3d7ffe2`:
- `atomic/commit/<sha>/v3/atomic.esm.js` → **403** (old)
- `atomic/commits/<sha>/atomic.esm.js` → **200** (fixed)

## Solution
Point the commit branch of `BASE_URL` at `atomic/commits/<sha>` (no `/v3`). The rolling-release path (`atomic/v3`) is unchanged.

Verified locally with `COMMIT_SHA=3d7ffe296f2faeaa6c7f616320b8fefdb5c45e1d pnpm --filter @coveo/atomic-cdn-smoke cdn-smoke` — all 4 specs load the assets, render, and pass the screenshot comparison.