### PR TITLE
feat(create-ui): publish @coveo/create-ui to npm

### DIFF
--- a/.changeset/create-ui-initial-release.md
+++ b/.changeset/create-ui-initial-release.md
@@ -1,0 +1,5 @@
+---
+"@coveo/create-ui": minor
+---
+
+Initial release of `@coveo/create-ui`.

--- a/packages/create-ui/package.json
+++ b/packages/create-ui/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@coveo/create-ui",
   "version": "0.0.0",
-  "private": true,
   "description": "Scaffold a Coveo UI project (Atomic or Headless) from the official samples.",
   "keywords": [
     "atomic",


### PR DESCRIPTION
## Problem

`@coveo/create-ui` (the `npm create @coveo/ui` scaffolding CLI) is marked `private: true`, so it is not published to npm and can't be used by consumers.

## Solution

Remove `private: true`. The package is already fully publish-ready — it has `bin`, `files: ["dist/"]`, `publishConfig.access: "public"`, a description/keywords/license/repository, and only public runtime dependencies (`@clack/prompts`, `commander`, `pacote`) — so this single change is all that's needed to make it publishable.

## Note

A Changeset will be needed to trigger the first release/version bump of the package; happy to add one here if that's expected in this PR.