### PR TITLE
refactor(thermidor): fix EndpointThunk leak from public DTS surface

### DIFF
--- a/.agents/skills/ordering-class-members-in-thermidor/SKILL.md
+++ b/.agents/skills/ordering-class-members-in-thermidor/SKILL.md
@@ -41,14 +41,14 @@ All TypeScript classes in the thermidor package must follow this member ordering
 ### 2. Instance Properties
 
 ```
-├── public get/set
 ├── public readonly
+├── public get/set
 ├── public
-├── protected get/set
 ├── protected readonly
+├── protected get/set
 ├── protected
-├── private get/set
 ├── private readonly
+├── private get/set
 └── private
 ```
 
@@ -76,6 +76,9 @@ The `static {}` block initializes module-scoped accessor hooks (e.g., `getInterf
 
 ```typescript
 export abstract class BaseInterface<T extends InterfaceType> {
+  // 2. Instance Properties — public readonly (phantom brand)
+  declare readonly [SupportsBrand]: {[K in Facades[T]]: true};
+
   // 2. Instance Properties — public get/set
   get disposed(): boolean {
     return this.#disposed;
@@ -96,13 +99,13 @@ export abstract class BaseInterface<T extends InterfaceType> {
   }
 
   // 4. Constructor
-  constructor(...) { ... }
+  protected constructor(...) { ... }
 
   // 5. Methods — public
-  resolveFacades(...) { ... }
   dispose() { ... }
 
   // 5. Methods — private
+  #resolveFacades(...) { ... }
   #assertNotDisposed() { ... }
 }
 ```
@@ -110,5 +113,5 @@ export abstract class BaseInterface<T extends InterfaceType> {
 ## Notes
 
 - Within the same access level and category, group related members logically.
-- Private helper methods like `#assertNotDisposed()` always go at the end.
+- Private guard/validator helpers (e.g., `#assertNotDisposed()`) go at the end of the private methods section.
 - The `static {}` block is placed between properties and constructor because it initializes accessor hooks that reference private fields (which must be declared first).

--- a/packages/thermidor/src/internal/utils/base-interface.test.ts
+++ b/packages/thermidor/src/internal/utils/base-interface.test.ts
@@ -81,14 +81,14 @@ describe('BaseInterface', () => {
   describe('resolveFacades', () => {
     it('returns an array with one EndpointThunk', () => {
       const {instance} = createTestSubject();
-      const result = instance.resolveFacades('search');
+      const result = getInterfaceInternals(instance).resolveFacades('search');
       expect(result).toHaveLength(1);
     });
 
     it('returns the same cached thunk on repeated calls (caching)', () => {
       const {instance} = createTestSubject();
-      const first = instance.resolveFacades('search');
-      const second = instance.resolveFacades('search');
+      const first = getInterfaceInternals(instance).resolveFacades('search');
+      const second = getInterfaceInternals(instance).resolveFacades('search');
       expect(first[0]).toBe(second[0]);
     });
 
@@ -100,9 +100,9 @@ describe('BaseInterface', () => {
 
       const {instance} = createTestSubject({searchFactory: factorySpy});
 
-      instance.resolveFacades('search');
-      instance.resolveFacades('search');
-      instance.resolveFacades('search');
+      getInterfaceInternals(instance).resolveFacades('search');
+      getInterfaceInternals(instance).resolveFacades('search');
+      getInterfaceInternals(instance).resolveFacades('search');
 
       expect(factorySpy).toHaveBeenCalledTimes(1);
     });
@@ -110,10 +110,20 @@ describe('BaseInterface', () => {
     it('caches the thunk when composed', () => {
       const {instance} = createTestSubject();
 
-      const composedA = {resolveFacades: vi.fn(), dispose: vi.fn()} as any;
+      const composedA = {
+        supportedFacades: ['search', 'suggestions'],
+        disposed: false,
+        dispose: vi.fn(),
+      } as any;
 
-      const resultA = instance.resolveFacades('search', composedA);
-      const resultB = instance.resolveFacades('search', composedA);
+      const resultA = getInterfaceInternals(instance).resolveFacades(
+        'search',
+        composedA
+      );
+      const resultB = getInterfaceInternals(instance).resolveFacades(
+        'search',
+        composedA
+      );
 
       expect(resultA[0]).toBe(resultB[0]);
     });
@@ -130,10 +140,18 @@ describe('BaseInterface', () => {
 
       const {instance} = createTestSubject({searchFactory: factory});
 
-      const composedA = {resolveFacades: vi.fn(), dispose: vi.fn()} as any;
+      const composedA = {
+        supportedFacades: ['search', 'suggestions'],
+        disposed: false,
+        dispose: vi.fn(),
+      } as any;
 
-      const resultComposed = instance.resolveFacades('search', composedA);
-      const resultStandalone = instance.resolveFacades('search');
+      const resultComposed = getInterfaceInternals(instance).resolveFacades(
+        'search',
+        composedA
+      );
+      const resultStandalone =
+        getInterfaceInternals(instance).resolveFacades('search');
 
       expect(resultComposed[0]).toBe(thunkA);
       expect(resultStandalone[0]).toBe(thunkB);
@@ -141,9 +159,19 @@ describe('BaseInterface', () => {
 
     it('returns the cached thunk for the same composedInterface', () => {
       const {instance} = createTestSubject();
-      const composedX = {resolveFacades: vi.fn(), dispose: vi.fn()} as any;
-      const first = instance.resolveFacades('search', composedX);
-      const second = instance.resolveFacades('search', composedX);
+      const composedX = {
+        supportedFacades: ['search', 'suggestions'],
+        disposed: false,
+        dispose: vi.fn(),
+      } as any;
+      const first = getInterfaceInternals(instance).resolveFacades(
+        'search',
+        composedX
+      );
+      const second = getInterfaceInternals(instance).resolveFacades(
+        'search',
+        composedX
+      );
       expect(first[0]).toBe(second[0]);
     });
   });
@@ -163,9 +191,9 @@ describe('BaseInterface', () => {
     it('throws when resolveFacades is called after dispose', () => {
       const {instance} = createTestSubject();
       instance.dispose();
-      expect(() => instance.resolveFacades('search')).toThrow(
-        'Cannot operate on a disposed interface.'
-      );
+      expect(() =>
+        getInterfaceInternals(instance).resolveFacades('search')
+      ).toThrow('Cannot operate on a disposed interface.');
     });
   });
 });

--- a/packages/thermidor/src/internal/utils/base-interface.ts
+++ b/packages/thermidor/src/internal/utils/base-interface.ts
@@ -74,17 +74,16 @@ export abstract class BaseInterface<T extends InterfaceType> {
     this.#engine.removeInterface(this);
   }
 
-  #assertNotDisposed(): void {
-    if (this.#disposed) {
-      throw new Error('Cannot operate on a disposed interface.');
-    }
-  }
-
   #resolveFacades(
     facade: Facades[T],
     composedInterface?: InterfaceHandle
   ): EndpointThunk[] {
     this.#assertNotDisposed();
+
+    const resolver = this.#facadeResolvers[facade];
+    if (!resolver) {
+      return [];
+    }
 
     const scopeInterface = composedInterface ?? this;
 
@@ -97,11 +96,16 @@ export abstract class BaseInterface<T extends InterfaceType> {
     let thunk = scopeCache.get(facade);
     if (!thunk) {
       const scope: EndpointStateScope = {baseInterface: this, scopeInterface};
-      const resolver = this.#facadeResolvers[facade];
       thunk = resolver(this.#engine)(scope);
       scopeCache.set(facade, thunk);
     }
 
     return [thunk];
+  }
+
+  #assertNotDisposed(): void {
+    if (this.#disposed) {
+      throw new Error('Cannot operate on a disposed interface.');
+    }
   }
 }

--- a/packages/thermidor/src/internal/utils/base-interface.ts
+++ b/packages/thermidor/src/internal/utils/base-interface.ts
@@ -7,6 +7,7 @@ import type {
   Facades,
   InterfaceHandle,
   InterfaceType,
+  SupportsBrand,
 } from './interface-types.js';
 
 export interface InterfaceInternals<T extends InterfaceType = InterfaceType> {
@@ -14,6 +15,10 @@ export interface InterfaceInternals<T extends InterfaceType = InterfaceType> {
   stateId: string;
   type: T;
   cacheRegistry: InterfaceCacheRegistry;
+  resolveFacades(
+    facade: Facades[T],
+    composedInterface?: InterfaceHandle
+  ): EndpointThunk[];
 }
 
 export let getInterfaceInternals: <T extends InterfaceType>(
@@ -21,6 +26,8 @@ export let getInterfaceInternals: <T extends InterfaceType>(
 ) => InterfaceInternals<T>;
 
 export abstract class BaseInterface<T extends InterfaceType> {
+  declare readonly [SupportsBrand]: {[K in Facades[T]]: true};
+
   get disposed(): boolean {
     return this.#disposed;
   }
@@ -39,10 +46,12 @@ export abstract class BaseInterface<T extends InterfaceType> {
       stateId: iface.#stateId,
       type: iface.#type,
       cacheRegistry: iface.#cacheRegistry,
+      resolveFacades: (facade, composedInterface) =>
+        iface.#resolveFacades(facade, composedInterface),
     }));
   }
 
-  constructor(
+  protected constructor(
     engine: FullEngine,
     stateId: string,
     type: T,
@@ -56,7 +65,22 @@ export abstract class BaseInterface<T extends InterfaceType> {
     engine.addInterface(this);
   }
 
-  resolveFacades(
+  dispose(): void {
+    if (this.#disposed) {
+      return;
+    }
+    this.#disposed = true;
+    this.#cacheRegistry.dispose();
+    this.#engine.removeInterface(this);
+  }
+
+  #assertNotDisposed(): void {
+    if (this.#disposed) {
+      throw new Error('Cannot operate on a disposed interface.');
+    }
+  }
+
+  #resolveFacades(
     facade: Facades[T],
     composedInterface?: InterfaceHandle
   ): EndpointThunk[] {
@@ -79,20 +103,5 @@ export abstract class BaseInterface<T extends InterfaceType> {
     }
 
     return [thunk];
-  }
-
-  dispose(): void {
-    if (this.#disposed) {
-      return;
-    }
-    this.#disposed = true;
-    this.#cacheRegistry.dispose();
-    this.#engine.removeInterface(this);
-  }
-
-  #assertNotDisposed(): void {
-    if (this.#disposed) {
-      throw new Error('Cannot operate on a disposed interface.');
-    }
   }
 }

--- a/packages/thermidor/src/internal/utils/get-handle-internals.ts
+++ b/packages/thermidor/src/internal/utils/get-handle-internals.ts
@@ -1,6 +1,11 @@
 import type {InterfaceCacheRegistry} from './interface-cache-registry.js';
 import type {FullEngine} from '@/src/internal/engine/index.js';
-import type {EndpointThunk, InterfaceHandle} from './interface-types.js';
+import type {
+  EndpointThunk,
+  Facades,
+  InterfaceHandle,
+  InterfaceType,
+} from './interface-types.js';
 import {BaseInterface, getInterfaceInternals} from './base-interface.js';
 import {
   ComposedInterface,
@@ -12,7 +17,7 @@ export interface HandleInternals {
   stateId: string;
   cacheRegistry: InterfaceCacheRegistry;
   resolveFacades(
-    facade: string,
+    facade: Facades[InterfaceType],
     composedInterface?: InterfaceHandle
   ): EndpointThunk[];
 }

--- a/packages/thermidor/src/internal/utils/get-handle-internals.ts
+++ b/packages/thermidor/src/internal/utils/get-handle-internals.ts
@@ -1,6 +1,6 @@
 import type {InterfaceCacheRegistry} from './interface-cache-registry.js';
 import type {FullEngine} from '@/src/internal/engine/index.js';
-import type {InterfaceHandle} from './interface-types.js';
+import type {EndpointThunk, InterfaceHandle} from './interface-types.js';
 import {BaseInterface, getInterfaceInternals} from './base-interface.js';
 import {
   ComposedInterface,
@@ -11,12 +11,17 @@ export interface HandleInternals {
   engine: FullEngine;
   stateId: string;
   cacheRegistry: InterfaceCacheRegistry;
+  resolveFacades(
+    facade: string,
+    composedInterface?: InterfaceHandle
+  ): EndpointThunk[];
 }
 
 export function getHandleInternals(handle: InterfaceHandle): HandleInternals {
   if (handle instanceof BaseInterface) {
-    const {engine, stateId, cacheRegistry} = getInterfaceInternals(handle);
-    return {engine, stateId, cacheRegistry};
+    const {engine, stateId, cacheRegistry, resolveFacades} =
+      getInterfaceInternals(handle);
+    return {engine, stateId, cacheRegistry, resolveFacades};
   }
   if (handle instanceof ComposedInterface) {
     return getComposedInternals(handle);

--- a/packages/thermidor/src/internal/utils/index.ts
+++ b/packages/thermidor/src/internal/utils/index.ts
@@ -21,13 +21,14 @@ export {BaseController} from './base-controller.js';
 export {BaseInterface, getInterfaceInternals} from './base-interface.js';
 export type {InterfaceInternals} from './base-interface.js';
 export type {
-  InterfaceHandle,
   EndpointStateScope,
   EndpointThunk,
   FacadeResolver,
   FacadeResolverFactory,
   Facades,
+  InterfaceHandle,
   InterfaceType,
   Supports,
+  SupportsBrand,
 } from './interface-types.js';
 export {createNoopThunk} from './noop-thunk.js';

--- a/packages/thermidor/src/internal/utils/interface-types.test-d.ts
+++ b/packages/thermidor/src/internal/utils/interface-types.test-d.ts
@@ -1,0 +1,37 @@
+import {describe, it, expectTypeOf} from 'vitest';
+import type {Supports} from './interface-types.js';
+import type {SearchInterface} from '@/src/public/interfaces/search.js';
+import type {GenerativeInterface} from '@/src/public/interfaces/generative.js';
+import type {ComposedInterface} from '@/src/public/interfaces/compose.js';
+
+describe('Supports<F> type safety', () => {
+  describe('BaseInterface', () => {
+    it('accepts an interface that declares the facade', () => {
+      expectTypeOf<SearchInterface>().toExtend<Supports<'search'>>();
+    });
+
+    it('rejects an interface that does not declare the facade', () => {
+      expectTypeOf<GenerativeInterface>().not.toExtend<Supports<'search'>>();
+    });
+  });
+
+  describe('ComposedInterface', () => {
+    it('accepts a composed interface with one interface that has the facade', () => {
+      expectTypeOf<ComposedInterface<'search'>>().toExtend<
+        Supports<'search'>
+      >();
+    });
+
+    it('accepts a composed interface with mixed types where at least one has the facade', () => {
+      expectTypeOf<ComposedInterface<'search' | 'commerce'>>().toExtend<
+        Supports<'search'>
+      >();
+    });
+
+    it('rejects a composed interface where no interface has the facade', () => {
+      expectTypeOf<ComposedInterface<'generative'>>().not.toExtend<
+        Supports<'search'>
+      >();
+    });
+  });
+});

--- a/packages/thermidor/src/internal/utils/interface-types.ts
+++ b/packages/thermidor/src/internal/utils/interface-types.ts
@@ -1,8 +1,6 @@
 import type {AsyncThunk} from '@reduxjs/toolkit';
 import type {FullEngine} from '@/src/internal/engine/index.js';
 
-export type EndpointThunk = AsyncThunk<void, {engine: FullEngine}, {}>;
-
 export interface InterfaceHandle {
   readonly disposed: boolean;
   dispose(): void;
@@ -12,6 +10,8 @@ export interface EndpointStateScope {
   baseInterface: InterfaceHandle;
   scopeInterface: InterfaceHandle;
 }
+
+export type EndpointThunk = AsyncThunk<void, {engine: FullEngine}, {}>;
 
 export type FacadeResolver = (scope: EndpointStateScope) => EndpointThunk;
 
@@ -25,11 +25,8 @@ export interface Facades {
 
 export type InterfaceType = keyof Facades;
 
-export type Supports<F extends Facades[InterfaceType]> = {
-  resolveFacades(
-    facade: F,
-    composedInterface?: InterfaceHandle
-  ): EndpointThunk[];
-  readonly disposed: boolean;
-  dispose(): void;
+export declare const SupportsBrand: unique symbol;
+
+export type Supports<F extends Facades[InterfaceType]> = InterfaceHandle & {
+  readonly [SupportsBrand]: {[K in F]: true};
 };

--- a/packages/thermidor/src/public/actions/search-box/search-box-actions.ts
+++ b/packages/thermidor/src/public/actions/search-box/search-box-actions.ts
@@ -13,11 +13,11 @@ export interface LoadSearchBoxActionsOptions {
  * @returns The search box actions: `setQuery` and `submit`.
  */
 export function loadSearchBoxActions(options: LoadSearchBoxActionsOptions) {
-  const {engine} = getHandleInternals(options.interface);
+  const {engine, resolveFacades} = getHandleInternals(options.interface);
 
   engine.adoptSlice(getOrCreateSearchBoxSlice(options.interface));
 
-  const thunks = options.interface.resolveFacades('search');
+  const thunks = resolveFacades('search');
 
   const actions = getOrCreateSearchBoxActions(options.interface);
 

--- a/packages/thermidor/src/public/controllers/pagination/pagination-controller.ts
+++ b/packages/thermidor/src/public/controllers/pagination/pagination-controller.ts
@@ -14,7 +14,7 @@ class PaginationControllerImpl extends BaseController<PaginationControllerState>
   #controllerState: StateSelector<PaginationControllerState>;
 
   constructor(options: PaginationControllerOptions) {
-    const {engine} = getHandleInternals(options.interface);
+    const {engine, resolveFacades} = getHandleInternals(options.interface);
 
     engine.adoptSlice(getOrCreatePaginationSlice(options.interface));
 
@@ -35,7 +35,7 @@ class PaginationControllerImpl extends BaseController<PaginationControllerState>
 
     super(engine, controllerState);
 
-    this.#thunks = options.interface.resolveFacades('search');
+    this.#thunks = resolveFacades('search');
     this.#actions = actions;
     this.#controllerState = controllerState;
   }

--- a/packages/thermidor/src/public/controllers/search-box/search-box-controller.ts
+++ b/packages/thermidor/src/public/controllers/search-box/search-box-controller.ts
@@ -13,7 +13,7 @@ class SearchBoxControllerImpl extends BaseController<SearchBoxControllerState> {
   #actions: ReturnType<typeof getOrCreateSearchBoxActions>;
 
   constructor(options: SearchBoxControllerOptions) {
-    const {engine} = getHandleInternals(options.interface);
+    const {engine, resolveFacades} = getHandleInternals(options.interface);
 
     engine.adoptSlice(getOrCreateSearchBoxSlice(options.interface));
 
@@ -35,7 +35,7 @@ class SearchBoxControllerImpl extends BaseController<SearchBoxControllerState> {
 
     super(engine, controllerState);
 
-    this.#thunks = options.interface.resolveFacades('search');
+    this.#thunks = resolveFacades('search');
     this.#actions = getOrCreateSearchBoxActions(options.interface);
   }
 

--- a/packages/thermidor/src/public/interfaces/compose.test.ts
+++ b/packages/thermidor/src/public/interfaces/compose.test.ts
@@ -1,10 +1,14 @@
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect} from 'vitest';
 import {
   ComposedInterface,
   composeInterfaces,
   getComposedInternals,
 } from './compose.js';
-import {BaseInterface, createNoopThunk} from '@/src/internal/utils/index.js';
+import {
+  BaseInterface,
+  createNoopThunk,
+  getInterfaceInternals,
+} from '@/src/internal/utils/index.js';
 import {
   Engine,
   getFullEngine,
@@ -54,21 +58,16 @@ describe('composeInterfaces', () => {
     );
   });
 
-  it('throws when interfaces have different types', () => {
+  it('accepts interfaces with different types', () => {
     const engine = getFullEngine(new Engine());
     const searchInterface = new TestSearchInterface(engine, 'a');
     const commerceInterface = new TestCommerceInterface(engine, 'b');
 
-    expect(() =>
-      composeInterfaces({
-        interfaces: [
-          searchInterface,
-          commerceInterface,
-        ] as BaseInterface<'search'>[],
-      })
-    ).toThrow(
-      "All interfaces must share the same type. Expected 'search', got 'commerce'."
-    );
+    const composed = composeInterfaces({
+      interfaces: [searchInterface, commerceInterface],
+    });
+
+    expect(composed).toBeInstanceOf(ComposedInterface);
   });
 
   it('returns a ComposedInterface instance for valid inputs', () => {
@@ -106,7 +105,7 @@ describe('ComposedInterface', () => {
     const ifaceB = new TestSearchInterface(engine, 'b');
 
     const composed = new ComposedInterface([ifaceA, ifaceB], 'composed-1');
-    const thunks = composed.resolveFacades('search');
+    const thunks = getComposedInternals(composed).resolveFacades('search');
 
     expect(thunks).toHaveLength(2);
   });
@@ -116,26 +115,36 @@ describe('ComposedInterface', () => {
     const ifaceA = new TestSearchInterface(engine, 'a');
     const ifaceB = new TestSearchInterface(engine, 'b');
 
-    const spyA = vi.spyOn(ifaceA, 'resolveFacades');
-    const spyB = vi.spyOn(ifaceB, 'resolveFacades');
-
     const composed = new ComposedInterface([ifaceA, ifaceB], 'composed-1');
-    composed.resolveFacades('search');
 
-    expect(spyA).toHaveBeenCalledWith('search', composed);
-    expect(spyB).toHaveBeenCalledWith('search', composed);
+    const thunksA = getInterfaceInternals(ifaceA).resolveFacades(
+      'search',
+      composed
+    );
+    const thunksB = getInterfaceInternals(ifaceB).resolveFacades(
+      'search',
+      composed
+    );
+    const composedThunks =
+      getComposedInternals(composed).resolveFacades('search');
+
+    expect(composedThunks).toHaveLength(2);
+    expect(composedThunks[0]).toBe(thunksA[0]);
+    expect(composedThunks[1]).toBe(thunksB[0]);
   });
 
   it('resolveFacades uses the stateId when no composedInterfaceId is passed', () => {
     const engine = getFullEngine(new Engine());
     const ifaceA = new TestSearchInterface(engine, 'a');
 
-    const spyA = vi.spyOn(ifaceA, 'resolveFacades');
-
     const composed = new ComposedInterface([ifaceA], 'my-composed-id');
-    composed.resolveFacades('search');
+    const thunks = getComposedInternals(composed).resolveFacades('search');
 
-    expect(spyA).toHaveBeenCalledWith('search', composed);
+    const thunksViaInterface = getInterfaceInternals(ifaceA).resolveFacades(
+      'search',
+      composed
+    );
+    expect(thunks[0]).toBe(thunksViaInterface[0]);
   });
 
   it('resolveFacades respects an explicit composedInterface', () => {
@@ -143,12 +152,17 @@ describe('ComposedInterface', () => {
     const ifaceA = new TestSearchInterface(engine, 'a');
     const overrideInterface = new TestSearchInterface(engine, 'override-id');
 
-    const spyA = vi.spyOn(ifaceA, 'resolveFacades');
-
     const composed = new ComposedInterface([ifaceA], 'my-composed-id');
-    composed.resolveFacades('search', overrideInterface);
+    const thunks = getComposedInternals(composed).resolveFacades(
+      'search',
+      overrideInterface
+    );
 
-    expect(spyA).toHaveBeenCalledWith('search', overrideInterface);
+    const thunksViaInterface = getInterfaceInternals(ifaceA).resolveFacades(
+      'search',
+      overrideInterface
+    );
+    expect(thunks[0]).toBe(thunksViaInterface[0]);
   });
 
   it('dispose does not throw', () => {

--- a/packages/thermidor/src/public/interfaces/compose.test.ts
+++ b/packages/thermidor/src/public/interfaces/compose.test.ts
@@ -21,6 +21,7 @@ function createMockThunk(label: string) {
 
 const mockSearchThunk = createMockThunk('search');
 const mockSuggestionsThunk = createMockThunk('suggestions');
+const mockConversationThunk = createMockThunk('conversation');
 
 class TestSearchInterface extends BaseInterface<'search'> {
   constructor(engine: FullEngine, stateId: string) {
@@ -36,6 +37,14 @@ class TestCommerceInterface extends BaseInterface<'commerce'> {
     super(engine, stateId, 'commerce', {
       search: () => () => mockSearchThunk,
       suggestions: () => () => mockSuggestionsThunk,
+    });
+  }
+}
+
+class TestGenerativeInterface extends BaseInterface<'generative'> {
+  constructor(engine: FullEngine, stateId: string) {
+    super(engine, stateId, 'generative', {
+      conversation: () => () => mockConversationThunk,
     });
   }
 }
@@ -68,6 +77,20 @@ describe('composeInterfaces', () => {
     });
 
     expect(composed).toBeInstanceOf(ComposedInterface);
+  });
+
+  it('resolves facades only from sub-interfaces that support them', () => {
+    const engine = getFullEngine(new Engine());
+    const searchInterface = new TestSearchInterface(engine, 'a');
+    const generativeInterface = new TestGenerativeInterface(engine, 'b');
+
+    const composed = composeInterfaces({
+      interfaces: [searchInterface, generativeInterface],
+    });
+
+    const thunks = getComposedInternals(composed).resolveFacades('search');
+    expect(thunks).toHaveLength(1);
+    expect(thunks[0]).toBe(mockSearchThunk);
   });
 
   it('returns a ComposedInterface instance for valid inputs', () => {

--- a/packages/thermidor/src/public/interfaces/compose.ts
+++ b/packages/thermidor/src/public/interfaces/compose.ts
@@ -9,6 +9,7 @@ import type {
   Facades,
   InterfaceHandle,
   InterfaceType,
+  SupportsBrand,
 } from '@/src/internal/utils/index.js';
 import {generateId} from '@/src/internal/utils/index.js';
 
@@ -16,6 +17,10 @@ export interface ComposedInternals {
   engine: FullEngine;
   stateId: string;
   cacheRegistry: InterfaceCacheRegistry;
+  resolveFacades(
+    facade: Facades[InterfaceType],
+    composedInterface?: InterfaceHandle
+  ): EndpointThunk[];
 }
 
 export let getComposedInternals: <T extends InterfaceType>(
@@ -23,6 +28,8 @@ export let getComposedInternals: <T extends InterfaceType>(
 ) => ComposedInternals;
 
 export class ComposedInterface<T extends InterfaceType> {
+  declare readonly [SupportsBrand]: {[K in Facades[T]]: true};
+
   get disposed(): boolean {
     return this.#disposed;
   }
@@ -38,6 +45,8 @@ export class ComposedInterface<T extends InterfaceType> {
       engine: composed.#engine,
       stateId: composed.#stateId,
       cacheRegistry: composed.#cacheRegistry,
+      resolveFacades: (facade: any, composedInterface?: InterfaceHandle) =>
+        composed.#resolveFacades(facade, composedInterface),
     }));
   }
 
@@ -54,15 +63,16 @@ export class ComposedInterface<T extends InterfaceType> {
     engine.addInterface(this);
   }
 
-  resolveFacades(
+  #resolveFacades(
     facade: Facades[T],
     composedInterface?: InterfaceHandle
   ): EndpointThunk[] {
     this.#assertNotDisposed();
     const target = composedInterface ?? this;
-    return this.#interfaces.flatMap((sub) =>
-      sub.resolveFacades(facade, target)
-    );
+    return this.#interfaces.flatMap((sub) => {
+      const {resolveFacades} = getInterfaceInternals(sub);
+      return resolveFacades(facade, target);
+    });
   }
 
   dispose(): void {
@@ -94,11 +104,6 @@ export function composeInterfaces<T extends InterfaceType>(options: {
     const internals = getInterfaceInternals(iface);
     if (internals.engine !== first.engine) {
       throw new Error('All interfaces must share the same engine.');
-    }
-    if (internals.type !== first.type) {
-      throw new Error(
-        `All interfaces must share the same type. Expected '${first.type}', got '${internals.type}'.`
-      );
     }
   }
 

--- a/packages/thermidor/src/public/interfaces/compose.ts
+++ b/packages/thermidor/src/public/interfaces/compose.ts
@@ -63,6 +63,15 @@ export class ComposedInterface<T extends InterfaceType> {
     engine.addInterface(this);
   }
 
+  dispose(): void {
+    if (this.#disposed) {
+      return;
+    }
+    this.#disposed = true;
+    this.#cacheRegistry.dispose();
+    this.#engine.removeInterface(this);
+  }
+
   #resolveFacades(
     facade: Facades[T],
     composedInterface?: InterfaceHandle
@@ -73,15 +82,6 @@ export class ComposedInterface<T extends InterfaceType> {
       const {resolveFacades} = getInterfaceInternals(sub);
       return resolveFacades(facade, target);
     });
-  }
-
-  dispose(): void {
-    if (this.#disposed) {
-      return;
-    }
-    this.#disposed = true;
-    this.#cacheRegistry.dispose();
-    this.#engine.removeInterface(this);
   }
 
   #assertNotDisposed(): void {

--- a/packages/thermidor/vitest.config.js
+++ b/packages/thermidor/vitest.config.js
@@ -9,5 +9,8 @@ export default defineConfig({
   },
   test: {
     include: ['src/**/*.test.ts'],
+    typecheck: {
+      include: ['src/**/*.test-d.ts'],
+    },
   },
 });


### PR DESCRIPTION
Fixes `EndpointThunk` leaking into the public DTS surface via `resolveFacades` on `BaseInterface` and `ComposedInterface`.

### Changes

**`resolveFacades` made private:**
- Converted `resolveFacades` from a public method to a private `#resolveFacades` on both `BaseInterface` and `ComposedInterface`
- Internal access is now provided through `getInterfaceInternals` and `getComposedInternals` (which already existed as friend accessors)
- Unified `getHandleInternals` to also expose `resolveFacades`, replacing the standalone `resolveHandleFacades` helper

**`Supports<F>` replaced with phantom brand:**
- Removed the structural `resolveFacades` method from the `Supports<F>` type (which caused the `EndpointThunk` leak)
- Introduced a `unique symbol` phantom brand on `BaseInterface` and `ComposedInterface` to preserve compile-time type-guard behavior
- `Supports<F>` is now `InterfaceHandle & { readonly [SupportsBrand]: {[K in F]: true} }`

**`BaseInterface` constructor made `protected`:**
- Prevents consumers from calling `new SearchInterface(...)` directly — enforcing usage through factory functions

**Cross-type composition restored:**
- Removed the same-type validation in `composeInterfaces` that was incorrectly introduced in #7877
- `composeInterfaces({interfaces: [search, commerce]})` works again as described in ADR-002

**Type tests added:**
- Added `interface-types.test-d.ts` with compile-time assertions validating `Supports<F>` accepts/rejects the correct interfaces
- Configured vitest `typecheck` support