### PR TITLE
ci: exclude samples from the CDN build

### DIFF
--- a/.github/actions/build-cdn/action.yml
+++ b/.github/actions/build-cdn/action.yml
@@ -15,6 +15,9 @@ runs:
         save-cache: 'true'
         load-cache: 'false'
         cache-retention-days: '7'
+        # Samples are not CDN artifacts. Exclude them so the CDN build does not try
+        # to bundle samples that depend on CDN-externalized packages.
+        build-command: "pnpm exec turbo build --filter='!./samples/**'"
       env:
         DEPLOYMENT_ENVIRONMENT: CDN
         CDN_COMMIT_SHA: ${{ inputs.commit-sha }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Skip the build step'
     required: false
     default: 'false'
+  build-command:
+    description: 'Command used to build. Defaults to building every package.'
+    required: false
+    default: 'pnpm run build'
   cache-retention-days:
     description: 'Number of days to retain the cache artifact'
     required: false
@@ -50,7 +54,7 @@ runs:
         path: .turbo
     #endregion
     #region Build
-    - run: pnpm run build
+    - run: ${{ inputs.build-command }}
       if: inputs.skip-build != 'true'
       shell: bash
     # Save turbo cache (controlled by save-cache input)


### PR DESCRIPTION
Related: [KIT-5452](https://coveord.atlassian.net/browse/KIT-5452)

## Problem

The "Build CDN" step runs `pnpm run build` (`turbo build`) with `DEPLOYMENT_ENVIRONMENT=CDN`, which compiles **every** package — including samples. Samples aren't CDN artifacts, so this is wasted work, and it's fragile: a sample that bundles a package built in CDN mode fails. Concretely, `@coveo/atomic-react`'s CDN build imports Headless from runtime CDN paths (`/headless/commits/<sha>/headless.esm.js`); a sample's `vite build` can't resolve those at bundle time and the CDN build fails with `UNRESOLVED_IMPORT`.

Until now the only way a sample avoided this was an `@coveo/ci if-not-cdn` guard in its build script — which doesn't work for **publishable** samples, since a scaffolded project has no access to `@coveo/ci`.

## Solution

Exclude samples from the CDN build at the build level instead of per-sample:

- `.github/actions/setup`: add an optional `build-command` input (default `pnpm run build`, so every existing caller is unchanged).
- `.github/actions/build-cdn`: pass `pnpm exec turbo build --filter='!./samples/**'`, skipping every package under `samples/`.

Atomic, Headless and the other CDN packages still build in CDN mode; only `samples/` is skipped. `@coveo/atomic-cdn-smoke` is a package (not a sample), so CDN checks are unaffected. Verified via `turbo build --filter='!./samples/**' --dry-run`: 0 sample packages, atomic/headless still built.

This lets the publishable Atomic samples keep a plain `build: vite build` with no CDN-specific config.

[KIT-5452]: https://coveord.atlassian.net/browse/KIT-5452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ