### PR TITLE
docs(samples): define the sample standards

### DIFF
--- a/samples/CONTRIBUTING.md
+++ b/samples/CONTRIBUTING.md
@@ -6,23 +6,49 @@ This guide outlines the conventions and requirements for creating and maintainin
 
 Every sample in this directory serves two roles:
 
-1. **Living documentation** — Demonstrates correct usage of Coveo libraries.
-2. **Scaffolding template** — Used by `npm create @coveo/ui` to bootstrap new projects.
+1. **Living documentation**: Demonstrates correct usage of Coveo libraries.
+2. **Scaffolding template**: Used by `npm create @coveo/ui` to bootstrap new projects.
 
 This means every sample must be **self-contained, zero-config, and runnable out of the box** without any Coveo platform credentials or OAuth setup.
+
+## Sample Standards
+
+These are the definitive standards for how every sample is set up and maintained. Because samples are dual-purpose (living documentation **and** scaffolding templates) and are relied on as minimal reproducible examples (MREs) for troubleshooting, every sample must meet all of them. Where a standard has a dedicated section below, it is linked rather than repeated.
+
+### Setup & structure
+
+1. **Zero-config & self-contained.** Runs immediately after `pnpm install` with no monorepo runtime dependencies and no user-provided credentials, only the public `searchuisamples` sample organization. See [Sample Requirements](#sample-requirements).
+2. **Single purpose.** Each sample focuses on one library + framework combination. See [Sample Requirements](#sample-requirements).
+3. **Correctly named & scoped.** The package is named `@coveo/ui-kit-sample-<category>-<use-case>[-<framework>][-<variant>]`, matching its `--template` name. See [Naming Convention](#naming-convention).
+4. **Standard script contract.** Exposes the expected `dev` / `build` / `test` / `e2e` scripts so CI discovers it with no extra wiring. See [Standard Script Contract](#standard-script-contract).
+5. **Dependency hygiene.** Use `catalog:` for shared dependencies (both runtime and dev), `workspace:*` for internal `@coveo/*` packages, and pinned versions otherwise, so samples stay consistent and publishable.
+
+### Quality & stability
+
+6. **Buildable and stable.** Every sample must build, start, and render the expected experience. The Playwright smoke test is the contract: a failing sample is treated as a broken build, not a nice-to-have.
+7. **Deterministic tests.** At least one Playwright smoke test verifies the sample loads and renders, using `@coveo/platform-mock-api` + MSW, never a live API. See [How Samples Are Tested in CI](#how-samples-are-tested-in-ci).
+8. **Simple and debuggable.** Prefer plain, readable code over heavy abstractions or code generation. A non-developer should be able to open the generated project and understand what was created. Keep indirection to a minimum.
+9. **Accessible.** Use semantic HTML and labeled, keyboard-operable controls so the rendered experience is usable and mirrors accessible real-world usage.
+10. **Version-alignable.** Make it easy to reproduce against a specific UI Kit version. Document in the README how to pin, upgrade, or downgrade the relevant `@coveo/*` dependency after scaffolding (for example, `pnpm add @coveo/headless@<version>`).
+
+### Documentation & distribution
+
+11. **MRE-first documentation.** Each README includes a "Using this sample as an MRE" section that explains where to plug in a custom configuration (organization ID, access token, search hub, pipeline), which files are safe to modify when reproducing an issue, and which are scaffolding you can ignore.
+12. **Customer-safe.** No Coveo-internal assumptions. Any hardcoded credentials must be the public `searchuisamples` sample credentials and clearly commented/documented as **public sample credentials**, never internal tokens.
+13. **Published to npm as the scaffolding source.** Samples are configured to publish (public, with `publishConfig` and a `files` allowlist) and are released together through the changesets pipeline; pnpm resolves `workspace:*` / `catalog:` to concrete versions at publish, and `npm create @coveo/ui` fetches the published package. See [Relationship to Scaffolding](#relationship-to-scaffolding) and [ADR 002](../packages/create-ui/docs/adr/002-sample-publishing.md).
 
 ## Sample Requirements
 
 Every sample **must** have:
 
-| Requirement                          | Details                                                                                                                                                |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Pre-configured credentials**       | Use the `searchuisamples` demo organization with the embedded public sample access token. No OAuth flow, no `.env` file, no user-provided credentials. |
-| **`pnpm install && pnpm dev` works** | A developer should be able to clone and run the sample with no additional setup. New samples must use a `dev` script.                                  |
-| **README.md**                        | Purpose, prerequisites, how to run, key features demonstrated.                                                                                         |
-| **Playwright smoke tests with MSW**  | At least one test verifying the sample loads and renders expected content, using `@coveo/platform-mock-api` for deterministic responses.               |
-| **Minimal configuration**            | No custom styling, no complex initialization. Use vanilla fields that work with the sample org.                                                        |
-| **Single purpose**                   | Each sample focuses on one library + framework combination.                                                                                            |
+| Requirement                          | Details                                                                                                                                                                                               |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pre-configured credentials**       | Use the `searchuisamples` demo organization with the embedded public sample access token. No OAuth flow, no `.env` file, no user-provided credentials.                                                |
+| **`pnpm install && pnpm dev` works** | A developer should be able to clone and run the sample with no additional setup. New samples must use a `dev` script.                                                                                 |
+| **README.md**                        | Purpose, prerequisites, how to run, key features demonstrated.                                                                                                                                        |
+| **Playwright smoke tests with MSW**  | At least one test verifying the sample loads and renders expected content, using `@coveo/platform-mock-api` for deterministic responses.                                                              |
+| **Minimal configuration**            | Keep styling minimal and unbranded (a clean, functional look comparable to a default Atomic experience); no heavy themes or complex initialization. Use vanilla fields that work with the sample org. |
+| **Single purpose**                   | Each sample focuses on one library + framework combination.                                                                                                                                           |
 
 ## Directory Structure
 
@@ -43,11 +69,10 @@ samples/
 
 **Examples:**
 
-- `headless/search-vite` — Vanilla headless search (JS + Vite)
-- `headless/commerce-react` — Headless commerce with React
-- `headless-ssr/commerce-nextjs` — Headless SSR commerce with Next.js
-- `headless-ssr/commerce-nextjs-v4` — Variant for Headless V4 preview
-- `atomic/search-commerce-angular` — Combined search + commerce in Angular
+- `headless/search-vite`: Vanilla headless search (JS + Vite)
+- `headless/commerce-react`: Headless commerce with React
+- `headless-ssr/commerce-nextjs`: Headless SSR commerce with Next.js
+- `atomic/search-commerce-angular`: Combined search + commerce in Angular
 
 **Package name in `package.json`:**
 
@@ -55,54 +80,58 @@ samples/
 @coveo/ui-kit-sample-<category>-<use-case>[-<framework>][-<variant>]
 ```
 
-Samples carry the `@coveo/ui-kit-sample-*` name from the start (matching the `--template` name used by `npm create @coveo/ui`) and stay `private: true` in the workspace. For example, `samples/headless/search-react` is named `@coveo/ui-kit-sample-headless-search-react`. When a sample is ready to publish, we simply flip it from private to public — remove `private: true` (and add `publishConfig.access: "public"` / a `files` allowlist). The package name never changes. See [ADR 002](../packages/create-ui/docs/adr/002-sample-publishing.md).
+Samples carry the `@coveo/ui-kit-sample-*` name from the start (matching the `--template` name used by `npm create @coveo/ui`). For example, `samples/headless/search-react` is named `@coveo/ui-kit-sample-headless-search-react`. They are configured to be published as part of the release (public, with `publishConfig.access: "public"` and a `files` allowlist). See [ADR 002](../packages/create-ui/docs/adr/002-sample-publishing.md).
 
 ### Guidelines
 
 - Use **kebab-case** for all names
 - **Use cases**: `search`, `commerce`, `search-commerce` (combined)
 - **Framework names**: `react`, `angular`, `nextjs`, `vuejs`
-- **Variant suffixes**: `-v4`, `-app-router`, etc. for alternative implementations
+- **Variant suffixes**: `-app-router`, etc. for alternative implementations
 - Vanilla (no-framework) samples use `-vite` as the framework suffix (e.g., `search-vite`)
 
 ## Creating a New Sample
 
 ### 1. Choose the correct category
 
-- **`atomic/`** — Uses `@coveo/atomic` or `@coveo/atomic-react` components
-- **`headless/`** — Uses `@coveo/headless` controllers with client-side rendering
-- **`headless-ssr/`** — Uses `@coveo/headless-react` or similar with server-side rendering
+- **`atomic/`**: Uses `@coveo/atomic` or `@coveo/atomic-react` components
+- **`headless/`**: Uses `@coveo/headless` controllers with client-side rendering
+- **`headless-ssr/`**: Uses `@coveo/headless-react` or similar with server-side rendering
 
 ### 2. Use sample credentials
 
 All samples connect to the `searchuisamples` organization using the public sample access token. No authentication flow, no environment variables to configure.
 
 ```typescript
-// Headless Search — uses embedded sample token
+// Headless Search - uses embedded sample token
 import {getSampleSearchEngineConfiguration} from '@coveo/headless';
 
-// Headless Commerce — uses explicit public sample token
+// Headless Commerce - uses explicit public sample token
 import {buildCommerceEngine} from '@coveo/headless/commerce';
 // accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457', organizationId: 'searchuisamples'
 ```
+
+For **search** samples, set the search hub to `BarcaKnowledge` (for example, `search.searchHub = 'BarcaKnowledge'` in Headless, or the `search-hub` attribute in Atomic). It returns richer, more relevant results than the default hub.
 
 ### 3. Write a README.md
 
 Include:
 
-- **Purpose** — One-liner on what the sample demonstrates
-- **Template name** — The scaffolding template identifier
-- **Prerequisites** — Node version, pnpm
-- **Running** — `pnpm install && pnpm dev`
-- **Key features** — What components/controllers are showcased
+- **Purpose**: One-liner on what the sample demonstrates
+- **Template name**: The scaffolding template identifier
+- **Prerequisites**: Node version, pnpm
+- **Running**: `pnpm install && pnpm dev`
+- **Key features**: What components/controllers are showcased
+- **Using this sample as an MRE**: Where to set a custom configuration (organization ID, access token, search hub, pipeline), which files are safe to modify when reproducing an issue, and a note that the embedded credentials are **public** `searchuisamples` sample credentials (safe to share) (see [Sample Standards](#sample-standards))
+- **Reproducing against a specific version**: How to pin/upgrade/downgrade the relevant `@coveo/*` dependency after scaffolding
 
 ### 4. Add Playwright smoke tests with `@coveo/platform-mock-api`
 
 Every sample must include Playwright tests that use the internal `@coveo/platform-mock-api` package (at `packages/platform-mock-api`) and `@msw/playwright` for network mocking. This ensures tests are:
 
-- **Deterministic** — No flakiness from live API calls
-- **Fast** — No network latency
-- **CI-friendly** — No dependency on external services
+- **Deterministic**: No flakiness from live API calls
+- **Fast**: No network latency
+- **CI-friendly**: No dependency on external services
 
 ```typescript
 // e2e/fixtures.ts
@@ -163,7 +192,7 @@ Required devDependencies:
 ### 5. Keep it minimal
 
 - Include only files necessary for the demonstration
-- No custom CSS themes or complex layouts
+- Keep styling minimal and unbranded: a clean, functional look comparable to a default Atomic experience is fine, but avoid heavy custom themes, design-system integrations, or complex layouts
 - No advanced configuration beyond what works with the sample org
 - Use default/vanilla field values
 
@@ -203,9 +232,9 @@ npm create @coveo/ui my-project -- --template headless-search
 
 The CLI downloads and extracts the corresponding published `@coveo/ui-kit-sample-<name>` package as their project starter. This is why samples must be:
 
-- **Zero-config** — Works immediately after `npm install`
-- **Self-contained** — No dependencies on the monorepo structure at runtime
-- **Tested** — Smoke tests give confidence the template works
+- **Zero-config**: Works immediately after `npm install`
+- **Self-contained**: No dependencies on the monorepo structure at runtime
+- **Tested**: Smoke tests give confidence the template works
 
 ## Standard Script Contract
 
@@ -226,7 +255,7 @@ Rules:
 ## How Samples Are Tested in CI
 
 - **Build & unit tests** are already affected-driven: `turbo build --affected` and `turbo test --affected` pick up any sample automatically.
-- **E2E** runs through a single `samples-e2e` job that executes `turbo run e2e --affected` inside the Playwright container. Because a sample that depends on `@coveo/headless` or `@coveo/atomic` is automatically marked affected when those libraries change, a library change that breaks a sample is caught immediately — and adding a new sample needs **zero** CI edits.
+- **E2E** runs through a single `samples-e2e` job that executes `turbo run e2e --affected` inside the Playwright container. Because a sample that depends on `@coveo/headless` or `@coveo/atomic` is automatically marked affected when those libraries change, a library change that breaks a sample is caught immediately, and adding a new sample needs **zero** CI edits.
 
 ## Testing Locally
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -4,8 +4,8 @@ This directory contains code samples demonstrating how to use Coveo's UI-Kit lib
 
 **These samples serve a dual purpose:**
 
-1. **Samples** — Living documentation showing how to use Coveo libraries correctly.
-2. **Scaffolding starters** — The source templates for `npm create @coveo/ui`. Each sample is published to npm as `@coveo/ui-kit-sample-<name>` and fetched by the CLI to give developers a working project in seconds.
+1. **Samples**: Living documentation showing how to use Coveo libraries correctly.
+2. **Scaffolding starters**: The source templates for `npm create @coveo/ui`. Each sample is published to npm as `@coveo/ui-kit-sample-<name>` and fetched by the CLI to give developers a working project in seconds.
 
 Because of this dual role, every sample must be **self-contained, runnable out of the box, and tested**. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full requirements.
 
@@ -63,15 +63,25 @@ pnpm install
 pnpm dev  # or check the sample's README for the correct start command
 ```
 
-No platform credentials are needed — all samples use the `searchuisamples` demo organization with a pre-configured public access token.
+No platform credentials are needed. All samples use the `searchuisamples` demo organization with a pre-configured public access token.
+
+## 🧪 Using a sample as a minimal reproducible example (MRE)
+
+These samples double as **MREs** for troubleshooting. To reproduce an issue:
+
+1. Scaffold or copy the sample closest to the customer's setup.
+2. Point it at the relevant configuration (organization ID, access token, search hub, pipeline). Each sample's README has a **"Using this sample as an MRE"** section that says exactly where to change these and which files are safe to modify.
+3. To reproduce against a specific UI Kit version, install it after scaffolding, for example `pnpm add @coveo/headless@<version>` (or the relevant `@coveo/*` package).
+
+The embedded credentials are the **public** `searchuisamples` sample credentials, so the generated projects are safe to share with customers or partners. They contain no Coveo-internal assumptions.
 
 ## 💡 Choosing the Right Approach
 
-**Atomic** — Use when you want pre-built, customizable components with minimal code. Best for rapid implementation.
+**Atomic**: Use when you want pre-built, customizable components with minimal code. Best for rapid implementation.
 
-**Headless** — Use when you need full control over the UI or are integrating with an existing design system.
+**Headless**: Use when you need full control over the UI or are integrating with an existing design system.
 
-**Headless SSR** — Use when SEO or initial page load performance is a priority.
+**Headless SSR**: Use when SEO or initial page load performance is a priority.
 
 ## 📖 Documentation
 


### PR DESCRIPTION
## Problem
The contributing guide and samples index don't define a single, definitive standard for how samples are set up and maintained. Samples are dual-purpose (living docs + scaffolding templates) and are relied on as minimal reproducible examples (MREs) for troubleshooting, but the expectations were scattered (naming, publishing, scripts, testing) or missing (MRE usage, version reproduction, ownership/reporting, customer-safe credentials).

## Solution
Add a canonical **Sample Standards** section to `samples/CONTRIBUTING.md` — the definitive checklist every sample must meet — grouped and linked to the detailed sections (DRY, no duplication):

**Setup & structure:** zero-config & self-contained · single purpose · correctly named & scoped (→ Naming Convention) · standard script contract (→ Standard Script Contract) · dependency hygiene

**Quality & stability:** buildable & stable · deterministic tests (→ CI testing) · simple & debuggable · accessible · version-alignable

**Documentation & distribution:** MRE-first documentation · customer-safe · published to npm (→ Relationship to Scaffolding + ADR 002) · owned & reportable

Also extends the per-sample README requirements (MRE section + version-reproduction note) and adds **"Using a sample as an MRE"** and **"Reporting a broken sample"** sections to `samples/README.md`.

Docs only — no sample code changed. Individual sample PRs (#7850, #7852, #7897, #7851) will be adjusted to satisfy these standards.

> Open question: whether to add an ADR 003 recording the *decision/rationale* (samples as support-critical MREs), referenced from these standards. CONTRIBUTING remains the enforceable standard either way.
