### PR TITLE
test(atomic-cdn-smoke): verify Chromatic diff detection

### DIFF
--- a/packages/atomic-cdn-smoke/pages/search.html
+++ b/packages/atomic-cdn-smoke/pages/search.html
@@ -8,6 +8,9 @@
         margin: 0;
         font-family: system-ui, sans-serif;
       }
+      atomic-search-box {
+        border: 2px solid #0f62fe;
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Problem
We want to confirm end-to-end that the CDN visual smoke test now goes red (in Chromatic and on the GitHub Actions job) when a snapshot differs from its baseline, after coveo-platform/ui-kit-cd#195.

## Solution
Introduce a small, localized visual change: a 2px border on `atomic-search-box` in `packages/atomic-cdn-smoke/pages/search.html`. Only the **search** snapshot changes; the other three are untouched.

Expected once merged: the deployment's `chromatic-smoke-test` job diffs the new search snapshot against the current baseline, detects the change, and the job goes **red** (deployment still proceeds — nothing depends on it). Chromatic shows the before/after for the search story.

## Cleanup
This is a **temporary test PR**. After confirming the red build, it will be reverted (the revert build matches the untouched baseline and returns green — no dashboard acceptance needed, since the changed snapshot is never accepted).