### PR TITLE
fix(atomic): remove opaque background from instant results show-all button

### DIFF
--- a/.changeset/instant-results-show-all-button-background.md
+++ b/.changeset/instant-results-show-all-button-background.md
@@ -1,0 +1,6 @@
+---
+'@coveo/atomic': patch
+---
+
+Fixed a visual glitch where the "See all results"/"See all products" button in
+the search suggestions showed a white box behind its label when hovered.

--- a/packages/atomic/src/components/common/suggestions/instant-item.spec.ts
+++ b/packages/atomic/src/components/common/suggestions/instant-item.spec.ts
@@ -87,15 +87,6 @@ describe('instant-item', () => {
       );
     });
 
-    it('should have the correct class for button style', () => {
-      const button = renderInstantItemShowAllButton({
-        i18n,
-        i18nKey: 'show-all-products',
-      });
-
-      expect(button.classList.contains('btn-text-primary')).toBe(true);
-    });
-
     it('should have the correct part', () => {
       const button = renderInstantItemShowAllButton({
         i18n,

--- a/packages/atomic/src/components/common/suggestions/instant-item.ts
+++ b/packages/atomic/src/components/common/suggestions/instant-item.ts
@@ -1,7 +1,6 @@
 import type {i18n} from 'i18next';
 import {html, render} from 'lit';
 import {encodeForDomAttribute} from '../../../utils/string-utils';
-import {getClassNameForButtonStyle} from '../button-style';
 import type {SearchBoxSuggestionElement} from './suggestions-types';
 
 type InstantItemSuggestionLabelKey =
@@ -48,7 +47,7 @@ export const renderInstantItemShowAllButton = ({
 }: InstantItemShowAllButtonProps): HTMLElement => {
   const template = html`<div
     part="instant-results-show-all-button"
-    class="pointer-events-none ${getClassNameForButtonStyle('text-primary')}"
+    class="text-primary pointer-events-none bg-transparent"
   >
     ${i18n.t(i18nKey)}
   </div>`;


### PR DESCRIPTION
## Problem

In the instant results / instant products suggestions, the **"See all results"** / **"See all products"** button rendered an opaque **white box behind its label** when the suggestion row was hovered or keyboard-active. The button uses `btn-text-primary`, which applies `bg-background` (opaque), but the button is `pointer-events-none` (the suggestion row owns the hover/active state and paints the row background). So the button's own opaque background sat on top of the row's hover color, showing a white rectangle around the text.

## Solution

Style the button as text only — `text-primary` + `bg-transparent` — so it no longer paints its own background and the row's hover/active color shows through uniformly behind the label. Text color (primary) is unchanged.

Shared by both search (`atomic-search-box-instant-results`) and commerce (`atomic-commerce-search-box-instant-products`) via `renderInstantItemShowAllButton`.

## Tested
### Before
<img width="345" height="43" alt="image" src="https://github.com/user-attachments/assets/52295976-eb65-4eb9-ac12-975da234c427" />


### After
<img width="363" height="46" alt="image" src="https://github.com/user-attachments/assets/900350ee-c01a-4703-8f3a-89306ea2def6" />


