### PR TITLE
chore: setup mise for unified tooling

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 min_version = "2026.7.0"
 
 [tools]
-node = "24.17.0"
+node = "24.16.0"
 pnpm = "10.34.4"
 
 [tasks.install]

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,8 @@
+min_version = "2026.7.0"
+
+[tools]
+node = "24.17.0"
+pnpm = "10.34.4"
+
+[tasks.install]
+run = "pnpm install"


### PR DESCRIPTION
# [KIT-5875](https://coveord.atlassian.net/browse/KIT-5875)

### Proposed changes

- Set up `mise` for unified tools installation
- Add an install task for use by [coveo-platform/thermidor-stack](https://github.com/coveo-platform/thermidor-stack/) or locally

See https://github.com/coveo-platform/thermidor-stack/pull/10

## How to test?

### Recommended: thermidor-stack

See "How to test" in https://github.com/coveo-platform/thermidor-stack/pull/10

### ui-kit only
1. Install [mise](https://mise.jdx.dev/getting-started.html#getting-started)
2. If you don't set the shell auto-activation, run `eval "$(mise activate)"` at the root of the repo
3. Run `mise install` at the root of the repo: it should use node and all the like from mise now. (e.g. `which node`)


[KIT-5875]: https://coveord.atlassian.net/browse/KIT-5875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ