### PR TITLE
fix(atomic-cdn-smoke): build platform-mock-api before running smoke tests

### DIFF
--- a/packages/atomic-cdn-smoke/package.json
+++ b/packages/atomic-cdn-smoke/package.json
@@ -5,7 +5,7 @@
   "description": "CDN visual smoke tests for Atomic components using Playwright + Chromatic",
   "type": "module",
   "scripts": {
-    "cdn-smoke": "playwright test",
+    "cdn-smoke": "pnpm --filter @coveo/platform-mock-api build && playwright test",
     "chromatic": "chromatic --playwright"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

The "Chromatic visual smoke test" job in the CD pipeline (`coveo-platform/ui-kit-cd`) started failing on `main`:

```
Error: Cannot find module '.../packages/atomic-cdn-smoke/node_modules/@coveo/platform-mock-api/dist/index.js'
       imported from .../packages/atomic-cdn-smoke/fixtures.ts
Error: No tests found
```

The subsequent `Upload to Chromatic` step then fails only as a side effect (`Chromatic archives directory cannot be found`), because no tests ran and no archives were produced.

Root cause: `atomic-cdn-smoke/fixtures.ts` imports from `@coveo/platform-mock-api`, whose entry point resolves via `exports` to `./dist/index.js` and must be built with `tsc`. The CD smoke job checks out ui-kit, runs `pnpm install`, installs Playwright browsers, then runs `playwright test` directly — it never builds the workspace dependency, so `dist/` is missing. In `coveo/ui-kit` CI this dependency is built transitively through Turbo's `^build`, which masked the problem. The regression was introduced when the mocks were extracted into `@coveo/platform-mock-api` (#7838) and the smoke tests were added (#7839).

## Solution

Make the `cdn-smoke` script build its workspace dependency before running Playwright, so the smoke tests work regardless of whether they are invoked through Turbo or via raw `pnpm --filter`:

```json
"cdn-smoke": "pnpm --filter @coveo/platform-mock-api build && playwright test"
```

Verified locally by deleting `packages/platform-mock-api/dist` and running the exact CD command (`pnpm --filter @coveo/atomic-cdn-smoke cdn-smoke`): the dependency is now built and all 4 smoke tests pass.