### PR TITLE
fix: fix commerce facet selector memoization 

### DIFF
--- a/.changeset/fix-commerce-facet-selector-memoization.md
+++ b/.changeset/fix-commerce-facet-selector-memoization.md
@@ -1,0 +1,7 @@
+---
+'@coveo/headless': patch
+---
+
+fix(headless): restore memoization of commerce facet selectors
+
+Rewrote the commerce facet selectors so their reselect input selectors return stable references (or primitives) instead of freshly allocated wrapper objects. This restores effective memoization and removes the dev-mode `inputStabilityCheck` and `identityFunctionCheck` warnings that were previously logged on every selector access. Selector outputs are unchanged.

--- a/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ts
+++ b/packages/headless/src/controllers/commerce/core/facets/generator/headless-commerce-facet-generator.ts
@@ -153,12 +153,11 @@ export function buildFacetGenerator(
   );
 
   const createFacetController = createSelector(
-    (commerceFacetSet: CommerceFacetSetState, facetId: string) => ({
-      facetId,
-      type: commerceFacetSet[facetId].request.type,
-    }),
+    (commerceFacetSet: CommerceFacetSetState, facetId: string) =>
+      commerceFacetSet[facetId].request.type,
+    (_commerceFacetSet: CommerceFacetSetState, facetId: string) => facetId,
 
-    ({type, facetId}) => {
+    (type, facetId) => {
       switch (type) {
         case 'dateRange':
           return options.buildDateFacet(engine, {facetId});

--- a/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-facet-options.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-facet-options.ts
@@ -7,16 +7,16 @@ import type {
 export const facetResponseSelector = createSelector(
   (state: ProductListingSection & CommerceFacetSetSection) =>
     state.productListing.facets,
-  (state: ProductListingSection & CommerceFacetSetSection) =>
-    state.commerceFacetSet,
+  (state: ProductListingSection & CommerceFacetSetSection, facetId: string) =>
+    facetId in state.commerceFacetSet,
   (_state: ProductListingSection & CommerceFacetSetSection, facetId: string) =>
     facetId,
 
-  (facets, commerceFacetSet, facetId) => {
+  (facets, isFacetIdInFacetSet, facetId) => {
     const facetResponse = facets.find(
       (facetResponse) => facetResponse.facetId === facetId
     );
-    if (facetResponse && facetResponse.facetId in commerceFacetSet) {
+    if (facetResponse && isFacetIdInFacetSet) {
       return facetResponse;
     }
 

--- a/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-facet-options.ts
+++ b/packages/headless/src/controllers/commerce/product-listing/facets/headless-product-listing-facet-options.ts
@@ -5,16 +5,18 @@ import type {
 } from '../../../../state/state-sections.js';
 
 export const facetResponseSelector = createSelector(
-  (
-    state: ProductListingSection & CommerceFacetSetSection,
-    facetId: string
-  ) => ({state, facetId}),
+  (state: ProductListingSection & CommerceFacetSetSection) =>
+    state.productListing.facets,
+  (state: ProductListingSection & CommerceFacetSetSection) =>
+    state.commerceFacetSet,
+  (_state: ProductListingSection & CommerceFacetSetSection, facetId: string) =>
+    facetId,
 
-  ({state, facetId}) => {
-    const facetResponse = state.productListing.facets.find(
+  (facets, commerceFacetSet, facetId) => {
+    const facetResponse = facets.find(
       (facetResponse) => facetResponse.facetId === facetId
     );
-    if (facetResponse && facetResponse.facetId in state.commerceFacetSet) {
+    if (facetResponse && facetResponse.facetId in commerceFacetSet) {
       return facetResponse;
     }
 
@@ -22,8 +24,5 @@ export const facetResponseSelector = createSelector(
   }
 );
 
-export const isFacetLoadingResponseSelector = createSelector(
-  (state: ProductListingSection) => ({state}),
-
-  ({state}) => state.productListing.isLoading
-);
+export const isFacetLoadingResponseSelector = (state: ProductListingSection) =>
+  state.productListing.isLoading;

--- a/packages/headless/src/controllers/commerce/search/facets/headless-search-facet-options.ts
+++ b/packages/headless/src/controllers/commerce/search/facets/headless-search-facet-options.ts
@@ -7,16 +7,16 @@ import type {
 export const facetResponseSelector = createSelector(
   (state: CommerceSearchSection & CommerceFacetSetSection) =>
     state.commerceSearch.facets,
-  (state: CommerceSearchSection & CommerceFacetSetSection) =>
-    state.commerceFacetSet,
+  (state: CommerceSearchSection & CommerceFacetSetSection, facetId: string) =>
+    facetId in state.commerceFacetSet,
   (_state: CommerceSearchSection & CommerceFacetSetSection, facetId: string) =>
     facetId,
 
-  (facets, commerceFacetSet, facetId) => {
+  (facets, isFacetIdInFacetSet, facetId) => {
     const facetResponse = facets.find(
       (facetResponse) => facetResponse.facetId === facetId
     );
-    if (facetResponse && facetResponse.facetId in commerceFacetSet) {
+    if (facetResponse && isFacetIdInFacetSet) {
       return facetResponse;
     }
 

--- a/packages/headless/src/controllers/commerce/search/facets/headless-search-facet-options.ts
+++ b/packages/headless/src/controllers/commerce/search/facets/headless-search-facet-options.ts
@@ -5,16 +5,18 @@ import type {
 } from '../../../../state/state-sections.js';
 
 export const facetResponseSelector = createSelector(
-  (
-    state: CommerceSearchSection & CommerceFacetSetSection,
-    facetId: string
-  ) => ({state, facetId}),
+  (state: CommerceSearchSection & CommerceFacetSetSection) =>
+    state.commerceSearch.facets,
+  (state: CommerceSearchSection & CommerceFacetSetSection) =>
+    state.commerceFacetSet,
+  (_state: CommerceSearchSection & CommerceFacetSetSection, facetId: string) =>
+    facetId,
 
-  ({state, facetId}) => {
-    const facetResponse = state.commerceSearch.facets.find(
+  (facets, commerceFacetSet, facetId) => {
+    const facetResponse = facets.find(
       (facetResponse) => facetResponse.facetId === facetId
     );
-    if (facetResponse && facetResponse.facetId in state.commerceFacetSet) {
+    if (facetResponse && facetResponse.facetId in commerceFacetSet) {
       return facetResponse;
     }
 
@@ -22,8 +24,5 @@ export const facetResponseSelector = createSelector(
   }
 );
 
-export const isFacetLoadingResponseSelector = createSelector(
-  (state: CommerceSearchSection) => ({state}),
-
-  ({state}) => state.commerceSearch.isLoading
-);
+export const isFacetLoadingResponseSelector = (state: CommerceSearchSection) =>
+  state.commerceSearch.isLoading;

--- a/packages/headless/src/features/commerce/facets/facet-set/facet-set-selector.ts
+++ b/packages/headless/src/features/commerce/facets/facet-set/facet-set-selector.ts
@@ -3,10 +3,7 @@ import type {CommerceFacetSetSection} from '../../../../state/state-sections.js'
 import type {AnyFacetRequest} from './interfaces/request.js';
 
 export const facetRequestSelector = createSelector(
-  (state: CommerceFacetSetSection, facetId: string) => ({
-    facetRequestSelector: state.commerceFacetSet[facetId],
-  }),
-  ({facetRequestSelector}): AnyFacetRequest | undefined => {
-    return facetRequestSelector?.request;
-  }
+  (state: CommerceFacetSetSection, facetId: string) =>
+    state.commerceFacetSet[facetId],
+  (facet): AnyFacetRequest | undefined => facet?.request
 );

--- a/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-state-selector.ts
+++ b/packages/headless/src/features/facets/facet-search-set/category/category-facet-search-state-selector.ts
@@ -1,12 +1,8 @@
-import {createSelector} from '@reduxjs/toolkit';
 import type {CategoryFacetSearchSection} from '../../../../state/state-sections.js';
 import type {CategoryFacetSearchState} from './category-facet-search-set-state.js';
 
-export const categoryFacetSearchStateSelector = createSelector(
-  (state: CategoryFacetSearchSection, facetId: string) => ({
-    facetSearchSelector: state.categoryFacetSearchSet[facetId],
-  }),
-  ({facetSearchSelector}): CategoryFacetSearchState | undefined => {
-    return facetSearchSelector;
-  }
-);
+export const categoryFacetSearchStateSelector = (
+  state: CategoryFacetSearchSection,
+  facetId: string
+): CategoryFacetSearchState | undefined =>
+  state.categoryFacetSearchSet[facetId];

--- a/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-state-selector.ts
+++ b/packages/headless/src/features/facets/facet-search-set/specific/specific-facet-search-state-selector.ts
@@ -1,12 +1,7 @@
-import {createSelector} from '@reduxjs/toolkit';
 import type {FacetSearchSection} from '../../../../state/state-sections.js';
 import type {SpecificFacetSearchState} from './specific-facet-search-set-state.js';
 
-export const specificFacetSearchStateSelector = createSelector(
-  (state: FacetSearchSection, facetId: string) => ({
-    facetSearchSelector: state.facetSearchSet[facetId],
-  }),
-  ({facetSearchSelector}): SpecificFacetSearchState | undefined => {
-    return facetSearchSelector;
-  }
-);
+export const specificFacetSearchStateSelector = (
+  state: FacetSearchSection,
+  facetId: string
+): SpecificFacetSearchState | undefined => state.facetSearchSet[facetId];


### PR DESCRIPTION
## Why

In development, the console (both browser and the Next.js server) gets flooded with reselect warnings coming from the commerce facet selectors, e.g.:

```
An input selector returned a different result when passed same arguments.
This means your output selector will likely run more frequently than intended.
  firstInputs:  [ { facetSearchSelector: undefined } ]
  secondInputs: [ { facetSearchSelector: undefined } ]
    at runInputStabilityCheck ...
```

These are emitted by reselect's dev-mode **`inputStabilityCheck`**. The affected selectors were written so their **input selector returns a brand-new object literal on every call**:

```ts
// Before
export const facetRequestSelector = createSelector(
  (state, facetId) => ({facetRequestSelector: state.commerceFacetSet[facetId]}), // new object every call
  ({facetRequestSelector}) => facetRequestSelector?.request
);
```

reselect decides whether to recompute by comparing each input selector's result to the previous one with `===`. A freshly-allocated object is never `===` the previous one, so:

- the result function recomputes on **every access** — memoization is effectively disabled; and
- reselect's `inputStabilityCheck` logs a warning on every call.

So this is a real (if small) latent memoization bug, and it's noisy in dev.

## What

Rewrote every affected commerce facet selector. Output is identical in all cases — only the memoization/allocation behavior changes.

**1. Return stable inputs instead of a fresh wrapper object** (kept as memoized `createSelector`s):
**2. Convert pure lookups to plain functions** (a `createSelector` around a value that is just read from state provides no memoization benefit and additionally trips reselect's **`identityFunctionCheck`**).


These keep the same `(state, …) => …` signature and return the same value.

## Why fix the selectors instead of suppressing the check

The quick alternative is `setGlobalDevModeChecks({inputStabilityCheck: 'never'})`, but that just mutes the warning globally and leaves the broken memoization in place (and hides it from every consumer, including anyone learning from our samples). Fixing the selectors removes the warning legitimately, restores real memoization, and changes no behavior.

## Safety

- reselect memoization is a **performance** optimization, not a correctness mechanism — a selector's output value is the same whether memoized, badly-memoized, or a plain function. Returned references here are as stable as before, or more so.
- The touched selectors are **internal** (not exported from the public entry points), except `facetRequestSelector`, which stays a `createSelector` with an unchanged `(state, facetId) => …` call signature.
- No consumer uses the reselect-specific members (`.recomputations()`, `.resultFunc`, …) of the selectors converted to plain functions.

## Verification

- Targeted `vitest` over the commerce facet selector, facet-options, and facet-generator suites: all green, with **0** reselect dev warnings (neither `inputStabilityCheck` nor `identityFunctionCheck`) in the output.
- `tsc` (definitions build) passes — selector signatures are unchanged at every call site.
- Exercised in the headless commerce SSR sample (search + listing pages, facet toggles, facet search, query suggestions): browser console and server log are clean, with the previous `setGlobalDevModeChecks` workaround removed.
