### PR TITLE
fix(changesets): remove unavailable sample packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,21 +15,14 @@
       "@coveo/ui-kit-sample-atomic-commerce-vite"
     ],
     [
-      "@coveo/atomic-react",
-      "@coveo/ui-kit-sample-atomic-search-react",
-      "@coveo/ui-kit-sample-atomic-commerce-react"
-    ],
-    [
       "@coveo/headless",
       "@coveo/ui-kit-sample-headless-search-vite",
       "@coveo/ui-kit-sample-headless-commerce-vite",
       "@coveo/ui-kit-sample-headless-search-react",
-      "@coveo/ui-kit-sample-headless-commerce-react",
-      "@coveo/ui-kit-sample-headless-ssr-commerce-express"
+      "@coveo/ui-kit-sample-headless-commerce-react"
     ],
     [
       "@coveo/headless-react",
-      "@coveo/ui-kit-sample-headless-ssr-search-nextjs",
       "@coveo/ui-kit-sample-headless-ssr-commerce-nextjs"
     ]
   ],


### PR DESCRIPTION
## Problem

The Changesets `fixed` configuration references sample packages that are not present in every merge-queue project state. `changeset version` fails validation when an expression does not match a workspace package.

## Solution

- Keep `@coveo/ui-kit-sample-atomic-search-vite` and `@coveo/ui-kit-sample-atomic-commerce-vite` in the Atomic fixed group because both packages are now on `main`.
- Remove the Atomic React fixed group because neither React sample is on `main` yet.
- Remove the unavailable Headless SSR Commerce Express and Headless SSR Search Next sample expressions.

Verified with `pnpm changeset status`, `oxlint`, and `oxfmt`; no missing-package validation errors remain.