### PR TITLE
chore(changesets): version-lock all sample packages to their source library

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -25,11 +25,11 @@
       "@coveo/ui-kit-sample-headless-commerce-vite",
       "@coveo/ui-kit-sample-headless-search-react",
       "@coveo/ui-kit-sample-headless-commerce-react",
-      "@coveo/ui-kit-sample-headless-ssr-search-nextjs",
       "@coveo/ui-kit-sample-headless-ssr-commerce-express"
     ],
     [
       "@coveo/headless-react",
+      "@coveo/ui-kit-sample-headless-ssr-search-nextjs",
       "@coveo/ui-kit-sample-headless-ssr-commerce-nextjs"
     ]
   ],

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,31 @@
     }
   ],
   "commit": false,
-  "fixed": [["@coveo/headless", "@coveo/ui-kit-sample-headless-*"]],
+  "fixed": [
+    [
+      "@coveo/atomic",
+      "@coveo/ui-kit-sample-atomic-search-vite",
+      "@coveo/ui-kit-sample-atomic-commerce-vite"
+    ],
+    [
+      "@coveo/atomic-react",
+      "@coveo/ui-kit-sample-atomic-search-react",
+      "@coveo/ui-kit-sample-atomic-commerce-react"
+    ],
+    [
+      "@coveo/headless",
+      "@coveo/ui-kit-sample-headless-search-vite",
+      "@coveo/ui-kit-sample-headless-commerce-vite",
+      "@coveo/ui-kit-sample-headless-search-react",
+      "@coveo/ui-kit-sample-headless-commerce-react",
+      "@coveo/ui-kit-sample-headless-ssr-search-nextjs",
+      "@coveo/ui-kit-sample-headless-ssr-commerce-express"
+    ],
+    [
+      "@coveo/headless-react",
+      "@coveo/ui-kit-sample-headless-ssr-commerce-nextjs"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Problem

Sample packages are versioned via the Changesets `fixed` option so they stay in lockstep with the library they showcase. Today only the Vite/React Headless samples are covered, through a broad glob:

```json
"fixed": [["@coveo/headless", "@coveo/ui-kit-sample-headless-*"]]
```

That glob is both incomplete and slightly wrong:

- The Atomic and Atomic React samples aren't locked to any library.
- The glob captures the SSR samples that depend on `@coveo/headless-react` (not `@coveo/headless`), so they're locked to the wrong package.

## Solution

Replace the single glob with explicit groups, one per source library, so every sample bumps with the package it actually depends on:

| Group | Samples |
|---|---|
| `@coveo/atomic` | `atomic-search-vite`, `atomic-commerce-vite` |
| `@coveo/atomic-react` | `atomic-search-react`, `atomic-commerce-react` |
| `@coveo/headless` | `headless-search-vite`, `headless-commerce-vite`, `headless-search-react`, `headless-commerce-react`, `headless-ssr-commerce-express` |
| `@coveo/headless-react` | `headless-ssr-search-nextjs`, `headless-ssr-commerce-nextjs` |

Notes:
- Changesets validation hard-errors on `fixed` entries that don't resolve to a workspace package. Six of these samples are still on their own unmerged branches (the 4 Atomic samples + `headless-ssr-search-nextjs` + `headless-ssr-commerce-express`), so `changeset status` will stay red until those land. This PR is intentionally opened ahead of them and should merge once they're all on `main`.
