### PR TITLE
chore(deps): group Playwright container image with playwright packages

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -61,6 +61,16 @@
         '/^@lwc/compiler$/',
       ],
     },
+    {
+      groupName: 'Playwright',
+      groupSlug: 'playwright',
+      description: 'Keep the Playwright CI container image (mcr.microsoft.com/playwright) in lockstep with the playwright/@playwright/test packages so browser binaries always match the installed version',
+      matchPackageNames: [
+        'mcr.microsoft.com/playwright',
+        'playwright',
+        '@playwright/test',
+      ],
+    },
   ],
   lockFileMaintenance: {
     enabled: true,


### PR DESCRIPTION
## Problem

Renovate updates the Playwright CI container image (`mcr.microsoft.com/playwright`, referenced in `ci.yml` and `e2e-quantic.yml`) independently from the `playwright` / `@playwright/test` npm packages pinned in the pnpm catalog.

This bit us in #7901: the container was bumped `v1.60.0-noble` → `v1.61.1-noble` while the catalog stayed at `1.60.0`. Playwright requires the installed package to match the browser binaries baked into the image, so every E2E job started failing with a version mismatch.

Worse, #7901 only touched `.github/workflows/*`, so affected-project gating **skipped** all the Playwright/E2E jobs on the PR itself — CI was green and it merged, only breaking once E2E actually ran on subsequent PRs and the merge queue.

## Solution

Add a Renovate package rule grouping `mcr.microsoft.com/playwright`, `playwright`, and `@playwright/test` under a single `Playwright` group. They now always bump together in one PR whose diff touches the catalog — which triggers the E2E suites — so an incompatible bump can't sneak through green again.

Validated with `renovate-config-validator` (Config validated successfully).