### PR TITLE
fix(atomic): respect tabs visibility for generated answer

### DIFF
--- a/.changeset/genqa-respect-tabs-options.md
+++ b/.changeset/genqa-respect-tabs-options.md
@@ -1,0 +1,6 @@
+---
+"@coveo/headless": patch
+"@coveo/atomic": patch
+---
+
+Fix `atomic-generated-answer` not respecting `tabs-included`/`tabs-excluded` when generating answers. The component no longer sends answer-generation queries when it is hidden on the current tab, including on the initial load. The Answer API and Agent API generation paths now honor the generated answer `isEnabled` state, and `buildGeneratedAnswer`'s `initialState.isEnabled` is now applied.

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts
@@ -983,6 +983,50 @@ describe('atomic-generated-answer', () => {
     });
   });
 
+  describe('initial enabled state based on the active tab', () => {
+    it('should initialize as enabled when the active tab is allowed', async () => {
+      await renderGeneratedAnswer({
+        props: {tabsIncluded: ['IncludedTab']},
+        tabManagerState: {activeTab: 'IncludedTab'},
+      });
+
+      expect(buildGeneratedAnswer).toHaveBeenCalledWith(
+        mockedEngine,
+        expect.objectContaining({
+          initialState: expect.objectContaining({isEnabled: true}),
+        })
+      );
+    });
+
+    it('should initialize as disabled when the active tab is excluded', async () => {
+      await renderGeneratedAnswer({
+        props: {tabsExcluded: ['ExcludedTab']},
+        tabManagerState: {activeTab: 'ExcludedTab'},
+      });
+
+      expect(buildGeneratedAnswer).toHaveBeenCalledWith(
+        mockedEngine,
+        expect.objectContaining({
+          initialState: expect.objectContaining({isEnabled: false}),
+        })
+      );
+    });
+
+    it('should initialize as disabled when the active tab is not in tabsIncluded', async () => {
+      await renderGeneratedAnswer({
+        props: {tabsIncluded: ['IncludedTab']},
+        tabManagerState: {activeTab: 'OtherTab'},
+      });
+
+      expect(buildGeneratedAnswer).toHaveBeenCalledWith(
+        mockedEngine,
+        expect.objectContaining({
+          initialState: expect.objectContaining({isEnabled: false}),
+        })
+      );
+    });
+  });
+
   describe('follow up capability', () => {
     it('should render a scrollable content container when agentId is provided', async () => {
       const {scrollableContainer} = await renderGeneratedAnswer({

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.spec.ts
@@ -984,6 +984,17 @@ describe('atomic-generated-answer', () => {
   });
 
   describe('initial enabled state based on the active tab', () => {
+    it('should initialize as enabled when no tabs configuration is provided', async () => {
+      await renderGeneratedAnswer();
+
+      expect(buildGeneratedAnswer).toHaveBeenCalledWith(
+        mockedEngine,
+        expect.objectContaining({
+          initialState: expect.objectContaining({isEnabled: true}),
+        })
+      );
+    });
+
     it('should initialize as enabled when the active tab is allowed', async () => {
       await renderGeneratedAnswer({
         props: {tabsIncluded: ['IncludedTab']},
@@ -1024,6 +1035,47 @@ describe('atomic-generated-answer', () => {
           initialState: expect.objectContaining({isEnabled: false}),
         })
       );
+    });
+  });
+
+  describe('reactivity to active tab changes', () => {
+    it('should disable the generated answer when switching to an excluded tab', async () => {
+      const {element} = await renderGeneratedAnswer({
+        props: {tabsExcluded: ['ExcludedTab']},
+        tabManagerState: {activeTab: 'All'},
+      });
+
+      element.tabManagerState = {activeTab: 'ExcludedTab'};
+      await element.updateComplete;
+
+      expect(mockedGeneratedAnswer.disable).toHaveBeenCalled();
+      expect(mockedGeneratedAnswer.enable).not.toHaveBeenCalled();
+    });
+
+    it('should enable the generated answer when switching back to an allowed tab', async () => {
+      const {element} = await renderGeneratedAnswer({
+        props: {tabsIncluded: ['IncludedTab']},
+        tabManagerState: {activeTab: 'OtherTab'},
+      });
+
+      element.tabManagerState = {activeTab: 'IncludedTab'};
+      await element.updateComplete;
+
+      expect(mockedGeneratedAnswer.enable).toHaveBeenCalled();
+      expect(mockedGeneratedAnswer.disable).not.toHaveBeenCalled();
+    });
+
+    it('should not toggle the enabled state when the active tab is unchanged', async () => {
+      const {element} = await renderGeneratedAnswer({
+        props: {tabsExcluded: ['ExcludedTab']},
+        tabManagerState: {activeTab: 'All'},
+      });
+
+      element.tabManagerState = {activeTab: 'All'};
+      await element.updateComplete;
+
+      expect(mockedGeneratedAnswer.enable).not.toHaveBeenCalled();
+      expect(mockedGeneratedAnswer.disable).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
@@ -323,9 +323,17 @@ export class AtomicGeneratedAnswer
       getBindings: () => this.bindings,
     });
 
+    this.searchStatus = buildSearchStatus(this.bindings.engine);
+    this.tabManager = buildTabManager(this.bindings.engine);
+
     this.generatedAnswer = buildGeneratedAnswer(this.bindings.engine, {
       initialState: {
         isVisible: this.controller.data.isVisible,
+        isEnabled: shouldDisplayOnCurrentTab(
+          this.tabsIncluded,
+          this.tabsExcluded,
+          this.tabManager.state.activeTab
+        ),
         responseFormat: {
           contentFormat: ['text/markdown', 'text/plain'],
         },
@@ -338,8 +346,6 @@ export class AtomicGeneratedAnswer
       }),
       fieldsToIncludeInCitations: this.getCitationFields(),
     });
-    this.searchStatus = buildSearchStatus(this.bindings.engine);
-    this.tabManager = buildTabManager(this.bindings.engine);
 
     this.controller.insertFeedbackModal();
 

--- a/packages/headless/src/app/listener-middleware/generate-answer-listener-middleware.test.ts
+++ b/packages/headless/src/app/listener-middleware/generate-answer-listener-middleware.test.ts
@@ -162,6 +162,48 @@ describe('generateAnswerListener', () => {
       });
     });
 
+    describe('when the generated answer is disabled', () => {
+      beforeEach(() => {
+        store = configureStore({
+          reducer: {
+            generatedAnswer: (
+              state = {
+                ...getGeneratedAnswerInitialState(),
+                isEnabled: false,
+              }
+            ) => state,
+            answerGenerationApi: () => ({}),
+            configuration: (state = {knowledge: {agentId: 'some-agent-id'}}) =>
+              state,
+            query: (state = {q: 'test'}) => state,
+          },
+          middleware: (getDefaultMiddleware) =>
+            getDefaultMiddleware().prepend(
+              createGenerateAnswerListener({
+                getNavigatorContext: buildMockNavigatorContextProvider(),
+                // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- unit test
+              }).middleware as Middleware<{}, any>
+            ),
+        });
+      });
+
+      it('should reset the head and follow-up answers but not run the answer agent', async () => {
+        const searchAction = executeSearch.pending('requestId', {
+          legacy: logInsightInterfaceLoad(),
+          next: interfaceLoad(),
+        });
+
+        store.dispatch(searchAction);
+
+        await vi.waitFor(() => {
+          expect(resetAnswer).toHaveBeenCalled();
+          expect(resetFollowUpAnswers).toHaveBeenCalled();
+          expect(answerRunnerAbortRun).toHaveBeenCalled();
+        });
+        expect(answerRunnerRun).not.toHaveBeenCalled();
+      });
+    });
+
     describe('when agentId is not set', () => {
       beforeEach(() => {
         store = configureStore({

--- a/packages/headless/src/app/listener-middleware/generate-answer-listener-middleware.ts
+++ b/packages/headless/src/app/listener-middleware/generate-answer-listener-middleware.ts
@@ -31,6 +31,10 @@ export const createGenerateAnswerListener = (extra: {
       listenerApi.dispatch(resetAnswer());
       listenerApi.dispatch(resetFollowUpAnswers());
 
+      if (state.generatedAnswer.isEnabled === false) {
+        return;
+      }
+
       const q = selectQuery(state)?.q;
       const queryIsEmpty = !q || q.trim() === '';
       if (queryIsEmpty) {

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.test.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.test.ts
@@ -381,6 +381,20 @@ describe('generated answer', () => {
         expect(updateResponseFormat).toHaveBeenCalledWith(responseFormat);
       });
     });
+
+    describe('when #isEnabled is set', () => {
+      it('should dispatch setIsEnabled action when set to true', () => {
+        initGeneratedAnswer({initialState: {isEnabled: true}});
+
+        expect(setIsEnabled).toHaveBeenCalledWith(true);
+      });
+
+      it('should dispatch setIsEnabled action when set to false', () => {
+        initGeneratedAnswer({initialState: {isEnabled: false}});
+
+        expect(setIsEnabled).toHaveBeenCalledWith(false);
+      });
+    });
   });
 
   describe('when passing fields to include in citations', () => {

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -237,6 +237,10 @@ export function buildCoreGeneratedAnswer(
   if (isVisible !== undefined) {
     dispatch(setIsVisible(isVisible));
   }
+  const isEnabled = props.initialState?.isEnabled;
+  if (isEnabled !== undefined) {
+    dispatch(setIsEnabled(isEnabled));
+  }
   const initialResponseFormat = props.initialState?.responseFormat;
   if (initialResponseFormat) {
     dispatch(updateResponseFormat(initialResponseFormat));

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
@@ -605,6 +605,32 @@ describe('knowledge-generated-answer', () => {
       });
     });
 
+    describe('when the generated answer is disabled', () => {
+      it('should reset the answer but not call generateAnswer', () => {
+        engine = buildEngineWithGeneratedAnswer({
+          generatedAnswer: {
+            ...getGeneratedAnswerInitialState(),
+            isEnabled: false,
+          },
+        });
+        createGeneratedAnswer();
+        const disabledListener = engine.subscribe.mock.calls[0][0];
+
+        mockSelectAnswerTriggerParams.mockReturnValue({
+          q: 'test query',
+          requestId: 'new-request',
+          cannotAnswer: false,
+          analyticsMode: 'legacy',
+          actionCause: 'searchboxSubmit',
+        });
+
+        disabledListener();
+
+        expect(mockResetAnswer).toHaveBeenCalledTimes(1);
+        expect(mockGenerateAnswer).not.toHaveBeenCalled();
+      });
+    });
+
     describe('user interaction scenarios', () => {
       describe('when the user clears their query', () => {
         it('should reset the answer and not generate a new one', () => {

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -114,6 +114,10 @@ const subscribeToSearchRequest = (
       lastRequestId = currentRequestId;
       engine.dispatch(resetAnswer());
 
+      if (state.generatedAnswer.isEnabled === false) {
+        return;
+      }
+
       if (triggerParams.q?.length > 0) {
         engine.dispatch(generateAnswer());
       }

--- a/packages/headless/src/features/generated-answer/generated-answer-actions.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-actions.test.ts
@@ -223,5 +223,45 @@ describe('generated answer', () => {
         )
       );
     });
+
+    describe('when the generated answer is disabled', () => {
+      const mockGetDisabledState = vi.fn(
+        () =>
+          ({
+            generatedAnswer: {
+              answerConfigurationId: 'test-config-id',
+              isEnabled: false,
+            },
+            searchHub: 'default',
+            pipeline: 'default',
+          }) as any
+      );
+
+      it('should reset the answer but not fetch a new one', async () => {
+        const thunk = generateAnswer();
+        await thunk(mockDispatch, mockGetDisabledState, mockExtra);
+
+        const resetAnswerCall = mockDispatch.mock.calls.find(
+          (call) => call[0]?.type === 'generatedAnswer/resetAnswer'
+        );
+        expect(resetAnswerCall).toBeDefined();
+
+        const setAnswerApiQueryParamsCall = mockDispatch.mock.calls.find(
+          (call) => call[0]?.type === 'generatedAnswer/setAnswerApiQueryParams'
+        );
+        expect(setAnswerApiQueryParamsCall).toBeUndefined();
+      });
+
+      it('should log a warning', async () => {
+        const thunk = generateAnswer();
+        await thunk(mockDispatch, mockGetDisabledState, mockExtra);
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'generateAnswer action was dispatched while the generated answer is disabled'
+          )
+        );
+      });
+    });
   });
 });

--- a/packages/headless/src/features/generated-answer/generated-answer-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-actions.ts
@@ -429,6 +429,14 @@ export const generateAnswer = createAsyncThunk<
     dispatch(resetAnswer());
 
     const state = getState() as StreamAnswerAPIState;
+    if (state.generatedAnswer.isEnabled === false) {
+      logger.warn(
+        '[WARNING] The generateAnswer action was dispatched while the generated answer is disabled. ' +
+          'No answer will be generated. Enable the generated answer before dispatching generateAnswer.'
+      );
+      return;
+    }
+
     if (state.generatedAnswer.answerConfigurationId) {
       const answerApiQueryParams = constructAnswerAPIQueryParams(
         state,


### PR DESCRIPTION
## SFINT-6838

This pull request addresses an issue where the `atomic-generated-answer` component did not respect the `tabs-included` and `tabs-excluded` options, resulting in answer generation queries being sent even when the component was hidden due to the active tab. The changes ensure that generated answers are only enabled and triggered when appropriate, based on tab visibility and explicit enablement state. Both the Answer API and Agent API paths now properly honor the `isEnabled` state, and tests have been added to verify this behavior.

Key changes grouped by theme:

**Respecting Tab Visibility and Enablement State:**

* The `atomic-generated-answer` component now checks if it should be enabled based on the current tab and the `tabsIncluded`/`tabsExcluded` properties, and sets the `isEnabled` state accordingly during initialization. This prevents answer generation when the component is hidden on the current tab, including on initial load. (`atomic-generated-answer.ts`, `atomic-generated-answer.spec.ts`) [[1]](diffhunk://#diff-e52de43696184e52e7dc47d6cca83c3b4a49a6c5dd99e402a06e322cc0473190R326-R336) [[2]](diffhunk://#diff-202d6317d889988d056ebb6d347d58d3c6b719f6a4b86ac651654f520f987facR986-R1029)
* The `buildGeneratedAnswer` controller and related logic now apply the `initialState.isEnabled` property, dispatching the appropriate action to set the enablement state. (`headless-core-generated-answer.ts`, `headless-core-generated-answer.test.ts`) [[1]](diffhunk://#diff-7409be0b72c2931d8b6f67a543483583ca497601bafd32145eaebab92ec8bc45R240-R243) [[2]](diffhunk://#diff-1ef715565fec9f1c4df1f249fd258357f14d305c1ca116c20d42971ae9ea9e62R384-R397)

**Preventing Unwanted Answer Generation:**

* Middleware and controller logic for both the Agent API and Answer API paths now check the `isEnabled` state before running answer generation. If disabled, they reset answers and abort generation, ensuring no unnecessary queries are sent. (`generate-answer-listener-middleware.ts`, `generate-answer-listener-middleware.test.ts`, `headless-answerapi-generated-answer.ts`, `headless-answerapi-generated-answer.test.ts`) [[1]](diffhunk://#diff-4ebafdda90019c187f8c919e10f7858e1bf448ee3233eafaaffc25e58150b4f5R34-R37) [[2]](diffhunk://#diff-ac130dd5464261b8d80c776724c817dc62fef8abe2c04f649dfb8814959f9916R165-R206) [[3]](diffhunk://#diff-dc66dab11c965fedd6559f13232b800b479909e91029cf121c120bebe2fe304bR117-R120) [[4]](diffhunk://#diff-b21e2b0065d9440ea533d8155d184ddad322a430575e3cac6ea70f769370e967R608-R633)


### Screens

#### Before
<img width="1417" height="168" alt="Screenshot 2026-06-30 161911" src="https://github.com/user-attachments/assets/b99f083b-0bab-4c2b-b488-73f6f0e30183" />

#### After 
<img width="1282" height="130" alt="Screenshot 2026-06-30 162357" src="https://github.com/user-attachments/assets/722e0550-f647-4cf8-b4bb-a5956e254e3b" /> |