### PR TITLE
chore(changesets): version-lock headless samples to @coveo/headless

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
     }
   ],
   "commit": false,
-  "fixed": [],
+  "fixed": [["@coveo/headless", "@coveo/ui-kit-sample-headless-*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Problem

Once the `headless-*` samples become public and published, we want each sample's published version to always match the version of `@coveo/headless` it ships with (e.g. sample `3.53.1` uses headless `3.53.1`). We also never author changesets for samples, so they can't bump themselves.

## Solution

Add a Changesets [`fixed`](https://github.com/changesets/changesets/blob/main/docs/fixed-packages.md) group pairing `@coveo/headless` with the `@coveo/ui-kit-sample-headless-*` glob. Fixed groups bump and publish all members together at the same version *even when a member has no changeset* — so every headless release carries the samples to the identical version, with no sample changeset needed.

This is intentionally staged ahead of time and is **dormant today**: the samples are still `private`, and `privatePackages.version: false` keeps private packages out of versioning. Each sample joins the group automatically the moment it is made public + published.

### Verification

Tested locally (temporary patch changeset for `@coveo/headless`, then reverted):
- Config loads with no validation error; the glob is accepted.
- While the sample is `private`, `changeset status` does **not** include it (dormant no-op).
- After flipping the sample to public, `changeset status` shows it bump to headless's exact next version (`3.53.1`), not its own `0.x` line.
- `oxfmt --check` passes on the config.

### Follow-up (not in this PR)

The `@samples/*`-scoped samples need their package names normalized to the `@coveo/ui-kit-sample-headless-*` prefix to be matched by the glob.