### PR TITLE
feat(quantic): added border on top of the follow up input section

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/conversation.html
+++ b/packages/quantic/force-app/main/default/lwc/quanticGeneratedAnswer/templates/conversation.html
@@ -43,7 +43,7 @@
           >
           </c-quantic-generated-answer-thread>
         </div>
-        <div class="slds-p-horizontal_large slds-p-vertical_medium">
+        <div class="slds-border_top slds-p-horizontal_large slds-p-vertical_medium">
           <c-quantic-generated-answer-follow-up-input
             onquantic__submitfollowup={handleFollowUpSubmit}
             submit-button-disabled={isAnswerGenerationOngoing}


### PR DESCRIPTION
[SFINT-6831](https://coveord.atlassian.net/browse/SFINT-6831)

Here is what it looks like now with a border:

<img width="686" height="723" alt="image" src="https://github.com/user-attachments/assets/0c9faa9e-7692-4a02-95ca-51038f232189" />

This follows the current behaviour in Atomic.

[SFINT-6831]: https://coveord.atlassian.net/browse/SFINT-6831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ