### PR TITLE
Backstage/devportal overhaul

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,6 +6,7 @@
   "bracketSpacing": false,
   "ignorePatterns": [
     "**/packages/quantic/**/*",
+    "!**/packages/quantic/catalog-info.yaml",
     "**/packages/create-atomic-template/**/*",
     "**/packages/create-atomic-component/template/**/*",
     "**/packages/create-atomic-component-project/template/**/*",

--- a/catalog-info.ui-kit.yaml
+++ b/catalog-info.ui-kit.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: ui-kit
+  title: UI Kit
+  description: Monorepo for Coveo UI packages, shared tooling, and release workflows
+  annotations:
+    github.com/project-slug: coveo/ui-kit
+spec:
+  owner: dxui

--- a/catalog-info.ui-kit.yaml
+++ b/catalog-info.ui-kit.yaml
@@ -7,4 +7,4 @@ metadata:
   annotations:
     github.com/project-slug: coveo/ui-kit
 spec:
-  owner: dxui
+  owner: group:default/dxui

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,17 @@
 apiVersion: backstage.io/v1alpha1
-kind: Component
+kind: Location
 metadata:
   name: ui-kit
   annotations:
     github.com/project-slug: coveo/ui-kit
 spec:
-  type: other
-  lifecycle: unknown
-  owner: dxui
+  type: url
+  targets:
+    - ./packages/atomic/catalog-info.yaml
+    - ./packages/headless/catalog-info.yaml
+    - ./packages/bueno/catalog-info.yaml
+    - ./packages/atomic-hosted-page/catalog-info.yaml
+    - ./packages/headless-react/catalog-info.yaml
+    - ./packages/quantic/catalog-info.yaml
+    - ./packages/shopify/catalog-info.yaml
+    - ./packages/thermidor/catalog-info.yaml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,6 +8,7 @@ spec:
   type: url
   targets:
     - ./packages/atomic/catalog-info.yaml
+    - ./packages/atomic-react/catalog-info.yaml
     - ./packages/headless/catalog-info.yaml
     - ./packages/bueno/catalog-info.yaml
     - ./packages/atomic-hosted-page/catalog-info.yaml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,12 +1,13 @@
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: ui-kit
+  name: ui-kit-catalog
   annotations:
     github.com/project-slug: coveo/ui-kit
 spec:
   type: url
   targets:
+    - ./catalog-info.ui-kit.yaml
     - ./packages/atomic/catalog-info.yaml
     - ./packages/atomic-react/catalog-info.yaml
     - ./packages/headless/catalog-info.yaml

--- a/packages/atomic-hosted-page/catalog-info.yaml
+++ b/packages/atomic-hosted-page/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: dxui
+  owner: group:default/dxui
   system: ui-kit
   dependsOn:
     - headless

--- a/packages/atomic-hosted-page/catalog-info.yaml
+++ b/packages/atomic-hosted-page/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "@coveo/atomic-hosted-page"
+  description: Web Component used to inject a Coveo Hosted Search Page in the DOM.
+  annotations:
+    github.com/project-slug: coveo/ui-kit
+spec:
+  type: library
+  lifecycle: production
+  owner: dxui
+  dependsOn:
+    - "@coveo/headless"
+    - "@coveo/bueno"

--- a/packages/atomic-hosted-page/catalog-info.yaml
+++ b/packages/atomic-hosted-page/catalog-info.yaml
@@ -10,6 +10,7 @@ spec:
   type: library
   lifecycle: production
   owner: dxui
+  system: ui-kit
   dependsOn:
     - headless
     - bueno

--- a/packages/atomic-hosted-page/catalog-info.yaml
+++ b/packages/atomic-hosted-page/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: atomic-hosted-page
-  title: "@coveo/atomic-hosted-page"
+  title: '@coveo/atomic-hosted-page'
   description: Web Component used to inject a Coveo Hosted Search Page in the DOM.
   annotations:
     github.com/project-slug: coveo/ui-kit

--- a/packages/atomic-hosted-page/catalog-info.yaml
+++ b/packages/atomic-hosted-page/catalog-info.yaml
@@ -1,7 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: "@coveo/atomic-hosted-page"
+  name: atomic-hosted-page
+  title: "@coveo/atomic-hosted-page"
   description: Web Component used to inject a Coveo Hosted Search Page in the DOM.
   annotations:
     github.com/project-slug: coveo/ui-kit
@@ -10,5 +11,5 @@ spec:
   lifecycle: production
   owner: dxui
   dependsOn:
-    - "@coveo/headless"
-    - "@coveo/bueno"
+    - headless
+    - bueno

--- a/packages/atomic-react/catalog-info.yaml
+++ b/packages/atomic-react/catalog-info.yaml
@@ -10,6 +10,7 @@ spec:
   type: library
   lifecycle: production
   owner: dxui
+  system: ui-kit
   dependsOn:
     - atomic
     - headless

--- a/packages/atomic-react/catalog-info.yaml
+++ b/packages/atomic-react/catalog-info.yaml
@@ -1,7 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: "@coveo/atomic-react"
+  name: atomic-react
+  title: "@coveo/atomic-react"
   description: React specific wrapper for the Atomic component library
   annotations:
     github.com/project-slug: coveo/ui-kit
@@ -10,5 +11,5 @@ spec:
   lifecycle: production
   owner: dxui
   dependsOn:
-    - "@coveo/atomic"
-    - "@coveo/headless"
+    - atomic
+    - headless

--- a/packages/atomic-react/catalog-info.yaml
+++ b/packages/atomic-react/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: dxui
+  owner: group:default/dxui
   system: ui-kit
   dependsOn:
     - atomic

--- a/packages/atomic-react/catalog-info.yaml
+++ b/packages/atomic-react/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: atomic-react
-  title: "@coveo/atomic-react"
+  title: '@coveo/atomic-react'
   description: React specific wrapper for the Atomic component library
   annotations:
     github.com/project-slug: coveo/ui-kit

--- a/packages/atomic-react/catalog-info.yaml
+++ b/packages/atomic-react/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "@coveo/atomic-react"
+  description: React specific wrapper for the Atomic component library
+  annotations:
+    github.com/project-slug: coveo/ui-kit
+spec:
+  type: library
+  lifecycle: production
+  owner: dxui
+  dependsOn:
+    - "@coveo/atomic"
+    - "@coveo/headless"

--- a/packages/atomic/catalog-info.yaml
+++ b/packages/atomic/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: dxui
+  owner: group:default/dxui
   system: ui-kit
   dependsOn:
     - headless

--- a/packages/atomic/catalog-info.yaml
+++ b/packages/atomic/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: atomic
-  title: "@coveo/atomic"
+  title: '@coveo/atomic'
   description: A web-component library for building modern UIs interfacing with the Coveo platform
   annotations:
     github.com/project-slug: coveo/ui-kit
@@ -15,5 +15,3 @@ spec:
     - bueno
   dependencyOf:
     - atomic-react
-    - atomic-angular
-

--- a/packages/atomic/catalog-info.yaml
+++ b/packages/atomic/catalog-info.yaml
@@ -1,7 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: "@coveo/atomic"
+  name: atomic
+  title: "@coveo/atomic"
   description: A web-component library for building modern UIs interfacing with the Coveo platform
   annotations:
     github.com/project-slug: coveo/ui-kit
@@ -10,9 +11,9 @@ spec:
   lifecycle: production
   owner: dxui
   dependsOn:
-    - "@coveo/headless"
-    - "@coveo/bueno"
+    - headless
+    - bueno
   dependencyOf:
-    - "@coveo/atomic-react"
-    - "@coveo/atomic-angular"
+    - atomic-react
+    - atomic-angular
 

--- a/packages/atomic/catalog-info.yaml
+++ b/packages/atomic/catalog-info.yaml
@@ -10,6 +10,7 @@ spec:
   type: library
   lifecycle: production
   owner: dxui
+  system: ui-kit
   dependsOn:
     - headless
     - bueno

--- a/packages/atomic/catalog-info.yaml
+++ b/packages/atomic/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "@coveo/atomic"
+  description: A web-component library for building modern UIs interfacing with the Coveo platform
+  annotations:
+    github.com/project-slug: coveo/ui-kit
+spec:
+  type: library
+  lifecycle: production
+  owner: dxui
+  dependsOn:
+    - "@coveo/headless"
+    - "@coveo/bueno"
+  dependencyOf:
+    - "@coveo/atomic-react"
+    - "@coveo/atomic-angular"
+

--- a/packages/bueno/catalog-info.yaml
+++ b/packages/bueno/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: bueno
-  title: "@coveo/bueno"
+  title: '@coveo/bueno'
   description: A simple validator
   annotations:
     github.com/project-slug: coveo/ui-kit
@@ -13,5 +13,3 @@ spec:
   dependencyOf:
     - headless
     - atomic
-    - bueno
-

--- a/packages/bueno/catalog-info.yaml
+++ b/packages/bueno/catalog-info.yaml
@@ -1,7 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: "@coveo/bueno"
+  name: bueno
+  title: "@coveo/bueno"
   description: A simple validator
   annotations:
     github.com/project-slug: coveo/ui-kit
@@ -10,7 +11,7 @@ spec:
   lifecycle: production
   owner: dxui
   dependencyOf:
-    - "@coveo/headless"
-    - "@coveo/atomic"
-    - "@coveo/bueno"
+    - headless
+    - atomic
+    - bueno
 

--- a/packages/bueno/catalog-info.yaml
+++ b/packages/bueno/catalog-info.yaml
@@ -10,6 +10,7 @@ spec:
   type: library
   lifecycle: production
   owner: dxui
+  system: ui-kit
   dependencyOf:
     - headless
     - atomic

--- a/packages/bueno/catalog-info.yaml
+++ b/packages/bueno/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "@coveo/bueno"
+  description: A simple validator
+  annotations:
+    github.com/project-slug: coveo/ui-kit
+spec:
+  type: library
+  lifecycle: production
+  owner: dxui
+  dependencyOf:
+    - "@coveo/headless"
+    - "@coveo/atomic"
+    - "@coveo/bueno"
+

--- a/packages/bueno/catalog-info.yaml
+++ b/packages/bueno/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: dxui
+  owner: group:default/dxui
   system: ui-kit
   dependencyOf:
     - headless

--- a/packages/bueno/package.json
+++ b/packages/bueno/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@coveo/bueno",
   "version": "1.1.9",
+  "description": "A simple validator",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/headless-react/catalog-info.yaml
+++ b/packages/headless-react/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: dxui
+  owner: group:default/dxui
   system: ui-kit
   dependsOn:
     - headless

--- a/packages/headless-react/catalog-info.yaml
+++ b/packages/headless-react/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "@coveo/headless-react"
+  description: React utilities for SSR (Server Side Rendering) with headless
+  annotations:
+    github.com/project-slug: coveo/ui-kit
+spec:
+  type: library
+  lifecycle: production
+  owner: dxui
+  dependsOn:
+    - "@coveo/headless"

--- a/packages/headless-react/catalog-info.yaml
+++ b/packages/headless-react/catalog-info.yaml
@@ -1,7 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: "@coveo/headless-react"
+  name: headless-react
+  title: "@coveo/headless-react"
   description: React utilities for SSR (Server Side Rendering) with headless
   annotations:
     github.com/project-slug: coveo/ui-kit
@@ -10,4 +11,4 @@ spec:
   lifecycle: production
   owner: dxui
   dependsOn:
-    - "@coveo/headless"
+    - headless

--- a/packages/headless-react/catalog-info.yaml
+++ b/packages/headless-react/catalog-info.yaml
@@ -10,5 +10,6 @@ spec:
   type: library
   lifecycle: production
   owner: dxui
+  system: ui-kit
   dependsOn:
     - headless

--- a/packages/headless-react/catalog-info.yaml
+++ b/packages/headless-react/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: headless-react
-  title: "@coveo/headless-react"
+  title: '@coveo/headless-react'
   description: React utilities for SSR (Server Side Rendering) with headless
   annotations:
     github.com/project-slug: coveo/ui-kit

--- a/packages/headless/catalog-info.yaml
+++ b/packages/headless/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: dxui
+  owner: group:default/dxui
   system: ui-kit
   dependsOn:
     - bueno

--- a/packages/headless/catalog-info.yaml
+++ b/packages/headless/catalog-info.yaml
@@ -1,7 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: "@coveo/headless"
+  name: headless
+  title: "@coveo/headless"
   description: A web-component library for building modern UIs interfacing with the Coveo platform
   annotations:
     github.com/project-slug: coveo/ui-kit
@@ -10,8 +11,8 @@ spec:
   lifecycle: production
   owner: dxui
   dependsOn:
-    - "@coveo/bueno"
+    - bueno
   dependencyOf:
-    - "@coveo/atomic"
-    - "@coveo/quantic"
+    - atomic
+    - quantic
 

--- a/packages/headless/catalog-info.yaml
+++ b/packages/headless/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "@coveo/headless"
+  description: A web-component library for building modern UIs interfacing with the Coveo platform
+  annotations:
+    github.com/project-slug: coveo/ui-kit
+spec:
+  type: library
+  lifecycle: production
+  owner: dxui
+  dependsOn:
+    - "@coveo/bueno"
+  dependencyOf:
+    - "@coveo/atomic"
+    - "@coveo/quantic"
+

--- a/packages/headless/catalog-info.yaml
+++ b/packages/headless/catalog-info.yaml
@@ -10,6 +10,7 @@ spec:
   type: library
   lifecycle: production
   owner: dxui
+  system: ui-kit
   dependsOn:
     - bueno
   dependencyOf:

--- a/packages/headless/catalog-info.yaml
+++ b/packages/headless/catalog-info.yaml
@@ -2,8 +2,8 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: headless
-  title: "@coveo/headless"
-  description: A web-component library for building modern UIs interfacing with the Coveo platform
+  title: '@coveo/headless'
+  description: A headless library for building search experiences on the Coveo platform
   annotations:
     github.com/project-slug: coveo/ui-kit
 spec:
@@ -15,4 +15,3 @@ spec:
   dependencyOf:
     - atomic
     - quantic
-

--- a/packages/quantic/catalog-info.yaml
+++ b/packages/quantic/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: quantic
-  title: "@coveo/quantic"
+  title: '@coveo/quantic'
   description: A Salesforce Lightning Web Component (LWC) library for building modern UIs interfacing with the Coveo platform
   annotations:
     github.com/project-slug: coveo/ui-kit

--- a/packages/quantic/catalog-info.yaml
+++ b/packages/quantic/catalog-info.yaml
@@ -10,6 +10,7 @@ spec:
   type: library
   lifecycle: production
   owner: group:default/knowledge-integrations
+  system: ui-kit
   dependsOn:
     - headless
     - bueno

--- a/packages/quantic/catalog-info.yaml
+++ b/packages/quantic/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "@coveo/quantic"
+  description: A Salesforce Lightning Web Component (LWC) library for building modern UIs interfacing with the Coveo platform
+  annotations:
+    github.com/project-slug: coveo/ui-kit
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/knowledge-integrations
+  dependsOn:
+    - "@coveo/headless"
+    - "@coveo/bueno"

--- a/packages/quantic/catalog-info.yaml
+++ b/packages/quantic/catalog-info.yaml
@@ -1,7 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: "@coveo/quantic"
+  name: quantic
+  title: "@coveo/quantic"
   description: A Salesforce Lightning Web Component (LWC) library for building modern UIs interfacing with the Coveo platform
   annotations:
     github.com/project-slug: coveo/ui-kit
@@ -10,5 +11,5 @@ spec:
   lifecycle: production
   owner: group:default/knowledge-integrations
   dependsOn:
-    - "@coveo/headless"
-    - "@coveo/bueno"
+    - headless
+    - bueno

--- a/packages/shopify/catalog-info.yaml
+++ b/packages/shopify/catalog-info.yaml
@@ -1,7 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: "@coveo/shopify"
+  name: shopify
+  title: "@coveo/shopify"
   description: Utilities to integrate Shopify with Coveo's commerce engine
   annotations:
     github.com/project-slug: coveo/ui-kit
@@ -10,4 +11,4 @@ spec:
   lifecycle: production
   owner: group:default/commerce-shopify
   dependsOn:
-    - "@coveo/headless"
+    - headless

--- a/packages/shopify/catalog-info.yaml
+++ b/packages/shopify/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "@coveo/shopify"
+  description: Utilities to integrate Shopify with Coveo's commerce engine
+  annotations:
+    github.com/project-slug: coveo/ui-kit
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/commerce-shopify
+  dependsOn:
+    - "@coveo/headless"

--- a/packages/shopify/catalog-info.yaml
+++ b/packages/shopify/catalog-info.yaml
@@ -10,5 +10,6 @@ spec:
   type: library
   lifecycle: production
   owner: group:default/commerce-shopify
+  system: ui-kit
   dependsOn:
     - headless

--- a/packages/shopify/catalog-info.yaml
+++ b/packages/shopify/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: shopify
-  title: "@coveo/shopify"
+  title: '@coveo/shopify'
   description: Utilities to integrate Shopify with Coveo's commerce engine
   annotations:
     github.com/project-slug: coveo/ui-kit

--- a/packages/shopify/package.json
+++ b/packages/shopify/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@coveo/shopify",
   "version": "1.9.37",
+  "description": "Utilities to integrate Shopify with Coveo's commerce engine",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/thermidor/catalog-info.yaml
+++ b/packages/thermidor/catalog-info.yaml
@@ -9,5 +9,5 @@ metadata:
 spec:
   type: library
   lifecycle: experimental
-  owner: dxui
+  owner: group:default/dxui
   system: ui-kit

--- a/packages/thermidor/catalog-info.yaml
+++ b/packages/thermidor/catalog-info.yaml
@@ -1,7 +1,8 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: "@coveo/thermidor"
+  name: thermidor
+  title: "@coveo/thermidor"
   description: Experimental package for a unified, framework-agnostic headless engine for search and conversational experiences
   annotations:
     github.com/project-slug: coveo/ui-kit

--- a/packages/thermidor/catalog-info.yaml
+++ b/packages/thermidor/catalog-info.yaml
@@ -10,3 +10,4 @@ spec:
   type: library
   lifecycle: experimental
   owner: dxui
+  system: ui-kit

--- a/packages/thermidor/catalog-info.yaml
+++ b/packages/thermidor/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: "@coveo/thermidor"
+  description: Experimental package for a unified, framework-agnostic headless engine for search and conversational experiences
+  annotations:
+    github.com/project-slug: coveo/ui-kit
+spec:
+  type: library
+  lifecycle: experimental
+  owner: dxui

--- a/packages/thermidor/catalog-info.yaml
+++ b/packages/thermidor/catalog-info.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: thermidor
-  title: "@coveo/thermidor"
+  title: '@coveo/thermidor'
   description: Experimental package for a unified, framework-agnostic headless engine for search and conversational experiences
   annotations:
     github.com/project-slug: coveo/ui-kit


### PR DESCRIPTION
This pull request introduces and standardizes Backstage `catalog-info.yaml` files across multiple packages in the monorepo, improving service discovery and dependency tracking. The root `catalog-info.yaml` is refactored to act as a location aggregator, and each package now has its own `catalog-info.yaml` describing its metadata, ownership, and dependencies. Additionally, missing descriptions are added to `package.json` files for better documentation.

> [!NOTE]
> I excluded a couple of packages to focus on the essential (could revisit later still)

**Backstage catalog integration and metadata:**

* Refactored the root `catalog-info.yaml` to be a `Location` kind, aggregating all package-level catalog files for easier Backstage integration.
* Added new `catalog-info.yaml` files for the following packages, specifying their name, description, type, lifecycle, owner, and dependencies:
  - `@coveo/atomic`
  - `@coveo/headless`
  - `@coveo/bueno`
  - `@coveo/atomic-hosted-page`
  - `@coveo/atomic-react`
  - `@coveo/headless-react`
  - `@coveo/quantic`
  - `@coveo/shopify`
  - `@coveo/thermidor`

**Documentation improvements:**

* Added missing `description` fields to `package.json` files for `@coveo/bueno` and `@coveo/shopify` to enhance package documentation. [[1]](diffhunk://#diff-02b0349bdb849c9d46d824831814e69bbd51314badca3c21afac76dcad8b8965R4) [[2]](diffhunk://#diff-bf2a5e94d855280a662f69168161b7395f94fb3ce78d74934ec68f2ccc882b18R4)