### PR TITLE
feat(thermidor): enrich search endpoint with organizationId, locale and analytics

### DIFF
--- a/packages/thermidor/src/internal/api/analytics-params.test.ts
+++ b/packages/thermidor/src/internal/api/analytics-params.test.ts
@@ -1,0 +1,131 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {buildAnalyticsParams} from './analytics-params.js';
+import type {FullEngine} from '@/src/internal/engine/index.js';
+
+function createMockEngine(
+  navigatorContext?: {
+    clientId: string;
+    location: string | null;
+    referrer: string | null;
+    userAgent: string | null;
+  } | null
+): FullEngine {
+  return {
+    getNavigatorContextProvider: () =>
+      navigatorContext === null ? undefined : () => navigatorContext!,
+  } as unknown as FullEngine;
+}
+
+describe('buildAnalyticsParams', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T10:30:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns undefined when navigator context provider is not available', () => {
+    const engine = createMockEngine(null);
+
+    const result = buildAnalyticsParams(engine, {originContext: 'Search'});
+
+    expect(result).toBeUndefined();
+  });
+
+  it('builds analytics params from navigator context', () => {
+    const engine = createMockEngine({
+      clientId: 'client-123',
+      location: 'https://example.com/search',
+      referrer: 'https://google.com',
+      userAgent: 'Mozilla/5.0',
+    });
+
+    const result = buildAnalyticsParams(engine, {originContext: 'Search'});
+
+    expect(result).toEqual({
+      clientId: 'client-123',
+      clientTimestamp: '2026-01-15T10:30:00.000Z',
+      documentReferrer: 'https://google.com',
+      originContext: 'Search',
+      documentLocation: 'https://example.com/search',
+    });
+  });
+
+  it('includes trackingId when provided and non-empty', () => {
+    const engine = createMockEngine({
+      clientId: 'client-123',
+      location: null,
+      referrer: null,
+      userAgent: null,
+    });
+
+    const result = buildAnalyticsParams(engine, {
+      originContext: 'Search',
+      trackingId: 'tracking-456',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({trackingId: 'tracking-456'})
+    );
+  });
+
+  it('omits trackingId when it is an empty string', () => {
+    const engine = createMockEngine({
+      clientId: 'client-123',
+      location: null,
+      referrer: null,
+      userAgent: null,
+    });
+
+    const result = buildAnalyticsParams(engine, {
+      originContext: 'Search',
+      trackingId: '',
+    });
+
+    expect(result).not.toHaveProperty('trackingId');
+  });
+
+  it('omits trackingId when not provided', () => {
+    const engine = createMockEngine({
+      clientId: 'client-123',
+      location: null,
+      referrer: null,
+      userAgent: null,
+    });
+
+    const result = buildAnalyticsParams(engine, {originContext: 'Search'});
+
+    expect(result).not.toHaveProperty('trackingId');
+  });
+
+  it('uses the provided originContext', () => {
+    const engine = createMockEngine({
+      clientId: 'client-123',
+      location: null,
+      referrer: null,
+      userAgent: null,
+    });
+
+    const result = buildAnalyticsParams(engine, {
+      originContext: 'Recommendation',
+    });
+
+    expect(result?.originContext).toBe('Recommendation');
+  });
+
+  it('handles null referrer and location from navigator context', () => {
+    const engine = createMockEngine({
+      clientId: 'client-123',
+      location: null,
+      referrer: null,
+      userAgent: null,
+    });
+
+    const result = buildAnalyticsParams(engine, {originContext: 'Search'});
+
+    expect(result?.documentReferrer).toBeNull();
+    expect(result?.documentLocation).toBeNull();
+  });
+});

--- a/packages/thermidor/src/internal/api/analytics-params.ts
+++ b/packages/thermidor/src/internal/api/analytics-params.ts
@@ -1,0 +1,37 @@
+import type {FullEngine} from '@/src/internal/engine/index.js';
+
+export interface AnalyticsParams {
+  clientId: string;
+  clientTimestamp: string;
+  documentReferrer: string | null;
+  originContext: string;
+  documentLocation?: string | null;
+  trackingId?: string;
+}
+
+export interface AnalyticsParamsOptions {
+  originContext: string;
+  trackingId?: string;
+}
+
+export function buildAnalyticsParams(
+  engine: FullEngine,
+  options: AnalyticsParamsOptions
+): AnalyticsParams | undefined {
+  const navigatorContextProvider = engine.getNavigatorContextProvider();
+  if (!navigatorContextProvider) {
+    return undefined;
+  }
+
+  const context = navigatorContextProvider();
+  const trackingId = options.trackingId;
+
+  return {
+    clientId: context.clientId,
+    clientTimestamp: new Date().toISOString(),
+    documentReferrer: context.referrer,
+    originContext: options.originContext,
+    documentLocation: context.location,
+    ...(trackingId && {trackingId}),
+  };
+}

--- a/packages/thermidor/src/internal/api/search/search-endpoint-client.test.ts
+++ b/packages/thermidor/src/internal/api/search/search-endpoint-client.test.ts
@@ -65,7 +65,7 @@ describe('SearchEndpointClient', () => {
 
     expect(response.success).toBe(true);
     expect(mockedExecuteHttpRequest).toHaveBeenCalledWith({
-      url: 'https://test-org-id.org.coveo.com/rest/search/v2',
+      url: 'https://test-org-id.org.coveo.com/rest/search/v2?organizationId=test-org-id',
       method: 'POST',
       body: request,
       headers: {
@@ -93,7 +93,7 @@ describe('SearchEndpointClient', () => {
 
     expect(mockedExecuteHttpRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: 'https://custom.platform.coveo.com/rest/search/v2',
+        url: 'https://custom.platform.coveo.com/rest/search/v2?organizationId=test-org-id',
       })
     );
   });
@@ -126,5 +126,45 @@ describe('SearchEndpointClient', () => {
       success: false,
       error: 'network down',
     });
+  });
+
+  it('should URL-encode the organizationId in the query param', async () => {
+    mockedExecuteHttpRequest.mockResolvedValue({
+      success: true,
+      data: {},
+    } as any);
+
+    await client.call(
+      {q: 'test'},
+      {
+        organizationId: 'my-org-123',
+        accessToken: 'test-token',
+        endpoint: 'https://proxy.example.com',
+      }
+    );
+
+    const calledUrl = mockedExecuteHttpRequest.mock.calls[0][0].url;
+    expect(calledUrl).toContain('?organizationId=my-org-123');
+  });
+
+  it('should pass the abort signal to the HTTP request', async () => {
+    mockedExecuteHttpRequest.mockResolvedValue({
+      success: true,
+      data: {},
+    } as any);
+
+    const controller = new AbortController();
+
+    await client.call(
+      {q: 'test'},
+      {organizationId: 'test-org-id', accessToken: 'test-token'},
+      {signal: controller.signal}
+    );
+
+    expect(mockedExecuteHttpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signal: controller.signal,
+      })
+    );
   });
 });

--- a/packages/thermidor/src/internal/api/search/search-endpoint-client.test.ts
+++ b/packages/thermidor/src/internal/api/search/search-endpoint-client.test.ts
@@ -128,7 +128,7 @@ describe('SearchEndpointClient', () => {
     });
   });
 
-  it('should URL-encode the organizationId in the query param', async () => {
+  it('should include organizationId as a query param in the URL', async () => {
     mockedExecuteHttpRequest.mockResolvedValue({
       success: true,
       data: {},

--- a/packages/thermidor/src/internal/api/search/search-endpoint-client.ts
+++ b/packages/thermidor/src/internal/api/search/search-endpoint-client.ts
@@ -34,7 +34,12 @@ const createCallSearchEndpoint = (): SearchEndpointClient['call'] => {
       const organizationEndpoint = getOrganizationEndpoint(organizationId, {
         endpoint,
       });
-      const url = `${organizationEndpoint}/rest/search/v2`;
+
+      const queryParams = new URLSearchParams({
+        organizationId,
+      });
+
+      const url = `${organizationEndpoint}/rest/search/v2?${queryParams}`;
 
       const httpResponse =
         await executeHttpRequest<CoveoSearchEndpointResponse>({

--- a/packages/thermidor/src/internal/api/search/search-endpoint-types.ts
+++ b/packages/thermidor/src/internal/api/search/search-endpoint-types.ts
@@ -1,3 +1,5 @@
+import type {AnalyticsParams} from '@/src/internal/api/analytics-params.js';
+
 export interface CoveoSearchEndpointRequest {
   q?: string;
   aq?: string;
@@ -10,19 +12,7 @@ export interface CoveoSearchEndpointRequest {
   pipeline?: string;
   locale?: string;
   timezone?: string;
-  analytics?: CoveoSearchAnalyticsParams;
-}
-
-export interface CoveoSearchAnalyticsParams {
-  clientId: string;
-  clientTimestamp: string;
-  documentReferrer: string | null;
-  originContext: string;
-  actionCause?: string;
-  documentLocation?: string | null;
-  trackingId?: string;
-  capture?: boolean;
-  source?: string[];
+  analytics?: AnalyticsParams;
 }
 
 export interface CoveoFacetRequest {

--- a/packages/thermidor/src/internal/api/search/search-endpoint-types.ts
+++ b/packages/thermidor/src/internal/api/search/search-endpoint-types.ts
@@ -7,6 +7,22 @@ export interface CoveoSearchEndpointRequest {
   fieldsToInclude?: string[];
   enableDidYouMean?: boolean;
   facets?: CoveoFacetRequest[];
+  pipeline?: string;
+  locale?: string;
+  timezone?: string;
+  analytics?: CoveoSearchAnalyticsParams;
+}
+
+export interface CoveoSearchAnalyticsParams {
+  clientId: string;
+  clientTimestamp: string;
+  documentReferrer: string | null;
+  originContext: string;
+  actionCause?: string;
+  documentLocation?: string | null;
+  trackingId?: string;
+  capture?: boolean;
+  source?: string[];
 }
 
 export interface CoveoFacetRequest {

--- a/packages/thermidor/src/internal/api/search/search-request-selector.test.ts
+++ b/packages/thermidor/src/internal/api/search/search-request-selector.test.ts
@@ -1,0 +1,122 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {createSearchEndpointRequestSelector} from './search-request-selector.js';
+import type {EndpointStateScope} from '@/src/internal/utils/index.js';
+
+vi.mock('@/src/internal/features/search-box/index.js', () => ({
+  getOrCreateSearchBoxSelectors: () => ({
+    getQuery: (state: any) => state.__query ?? '',
+  }),
+}));
+
+vi.mock('@/src/internal/features/pagination/index.js', () => ({
+  getOrCreatePaginationSelectors: () => ({
+    getFirstResult: (state: any) => state.__firstResult ?? 0,
+    getPageSize: (state: any) => state.__pageSize ?? 10,
+  }),
+}));
+
+vi.mock('@/src/internal/features/facets/index.js', () => ({
+  getOrCreateFacetsSelectors: () => ({
+    buildFacetsRequest: (state: any) => state.__facets ?? undefined,
+  }),
+}));
+
+vi.mock('@/src/internal/features/search-parameters/index.js', () => ({
+  getOrCreateSearchParametersSelectors: () => ({
+    getPipeline: (state: any) => state.__pipeline ?? '',
+    getConstantQuery: (state: any) => state.__cq ?? '',
+  }),
+}));
+
+vi.mock('@/src/internal/features/configuration/index.js', () => ({
+  getOrCreateConfigurationSelectors: () => ({
+    getLanguage: (state: any) => state.__language ?? '',
+  }),
+}));
+
+const mockScope: EndpointStateScope = {
+  scopeInterface: {} as any,
+  baseInterface: {} as any,
+};
+
+describe('createSearchEndpointRequestSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds request with all fields from state', () => {
+    const selector = createSearchEndpointRequestSelector(mockScope);
+
+    const state = {
+      __query: 'hello world',
+      __firstResult: 20,
+      __pageSize: 5,
+      __facets: [{facetId: 'author', selectedValues: ['John']}],
+      __pipeline: 'my-pipeline',
+      __cq: '@source=="KB"',
+      __language: 'fr',
+    };
+
+    const result = selector(state);
+
+    expect(result).toEqual({
+      q: 'hello world',
+      firstResult: 20,
+      numberOfResults: 5,
+      facets: [{facetId: 'author', selectedValues: ['John']}],
+      pipeline: 'my-pipeline',
+      cq: '@source=="KB"',
+      locale: 'fr',
+    });
+  });
+
+  it('sets locale to undefined when language is empty', () => {
+    const selector = createSearchEndpointRequestSelector(mockScope);
+
+    const state = {
+      __query: 'test',
+      __language: '',
+    };
+
+    const result = selector(state);
+
+    expect(result.locale).toBeUndefined();
+  });
+
+  it('uses default values when state slices are empty', () => {
+    const selector = createSearchEndpointRequestSelector(mockScope);
+
+    const result = selector({});
+
+    expect(result).toEqual({
+      q: '',
+      firstResult: 0,
+      numberOfResults: 10,
+      facets: undefined,
+      pipeline: '',
+      cq: '',
+      locale: undefined,
+    });
+  });
+
+  it('returns memoized result when state has not changed', () => {
+    const selector = createSearchEndpointRequestSelector(mockScope);
+    const state = {__query: 'same'};
+
+    const result1 = selector(state);
+    const result2 = selector(state);
+
+    expect(result1).toBe(result2);
+  });
+
+  it('returns new result when state changes', () => {
+    const selector = createSearchEndpointRequestSelector(mockScope);
+
+    const result1 = selector({__query: 'first'});
+    const result2 = selector({__query: 'second'});
+
+    expect(result1).not.toBe(result2);
+    expect(result1.q).toBe('first');
+    expect(result2.q).toBe('second');
+  });
+});

--- a/packages/thermidor/src/internal/api/search/search-request-selector.ts
+++ b/packages/thermidor/src/internal/api/search/search-request-selector.ts
@@ -4,6 +4,7 @@ import {getOrCreateSearchBoxSelectors} from '@/src/internal/features/search-box/
 import {getOrCreatePaginationSelectors} from '@/src/internal/features/pagination/index.js';
 import {getOrCreateFacetsSelectors} from '@/src/internal/features/facets/index.js';
 import {getOrCreateSearchParametersSelectors} from '@/src/internal/features/search-parameters/index.js';
+import {getOrCreateConfigurationSelectors} from '@/src/internal/features/configuration/index.js';
 
 export function createSearchEndpointRequestSelector(scope: EndpointStateScope) {
   const searchBox = getOrCreateSearchBoxSelectors(scope.scopeInterface);
@@ -12,6 +13,7 @@ export function createSearchEndpointRequestSelector(scope: EndpointStateScope) {
   const searchParams = getOrCreateSearchParametersSelectors(
     scope.baseInterface
   );
+  const configuration = getOrCreateConfigurationSelectors();
 
   return createMemoizedStateSelector(
     searchBox.getQuery,
@@ -20,13 +22,15 @@ export function createSearchEndpointRequestSelector(scope: EndpointStateScope) {
     facets.buildFacetsRequest,
     searchParams.getPipeline,
     searchParams.getConstantQuery,
-    (query, firstResult, pageSize, facets, pipeline, cq) => ({
+    configuration.getLanguage,
+    (query, firstResult, pageSize, facets, pipeline, cq, language) => ({
       q: query,
       firstResult,
       numberOfResults: pageSize,
       facets,
       pipeline,
       cq,
+      locale: language || undefined,
     })
   );
 }

--- a/packages/thermidor/src/internal/api/search/search-thunk.test.ts
+++ b/packages/thermidor/src/internal/api/search/search-thunk.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {createSearchEndpointThunk} from './search-thunk.js';
 import type {FullEngine} from '@/src/internal/engine/index.js';
 import type {EndpointStateScope} from '@/src/internal/utils/index.js';
@@ -70,6 +70,10 @@ describe('createSearchEndpointThunk', () => {
     vi.setSystemTime(new Date('2026-03-01T12:00:00.000Z'));
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('includes analytics in the request when navigator context is available', async () => {
     mockCall.mockResolvedValue({
       success: true,
@@ -104,8 +108,6 @@ describe('createSearchEndpointThunk', () => {
       }),
       expect.any(Object)
     );
-
-    vi.useRealTimers();
   });
 
   it('omits analytics when navigator context provider is not available', async () => {
@@ -134,8 +136,6 @@ describe('createSearchEndpointThunk', () => {
       expect.not.objectContaining({analytics: expect.anything()}),
       expect.any(Object)
     );
-
-    vi.useRealTimers();
   });
 
   it('rejects the thunk when the endpoint client returns an error', async () => {
@@ -153,7 +153,5 @@ describe('createSearchEndpointThunk', () => {
 
     expect(result.meta.rejectedWithValue).toBeFalsy();
     expect((result as any).error.message).toBe('Something went wrong');
-
-    vi.useRealTimers();
   });
 });

--- a/packages/thermidor/src/internal/api/search/search-thunk.test.ts
+++ b/packages/thermidor/src/internal/api/search/search-thunk.test.ts
@@ -1,0 +1,159 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {createSearchEndpointThunk} from './search-thunk.js';
+import type {FullEngine} from '@/src/internal/engine/index.js';
+import type {EndpointStateScope} from '@/src/internal/utils/index.js';
+
+const mockCall = vi.fn();
+
+vi.mock('./search-request-selector.js', () => ({
+  createSearchEndpointRequestSelector: () => (state: any) =>
+    state.__request ?? {q: ''},
+}));
+
+vi.mock('./search-response-handler.js', () => ({
+  createSearchEndpointResponseHandler: () => vi.fn(),
+}));
+
+vi.mock('@/src/internal/features/configuration/index.js', () => ({
+  readEndpointClientConfiguration: () => ({
+    organizationId: 'test-org',
+    accessToken: 'test-token',
+  }),
+  getOrCreateConfigurationSelectors: () => ({
+    getTrackingId: (state: any) => state.__trackingId ?? '',
+  }),
+}));
+
+vi.mock('@/src/internal/api/search/index.js', () => ({
+  createSearchEndpointClient: () => ({call: mockCall}),
+}));
+
+vi.mock('./search-thunk-slice.js', () => ({
+  getOrCreateSearchEndpointSlice: () => ({
+    name: 'mock/searchEndpoint',
+    reducer: () => ({}),
+  }),
+}));
+
+vi.mock('@/src/internal/api/analytics-params.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/src/internal/api/analytics-params.js')
+  >('@/src/internal/api/analytics-params.js');
+  return actual;
+});
+
+vi.mock('@/src/internal/utils/index.js', () => ({
+  getHandleInternals: () => ({
+    stateId: 'test-interface',
+    cacheRegistry: {getOrCreate: (_key: any, factory: any) => factory()},
+  }),
+}));
+
+function createMockEngine(state: Record<string, any> = {}): FullEngine {
+  return {
+    read: (selector: any) => selector(state),
+    mutate: vi.fn(),
+    adoptSlice: vi.fn(),
+    getNavigatorContextProvider: () => () => ({
+      clientId: 'client-abc',
+      location: 'https://example.com',
+      referrer: 'https://google.com',
+      userAgent: 'test-agent',
+    }),
+  } as unknown as FullEngine;
+}
+
+describe('createSearchEndpointThunk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-01T12:00:00.000Z'));
+  });
+
+  it('includes analytics in the request when navigator context is available', async () => {
+    mockCall.mockResolvedValue({
+      success: true,
+      data: {totalCount: 0, results: []},
+    });
+
+    const engine = createMockEngine({
+      __request: {q: 'test', firstResult: 0, numberOfResults: 10},
+      __trackingId: 'track-123',
+    });
+
+    const scope: EndpointStateScope = {
+      scopeInterface: {} as any,
+      baseInterface: {} as any,
+    };
+
+    const thunk = createSearchEndpointThunk(engine, scope);
+    const action = thunk({engine});
+    await action(vi.fn(), () => ({}), undefined);
+
+    expect(mockCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: 'test',
+        analytics: expect.objectContaining({
+          clientId: 'client-abc',
+          originContext: 'Search',
+          trackingId: 'track-123',
+          documentReferrer: 'https://google.com',
+          documentLocation: 'https://example.com',
+          clientTimestamp: '2026-03-01T12:00:00.000Z',
+        }),
+      }),
+      expect.any(Object)
+    );
+
+    vi.useRealTimers();
+  });
+
+  it('omits analytics when navigator context provider is not available', async () => {
+    mockCall.mockResolvedValue({
+      success: true,
+      data: {totalCount: 0, results: []},
+    });
+
+    const engine = {
+      read: (selector: any) => selector({__request: {q: 'test'}}),
+      mutate: vi.fn(),
+      adoptSlice: vi.fn(),
+      getNavigatorContextProvider: () => undefined,
+    } as unknown as FullEngine;
+
+    const scope: EndpointStateScope = {
+      scopeInterface: {} as any,
+      baseInterface: {} as any,
+    };
+
+    const thunk = createSearchEndpointThunk(engine, scope);
+    const action = thunk({engine});
+    await action(vi.fn(), () => ({}), undefined);
+
+    expect(mockCall).toHaveBeenCalledWith(
+      expect.not.objectContaining({analytics: expect.anything()}),
+      expect.any(Object)
+    );
+
+    vi.useRealTimers();
+  });
+
+  it('rejects the thunk when the endpoint client returns an error', async () => {
+    mockCall.mockResolvedValue({success: false, error: 'Something went wrong'});
+
+    const engine = createMockEngine({__request: {q: 'fail'}});
+    const scope: EndpointStateScope = {
+      scopeInterface: {} as any,
+      baseInterface: {} as any,
+    };
+
+    const thunk = createSearchEndpointThunk(engine, scope);
+    const action = thunk({engine});
+    const result = await action(vi.fn(), () => ({}), undefined);
+
+    expect(result.meta.rejectedWithValue).toBeFalsy();
+    expect((result as any).error.message).toBe('Something went wrong');
+
+    vi.useRealTimers();
+  });
+});

--- a/packages/thermidor/src/internal/api/search/search-thunk.ts
+++ b/packages/thermidor/src/internal/api/search/search-thunk.ts
@@ -5,8 +5,10 @@ import {getHandleInternals} from '@/src/internal/utils/index.js';
 import {createSearchEndpointRequestSelector} from './search-request-selector.js';
 import {createSearchEndpointResponseHandler} from './search-response-handler.js';
 import {readEndpointClientConfiguration} from '@/src/internal/features/configuration/index.js';
+import {getOrCreateConfigurationSelectors} from '@/src/internal/features/configuration/index.js';
 import {createSearchEndpointClient} from '@/src/internal/api/search/index.js';
 import {getOrCreateSearchEndpointSlice} from './search-thunk-slice.js';
+import {buildAnalyticsParams} from '@/src/internal/api/analytics-params.js';
 
 export function createSearchEndpointThunk(
   engine: FullEngine,
@@ -17,17 +19,34 @@ export function createSearchEndpointThunk(
   const handleResponse = createSearchEndpointResponseHandler(
     scope.baseInterface
   );
+  const configSelectors = getOrCreateConfigurationSelectors();
 
   const thunk = createAsyncThunk<void, {engine: FullEngine}>(
     `${stateId}/searchEndpoint/execute`,
     async ({engine}) => {
       const request = engine.read(buildRequest);
+      const trackingId = engine.read(configSelectors.getTrackingId);
+
       const config = readEndpointClientConfiguration(engine);
-      const response = await createSearchEndpointClient().call(request, config);
+      const analytics = buildAnalyticsParams(engine, {
+        originContext: 'Search',
+        trackingId,
+      });
+
+      const fullRequest = {
+        ...request,
+        ...(analytics && {analytics}),
+      };
+
+      const response = await createSearchEndpointClient().call(
+        fullRequest,
+        config
+      );
 
       if (!response.success) {
         throw new Error(response.error);
       }
+
       if (response.data) {
         handleResponse(engine, response.data);
       }

--- a/packages/thermidor/src/internal/features/configuration/configuration-selectors.ts
+++ b/packages/thermidor/src/internal/features/configuration/configuration-selectors.ts
@@ -4,6 +4,7 @@ import {
   initialConfigurationState,
 } from './configuration-slice.js';
 import type {ConfigurationState} from './configuration-types.js';
+import type {State} from '@/src/internal/engine/engine-types.js';
 
 // ---------------------------------------------------------------------------
 // Standalone selectors (formerly core/interface/configuration/configuration-selectors.ts)
@@ -37,13 +38,8 @@ export const endpoint = (state: StateWithConfigurationSlice) => {
 // Factory-based selectors (formerly core/internal/configuration/configuration-selectors.ts)
 // ---------------------------------------------------------------------------
 
-function selectConfigurationSlice(
-  state: Record<string, unknown>
-): typeof initialConfigurationState {
-  const slice = state['configuration'];
-  return slice === undefined
-    ? initialConfigurationState
-    : (slice as typeof initialConfigurationState);
+function selectConfigurationSlice(state: State) {
+  return state.configuration ?? initialConfigurationState;
 }
 
 export function createConfigurationSelectors() {
@@ -69,6 +65,7 @@ export function createConfigurationSelectors() {
 
 let cachedSelectors: ReturnType<typeof createConfigurationSelectors> | null =
   null;
+
 export function getOrCreateConfigurationSelectors() {
   if (!cachedSelectors) {
     cachedSelectors = createConfigurationSelectors();


### PR DESCRIPTION
Enrich the search endpoint request to align with what the Coveo Search API expects for proper tracking and routing.

## Changes

- Append `organizationId` as a query param on the URL
- Add `locale` from configuration to the request body
- Build and inject the `analytics` section from the engine's `NavigatorContextProvider` (clientId, trackingId, referrer, etc.)
- Extract `buildAnalyticsParams` into a shared `api/analytics-params` module for reuse across endpoints

### Testing

Added/adjusted unit tests:
- `analytics-params.ts`
- `search-request-selector.ts`
- `search-thunk.ts`
- `search-endpoint-client.ts`
