### PR TITLE
fix(atomic): strip markdown from generated answer aria-live announcement

### DIFF
--- a/.changeset/fix-generated-answer-aria-markdown.md
+++ b/.changeset/fix-generated-answer-aria-markdown.md
@@ -1,0 +1,7 @@
+---
+"@coveo/atomic": patch
+---
+
+Fix two generated answer accessibility issues:
+- Strip markdown syntax from the aria-live announcement so screen readers read clean prose instead of raw markdown characters (e.g. `##`, `**`, `` ` ``).
+- Announce error states (e.g. "Answer could not be generated") assertively so the message is not skipped when a screen reader is already announcing "Generating answer".

--- a/packages/atomic/src/components/common/atomic-citation/atomic-citation.spec.ts
+++ b/packages/atomic/src/components/common/atomic-citation/atomic-citation.spec.ts
@@ -74,6 +74,11 @@ describe('atomic-citation', () => {
             '.citation-title'
           ) as HTMLElement | null;
         },
+        get citationText() {
+          return element.shadowRoot?.querySelector(
+            'p.text-on-background'
+          ) as HTMLElement | null;
+        },
       },
     };
   };
@@ -130,6 +135,19 @@ describe('atomic-citation', () => {
 
       expect(locators.citationPopover?.textContent).toContain(
         `${'a'.repeat(200)}...`
+      );
+    });
+
+    it('should render citation preview text without Markdown syntax', async () => {
+      const {locators} = await renderComponent({
+        citation: {
+          ...mockCitation,
+          text: '## About the search hub\n\nOn the [**Query Pipelines**](https://example.com/pipelines) page.',
+        },
+      });
+
+      expect(locators.citationText).toHaveTextContent(
+        'About the search hub On the Query Pipelines page.'
       );
     });
   });

--- a/packages/atomic/src/components/common/atomic-citation/atomic-citation.ts
+++ b/packages/atomic/src/components/common/atomic-citation/atomic-citation.ts
@@ -13,6 +13,7 @@ import {classMap} from 'lit/directives/class-map.js';
 import {createRef, type Ref, ref} from 'lit/directives/ref.js';
 import {watch} from '@/src/decorators/watch';
 import {withTailwindStyles} from '@/src/decorators/with-tailwind-styles';
+import {markdownToPlainText} from '@/src/components/common/generated-answer/generated-content/markdown-utils';
 import {renderHeading} from '../heading';
 import {renderLinkWithItemAnalytics} from '../item-link/item-link';
 import styles from './atomic-citation.tw.css';
@@ -191,12 +192,11 @@ export class AtomicCitation extends LitElement {
   }
 
   private getTruncatedText() {
-    return (
-      this.citation.text &&
-      `${this.citation.text?.trim().slice(0, 200)}${
-        this.citation.text.length > 200 ? '...' : ''
-      }`
-    );
+    const plainText = markdownToPlainText(this.citation.text ?? '');
+
+    return plainText
+      ? `${plainText.slice(0, 200)}${plainText.length > 200 ? '...' : ''}`
+      : undefined;
   }
 
   private anchorUrl(

--- a/packages/atomic/src/components/common/generated-answer/generated-answer-controller.spec.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-answer-controller.spec.ts
@@ -199,84 +199,22 @@ describe('GeneratedAnswerController', () => {
       expect(controller.getGeneratedAnswerStatus()).toBe('');
     });
 
-    describe('bug condition exploration: status precedence when a non-empty answer coexists with a (possibly stale) error', () => {
-      it('should return the answer message, not the error message, when both answer and error.message are set', () => {
-        const controller = createController({
-          getGeneratedAnswerState: () => ({
-            isVisible: true,
-            isStreaming: false,
-            answer: 'Test answer',
-            error: {message: 'some error', code: 500},
-          }),
-        });
-
-        expect(controller.getGeneratedAnswerStatus()).toBe(
-          'Generated answer: Test answer'
-        );
+    it('should return the error message when a partial answer and error are present', () => {
+      const controller = createController({
+        getGeneratedAnswerState: () => ({
+          isVisible: true,
+          isStreaming: false,
+          answer: 'Partial answer',
+          error: {message: 'some error', code: 500},
+        }),
       });
 
-      it('should always return the answer message, never "Answer could not be generated", for any non-empty answer crossed with any truthy error message', () => {
-        const answers = [
-          'Test answer',
-          'A',
-          'A much longer generated answer with several words in it.',
-          'Réponse générée avec des caractères accentués.',
-        ];
-        const errorMessages = [
-          'some error',
-          'Internal server error.',
-          'timeout',
-          'Unknown error occurred',
-        ];
-
-        for (const answer of answers) {
-          for (const errorMessage of errorMessages) {
-            const controller = createController({
-              getGeneratedAnswerState: () => ({
-                isVisible: true,
-                isStreaming: false,
-                answer,
-                error: {message: errorMessage, code: 500},
-              }),
-            });
-
-            const result = controller.getGeneratedAnswerStatus();
-
-            expect(result).not.toBe('Answer could not be generated');
-            expect(result).toBe(`Generated answer: ${answer}`);
-          }
-        }
-      });
+      expect(controller.getGeneratedAnswerStatus()).toBe(
+        'Answer could not be generated'
+      );
     });
 
-    describe('preservation: genuine failures and hidden/generating precedence are unaffected', () => {
-      it('should always return "Answer could not be generated" for any truthy error message crossed with any empty, undefined, or whitespace-only answer', () => {
-        const errorMessages = [
-          'some error',
-          'Internal server error.',
-          'timeout',
-          'Unknown error occurred',
-        ];
-        const emptyAnswers = [undefined, '', '   ', '\n\t', '\u00a0'];
-
-        for (const errorMessage of errorMessages) {
-          for (const answer of emptyAnswers) {
-            const controller = createController({
-              getGeneratedAnswerState: () => ({
-                isVisible: true,
-                isStreaming: false,
-                answer,
-                error: {message: errorMessage, code: 500},
-              }),
-            });
-
-            expect(controller.getGeneratedAnswerStatus()).toBe(
-              'Answer could not be generated'
-            );
-          }
-        }
-      });
-
+    describe('when status conditions overlap', () => {
       it('should return the hidden status regardless of error/answer/generating combination', () => {
         const combinations: Array<{
           isStreaming?: boolean;
@@ -358,7 +296,7 @@ describe('GeneratedAnswerController', () => {
       expect(controller.isStatusAssertive()).toBe(false);
     });
 
-    it('should return false when non-empty answer is present alongside error', () => {
+    it('should return true when a partial answer is present alongside error', () => {
       const controller = createController({
         getGeneratedAnswerState: () => ({
           isVisible: true,
@@ -368,7 +306,7 @@ describe('GeneratedAnswerController', () => {
         }),
       });
 
-      expect(controller.isStatusAssertive()).toBe(false);
+      expect(controller.isStatusAssertive()).toBe(true);
     });
 
     it('should return false when hidden', () => {

--- a/packages/atomic/src/components/common/generated-answer/generated-answer-controller.spec.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-answer-controller.spec.ts
@@ -158,6 +158,20 @@ describe('GeneratedAnswerController', () => {
       );
     });
 
+    it('should strip markdown syntax from answer before announcing it', () => {
+      const controller = createController({
+        getGeneratedAnswerState: () => ({
+          isVisible: true,
+          isStreaming: false,
+          answer: '**Bold** and *italic* with `code`',
+        }),
+      });
+
+      expect(controller.getGeneratedAnswerStatus()).toBe(
+        'Generated answer: Bold and italic with code'
+      );
+    });
+
     it('should announce the answer when the error wrapper has no message (Answer API success)', () => {
       const controller = createController({
         getGeneratedAnswerState: () => ({
@@ -183,6 +197,209 @@ describe('GeneratedAnswerController', () => {
       });
 
       expect(controller.getGeneratedAnswerStatus()).toBe('');
+    });
+
+    describe('bug condition exploration: status precedence when a non-empty answer coexists with a (possibly stale) error', () => {
+      it('should return the answer message, not the error message, when both answer and error.message are set', () => {
+        const controller = createController({
+          getGeneratedAnswerState: () => ({
+            isVisible: true,
+            isStreaming: false,
+            answer: 'Test answer',
+            error: {message: 'some error', code: 500},
+          }),
+        });
+
+        expect(controller.getGeneratedAnswerStatus()).toBe(
+          'Generated answer: Test answer'
+        );
+      });
+
+      it('should always return the answer message, never "Answer could not be generated", for any non-empty answer crossed with any truthy error message', () => {
+        const answers = [
+          'Test answer',
+          'A',
+          'A much longer generated answer with several words in it.',
+          'Réponse générée avec des caractères accentués.',
+        ];
+        const errorMessages = [
+          'some error',
+          'Internal server error.',
+          'timeout',
+          'Unknown error occurred',
+        ];
+
+        for (const answer of answers) {
+          for (const errorMessage of errorMessages) {
+            const controller = createController({
+              getGeneratedAnswerState: () => ({
+                isVisible: true,
+                isStreaming: false,
+                answer,
+                error: {message: errorMessage, code: 500},
+              }),
+            });
+
+            const result = controller.getGeneratedAnswerStatus();
+
+            expect(result).not.toBe('Answer could not be generated');
+            expect(result).toBe(`Generated answer: ${answer}`);
+          }
+        }
+      });
+    });
+
+    describe('preservation: genuine failures and hidden/generating precedence are unaffected', () => {
+      it('should always return "Answer could not be generated" for any truthy error message crossed with any empty, undefined, or whitespace-only answer', () => {
+        const errorMessages = [
+          'some error',
+          'Internal server error.',
+          'timeout',
+          'Unknown error occurred',
+        ];
+        const emptyAnswers = [undefined, '', '   ', '\n\t', '\u00a0'];
+
+        for (const errorMessage of errorMessages) {
+          for (const answer of emptyAnswers) {
+            const controller = createController({
+              getGeneratedAnswerState: () => ({
+                isVisible: true,
+                isStreaming: false,
+                answer,
+                error: {message: errorMessage, code: 500},
+              }),
+            });
+
+            expect(controller.getGeneratedAnswerStatus()).toBe(
+              'Answer could not be generated'
+            );
+          }
+        }
+      });
+
+      it('should return the hidden status regardless of error/answer/generating combination', () => {
+        const combinations: Array<{
+          isStreaming?: boolean;
+          answer?: string;
+          error?: {message?: string; code?: number};
+        }> = [
+          {},
+          {isStreaming: true},
+          {answer: 'Test answer'},
+          {error: {message: 'some error', code: 500}},
+          {answer: 'Test answer', error: {message: 'some error', code: 500}},
+        ];
+
+        for (const combination of combinations) {
+          const controller = createController({
+            getGeneratedAnswerState: () => ({
+              isVisible: false,
+              ...combination,
+            }),
+          });
+
+          expect(controller.getGeneratedAnswerStatus()).toBe(
+            'Generated answer is hidden'
+          );
+        }
+      });
+
+      it('should return the generating status regardless of error/answer combination, as long as visible and streaming', () => {
+        const combinations: Array<{
+          answer?: string;
+          error?: {message?: string; code?: number};
+        }> = [
+          {},
+          {answer: 'Test answer'},
+          {error: {message: 'some error', code: 500}},
+          {answer: 'Test answer', error: {message: 'some error', code: 500}},
+        ];
+
+        for (const combination of combinations) {
+          const controller = createController({
+            getGeneratedAnswerState: () => ({
+              isVisible: true,
+              isStreaming: true,
+              ...combination,
+            }),
+          });
+
+          expect(controller.getGeneratedAnswerStatus()).toBe(
+            'Generating answer'
+          );
+        }
+      });
+    });
+  });
+
+  describe('#isStatusAssertive', () => {
+    it('should return true when there is an error and no answer', () => {
+      const controller = createController({
+        getGeneratedAnswerState: () => ({
+          isVisible: true,
+          isStreaming: false,
+          answer: '',
+          error: {message: 'some error', code: 500},
+        }),
+      });
+
+      expect(controller.isStatusAssertive()).toBe(true);
+    });
+
+    it('should return false when streaming (error may be stale)', () => {
+      const controller = createController({
+        getGeneratedAnswerState: () => ({
+          isVisible: true,
+          isStreaming: true,
+          error: {message: 'some error', code: 500},
+        }),
+      });
+
+      expect(controller.isStatusAssertive()).toBe(false);
+    });
+
+    it('should return false when non-empty answer is present alongside error', () => {
+      const controller = createController({
+        getGeneratedAnswerState: () => ({
+          isVisible: true,
+          isStreaming: false,
+          answer: 'Test answer',
+          error: {message: 'some error', code: 500},
+        }),
+      });
+
+      expect(controller.isStatusAssertive()).toBe(false);
+    });
+
+    it('should return false when hidden', () => {
+      const controller = createController({
+        getGeneratedAnswerState: () => ({
+          isVisible: false,
+          error: {message: 'some error', code: 500},
+        }),
+      });
+
+      expect(controller.isStatusAssertive()).toBe(false);
+    });
+
+    it('should return false when no error', () => {
+      const controller = createController({
+        getGeneratedAnswerState: () => ({
+          isVisible: true,
+          isStreaming: false,
+          answer: 'Test answer',
+        }),
+      });
+
+      expect(controller.isStatusAssertive()).toBe(false);
+    });
+
+    it('should return false when state is undefined', () => {
+      const controller = createController({
+        getGeneratedAnswerState: () => undefined,
+      });
+
+      expect(controller.isStatusAssertive()).toBe(false);
     });
   });
 

--- a/packages/atomic/src/components/common/generated-answer/generated-answer-controller.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-answer-controller.ts
@@ -115,14 +115,14 @@ export class GeneratedAnswerController implements ReactiveController {
       return bindings.i18n.t('generating-answer');
     }
 
+    if (hasError) {
+      return bindings.i18n.t('answer-could-not-be-generated');
+    }
+
     if (hasNonEmptyAnswer) {
       return bindings.i18n.t('answer-generated', {
         answer: markdownToPlainText(state.answer!),
       });
-    }
-
-    if (hasError) {
-      return bindings.i18n.t('answer-could-not-be-generated');
     }
 
     return '';
@@ -137,9 +137,8 @@ export class GeneratedAnswerController implements ReactiveController {
     if (!state) return false;
     const isHidden = !state.isVisible;
     const isGenerating = !!state.isStreaming;
-    const hasNonEmptyAnswer = !!state.answer?.trim();
     const hasError = !!state.error?.message;
-    return !isHidden && !isGenerating && !hasNonEmptyAnswer && hasError;
+    return !isHidden && !isGenerating && hasError;
   }
 
   /**

--- a/packages/atomic/src/components/common/generated-answer/generated-answer-controller.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-answer-controller.ts
@@ -13,6 +13,7 @@ import {
 } from '@/src/utils/local-storage-utils';
 import type {AtomicGeneratedAnswerFeedbackModal} from '../atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal';
 import '@/src/components/common/atomic-generated-answer-feedback-modal/atomic-generated-answer-feedback-modal';
+import {markdownToPlainText} from './generated-content/markdown-utils';
 
 export interface GeneratedAnswerControllerOptions {
   withToggle?: boolean;
@@ -114,17 +115,31 @@ export class GeneratedAnswerController implements ReactiveController {
       return bindings.i18n.t('generating-answer');
     }
 
+    if (hasNonEmptyAnswer) {
+      return bindings.i18n.t('answer-generated', {
+        answer: markdownToPlainText(state.answer!),
+      });
+    }
+
     if (hasError) {
       return bindings.i18n.t('answer-could-not-be-generated');
     }
 
-    if (hasNonEmptyAnswer) {
-      return bindings.i18n.t('answer-generated', {
-        answer: state.answer,
-      });
-    }
-
     return '';
+  }
+
+  /**
+   * Checks if the current status message should be announced assertively.
+   * Error states should interrupt any in-progress announcement (e.g. "Generating answer").
+   */
+  public isStatusAssertive(): boolean {
+    const state = this.options.getGeneratedAnswerState();
+    if (!state) return false;
+    const isHidden = !state.isVisible;
+    const isGenerating = !!state.isStreaming;
+    const hasNonEmptyAnswer = !!state.answer?.trim();
+    const hasError = !!state.error?.message;
+    return !isHidden && !isGenerating && !hasNonEmptyAnswer && hasError;
   }
 
   /**

--- a/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.spec.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.spec.ts
@@ -471,5 +471,9 @@ describe('markdownUtils', () => {
       const result = markdownToPlainText('**Bold** and *italic* with `code`');
       expect(result).toBe('Bold and italic with code');
     });
+
+    it('should decode HTML entities produced by the markdown renderer', () => {
+      expect(markdownToPlainText('AT&T < 5')).toBe('AT&T < 5');
+    });
   });
 });

--- a/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.spec.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.spec.ts
@@ -1,5 +1,8 @@
 import {describe, expect, it} from 'vitest';
-import {transformMarkdownToHtml} from './markdown-utils.js';
+import {
+  markdownToPlainText,
+  transformMarkdownToHtml,
+} from './markdown-utils.js';
 
 describe('markdownUtils', () => {
   describe('transformMarkdownToHtml', () => {
@@ -433,6 +436,40 @@ describe('markdownUtils', () => {
           )
         );
       });
+    });
+  });
+
+  describe('markdownToPlainText', () => {
+    it('should return plain text unchanged', () => {
+      expect(markdownToPlainText('Hello world')).toBe('Hello world');
+    });
+
+    it('should strip bold syntax', () => {
+      expect(markdownToPlainText('**bold text**')).toBe('bold text');
+    });
+
+    it('should strip italic syntax', () => {
+      expect(markdownToPlainText('*italic text*')).toBe('italic text');
+    });
+
+    it('should strip heading syntax', () => {
+      expect(markdownToPlainText('# Heading')).toBe('Heading');
+    });
+
+    it('should strip inline code syntax', () => {
+      expect(markdownToPlainText('`code`')).toBe('code');
+    });
+
+    it('should strip list syntax and preserve item text', () => {
+      const result = markdownToPlainText('- Item 1\n- Item 2');
+      expect(result).toContain('Item 1');
+      expect(result).toContain('Item 2');
+      expect(result).not.toContain('-');
+    });
+
+    it('should produce readable text from mixed markdown', () => {
+      const result = markdownToPlainText('**Bold** and *italic* with `code`');
+      expect(result).toBe('Bold and italic with code');
     });
   });
 });

--- a/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.spec.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.spec.ts
@@ -473,7 +473,39 @@ describe('markdownUtils', () => {
     });
 
     it('should decode HTML entities produced by the markdown renderer', () => {
-      expect(markdownToPlainText('AT&T < 5')).toBe('AT&T < 5');
+      expect(markdownToPlainText('AT&T < 5 &quot;quoted&quot;')).toBe(
+        'AT&T < 5 "quoted"'
+      );
+    });
+
+    it('should remove HTML tags while preserving their text content', () => {
+      expect(markdownToPlainText('<span>Inline HTML</span>')).toBe(
+        'Inline HTML'
+      );
+    });
+
+    it('should preserve image alt text', () => {
+      expect(
+        markdownToPlainText('![Search interface](search-interface.png)')
+      ).toBe('Search interface');
+    });
+
+    it('should preserve table content without Markdown syntax', () => {
+      expect(
+        markdownToPlainText('| Name | Value |\n| --- | --- |\n| A | B |')
+      ).toBe('Name Value A B');
+    });
+
+    it('should remove horizontal rule syntax', () => {
+      expect(markdownToPlainText('Before\n\n---\n\nAfter')).toBe(
+        'Before After'
+      );
+    });
+
+    it('should remove incomplete inline formatting syntax', () => {
+      expect(markdownToPlainText('An **incomplete answer')).toBe(
+        'An incomplete answer'
+      );
     });
   });
 });

--- a/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.ts
@@ -146,5 +146,22 @@ export const transformMarkdownToHtml = (text: string): string => {
 };
 
 export const markdownToPlainText = (text: string): string => {
-  return toInlinePlainText(transformMarkdownToHtml(text));
+  const plain = toInlinePlainText(transformMarkdownToHtml(text));
+
+  // marked outputs HTML-escaped entities; decode them so aria-live announces human text.
+  const decoded = plain
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#x([0-9a-fA-F]+);/g, (_m, hex) =>
+      String.fromCodePoint(Number.parseInt(hex, 16))
+    )
+    .replace(/&#(\d+);/g, (_m, num) =>
+      String.fromCodePoint(Number.parseInt(num, 10))
+    );
+
+  return decoded.replace(/\s{2,}/g, ' ').trim();
 };

--- a/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.ts
@@ -150,7 +150,6 @@ export const markdownToPlainText = (text: string): string => {
 
   // marked outputs HTML-escaped entities; decode them so aria-live announces human text.
   const decoded = plain
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
@@ -161,7 +160,8 @@ export const markdownToPlainText = (text: string): string => {
     )
     .replace(/&#(\d+);/g, (_m, num) =>
       String.fromCodePoint(Number.parseInt(num, 10))
-    );
+    )
+    .replace(/&amp;/g, '&');
 
   return decoded.replace(/\s{2,}/g, ' ').trim();
 };

--- a/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.ts
@@ -144,3 +144,7 @@ const customRenderer = {
 export const transformMarkdownToHtml = (text: string): string => {
   return marked.use({renderer: customRenderer}).parse(text) as string;
 };
+
+export const markdownToPlainText = (text: string): string => {
+  return toInlinePlainText(transformMarkdownToHtml(text));
+};

--- a/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.ts
+++ b/packages/atomic/src/components/common/generated-answer/generated-content/markdown-utils.ts
@@ -1,4 +1,5 @@
-import {marked} from 'marked';
+import {Marked, Renderer} from 'marked';
+import {parseHTML} from '@/src/utils/utils';
 
 const toInlinePlainText = (textWithHtml: string): string => {
   const withoutHtmlTags = textWithHtml.replace(/<[^>]*>/g, ' ');
@@ -26,6 +27,10 @@ const completeUnclosedElement = (text: string) => {
   }
 
   return text;
+};
+
+const decodeHtmlEntities = (text: string) => {
+  return parseHTML(text).body.textContent ?? '';
 };
 
 const escapeHtml = (text: string) => {
@@ -141,27 +146,101 @@ const customRenderer = {
   },
 };
 
+class PlainTextRenderer extends Renderer {
+  blockquote(quote: string) {
+    return ` ${quote} `;
+  }
+
+  br() {
+    return ' ';
+  }
+
+  checkbox() {
+    return '';
+  }
+
+  code(code: string) {
+    return ` ${code} `;
+  }
+
+  codespan(text: string) {
+    return text;
+  }
+
+  del(text: string) {
+    return text;
+  }
+
+  em(text: string) {
+    return text;
+  }
+
+  heading(text: string) {
+    return ` ${text} `;
+  }
+
+  hr() {
+    return ' ';
+  }
+
+  html(text: string) {
+    return toInlinePlainText(text);
+  }
+
+  image(_href: string, _title: string | null, text: string) {
+    return text;
+  }
+
+  link(_href: string, _title: string | null | undefined, text: string) {
+    return text;
+  }
+
+  list(body: string) {
+    return ` ${body} `;
+  }
+
+  listitem(text: string) {
+    return ` ${text} `;
+  }
+
+  paragraph(text: string) {
+    return ` ${text} `;
+  }
+
+  strong(text: string) {
+    return text;
+  }
+
+  table(header: string, body: string) {
+    return ` ${header} ${body} `;
+  }
+
+  tablecell(content: string) {
+    return `${content} `;
+  }
+
+  tablerow(content: string) {
+    return ` ${content} `;
+  }
+
+  text(text: string) {
+    return text.replace(unclosedElement, '$2');
+  }
+}
+
+const markdownParser = new Marked();
+const plainTextMarkdownParser = new Marked();
+const htmlRenderer = Object.assign(new Renderer(), customRenderer);
+const plainTextRenderer = new PlainTextRenderer();
+
 export const transformMarkdownToHtml = (text: string): string => {
-  return marked.use({renderer: customRenderer}).parse(text) as string;
+  return markdownParser.parse(text, {renderer: htmlRenderer}) as string;
 };
 
 export const markdownToPlainText = (text: string): string => {
-  const plain = toInlinePlainText(transformMarkdownToHtml(text));
+  const plain = plainTextMarkdownParser.parse(text, {
+    renderer: plainTextRenderer,
+  }) as string;
 
-  // marked outputs HTML-escaped entities; decode them so aria-live announces human text.
-  const decoded = plain
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&#x([0-9a-fA-F]+);/g, (_m, hex) =>
-      String.fromCodePoint(Number.parseInt(hex, 16))
-    )
-    .replace(/&#(\d+);/g, (_m, num) =>
-      String.fromCodePoint(Number.parseInt(num, 10))
-    )
-    .replace(/&amp;/g, '&');
-
-  return decoded.replace(/\s{2,}/g, ' ').trim();
+  return decodeHtmlEntities(plain).replace(/\s+/g, ' ').trim();
 };

--- a/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.ts
@@ -182,6 +182,11 @@ export class AtomicInsightGeneratedAnswer
   private copyError = false;
 
   private ariaMessage = new AriaLiveRegionController(this, 'generated-answer');
+  private ariaErrorMessage = new AriaLiveRegionController(
+    this,
+    'generated-answer-error',
+    true
+  );
 
   constructor() {
     super();
@@ -328,7 +333,12 @@ export class AtomicInsightGeneratedAnswer
       this.controller.writeStoredData(this.controller.data);
     }
 
-    this.ariaMessage.message = this.controller.getGeneratedAnswerStatus();
+    const status = this.controller.getGeneratedAnswerStatus();
+    if (this.controller.isStatusAssertive()) {
+      this.ariaErrorMessage.message = status;
+    } else {
+      this.ariaMessage.message = status;
+    }
   };
 
   private get hasNoAnswerGenerated() {

--- a/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-generated-answer/atomic-insight-generated-answer.ts
@@ -335,8 +335,10 @@ export class AtomicInsightGeneratedAnswer
 
     const status = this.controller.getGeneratedAnswerStatus();
     if (this.controller.isStatusAssertive()) {
+      this.ariaMessage.message = '';
       this.ariaErrorMessage.message = status;
     } else {
+      this.ariaErrorMessage.message = '';
       this.ariaMessage.message = status;
     }
   };

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.new.stories.tsx
@@ -224,7 +224,7 @@ export const A11yStatusMessage: Story = {
       },
       expectedSequence: [
         'Generating answer',
-        /Generated answer: # Resolving Netflix Connection Issues with TiVo[\s\S]*Test Internet Connection/,
+        /Generated answer: Resolving Netflix Connection Issues with TiVo[\s\S]*Test Internet Connection/,
       ],
       timeout: 12000,
     });

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
@@ -522,8 +522,10 @@ export class AtomicGeneratedAnswer
 
     const status = this.controller.getGeneratedAnswerStatus();
     if (this.controller.isStatusAssertive()) {
+      this.ariaMessage.message = '';
       this.ariaErrorMessage.message = status;
     } else {
+      this.ariaErrorMessage.message = '';
       this.ariaMessage.message = status;
     }
   };

--- a/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
+++ b/packages/atomic/src/components/search/atomic-generated-answer/atomic-generated-answer.ts
@@ -295,6 +295,11 @@ export class AtomicGeneratedAnswer
   private copyError = false;
 
   private ariaMessage = new AriaLiveRegionController(this, 'generated-answer');
+  private ariaErrorMessage = new AriaLiveRegionController(
+    this,
+    'generated-answer-error',
+    true
+  );
 
   constructor() {
     super();
@@ -515,7 +520,12 @@ export class AtomicGeneratedAnswer
       this.controller.writeStoredData(this.controller.data);
     }
 
-    this.ariaMessage.message = this.controller.getGeneratedAnswerStatus();
+    const status = this.controller.getGeneratedAnswerStatus();
+    if (this.controller.isStatusAssertive()) {
+      this.ariaErrorMessage.message = status;
+    } else {
+      this.ariaMessage.message = status;
+    }
   };
 
   private get hasNoAnswerGenerated() {


### PR DESCRIPTION
## SFINT-6826

Fix a bug where when the answer is streamed, the voiceover reads the answer including the markdown syntax, speaking things like “number-number-number” or “star-star” for every title and bolded text. Simply, the raw answer as markdown was output in the aria element which is read by screen readers, so we have to parse it back to plain text!

You can test in the Storybook > Generated Answer component 

#### Before

<img width="965" height="194" alt="image" src="https://github.com/user-attachments/assets/923cc965-b042-4d3b-a4f5-7ebfa72cafb2" />

#### After

<img width="920" height="161" alt="image" src="https://github.com/user-attachments/assets/3f8edfc7-49ee-4796-a2e0-5028a40f0105" />

---

Also fixes the markdown in Citations content:

#### Before

<img width="418" height="172" alt="image" src="https://github.com/user-attachments/assets/23dba7fd-1e1e-4e26-a849-81caff20a483" />

#### After

<img width="387" height="175" alt="image" src="https://github.com/user-attachments/assets/206142ea-c69c-4561-89bb-02bfe0a2c3c7" />


