### PR TITLE
test(atomic-cdn-smoke): rely on Chromatic snapshots, drop local toHaveScreenshot

### DIFF
--- a/packages/atomic-cdn-smoke/fixtures.ts
+++ b/packages/atomic-cdn-smoke/fixtures.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import {test as base, expect} from '@chromatic-com/playwright';
+import {test as base} from '@chromatic-com/playwright';
 import {defineNetworkFixture, type NetworkFixture} from '@msw/playwright';
 import {
   MockSearchApi,
@@ -14,8 +14,6 @@ const BASE_URL = COMMIT_SHA
   : 'https://static.cloud.coveo.com/atomic/v3';
 const ATOMIC_URL = `${BASE_URL}/atomic.esm.js`;
 const THEME_URL = `${BASE_URL}/themes/coveo.css`;
-
-export {expect};
 
 export const searchApi = new MockSearchApi();
 export const commerceApi = new MockCommerceApi();

--- a/packages/atomic-cdn-smoke/tests/commerce.spec.ts
+++ b/packages/atomic-cdn-smoke/tests/commerce.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect, commerceApi} from '../fixtures.js';
+import {test, commerceApi} from '../fixtures.js';
 
 test('Commerce page renders products', async ({
   page,
@@ -30,5 +30,4 @@ test('Commerce page renders products', async ({
     .locator('atomic-commerce-product-list atomic-product')
     .first()
     .waitFor();
-  await expect(page).toHaveScreenshot();
 });

--- a/packages/atomic-cdn-smoke/tests/insight.spec.ts
+++ b/packages/atomic-cdn-smoke/tests/insight.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect, insightApi} from '../fixtures.js';
+import {test, insightApi} from '../fixtures.js';
 
 test('Insight page renders results', async ({page, openPage, useHandlers}) => {
   await useHandlers(insightApi.handlers);
@@ -20,5 +20,4 @@ test('Insight page renders results', async ({page, openPage, useHandlers}) => {
     .locator('atomic-insight-result-list atomic-insight-result')
     .first()
     .waitFor();
-  await expect(page).toHaveScreenshot();
 });

--- a/packages/atomic-cdn-smoke/tests/ipx.spec.ts
+++ b/packages/atomic-cdn-smoke/tests/ipx.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect, searchApi} from '../fixtures.js';
+import {test, searchApi} from '../fixtures.js';
 
 test('IPX modal renders results', async ({page, openPage, useHandlers}) => {
   await useHandlers(searchApi.handlers);
@@ -16,5 +16,4 @@ test('IPX modal renders results', async ({page, openPage, useHandlers}) => {
     .locator('atomic-search-interface')
     .evaluate((el: any) => el.executeFirstSearch());
   await page.locator('atomic-result-list atomic-result').first().waitFor();
-  await expect(page).toHaveScreenshot();
 });

--- a/packages/atomic-cdn-smoke/tests/search.spec.ts
+++ b/packages/atomic-cdn-smoke/tests/search.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect, searchApi} from '../fixtures.js';
+import {test, searchApi} from '../fixtures.js';
 
 test('Search page renders results', async ({page, openPage, useHandlers}) => {
   await useHandlers(searchApi.handlers);
@@ -16,5 +16,4 @@ test('Search page renders results', async ({page, openPage, useHandlers}) => {
     .locator('atomic-search-interface')
     .evaluate((el: any) => el.executeFirstSearch());
   await page.locator('atomic-result-list atomic-result').first().waitFor();
-  await expect(page).toHaveScreenshot();
 });


### PR DESCRIPTION
## Problem
The CDN smoke specs ended each test with `await expect(page).toHaveScreenshot()`, Playwright's **native pixel-comparison** assertion. That requires committed baseline PNGs per platform, which don't exist in the repo — so in CI (Linux) every spec fails with:

```
Error: A snapshot doesn't exist at …/Commerce-page-renders-products-1-linux.png, writing actual.
```

Visual regression for these tests is meant to be handled by **Chromatic**, not local Playwright snapshots, so the `toHaveScreenshot()` calls were both redundant and the source of the failures.

## Solution
Go Chromatic-only:
- Remove `expect(page).toHaveScreenshot()` from all four specs (commerce, insight, ipx, search).
- Drop the now-unused `expect` import from the specs and the `export {expect}` re-export in `fixtures.ts`.

`@chromatic-com/playwright` already captures a Chromatic snapshot automatically at the end of every test (auto-snapshot is on by default; `disableAutoSnapshot` is opt-out), so the visual capture still happens. The functional smoke check is preserved by the existing `.waitFor()` on the rendered results/products, which fails the test if the components never render.

## Verification
- `pnpm --filter @coveo/atomic-cdn-smoke cdn-smoke` → **4 passed** (against live `atomic/v3`), no baseline errors.
- `biome check packages/atomic-cdn-smoke` → clean.

Follow-up to the discussion on coveo-platform/ui-kit-cd#188, where the missing-baseline failure was flagged as a separate, non-blocking issue.