### PR TITLE
refactor(thermidor): enforce internal/public boundary

### DIFF
--- a/packages/thermidor/.oxlintrc.json
+++ b/packages/thermidor/.oxlintrc.json
@@ -37,6 +37,23 @@
           }
         ]
       }
+    },
+    {
+      "files": ["src/internal/**"],
+      "excludeFiles": ["**/*.test.ts", "**/*.test-d.ts"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["@/src/public/**"],
+                "message": "Internal modules must not import from the public surface. Move the shared code into src/internal/."
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/packages/thermidor/src/internal/features/generative/generative-hydration.test.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-hydration.test.ts
@@ -1,5 +1,9 @@
 import {describe, it, expect, beforeEach} from 'vitest';
-import {Engine, getFullEngine} from '@/src/internal/engine/index.js';
+import {
+  Engine,
+  getFullEngine,
+  type FullEngine,
+} from '@/src/internal/engine/index.js';
 import {getInterfaceInternals} from '@/src/internal/utils/index.js';
 import {
   createHydrateSubInterface,
@@ -49,20 +53,20 @@ describe('getOrCreateHydrateFromSnapshotAction', () => {
 });
 
 describe('createHydrateSubInterface', () => {
-  let engine: Engine;
+  let fullEngine: FullEngine;
 
   beforeEach(() => {
-    engine = createTestEngine();
+    fullEngine = getFullEngine(createTestEngine());
   });
 
   it('returns null for unrecognized activity types', () => {
-    const hydrate = createHydrateSubInterface(engine);
+    const hydrate = createHydrateSubInterface(fullEngine);
     const result = hydrate('unknown-activity-type', {});
     expect(result).toBeNull();
   });
 
   it('returns a RoutedInterface for commerce-search-api-response', () => {
-    const hydrate = createHydrateSubInterface(engine);
+    const hydrate = createHydrateSubInterface(fullEngine);
     const content = {
       products: [
         {
@@ -85,7 +89,7 @@ describe('createHydrateSubInterface', () => {
   });
 
   it('returns a RoutedInterface for search-api-response', () => {
-    const hydrate = createHydrateSubInterface(engine);
+    const hydrate = createHydrateSubInterface(fullEngine);
     const content = {
       results: [
         {
@@ -109,7 +113,7 @@ describe('createHydrateSubInterface', () => {
   });
 
   it('stores hydration snapshot and hydrates products into the sub-interface', async () => {
-    const hydrate = createHydrateSubInterface(engine);
+    const hydrate = createHydrateSubInterface(fullEngine);
     const content = {
       products: [
         {
@@ -125,7 +129,6 @@ describe('createHydrateSubInterface', () => {
 
     const result = hydrate('commerce-search-api-response', content);
     const subInterface = result!.interface;
-    const fullEngine = getFullEngine(engine);
 
     const productSlice = getOrCreateProductListSlice(subInterface);
     await fullEngine.adoptSlice(productSlice);
@@ -141,7 +144,7 @@ describe('createHydrateSubInterface', () => {
   });
 
   it('stores hydration snapshot and hydrates results into the sub-interface', async () => {
-    const hydrate = createHydrateSubInterface(engine);
+    const hydrate = createHydrateSubInterface(fullEngine);
     const content = {
       results: [
         {
@@ -160,7 +163,6 @@ describe('createHydrateSubInterface', () => {
 
     const result = hydrate('search-api-response', content);
     const subInterface = result!.interface;
-    const fullEngine = getFullEngine(engine);
 
     const resultsSlice = getOrCreateResultsSlice(subInterface);
     await fullEngine.adoptSlice(resultsSlice);

--- a/packages/thermidor/src/internal/features/generative/generative-hydration.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-hydration.ts
@@ -1,12 +1,13 @@
 import {createAction} from '@reduxjs/toolkit';
 import {type CacheKey, createCacheKey} from '@/src/internal/utils/index.js';
 import {getHandleInternals} from '@/src/internal/utils/index.js';
+import {generateId} from '@/src/internal/utils/index.js';
 import type {InterfaceHandle} from '@/src/internal/utils/index.js';
-import {Engine, getFullEngine} from '@/src/internal/engine/index.js';
+import type {FullEngine} from '@/src/internal/engine/index.js';
 import type {RoutedInterface, RoutedUseCase} from './generative-types.js';
 import type {HydrateSubInterface} from '@/src/internal/api/generative/index.js';
-import {buildCommerceInterface} from '@/src/public/interfaces/commerce.js';
-import {buildSearchInterface} from '@/src/public/interfaces/search.js';
+import {CommerceInterfaceImpl} from '@/src/internal/interfaces/index.js';
+import {SearchInterfaceImpl} from '@/src/internal/interfaces/index.js';
 import {getOrCreateSearchBoxActions} from '@/src/internal/features/search-box/index.js';
 import {getOrCreateSearchBoxSlice} from '@/src/internal/features/search-box/index.js';
 
@@ -34,9 +35,9 @@ export function getOrCreateHydrateFromSnapshotAction(iface: InterfaceHandle) {
   );
 }
 
-export function createHydrateSubInterface(engine: Engine): HydrateSubInterface {
-  const fullEngine = getFullEngine(engine);
-
+export function createHydrateSubInterface(
+  fullEngine: FullEngine
+): HydrateSubInterface {
   return (
     activityType: string,
     content: unknown,
@@ -51,7 +52,7 @@ export function createHydrateSubInterface(engine: Engine): HydrateSubInterface {
     const effectiveQuery = extractEffectiveQuery(contentRecord, query);
 
     if (routedUseCase === 'commerceSearch') {
-      const subInterface = buildCommerceInterface({engine});
+      const subInterface = new CommerceInterfaceImpl(fullEngine, generateId());
       fullEngine.storeHydrationSnapshot(contentRecord, subInterface);
       const hydrateAction = getOrCreateHydrateFromSnapshotAction(subInterface);
       fullEngine.mutate(hydrateAction(contentRecord));
@@ -63,7 +64,7 @@ export function createHydrateSubInterface(engine: Engine): HydrateSubInterface {
       return {useCase: 'commerceSearch' as const, interface: subInterface};
     }
 
-    const subInterface = buildSearchInterface({engine});
+    const subInterface = new SearchInterfaceImpl(fullEngine, generateId());
     fullEngine.storeHydrationSnapshot(contentRecord, subInterface);
     const hydrateAction = getOrCreateHydrateFromSnapshotAction(subInterface);
     fullEngine.mutate(hydrateAction(contentRecord));

--- a/packages/thermidor/src/internal/features/generative/generative-types.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-types.ts
@@ -1,5 +1,5 @@
-import type {CommerceInterface} from '@/src/public/interfaces/commerce.js';
-import type {SearchInterface} from '@/src/public/interfaces/search.js';
+import type {CommerceInterface} from '@/src/internal/utils/index.js';
+import type {SearchInterface} from '@/src/internal/utils/index.js';
 
 /**
  * ============================================================================

--- a/packages/thermidor/src/internal/interfaces/commerce.ts
+++ b/packages/thermidor/src/internal/interfaces/commerce.ts
@@ -1,0 +1,23 @@
+import {BaseInterface} from '@/src/internal/utils/index.js';
+import type {FullEngine} from '@/src/internal/engine/index.js';
+import type {
+  CommerceInterface,
+  FacadeResolverFactory,
+  Facades,
+} from '@/src/internal/utils/index.js';
+import {createCommerceSearchFacadeResolver} from '@/src/internal/api/commerce-search/index.js';
+import {createCommerceSuggestionsFacadeResolver} from '@/src/internal/api/commerce-query-suggest/index.js';
+
+const resolverFactories: Record<Facades['commerce'], FacadeResolverFactory> = {
+  search: createCommerceSearchFacadeResolver,
+  suggestions: createCommerceSuggestionsFacadeResolver,
+};
+
+export class CommerceInterfaceImpl
+  extends BaseInterface<'commerce'>
+  implements CommerceInterface
+{
+  constructor(engine: FullEngine, stateId: string) {
+    super(engine, stateId, 'commerce', resolverFactories);
+  }
+}

--- a/packages/thermidor/src/internal/interfaces/compose.ts
+++ b/packages/thermidor/src/internal/interfaces/compose.ts
@@ -1,0 +1,91 @@
+import {InterfaceCacheRegistry} from '@/src/internal/utils/index.js';
+import {getHandleInternals} from '@/src/internal/utils/index.js';
+import type {FullEngine} from '@/src/internal/engine/index.js';
+import type {
+  ComposedInterface,
+  EndpointThunk,
+  Facades,
+  InterfaceHandle,
+  InterfaceType,
+  SupportsBrand,
+} from '@/src/internal/utils/index.js';
+
+export interface ComposedInternals {
+  engine: FullEngine;
+  stateId: string;
+  cacheRegistry: InterfaceCacheRegistry;
+  resolveFacades(
+    facade: Facades[InterfaceType],
+    composedInterface?: InterfaceHandle
+  ): EndpointThunk[];
+}
+
+export let getComposedInternals: <T extends InterfaceType>(
+  composed: ComposedInterfaceImpl<T>
+) => ComposedInternals;
+
+export class ComposedInterfaceImpl<
+  T extends InterfaceType,
+> implements ComposedInterface<T> {
+  declare readonly [SupportsBrand]: {[K in Facades[T]]: true};
+
+  get disposed(): boolean {
+    return this.#disposed;
+  }
+
+  #engine: FullEngine;
+  #stateId: string;
+  #interfaces: InterfaceHandle[];
+  #cacheRegistry = new InterfaceCacheRegistry();
+  #disposed = false;
+
+  static {
+    getComposedInternals = <typeof getComposedInternals>((composed) => ({
+      engine: composed.#engine,
+      stateId: composed.#stateId,
+      cacheRegistry: composed.#cacheRegistry,
+      resolveFacades: (facade: any, composedInterface?: InterfaceHandle) =>
+        composed.#resolveFacades(facade, composedInterface),
+    }));
+  }
+
+  constructor(interfaces: InterfaceHandle[], composedId: string) {
+    if (interfaces.length === 0) {
+      throw new Error('ComposedInterface requires at least one interface.');
+    }
+
+    const {engine} = getHandleInternals(interfaces[0]);
+    this.#engine = engine;
+    this.#stateId = composedId;
+    this.#interfaces = interfaces;
+
+    engine.addInterface(this);
+  }
+
+  dispose(): void {
+    if (this.#disposed) {
+      return;
+    }
+    this.#disposed = true;
+    this.#cacheRegistry.dispose();
+    this.#engine.removeInterface(this);
+  }
+
+  #resolveFacades(
+    facade: Facades[T],
+    composedInterface?: InterfaceHandle
+  ): EndpointThunk[] {
+    this.#assertNotDisposed();
+    const target = composedInterface ?? this;
+    return this.#interfaces.flatMap((sub) => {
+      const {resolveFacades} = getHandleInternals(sub);
+      return resolveFacades(facade, target);
+    });
+  }
+
+  #assertNotDisposed(): void {
+    if (this.#disposed) {
+      throw new Error('Cannot operate on a disposed composed interface.');
+    }
+  }
+}

--- a/packages/thermidor/src/internal/interfaces/generative.ts
+++ b/packages/thermidor/src/internal/interfaces/generative.ts
@@ -1,0 +1,29 @@
+import {BaseInterface} from '@/src/internal/utils/index.js';
+import type {FullEngine} from '@/src/internal/engine/index.js';
+import type {
+  FacadeResolverFactory,
+  Facades,
+  GenerativeInterface,
+} from '@/src/internal/utils/index.js';
+import {createNoopThunk} from '@/src/internal/utils/index.js';
+import {getOrCreateGenerativeSlice} from '@/src/internal/features/generative/index.js';
+
+const noopThunk = createNoopThunk('generative');
+
+const noopResolverFactory: FacadeResolverFactory = (_engine) => (_scope) =>
+  noopThunk;
+
+const resolverFactories: Record<Facades['generative'], FacadeResolverFactory> =
+  {
+    conversation: noopResolverFactory,
+  };
+
+export class GenerativeInterfaceImpl
+  extends BaseInterface<'generative'>
+  implements GenerativeInterface
+{
+  constructor(engine: FullEngine, stateId: string) {
+    super(engine, stateId, 'generative', resolverFactories);
+    engine.adoptSlice(getOrCreateGenerativeSlice(this));
+  }
+}

--- a/packages/thermidor/src/internal/interfaces/index.ts
+++ b/packages/thermidor/src/internal/interfaces/index.ts
@@ -1,0 +1,5 @@
+export {CommerceInterfaceImpl} from './commerce.js';
+export {SearchInterfaceImpl} from './search.js';
+export {GenerativeInterfaceImpl} from './generative.js';
+export {ComposedInterfaceImpl, getComposedInternals} from './compose.js';
+export type {ComposedInternals} from './compose.js';

--- a/packages/thermidor/src/internal/interfaces/search.ts
+++ b/packages/thermidor/src/internal/interfaces/search.ts
@@ -1,0 +1,25 @@
+import {BaseInterface} from '@/src/internal/utils/index.js';
+import type {FullEngine} from '@/src/internal/engine/index.js';
+import type {
+  FacadeResolverFactory,
+  Facades,
+  SearchInterface,
+} from '@/src/internal/utils/index.js';
+import {createSearchFacadeResolver} from '@/src/internal/api/search/index.js';
+import {createQuerySuggestFacadeResolver} from '@/src/internal/api/query-suggest/index.js';
+import {getOrCreateSearchParametersSlice} from '@/src/internal/features/search-parameters/index.js';
+
+const resolverFactories: Record<Facades['search'], FacadeResolverFactory> = {
+  search: createSearchFacadeResolver,
+  suggestions: createQuerySuggestFacadeResolver,
+};
+
+export class SearchInterfaceImpl
+  extends BaseInterface<'search'>
+  implements SearchInterface
+{
+  constructor(engine: FullEngine, stateId: string) {
+    super(engine, stateId, 'search', resolverFactories);
+    engine.adoptSlice(getOrCreateSearchParametersSlice(this));
+  }
+}

--- a/packages/thermidor/src/internal/utils/base-controller.ts
+++ b/packages/thermidor/src/internal/utils/base-controller.ts
@@ -1,6 +1,6 @@
 import type {FullEngine} from '@/src/internal/engine/index.js';
 import type {StateSelector, Unsubscribe} from '@/src/internal/engine/index.js';
-import type {Controller} from '@/src/public/controllers/controller-types.js';
+import type {Controller} from './controller-types.js';
 
 export abstract class BaseController<TState> implements Controller<TState> {
   get state(): TState {

--- a/packages/thermidor/src/internal/utils/controller-types.ts
+++ b/packages/thermidor/src/internal/utils/controller-types.ts
@@ -1,0 +1,16 @@
+import {Unsubscribe} from '@/src/internal/engine/index.js';
+
+export interface Controller<T = unknown> {
+  /**
+   * The current state of the controller.
+   */
+  readonly state: T;
+
+  /**
+   * Subscribes to controller state changes.
+   *
+   * @param callback - Invoked with the new state when the controller state changes.
+   * @returns A function that unsubscribes the listener.
+   */
+  subscribe(callback: (state: T) => void): Unsubscribe;
+}

--- a/packages/thermidor/src/internal/utils/get-handle-internals.ts
+++ b/packages/thermidor/src/internal/utils/get-handle-internals.ts
@@ -10,7 +10,7 @@ import {BaseInterface, getInterfaceInternals} from './base-interface.js';
 import {
   ComposedInterfaceImpl,
   getComposedInternals,
-} from '@/src/public/interfaces/compose.js';
+} from '@/src/internal/interfaces/compose.js';
 
 export interface HandleInternals {
   engine: FullEngine;

--- a/packages/thermidor/src/internal/utils/index.ts
+++ b/packages/thermidor/src/internal/utils/index.ts
@@ -18,19 +18,24 @@ export type {
   NavigatorContextProvider,
 } from './navigator-context-types.js';
 export {BaseController} from './base-controller.js';
+export type {Controller} from './controller-types.js';
 export {BaseInterface, getInterfaceInternals} from './base-interface.js';
 export type {InterfaceInternals} from './base-interface.js';
 export type {
+  CommerceInterface,
+  ComposedInterface,
   EndpointStateScope,
   EndpointThunk,
   FacadeResolver,
   FacadeResolverFactory,
   Facades,
+  GenerativeInterface,
   InferInterfaceType,
   InterfaceHandle,
   InterfaceRegistry,
   InterfaceType,
   InterfaceTypeMap,
+  SearchInterface,
   Supports,
   SupportsBrand,
 } from './interface-types.js';

--- a/packages/thermidor/src/internal/utils/interface-types.ts
+++ b/packages/thermidor/src/internal/utils/interface-types.ts
@@ -1,8 +1,5 @@
 import type {AsyncThunk} from '@reduxjs/toolkit';
 import type {FullEngine} from '@/src/internal/engine/index.js';
-import type {SearchInterface} from '@/src/public/interfaces/search.js';
-import type {CommerceInterface} from '@/src/public/interfaces/commerce.js';
-import type {GenerativeInterface} from '@/src/public/interfaces/generative.js';
 
 export interface InterfaceHandle {
   readonly disposed: boolean;
@@ -43,3 +40,13 @@ export declare const SupportsBrand: unique symbol;
 export type Supports<F extends Facades[InterfaceType]> = InterfaceHandle & {
   readonly [SupportsBrand]: {[K in F]: true};
 };
+
+export interface SearchInterface extends Supports<Facades['search']> {}
+
+export interface CommerceInterface extends Supports<Facades['commerce']> {}
+
+export interface GenerativeInterface extends Supports<Facades['generative']> {}
+
+export interface ComposedInterface<T extends InterfaceType> extends Supports<
+  Facades[T]
+> {}

--- a/packages/thermidor/src/public/controllers/controller-types.ts
+++ b/packages/thermidor/src/public/controllers/controller-types.ts
@@ -1,16 +1,1 @@
-import {Unsubscribe} from '@/src/internal/engine/index.js';
-
-export interface Controller<T = unknown> {
-  /**
-   * The current state of the controller.
-   */
-  readonly state: T;
-
-  /**
-   * Subscribes to controller state changes.
-   *
-   * @param callback - Invoked with the new state when the controller state changes.
-   * @returns A function that unsubscribes the listener.
-   */
-  subscribe(callback: (state: T) => void): Unsubscribe;
-}
+export type {Controller} from '@/src/internal/utils/index.js';

--- a/packages/thermidor/src/public/controllers/converse/converse-controller.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller.ts
@@ -1,15 +1,13 @@
 import type {Turn} from '@/src/internal/features/generative/index.js';
 import {GenerativeRuntime} from '@/src/internal/api/generative/index.js';
 import {createHydrateSubInterface} from '@/src/internal/features/generative/index.js';
-import {getOrCreateGenerativeSlice} from '@/src/internal/features/generative/index.js';
 import {BaseController} from '@/src/internal/utils/index.js';
 import {createMemoizedStateSelector} from '@/src/internal/utils/index.js';
 import {getHandleInternals} from '@/src/internal/utils/index.js';
-import {getGenerativeSourceEngine} from '@/src/public/interfaces/generative.js';
 import {getOrCreateGenerativeActions} from '@/src/internal/features/generative/index.js';
 import {getOrCreateGenerativeSelectors} from '@/src/internal/features/generative/index.js';
-import type {GenerativeInterface} from '@/src/public/interfaces/generative.js';
-import type {Controller} from '../controller-types.js';
+import type {GenerativeInterface} from '@/src/internal/utils/index.js';
+import type {Controller} from '@/src/internal/utils/index.js';
 
 class ConverseControllerImpl extends BaseController<ConverseControllerState> {
   #runtime: GenerativeRuntime;
@@ -18,9 +16,6 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
 
   constructor(options: ConverseControllerOptions) {
     const {engine: fullEngine} = getHandleInternals(options.interface);
-    const sourceEngine = getGenerativeSourceEngine(options.interface);
-
-    fullEngine.adoptSlice(getOrCreateGenerativeSlice(options.interface));
 
     const actions = getOrCreateGenerativeActions(options.interface);
     const selectors = getOrCreateGenerativeSelectors(options.interface);
@@ -99,7 +94,7 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
           this.engine.mutate(this.#actions.clearTurnResponse({turnId}));
         },
       },
-      hydrateSubInterface: createHydrateSubInterface(sourceEngine),
+      hydrateSubInterface: createHydrateSubInterface(fullEngine),
     });
   }
 

--- a/packages/thermidor/src/public/interfaces/commerce.ts
+++ b/packages/thermidor/src/public/interfaces/commerce.ts
@@ -1,33 +1,9 @@
-import {BaseInterface} from '@/src/internal/utils/index.js';
-import {
-  Engine,
-  getFullEngine,
-  type FullEngine,
-} from '@/src/internal/engine/index.js';
-import type {
-  FacadeResolverFactory,
-  Facades,
-  Supports,
-} from '@/src/internal/utils/index.js';
+import {Engine, getFullEngine} from '@/src/internal/engine/index.js';
 import {generateId} from '@/src/internal/utils/index.js';
-import {createCommerceSearchFacadeResolver} from '@/src/internal/api/commerce-search/index.js';
-import {createCommerceSuggestionsFacadeResolver} from '@/src/internal/api/commerce-query-suggest/index.js';
+import type {CommerceInterface} from '@/src/internal/utils/index.js';
+import {CommerceInterfaceImpl} from '@/src/internal/interfaces/index.js';
 
-const resolverFactories: Record<Facades['commerce'], FacadeResolverFactory> = {
-  search: createCommerceSearchFacadeResolver,
-  suggestions: createCommerceSuggestionsFacadeResolver,
-};
-
-export interface CommerceInterface extends Supports<Facades['commerce']> {}
-
-export class CommerceInterfaceImpl
-  extends BaseInterface<'commerce'>
-  implements CommerceInterface
-{
-  constructor(engine: FullEngine, stateId: string) {
-    super(engine, stateId, 'commerce', resolverFactories);
-  }
-}
+export type {CommerceInterface} from '@/src/internal/utils/index.js';
 
 export interface BuildCommerceInterfaceOptions {
   engine: Engine;

--- a/packages/thermidor/src/public/interfaces/compose.test.ts
+++ b/packages/thermidor/src/public/interfaces/compose.test.ts
@@ -88,7 +88,9 @@ describe('composeInterfaces', () => {
       interfaces: [searchInterface, generativeInterface],
     });
 
-    const thunks = getComposedInternals(composed).resolveFacades('search');
+    const thunks = getComposedInternals(
+      composed as ComposedInterfaceImpl<'search' | 'generative'>
+    ).resolveFacades('search');
     expect(thunks).toHaveLength(1);
     expect(thunks[0]).toBe(mockSearchThunk);
   });
@@ -108,7 +110,9 @@ describe('composeInterfaces', () => {
     const ifaceA = new TestSearchInterface(engine, 'a');
 
     const composed = composeInterfaces({interfaces: [ifaceA]});
-    const {stateId} = getComposedInternals(composed);
+    const {stateId} = getComposedInternals(
+      composed as ComposedInterfaceImpl<'search'>
+    );
 
     expect(typeof stateId).toBe('string');
     expect(stateId.length).toBeGreaterThan(0);

--- a/packages/thermidor/src/public/interfaces/compose.ts
+++ b/packages/thermidor/src/public/interfaces/compose.ts
@@ -1,101 +1,18 @@
-import {InterfaceCacheRegistry} from '@/src/internal/utils/index.js';
 import {getHandleInternals} from '@/src/internal/utils/index.js';
-import type {FullEngine} from '@/src/internal/engine/index.js';
+import {generateId} from '@/src/internal/utils/index.js';
 import type {
-  EndpointThunk,
-  Facades,
+  ComposedInterface,
   InferInterfaceType,
-  InterfaceHandle,
   InterfaceType,
   InterfaceTypeMap,
-  Supports,
-  SupportsBrand,
 } from '@/src/internal/utils/index.js';
-import {generateId} from '@/src/internal/utils/index.js';
+import {ComposedInterfaceImpl} from '@/src/internal/interfaces/index.js';
 
-export interface ComposedInternals {
-  engine: FullEngine;
-  stateId: string;
-  cacheRegistry: InterfaceCacheRegistry;
-  resolveFacades(
-    facade: Facades[InterfaceType],
-    composedInterface?: InterfaceHandle
-  ): EndpointThunk[];
-}
-
-export let getComposedInternals: <T extends InterfaceType>(
-  composed: ComposedInterfaceImpl<T>
-) => ComposedInternals;
-
-export interface ComposedInterface<T extends InterfaceType> extends Supports<
-  Facades[T]
-> {}
-
-export class ComposedInterfaceImpl<
-  T extends InterfaceType,
-> implements ComposedInterface<T> {
-  declare readonly [SupportsBrand]: {[K in Facades[T]]: true};
-
-  get disposed(): boolean {
-    return this.#disposed;
-  }
-
-  #engine: FullEngine;
-  #stateId: string;
-  #interfaces: InterfaceHandle[];
-  #cacheRegistry = new InterfaceCacheRegistry();
-  #disposed = false;
-
-  static {
-    getComposedInternals = <typeof getComposedInternals>((composed) => ({
-      engine: composed.#engine,
-      stateId: composed.#stateId,
-      cacheRegistry: composed.#cacheRegistry,
-      resolveFacades: (facade: any, composedInterface?: InterfaceHandle) =>
-        composed.#resolveFacades(facade, composedInterface),
-    }));
-  }
-
-  constructor(interfaces: InterfaceHandle[], composedId: string) {
-    if (interfaces.length === 0) {
-      throw new Error('ComposedInterface requires at least one interface.');
-    }
-
-    const {engine} = getHandleInternals(interfaces[0]);
-    this.#engine = engine;
-    this.#stateId = composedId;
-    this.#interfaces = interfaces;
-
-    engine.addInterface(this);
-  }
-
-  dispose(): void {
-    if (this.#disposed) {
-      return;
-    }
-    this.#disposed = true;
-    this.#cacheRegistry.dispose();
-    this.#engine.removeInterface(this);
-  }
-
-  #resolveFacades(
-    facade: Facades[T],
-    composedInterface?: InterfaceHandle
-  ): EndpointThunk[] {
-    this.#assertNotDisposed();
-    const target = composedInterface ?? this;
-    return this.#interfaces.flatMap((sub) => {
-      const {resolveFacades} = getHandleInternals(sub);
-      return resolveFacades(facade, target);
-    });
-  }
-
-  #assertNotDisposed(): void {
-    if (this.#disposed) {
-      throw new Error('Cannot operate on a disposed composed interface.');
-    }
-  }
-}
+export type {ComposedInterface} from '@/src/internal/utils/index.js';
+export {
+  ComposedInterfaceImpl,
+  getComposedInternals,
+} from '@/src/internal/interfaces/index.js';
 
 export function composeInterfaces<
   I extends InterfaceTypeMap[InterfaceType],

--- a/packages/thermidor/src/public/interfaces/generative.ts
+++ b/packages/thermidor/src/public/interfaces/generative.ts
@@ -1,48 +1,9 @@
-import {BaseInterface} from '@/src/internal/utils/index.js';
-import {
-  Engine,
-  getFullEngine,
-  type FullEngine,
-} from '@/src/internal/engine/index.js';
-import type {
-  FacadeResolverFactory,
-  Facades,
-  Supports,
-} from '@/src/internal/utils/index.js';
-import {generateId, createNoopThunk} from '@/src/internal/utils/index.js';
-import {getOrCreateGenerativeSlice} from '@/src/internal/features/generative/index.js';
+import {Engine, getFullEngine} from '@/src/internal/engine/index.js';
+import {generateId} from '@/src/internal/utils/index.js';
+import type {GenerativeInterface} from '@/src/internal/utils/index.js';
+import {GenerativeInterfaceImpl} from '@/src/internal/interfaces/index.js';
 
-const noopThunk = createNoopThunk('generative');
-
-const noopResolverFactory: FacadeResolverFactory = (_engine) => (_scope) =>
-  noopThunk;
-
-const resolverFactories: Record<Facades['generative'], FacadeResolverFactory> =
-  {
-    conversation: noopResolverFactory,
-  };
-
-export interface GenerativeInterface extends Supports<Facades['generative']> {}
-
-export let getGenerativeSourceEngine: (iface: GenerativeInterface) => Engine;
-
-export class GenerativeInterfaceImpl
-  extends BaseInterface<'generative'>
-  implements GenerativeInterface
-{
-  #sourceEngine: Engine;
-
-  static {
-    getGenerativeSourceEngine = <typeof getGenerativeSourceEngine>(
-      ((iface: GenerativeInterfaceImpl) => iface.#sourceEngine)
-    );
-  }
-
-  constructor(engine: FullEngine, stateId: string, sourceEngine: Engine) {
-    super(engine, stateId, 'generative', resolverFactories);
-    this.#sourceEngine = sourceEngine;
-  }
-}
+export type {GenerativeInterface} from '@/src/internal/utils/index.js';
 
 export interface BuildGenerativeInterfaceOptions {
   engine: Engine;
@@ -55,13 +16,5 @@ export function buildGenerativeInterface(
   const fullEngine = getFullEngine(options.engine);
   const interfaceId = options.id ?? generateId();
 
-  const iface = new GenerativeInterfaceImpl(
-    fullEngine,
-    interfaceId,
-    options.engine
-  );
-
-  fullEngine.adoptSlice(getOrCreateGenerativeSlice(iface));
-
-  return iface;
+  return new GenerativeInterfaceImpl(fullEngine, interfaceId);
 }

--- a/packages/thermidor/src/public/interfaces/search.ts
+++ b/packages/thermidor/src/public/interfaces/search.ts
@@ -1,31 +1,9 @@
-import {BaseInterface} from '@/src/internal/utils/index.js';
-import type {FullEngine} from '@/src/internal/engine/index.js';
 import {Engine, getFullEngine} from '@/src/internal/engine/index.js';
-import type {
-  FacadeResolverFactory,
-  Facades,
-  Supports,
-} from '@/src/internal/utils/index.js';
 import {generateId} from '@/src/internal/utils/index.js';
-import {getOrCreateSearchParametersSlice} from '@/src/internal/features/search-parameters/index.js';
-import {createSearchFacadeResolver} from '@/src/internal/api/search/index.js';
-import {createQuerySuggestFacadeResolver} from '@/src/internal/api/query-suggest/index.js';
+import type {SearchInterface} from '@/src/internal/utils/index.js';
+import {SearchInterfaceImpl} from '@/src/internal/interfaces/index.js';
 
-const resolverFactories: Record<Facades['search'], FacadeResolverFactory> = {
-  search: createSearchFacadeResolver,
-  suggestions: createQuerySuggestFacadeResolver,
-};
-
-export interface SearchInterface extends Supports<Facades['search']> {}
-
-export class SearchInterfaceImpl
-  extends BaseInterface<'search'>
-  implements SearchInterface
-{
-  constructor(engine: FullEngine, stateId: string) {
-    super(engine, stateId, 'search', resolverFactories);
-  }
-}
+export type {SearchInterface} from '@/src/internal/utils/index.js';
 
 export interface BuildSearchInterfaceOptions {
   engine: Engine;
@@ -38,9 +16,5 @@ export function buildSearchInterface(
   const fullEngine = getFullEngine(options.engine);
   const interfaceId = options.id ?? generateId();
 
-  const iface = new SearchInterfaceImpl(fullEngine, interfaceId);
-
-  fullEngine.adoptSlice(getOrCreateSearchParametersSlice(iface));
-
-  return iface;
+  return new SearchInterfaceImpl(fullEngine, interfaceId);
 }


### PR DESCRIPTION
Enforces a strict `public → internal` dependency flow in thermidor by moving all `Impl` classes into `src/internal/interfaces/`. The public layer becomes thin builders + type re-exports only.

### Motivation

Before this change, 4 files in `src/internal/` imported from `src/public/`, creating an architectural circular dependency. This caused forced workarounds (`#sourceEngine` existed solely because `createHydrateSubInterface` had to go through public builders), slice adoption duplication across builders/hydration/controllers, and fragility where touching a public file could break internal logic non-obviously. Nothing prevented reintroducing an `internal → public` import.

### Changes

**Architectural boundary**
- Moved `CommerceInterfaceImpl`, `SearchInterfaceImpl`, `GenerativeInterfaceImpl`, `ComposedInterfaceImpl` from `src/public/` to `src/internal/interfaces/`
- Defined interface types (`SearchInterface`, `CommerceInterface`, `GenerativeInterface`, `ComposedInterface`) in `internal/utils/interface-types.ts` to avoid circular dependencies
- Moved `Controller` type to `internal/utils/` alongside `BaseController`
- Added oxlint rule (`no-restricted-imports`) that errors on any `internal → public` import in production code

**Simplifications enabled by the move**
- Removed `#sourceEngine` from `GenerativeInterfaceImpl` and `getGenerativeSourceEngine` accessor
- `createHydrateSubInterface` now accepts `FullEngine` directly instead of raw `Engine` + internal `getFullEngine` call
- Slice adoption (`searchParametersSlice`, `generativeSlice`) moved into Impl constructors, eliminating duplication between builders and hydration