### PR TITLE
Fix syntax errors in catalog-info.yaml

### DIFF
--- a/packages/atomic-hosted-page/catalog-info.yaml
+++ b/packages/atomic-hosted-page/catalog-info.yaml
@@ -12,5 +12,5 @@ spec:
   owner: group:default/dxui
   system: ui-kit
   dependsOn:
-    - bueno
-    - headless
+    - component:bueno
+    - component:headless

--- a/packages/atomic-react/catalog-info.yaml
+++ b/packages/atomic-react/catalog-info.yaml
@@ -12,5 +12,5 @@ spec:
   owner: group:default/dxui
   system: ui-kit
   dependsOn:
-    - atomic
-    - headless
+    - component:atomic
+    - component:headless

--- a/packages/atomic/catalog-info.yaml
+++ b/packages/atomic/catalog-info.yaml
@@ -12,7 +12,5 @@ spec:
   owner: group:default/dxui
   system: ui-kit
   dependsOn:
-    - bueno
-    - headless
-  dependencyOf:
-    - atomic-react
+    - component:bueno
+    - component:headless

--- a/packages/bueno/catalog-info.yaml
+++ b/packages/bueno/catalog-info.yaml
@@ -11,8 +11,3 @@ spec:
   lifecycle: production
   owner: group:default/dxui
   system: ui-kit
-  dependencyOf:
-    - atomic
-    - atomic-hosted-page
-    - headless
-    - quantic

--- a/packages/headless-react/catalog-info.yaml
+++ b/packages/headless-react/catalog-info.yaml
@@ -12,4 +12,4 @@ spec:
   owner: group:default/dxui
   system: ui-kit
   dependsOn:
-    - headless
+    - component:headless

--- a/packages/headless/catalog-info.yaml
+++ b/packages/headless/catalog-info.yaml
@@ -12,11 +12,4 @@ spec:
   owner: group:default/dxui
   system: ui-kit
   dependsOn:
-    - bueno
-  dependencyOf:
-    - atomic
-    - atomic-hosted-page
-    - atomic-react
-    - headless-react
-    - quantic
-    - shopify
+    - component:bueno

--- a/packages/quantic/catalog-info.yaml
+++ b/packages/quantic/catalog-info.yaml
@@ -12,5 +12,5 @@ spec:
   owner: group:default/knowledge-integrations
   system: ui-kit
   dependsOn:
-    - bueno
-    - headless
+    - component:bueno
+    - component:headless

--- a/packages/shopify/catalog-info.yaml
+++ b/packages/shopify/catalog-info.yaml
@@ -12,4 +12,4 @@ spec:
   owner: group:default/commerce-shopify
   system: ui-kit
   dependsOn:
-    - headless
+    - component:headless

--- a/scripts/generate-catalog-info.mjs
+++ b/scripts/generate-catalog-info.mjs
@@ -108,7 +108,7 @@ function toYaml(doc) {
  * Generates a catalog-info.yaml for a single package.
  * @param {object} manifest - parsed package.json
  * @param {Record<string, string>} config - parsed catalog-info.config.yaml
- * @param {{dependsOn: string[], dependencyOf: string[]}} relations
+ * @param {{dependsOn: string[]}} relations
  * @returns {string}
  */
 function generateComponentYaml(manifest, config, relations) {
@@ -136,10 +136,6 @@ function generateComponentYaml(manifest, config, relations) {
   if (relations.dependsOn.length) {
     doc.spec.dependsOn = [...relations.dependsOn].sort();
   }
-  if (relations.dependencyOf.length) {
-    doc.spec.dependencyOf = [...relations.dependencyOf].sort();
-  }
-
   return toYaml(doc);
 }
 
@@ -213,7 +209,7 @@ function getWorkspaceDependsOn(manifest, catalogComponents) {
     if (version.startsWith('workspace:')) {
       const componentName = getComponentName(name);
       if (catalogComponents.has(componentName)) {
-        result.push(componentName);
+        result.push(`component:${componentName}`);
       }
     }
   }
@@ -247,21 +243,12 @@ function main() {
   );
 
   /** @type {Map<string, string[]>} */
-  const dependencyOfMap = new Map();
-  /** @type {Map<string, string[]>} */
   const dependsOnMap = new Map();
 
   for (const [, {manifest}] of catalogPackages) {
     const componentName = getComponentName(manifest.name);
     const dependsOn = getWorkspaceDependsOn(manifest, catalogComponents);
     dependsOnMap.set(componentName, dependsOn);
-
-    for (const dep of dependsOn) {
-      if (!dependencyOfMap.has(dep)) {
-        dependencyOfMap.set(dep, []);
-      }
-      dependencyOfMap.get(dep).push(componentName);
-    }
   }
 
   const targets = ['./catalog-info.ui-kit.yaml'];
@@ -271,7 +258,6 @@ function main() {
     const componentName = getComponentName(manifest.name);
     const relations = {
       dependsOn: dependsOnMap.get(componentName) || [],
-      dependencyOf: dependencyOfMap.get(componentName) || [],
     };
 
     const yaml = generateComponentYaml(manifest, config, relations);


### PR DESCRIPTION
Following suggestions from @abdellahhn in  PES-3340

> The dependsOn / dependencyOf entries use bare entity names:
> ```
> spec:
>   dependsOn:
>     - headless
>     - bueno
> ```
> 
> Backstage rejects these during processing because the entity reference "bueno" and headless have missing or empty kinds, so the component never lands cleanly in the catalogue.
> The fix is to prefix every relation ref with its kind:
> 
> ```
> spec:
>   dependsOn:
>     - component:headless
>     - component:bueno
> ```
> 
> We should also drop the dependencyOf entries; they're the inverse of dependsOn, which Backstage generates automatically.
> 
> The overall structure is right, a root Location pointing at the per-package files is the correct pattern. Once the refs are qualified, the components should populate (allow a few minutes for discovery).