### PR TITLE
ci(deps): bump step-security/changeset-action to v1.9.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,7 +47,7 @@ jobs:
           cache-retention-days: 7
       - name: Create release PR or publish
         id: changesets
-        uses: step-security/changeset-action@4ec991f6d4d311458205f6954cf513f63efe15a3 # v1.7.0
+        uses: step-security/changeset-action@6ddf46283ed49170eb6ca2179818f7d2a0ae687c # v1.9.0
         with:
           version: pnpm changeset version
           publish: pnpm run release


### PR DESCRIPTION
## Problem

The release job in `cd.yml` pins `step-security/changeset-action@v1.7.0`. In a monorepo, if a single package fails to publish (e.g. missing npm permissions for a new package), the whole action fails because `getExecOutput` throws on the non-zero exit code from `changeset publish`. As a result, packages that *did* publish successfully never get their GitHub releases created and the `published` output is never set to `true`.

This was reported upstream in step-security/changeset-action#89.

## Solution

Bump the pinned action from `v1.7.0` (`4ec991f`) to `v1.9.0` (`6ddf462`), which syncs with upstream `changesets/action@v1.9.0` (PR changesets/action#535 by @Andarist). That fix adds `ignoreReturnCode: true` to the `getExecOutput` call in `runPublish`, so the action still processes `New tag:` lines, creates GitHub releases for the successfully published packages, and sets the `published` output even when some packages fail to publish.

Note: `ignoreReturnCode` is an internal fix within the action — there is no new workflow input to enable. Upgrading to v1.9.0 is all that is required to get the resilient-publish behavior.