### PR TITLE
fix(atomic): render result excerpt in Chrome at compact density

### DIFF
--- a/.changeset/kit-5881-excerpt-line-clamp.md
+++ b/.changeset/kit-5881-excerpt-line-clamp.md
@@ -1,0 +1,7 @@
+---
+'@coveo/atomic': patch
+---
+
+fix(atomic): render result excerpt in Chrome at compact density
+
+Removed the redundant `max-height` from the `atomic-result-section-excerpt` list and table utilities. A `max-height` equal to the clamped number of lines, stacked on top of `-webkit-line-clamp`, caused Chrome/Blink to collapse the excerpt to 0 height (the text was present in the DOM but not rendered) at `density="compact"` on desktop viewports (>= 1024px). Truncation is now handled by `-webkit-line-clamp` alone, consistent with the grid variant, which was unaffected.

--- a/packages/atomic/src/components/common/template-system/sections/section-excerpt.css
+++ b/packages/atomic/src/components/common/template-system/sections/section-excerpt.css
@@ -1,13 +1,5 @@
 @reference './sections-utilities.css';
 
-/*
- * Truncation is handled by line-clamp (see the section-excerpt utility below).
- * Do NOT add a max-height here: a max-height equal to the clamped number of lines
- * clips the text to 0 height in Chrome/Blink (KIT-5881), because -webkit-line-clamp
- * on display:-webkit-box combined with a max-height <= one line's height is
- * under-specified and Blink collapses it. The grid variants rely on line-clamp
- * alone and are unaffected.
- */
 @utility section-excerpt-row-result-desktop {
   &.density-comfortable {
     margin-top: 1.75rem;

--- a/packages/atomic/src/components/common/template-system/sections/section-excerpt.css
+++ b/packages/atomic/src/components/common/template-system/sections/section-excerpt.css
@@ -1,27 +1,27 @@
 @reference './sections-utilities.css';
 
+/*
+ * Truncation is handled by line-clamp (see the section-excerpt utility below).
+ * Do NOT add a max-height here: a max-height equal to the clamped number of lines
+ * clips the text to 0 height in Chrome/Blink (KIT-5881), because -webkit-line-clamp
+ * on display:-webkit-box combined with a max-height <= one line's height is
+ * under-specified and Blink collapses it. The grid variants rely on line-clamp
+ * alone and are unaffected.
+ */
 @utility section-excerpt-row-result-desktop {
   &.density-comfortable {
     margin-top: 1.75rem;
-    max-height: 4.5rem;
   }
 
   &.density-normal {
     margin-top: 1.25rem;
-    max-height: 2.5rem;
   }
 
   &.density-compact {
     margin-top: 1rem;
-    max-height: 1.25rem;
   }
 }
 @utility section-excerpt-row-result-mobile {
-  &.density-comfortable,
-  &.density-normal {
-    max-height: 2.5rem;
-  }
-
   &.density-comfortable {
     margin-top: 1.25rem;
   }


### PR DESCRIPTION
## Issue

[KIT-5881](https://coveord.atlassian.net/browse/KIT-5881) — `atomic-result-section-excerpt` renders blank in Chrome/Blink at `density="compact"` on desktop viewports (≥1024px). The excerpt text is present in the DOM but not rendered. Reproduced out-of-the-box with no custom code; Safari renders it correctly.

## Solution

At compact density on desktop, the excerpt stacked a redundant `max-height` (≈ one line's height) on top of `-webkit-line-clamp: 1`. The line-clamp already truncates to N lines, and the extra `max-height` clips the single clamped line — Blink collapses it to 0 height, while WebKit renders it (`-webkit-line-clamp` + `max-height` on `display:-webkit-box` is under-specified).

Removed `max-height` from the list/table excerpt utilities so `-webkit-line-clamp` alone handles truncation, matching the grid variant (which never had `max-height` and was unaffected).

## Testing
Tested in chrome, firefox and Safari


[KIT-5881]: https://coveord.atlassian.net/browse/KIT-5881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ