### PR TITLE
feat(skills): add managing-ui-kit-samples agent skill

### DIFF
--- a/.agents/skills/managing-ui-kit-samples/SKILL.md
+++ b/.agents/skills/managing-ui-kit-samples/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: managing-ui-kit-samples
+description: Creates, modifies, and publishes the Coveo UI-Kit samples under samples/ (Atomic and Headless, search and commerce, across vanilla/React/Angular/Next.js) that double as the npm create @coveo/ui scaffolding templates. Use when adding a new sample, changing an existing one, making a sample publishable, keeping samples consistent (features, styling, tests, script contract), or debugging their publish/lockfile/CI setup.
+license: Apache-2.0
+metadata:
+  author: coveo
+  version: '2.0'
+---
+
+# Managing UI-Kit Samples
+
+The apps under `samples/` are **dual-purpose**: living documentation for the
+Coveo libraries **and** the source templates published to npm as
+`@coveo/ui-kit-sample-<name>` and fetched by `npm create @coveo/ui`. Part of
+epic KIT-5452 ("Improve Atomic & Headless Samples/Scaffolding"). Every change
+must keep them consistent, runnable out of the box, tested, and publishable.
+
+This skill is the actionable layer on top of the canonical standard in
+[`samples/CONTRIBUTING.md`](../../../samples/CONTRIBUTING.md) — read that first.
+It adds the cross-cutting recipe and the error-prone publishing/lockfile
+mechanics (see [`references/publishing.md`](references/publishing.md)).
+
+## When to use
+
+- Adding a new sample (any library/framework in the matrix below).
+- Modifying an existing one (a feature/component, styling, a fix).
+- Making a sample publishable, or auditing that samples stay consistent.
+- Debugging a sample's publish output, a broken lockfile after a rebase, or its
+  e2e CI wiring.
+
+## The template matrix
+
+Samples span two axes. `samples = scaffolding`: each folder is published 1:1 as a
+`--template`.
+
+| Category (folder)   | Library                             | Use cases          | Frameworks                              |
+| ------------------- | ----------------------------------- | ------------------ | --------------------------------------- |
+| `atomic/`           | `@coveo/atomic`, `@coveo/atomic-react` | search, commerce | vanilla (Vite), React, Angular, Next.js, Vue |
+| `headless/`         | `@coveo/headless` (client-side)     | search, commerce   | vanilla (Vite, e.g. Lit), React         |
+| `headless-ssr/`     | `@coveo/headless` (SSR)             | search, commerce   | Next.js, Express, React Router          |
+| `thermidor/`        | `@coveo/thermidor`                  | conversation, search | React                                  |
+
+Framework version policy: support **current + previous major** of Angular,
+React, Next.js.
+
+## Golden rules
+
+1. **Keep samples consistent.** A feature, style, a11y fix, or convention change
+   in one sample usually belongs in its siblings (mirror across React and
+   vanilla/Lit; across search and commerce where applicable).
+2. **Zero-config & self-contained.** Runs after `pnpm install` with no
+   credentials — only the public `searchuisamples` org via
+   `getSampleSearchEngineConfiguration()` /
+   `getSampleCommerceEngineConfiguration()`. **Search samples set the search hub
+   to `BarcaKnowledge`.** No `.env`, no OAuth.
+3. **The published copy must install & build for an outside user.** No internal
+   workspace packages (e.g. `@coveo/platform-mock-api`) or test tooling may reach
+   a scaffolded project — the prepack builder enforces this.
+4. **Minimal & single-purpose.** One library + framework per sample; simple,
+   readable code a non-developer can follow.
+5. **Verify, don't assume.** End with build + lint + e2e, and for publish changes
+   run the scaffold deploy-test.
+
+## Relationship to the CLI
+
+`npm create @coveo/ui@latest my-app --template <id>` downloads the published
+`@coveo/ui-kit-sample-<id>` tarball (via `pacote`), renames it, and installs.
+Sample versions are **fixed in lockstep with their library** (Headless/Atomic)
+through changesets fixed packages, so `--template-version <v>` selects the sample
+built against library version `v` (defaults to `latest`). See
+[`packages/create-ui/README.md`](../../../packages/create-ui/README.md) and
+[ADR 001/002](../../../packages/create-ui/docs/adr/).
+
+## Required features per sample type
+
+Follow "What Belongs in a Sample" in CONTRIBUTING.md:
+
+- **Atomic Search** — every relevant `atomic-*` component with minimal config,
+  using fields available in `searchuisamples`. Styling comes from Atomic's own
+  themes; don't hand-roll CSS.
+- **Atomic Commerce** — 1 search page, 2 product listing pages, 1 recommendations
+  page.
+- **Headless Search** — at minimum search box + result list + pager; also facets
+  and sort. The current React/vanilla samples also include: query suggestions +
+  instant results with `role=listbox`/`option` + valid `aria-selected`, a
+  hierarchical **category facet** shown in the breadbox
+  (`categoryFacetBreadcrumbs`), breadcrumbs, sort (Relevance/Newest/Oldest),
+  numbered pager, query summary, and href sanitizing via `filterProtocol`.
+- **Headless Commerce** — 1 search page, 1+ product listing page(s), 1
+  recommendations section; instant products in the search-box dropdown.
+- **Headless SSR** — the SSR wiring for the framework (Next.js App Router,
+  Express, React Router) plus the search/commerce experience.
+
+Keep implementations feature-equivalent across frameworks.
+
+## Standard script contract
+
+CI discovers samples via Turbo, so scripts must match (adding a compliant sample
+needs **zero** CI changes):
+
+| Script  | Required | Command           |
+| ------- | -------- | ----------------- |
+| `dev`   | yes      | start dev server  |
+| `build` | yes      | production build  |
+| `e2e`   | yes      | `playwright test` |
+| `test`  | optional | `vitest run` (unit tests only) |
+
+- Playwright goes under **`e2e`**, never `test`.
+- **Atomic-React exception:** samples consuming `@coveo/atomic-react` assets may
+  add a `build:assets` step (copying `dist/assets`, `dist/lang`, `dist/themes`)
+  called from a `predev`/`build` hook — the only permitted script deviation.
+
+## Testing
+
+Deterministic Playwright smoke tests are the contract (never a live API):
+`@coveo/platform-mock-api` + `@msw/playwright` + `msw`. See CONTRIBUTING.md for
+the `e2e/fixtures.ts` + `e2e/smoke.spec.ts` template and required devDeps. E2E
+runs through a single glob/affected-driven `samples-e2e` CI job
+(`turbo run e2e --affected`).
+
+## Styling conventions
+
+- **Headless (custom UI) samples**: clean, unbranded, Atomic-like. Define the
+  palette/scale as `:root` CSS custom properties in `src/index.css` using the
+  shared tokens in [`assets/design-tokens.css`](assets/design-tokens.css); use
+  BEM-ish class names, semantic HTML, and `:focus-visible` outlines. Don't invent
+  per-sample colors — copy the tokens into siblings so they match.
+- **Atomic samples**: styling comes from Atomic's components/themes — keep it
+  minimal, don't add custom design systems.
+
+## Making a sample publishable
+
+Samples publish via pnpm's `publishConfig.directory` + a shared **prepack
+builder** ([`scripts/build-sample-publish-dir.mjs`](../../../scripts/build-sample-publish-dir.mjs))
+that emits a trimmed `./publish/`. This is the current mechanism and
+**supersedes the `files`-allowlist approach proposed in ADR 002**. Full diffs and
+lockfile details: [`references/publishing.md`](references/publishing.md).
+
+Checklist:
+
+1. **`package.json`**: remove `private`; add
+   `"publishConfig": {"access": "public", "directory": "publish", "linkDirectory": false}`
+   and `"prepack": "node ../../../scripts/build-sample-publish-dir.mjs"`. Keep
+   `dev`/`build`/`e2e` (+ `preview`); drop stray `test`/`e2e:watch` scripts and
+   any vitest/testing-library devDeps if the sample has no unit tests.
+2. **`.gitignore`**: add `publish`.
+3. **Lockfile**: add `    publishDirectory: publish` (4-space indent) to this
+   sample's importer, after its last devDependency — do **not** regenerate the
+   whole lockfile. See [`references/publishing.md`](references/publishing.md).
+4. Verify: `pnpm install --frozen-lockfile`, run the builder + `pnpm pack`, and
+   run the scaffold deploy-test.
+
+The builder is **shared** — generalize it (e.g. `existsSync` guard for optional
+shipped paths) rather than forking per-sample, and never let a branch diverge it
+from `main`.
+
+## Verification (always)
+
+From the sample dir: `pnpm install`, `pnpm dev` (renders?), `pnpm e2e` (smoke
+passes?). From the repo root: `pnpm run lint:check` (or `oxlint`/`oxfmt` on
+changed files). For any **publish** change, also run the scaffold deploy-test
+(pack → extract → `npm install` → `npm run build` → render) per
+[`references/publishing.md`](references/publishing.md).
+
+## Git workflow
+
+- Worktree per branch; keep sample PRs to a **single, squashed commit**.
+- **Rebase** onto `main` (never merge). After a rebase the auto-merged
+  `pnpm-lock.yaml` is often silently broken — always re-run `pnpm install
+  --frozen-lockfile` and fix per [`references/publishing.md`](references/publishing.md)
+  before pushing.
+- Keep the PR description in sync with the final branch state.
+
+## Reference & assets
+
+| File | When to load |
+| ---- | ------------ |
+| [`samples/CONTRIBUTING.md`](../../../samples/CONTRIBUTING.md) | Canonical standards, naming taxonomy, test template, script contract |
+| [`packages/create-ui/README.md`](../../../packages/create-ui/README.md) + [ADRs](../../../packages/create-ui/docs/adr/) | CLI usage, template versioning, publishing/consumption decisions |
+| [`references/publishing.md`](references/publishing.md) | publishConfig.directory + builder, lockfile edits, rebase fix, deploy-test |
+| [`assets/design-tokens.css`](assets/design-tokens.css) | Baseline shared CSS tokens for a headless custom-UI sample |
+
+## Checklist
+
+- [ ] Correct category/naming: `@coveo/ui-kit-sample-<category>-<usecase>[-<framework>]`, matches `--template`
+- [ ] Feature set matches the sample type and mirrors siblings
+- [ ] Zero-config; `searchuisamples`; search hub `BarcaKnowledge` for search
+- [ ] Script contract (`dev`/`build`/`e2e`, `test` optional); Atomic-React `build:assets` only if needed
+- [ ] Styling: shared tokens (headless) or Atomic themes (atomic); accessible markup
+- [ ] `e2e` Playwright smoke test with `@coveo/platform-mock-api` + MSW
+- [ ] Publishable: `publishConfig.directory` + `prepack`, `publish` gitignored, `publishDirectory` in the lockfile importer
+- [ ] `pnpm install --frozen-lockfile` passes (no `@types/node` drift)
+- [ ] build + lint + e2e green; scaffold deploy-test renders with live data
+- [ ] README has "Using this sample as an MRE" + version-pinning sections
+- [ ] Single squashed commit, rebased on `main`, PR description in sync

--- a/.agents/skills/managing-ui-kit-samples/assets/design-tokens.css
+++ b/.agents/skills/managing-ui-kit-samples/assets/design-tokens.css
@@ -1,0 +1,61 @@
+/*
+ * Shared design tokens for @coveo/ui-kit-sample-headless-* apps.
+ *
+ * Copy this :root block into a new/updated sample's src/index.css so the
+ * samples stay visually consistent: a clean, unbranded, Atomic-like look
+ * (neutral surface, white panels/cards, a single accent). Do not invent
+ * per-sample colors — extend these tokens instead.
+ */
+
+:root {
+  --bg: #f4f6f8;
+  --surface: #ffffff;
+  --text: #1c1c28;
+  --text-muted: #6b7280;
+  --border: #e4e8ec;
+  --accent: #1372ec;
+  --accent-hover: #0f5ec4;
+  --accent-soft: #e8f1fd;
+  --accent-contrast: #ffffff;
+  --radius: 10px;
+  --radius-sm: 6px;
+  --shadow-sm: 0 1px 2px rgba(20, 30, 45, 0.06);
+  --shadow: 0 6px 20px rgba(20, 30, 45, 0.1);
+
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    sans-serif;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+/* Baseline resets/affordances the samples share. */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Always keep a visible keyboard focus indicator. */
+button:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/.agents/skills/managing-ui-kit-samples/references/publishing.md
+++ b/.agents/skills/managing-ui-kit-samples/references/publishing.md
@@ -1,0 +1,168 @@
+# Publishing samples
+
+How any `samples/*` app (Atomic or Headless) is published to npm as a
+`@coveo/create-ui` scaffolding template, and the gotchas that bite every time.
+The mechanism is library-agnostic; the only per-sample differences are which
+build tooling is kept (e.g. `@vitejs/plugin-react`/`typescript` for React/TS,
+or an Atomic-React `build:assets` step) versus stripped.
+
+## Mechanism: `publishConfig.directory` + prepack builder
+
+Each sample publishes a **trimmed copy** of itself, not its working directory.
+On `pnpm pack`/`publish`, pnpm runs the `prepack` script, which builds a
+`./publish/` folder; `publishConfig.directory: "publish"` tells pnpm to publish
+that folder.
+
+The builder is shared: [`scripts/build-sample-publish-dir.mjs`](../../../../scripts/build-sample-publish-dir.mjs).
+It:
+
+- Copies only `SHIPPED_PATHS` (`src`, `public`, `index.html`, `vite.config.js`,
+  `tsconfig.json`, `README.md`), skipping any that don't exist (`existsSync`
+  guard, needed for vanilla samples with no `tsconfig.json`) and excluding test
+  files (`*.test.*` / `*.spec.*`).
+- Removes test-only devDependencies (`@coveo/platform-mock-api`, `@msw/playwright`,
+  `@playwright/test`, `msw`) — the internal `@coveo/platform-mock-api` is
+  unpublished and would break `install` for a scaffolded user. **Build tooling
+  (`vite`, `@vitejs/plugin-react`, `typescript`, `@types/*`) is intentionally
+  kept.**
+- Removes test-only scripts (`e2e`) and the publish-only fields (`prepack`,
+  `publishConfig.directory`, `publishConfig.linkDirectory`) so the published copy
+  is a plain, runnable project.
+
+**Prefer generalizing this shared script over per-sample logic.** If a sample has
+an extra test-only script (e.g. `e2e:watch`), the cleaner fix is usually to
+remove that script from the sample rather than special-case the builder. Never
+let a branch's copy of the builder diverge from `main`.
+
+## package.json shape (publishable sample)
+
+```jsonc
+{
+  "name": "@coveo/ui-kit-sample-<category>-<use-case>[-<framework>]",
+  "version": "0.0.0",
+  "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "directory": "publish",
+    "linkDirectory": false
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "e2e": "playwright test",
+    "prepack": "node ../../../scripts/build-sample-publish-dir.mjs"
+  },
+  "dependencies": {
+    "@coveo/headless": "workspace:*"
+    // + react/react-dom (catalog:) or lit (catalog:)
+  },
+  "devDependencies": {
+    "@coveo/platform-mock-api": "workspace:*",
+    "@msw/playwright": "catalog:",
+    "@playwright/test": "catalog:",
+    "msw": "catalog:"
+    // + build tooling: vite (catalog:), and for TS/react:
+    //   @vitejs/plugin-react, typescript, @types/node, @types/react, @types/react-dom
+  }
+}
+```
+
+Also add `publish` to the sample's `.gitignore`.
+
+## Lockfile: the `publishDirectory` field
+
+`publishConfig.directory` must be recorded in the sample's importer in
+`pnpm-lock.yaml` as `publishDirectory`, or `--frozen-lockfile` fails:
+
+```
+ERR_PNPM_OUTDATED_LOCKFILE ... "publishDirectory" in the lockfile (undefined)
+doesn't match "publishConfig.directory" in package.json (publish)
+```
+
+### Surgical edit (preferred — no drift)
+
+A full `pnpm install` can drift unrelated versions (e.g. bump `@types/node`
+across the lockfile). For an existing sample whose deps don't change, edit the
+lockfile by hand: find the sample's importer block and add, at 4-space indent
+right after its last devDependency version line:
+
+```yaml
+    publishDirectory: publish
+```
+
+Then confirm: `pnpm install --frozen-lockfile` → `Lockfile is up to date`.
+`--frozen-lockfile` tolerates stale transitive versions; it only flags
+importer ↔ package.json mismatches.
+
+### When adding a brand-new sample
+
+The importer doesn't exist in `main`'s lockfile yet, so regenerate additively:
+
+```bash
+git checkout origin/main -- pnpm-lock.yaml   # start from a clean base
+pnpm install --lockfile-only                 # adds the new importer (+ publishDirectory)
+pnpm install --frozen-lockfile               # verify (exit 0)
+git diff --stat origin/main -- pnpm-lock.yaml   # expect a small, additive diff
+```
+
+## Broken lockfile after a rebase (recurring!)
+
+A conflict-free `git rebase origin/main` frequently leaves `pnpm-lock.yaml`
+**semantically broken** even though git reported no conflict: the sample importer
+still references version hashes (e.g. `vite@8.1.2(@types/node@26.0.1)...`) that no
+longer exist in `main`'s updated `packages:`/`snapshots:` section. Symptom:
+
+```
+ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for
+'@msw/playwright@0.6.7(msw@2.14.6(@types/node@26.0.1)...)' in pnpm-lock.yaml
+```
+
+**Always run `pnpm install --frozen-lockfile` after any rebase, before pushing.**
+Fix by regenerating just this importer against main's lockfile:
+
+```bash
+git checkout origin/main -- pnpm-lock.yaml
+pnpm install --lockfile-only        # re-resolves the importer against main's packages
+pnpm install --frozen-lockfile      # verify exit 0
+# re-add publishDirectory if the regen dropped it, then amend + force-push
+```
+
+The result should be a small additive diff (just this sample's importer +
+`publishDirectory`), not a repo-wide version churn.
+
+## Verify the published output (builder check)
+
+```bash
+cd samples/headless/<sample>
+node ../../../scripts/build-sample-publish-dir.mjs
+# inspect publish/package.json: no "private", access "public",
+#   scripts = dev/build/preview, devDeps = build tooling only (no @coveo/platform-mock-api/msw/@playwright)
+find publish -name '*.spec.*' -o -path '*/e2e/*'   # must be empty
+rm -rf publish
+```
+
+## Scaffold deploy-test (prove it works for an outside user)
+
+```bash
+SRC=$(pwd)                       # the sample dir
+pnpm pack                        # writes publish/*.tgz (publishConfig.directory)
+DEST=/tmp/<sample>-scaffold-test
+rm -rf "$DEST" && mkdir -p "$DEST"
+tar -xzf "$SRC"/publish/*.tgz -C "$DEST" --strip-components=1
+cd "$DEST"
+npm install                      # from the public registry — must resolve with no internal deps
+npm run build                    # must succeed
+npm run dev                      # open the URL; confirm it renders with live results
+```
+
+A correct scaffold installs (~300 packages, no `@coveo/platform-mock-api`),
+builds, and renders the live experience (e.g. search results counted from the
+`searchuisamples` org) with no console errors.
+
+## CI signals
+
+The lockfile-sensitive jobs to watch on the PR: **Build**, **Build & commit
+missing generated files**, **Build CDN**, **Build Windows**. If the lockfile is
+inconsistent they fail fast. The `samples-e2e` job runs the Playwright smoke test
+via `turbo run e2e --affected`.


### PR DESCRIPTION
[KIT-5452](https://coveord.atlassian.net/browse/KIT-5452)

## Problem

Creating and maintaining the `samples/*` apps is repetitive and easy to get wrong. Per epic KIT-5452, they span a matrix — **Atomic (search/commerce) × {vanilla, Angular, React, Next.js} + Headless (CSR/SSR) × framework** — and are dual-purpose: living library docs **and** the source templates for `npm create @coveo/ui`. Each has to stay consistent in features, styling, tests, and the script contract, and be correctly publishable. The publishing mechanics (the `publishConfig.directory` + prepack builder and the lockfile handling) are non-obvious and bite on every rebase.

## Solution

Adds a `managing-ui-kit-samples` Agent Skill under `.agents/skills/` that encodes the whole recipe so it's discoverable and repeatable across **all** sample types, not just headless:

- **`SKILL.md`** — when to use; the template matrix; golden rules; the CLI relationship (`--template`/`--template-version`, versions fixed to the library, `pacote`); required features per type (Atomic search/commerce, Headless search/commerce, Headless SSR); the standard script contract incl. the **Atomic-React `build:assets` exception**; deterministic Playwright+MSW testing and the glob-driven `samples-e2e` job; styling (shared tokens for headless custom UIs vs Atomic themes); the publishable checklist; verification; and the git/rebase workflow. Defers to `samples/CONTRIBUTING.md` and `packages/create-ui` docs as canonical rather than duplicating them.
- **`references/publishing.md`** — library-agnostic: the shared `scripts/build-sample-publish-dir.mjs` builder, the publishable `package.json` shape, the surgical `publishDirectory` lockfile edit (avoids `@types/node` drift), the recurring broken-lockfile-after-rebase fix, the builder/output check, and the scaffold deploy-test.
- **`assets/design-tokens.css`** — shared `:root` tokens so headless custom-UI samples stay visually consistent.

Validated with the repo's own `creating-skills` validator (valid); all relative links resolve; `SKILL.md` is 195 lines (under the 500-line guideline).

Note: this documents the current `publishConfig.directory` + builder mechanism, which **supersedes the `files`-allowlist approach proposed in ADR 002** and the older wording in `CONTRIBUTING.md` — aligning those docs could be a small follow-up.

[KIT-5452]: https://coveord.atlassian.net/browse/KIT-5452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ