### PR TITLE
ci: exclude samples from CDN checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-prefix: 'cdn'
+          build-command: "pnpm exec turbo build --filter='!./samples/**'"
       - name: 'Run CDN checks'
         uses: ./.github/actions/cdn-checks
   lint-check:


### PR DESCRIPTION
Related: #7994

## Problem

The CDN build now excludes sample packages, but the CDN Checks job still invokes the shared setup action with its default `pnpm run build`. That rebuilds samples before CDN validation and can fail when a sample bundles a package built in CDN externalization mode.

## Solution

Pass the same sample-excluding command to CDN Checks setup:

`pnpm exec turbo build --filter='!./samples/**'`

This keeps package CDN checks, including `@coveo/atomic-cdn-smoke`, while excluding packages under `samples/` consistently with Build CDN.

## Validation

- Workflow YAML parses successfully.
- Turbo dry-run selects zero sample packages and retains `@coveo/atomic` and `@coveo/atomic-cdn-smoke`.
