### PR TITLE
chore(catalog-info): remove github project slug annotation

### DIFF
--- a/catalog-info.ui-kit.yaml
+++ b/catalog-info.ui-kit.yaml
@@ -4,7 +4,5 @@ metadata:
   name: ui-kit
   title: UI Kit
   description: Monorepo for Coveo UI packages, shared tooling, and release workflows
-  annotations:
-    github.com/project-slug: coveo/ui-kit
 spec:
   owner: group:default/dxui

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -2,8 +2,6 @@ apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
   name: ui-kit-catalog
-  annotations:
-    github.com/project-slug: coveo/ui-kit
 spec:
   type: url
   targets:

--- a/packages/atomic-hosted-page/catalog-info.yaml
+++ b/packages/atomic-hosted-page/catalog-info.yaml
@@ -4,13 +4,11 @@ metadata:
   name: atomic-hosted-page
   title: '@coveo/atomic-hosted-page'
   description: Web Component used to inject a Coveo Hosted Search Page in the DOM.
-  annotations:
-    github.com/project-slug: coveo/ui-kit
 spec:
   type: library
   lifecycle: production
   owner: group:default/dxui
   system: ui-kit
   dependsOn:
-    - bueno
-    - headless
+    - component:default/bueno
+    - component:default/headless

--- a/packages/atomic-react/catalog-info.yaml
+++ b/packages/atomic-react/catalog-info.yaml
@@ -4,13 +4,11 @@ metadata:
   name: atomic-react
   title: '@coveo/atomic-react'
   description: React specific wrapper for the Atomic component library
-  annotations:
-    github.com/project-slug: coveo/ui-kit
 spec:
   type: library
   lifecycle: production
   owner: group:default/dxui
   system: ui-kit
   dependsOn:
-    - atomic
-    - headless
+    - component:default/atomic
+    - component:default/headless

--- a/packages/atomic/catalog-info.yaml
+++ b/packages/atomic/catalog-info.yaml
@@ -4,15 +4,11 @@ metadata:
   name: atomic
   title: '@coveo/atomic'
   description: A web-component library for building modern UIs interfacing with the Coveo platform
-  annotations:
-    github.com/project-slug: coveo/ui-kit
 spec:
   type: library
   lifecycle: production
   owner: group:default/dxui
   system: ui-kit
   dependsOn:
-    - bueno
-    - headless
-  dependencyOf:
-    - atomic-react
+    - component:default/bueno
+    - component:default/headless

--- a/packages/bueno/catalog-info.yaml
+++ b/packages/bueno/catalog-info.yaml
@@ -4,15 +4,8 @@ metadata:
   name: bueno
   title: '@coveo/bueno'
   description: A simple validator
-  annotations:
-    github.com/project-slug: coveo/ui-kit
 spec:
   type: library
   lifecycle: production
   owner: group:default/dxui
   system: ui-kit
-  dependencyOf:
-    - atomic
-    - atomic-hosted-page
-    - headless
-    - quantic

--- a/packages/headless-react/catalog-info.yaml
+++ b/packages/headless-react/catalog-info.yaml
@@ -4,12 +4,10 @@ metadata:
   name: headless-react
   title: '@coveo/headless-react'
   description: React utilities for SSR (Server Side Rendering) with headless
-  annotations:
-    github.com/project-slug: coveo/ui-kit
 spec:
   type: library
   lifecycle: production
   owner: group:default/dxui
   system: ui-kit
   dependsOn:
-    - headless
+    - component:default/headless

--- a/packages/headless/catalog-info.yaml
+++ b/packages/headless/catalog-info.yaml
@@ -4,19 +4,10 @@ metadata:
   name: headless
   title: '@coveo/headless'
   description: A headless library for building search experiences on the Coveo platform
-  annotations:
-    github.com/project-slug: coveo/ui-kit
 spec:
   type: library
   lifecycle: production
   owner: group:default/dxui
   system: ui-kit
   dependsOn:
-    - bueno
-  dependencyOf:
-    - atomic
-    - atomic-hosted-page
-    - atomic-react
-    - headless-react
-    - quantic
-    - shopify
+    - component:default/bueno

--- a/packages/quantic/catalog-info.yaml
+++ b/packages/quantic/catalog-info.yaml
@@ -4,13 +4,11 @@ metadata:
   name: quantic
   title: '@coveo/quantic'
   description: A Salesforce Lightning Web Component (LWC) library for building modern UIs interfacing with the Coveo platform
-  annotations:
-    github.com/project-slug: coveo/ui-kit
 spec:
   type: library
   lifecycle: production
   owner: group:default/knowledge-integrations
   system: ui-kit
   dependsOn:
-    - bueno
-    - headless
+    - component:default/bueno
+    - component:default/headless

--- a/packages/shopify/catalog-info.yaml
+++ b/packages/shopify/catalog-info.yaml
@@ -4,12 +4,10 @@ metadata:
   name: shopify
   title: '@coveo/shopify'
   description: Utilities to integrate Shopify with Coveo's commerce engine
-  annotations:
-    github.com/project-slug: coveo/ui-kit
 spec:
   type: library
   lifecycle: production
   owner: group:default/commerce-shopify
   system: ui-kit
   dependsOn:
-    - headless
+    - component:default/headless

--- a/packages/thermidor/catalog-info.yaml
+++ b/packages/thermidor/catalog-info.yaml
@@ -4,8 +4,6 @@ metadata:
   name: thermidor
   title: '@coveo/thermidor'
   description: Experimental package for a unified, framework-agnostic headless engine for search and conversational experiences
-  annotations:
-    github.com/project-slug: coveo/ui-kit
 spec:
   type: library
   lifecycle: experimental

--- a/scripts/generate-catalog-info.mjs
+++ b/scripts/generate-catalog-info.mjs
@@ -108,7 +108,7 @@ function toYaml(doc) {
  * Generates a catalog-info.yaml for a single package.
  * @param {object} manifest - parsed package.json
  * @param {Record<string, string>} config - parsed catalog-info.config.yaml
- * @param {{dependsOn: string[], dependencyOf: string[]}} relations
+ * @param {{dependsOn: string[]}} relations
  * @returns {string}
  */
 function generateComponentYaml(manifest, config, relations) {
@@ -134,10 +134,9 @@ function generateComponentYaml(manifest, config, relations) {
   };
 
   if (relations.dependsOn.length) {
-    doc.spec.dependsOn = [...relations.dependsOn].sort();
-  }
-  if (relations.dependencyOf.length) {
-    doc.spec.dependencyOf = [...relations.dependencyOf].sort();
+    doc.spec.dependsOn = relations.dependsOn
+      .map((dep) => `component:default/${dep}`)
+      .toSorted();
   }
 
   return toYaml(doc);
@@ -247,21 +246,12 @@ function main() {
   );
 
   /** @type {Map<string, string[]>} */
-  const dependencyOfMap = new Map();
-  /** @type {Map<string, string[]>} */
   const dependsOnMap = new Map();
 
   for (const [, {manifest}] of catalogPackages) {
     const componentName = getComponentName(manifest.name);
     const dependsOn = getWorkspaceDependsOn(manifest, catalogComponents);
     dependsOnMap.set(componentName, dependsOn);
-
-    for (const dep of dependsOn) {
-      if (!dependencyOfMap.has(dep)) {
-        dependencyOfMap.set(dep, []);
-      }
-      dependencyOfMap.get(dep).push(componentName);
-    }
   }
 
   const targets = ['./catalog-info.ui-kit.yaml'];
@@ -271,7 +261,6 @@ function main() {
     const componentName = getComponentName(manifest.name);
     const relations = {
       dependsOn: dependsOnMap.get(componentName) || [],
-      dependencyOf: dependencyOfMap.get(componentName) || [],
     };
 
     const yaml = generateComponentYaml(manifest, config, relations);

--- a/scripts/generate-catalog-info.mjs
+++ b/scripts/generate-catalog-info.mjs
@@ -45,10 +45,6 @@ function parseSimpleYaml(filePath) {
   return result;
 }
 
-function getProjectSlug() {
-  return 'coveo/ui-kit';
-}
-
 /**
  * Strips the npm scope from a package name.
  * @param {string} name
@@ -121,9 +117,6 @@ function generateComponentYaml(manifest, config, relations) {
       name: componentName,
       title: manifest.name,
       description: manifest.description,
-      annotations: {
-        'github.com/project-slug': getProjectSlug(),
-      },
     },
     spec: {
       type: config.type || 'library',
@@ -153,9 +146,6 @@ function generateLocationYaml(targetPaths) {
     kind: 'Location',
     metadata: {
       name: 'ui-kit-catalog',
-      annotations: {
-        'github.com/project-slug': getProjectSlug(),
-      },
     },
     spec: {
       type: 'url',
@@ -187,9 +177,6 @@ function generateSystemYaml(rootManifest, config) {
         )
         .join(' '),
       description: rootManifest.description,
-      annotations: {
-        'github.com/project-slug': getProjectSlug(),
-      },
     },
     spec: {
       owner: config.owner || 'group:default/dxui',


### PR DESCRIPTION
This PR removes the GitHub annotation from the generated catalog-info.yaml files. Those are not required since dev portal can infer them automatically.