### PR TITLE
docs(thermidor): apply the same useController hook pattern as in the search-react sample

### DIFF
--- a/samples/thermidor/generative-react/package.json
+++ b/samples/thermidor/generative-react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@samples/thermidor-shiny-conversation-react",
+  "name": "@samples/thermidor-generative-react",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/samples/thermidor/generative-react/src/components/ConversePage/ConversePage.tsx
+++ b/samples/thermidor/generative-react/src/components/ConversePage/ConversePage.tsx
@@ -1,5 +1,6 @@
-import {useState, useEffect, useRef, useCallback} from 'react';
+import {useEffect, useRef, useCallback, useState} from 'react';
 import {converseController} from '../../generative-setup.js';
+import {useController} from '../../hooks/use-controller.js';
 import {TurnsMenu} from '../TurnsMenu/TurnsMenu.js';
 import {ConversationArea} from '../ConversationArea/ConversationArea.js';
 import {PromptInput} from '../PromptInput/PromptInput.js';
@@ -15,38 +16,12 @@ const PROMPT_SUGGESTIONS = [
   'I like cold-water surfing. Compare wetsuits for it',
 ];
 
-interface Turn {
-  id: string;
-  prompt: string;
-  status: 'streaming' | 'complete' | 'error';
-  routedInterface?: {useCase: string; interface: unknown};
-  agentResponse?: {
-    messages: {content: string; role: string}[];
-    surfaces: Record<string, unknown>[];
-    toolCalls: {
-      id: string;
-      name: string;
-      args: string;
-      result?: string;
-      status: 'calling' | 'completed';
-    }[];
-  };
-  error?: string;
-}
-
-interface ConverseState {
-  turns: Turn[];
-  activeTurnId: string | undefined;
-  activeTurn: Turn | undefined;
-  isStreaming: boolean;
-}
-
 export function ConversePage() {
-  const [state, setState] = useState<ConverseState>(converseController.state);
+  const state = useController(converseController);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
   const scrollCooldownRef = useRef(false);
-  const prevTurnCountRef = useRef(converseController.state.turns.length);
+  const prevTurnCountRef = useRef(state.turns.length);
   const overscrollAccumRef = useRef(0);
   const overscrollResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
@@ -57,26 +32,19 @@ export function ConversePage() {
   const OVERSCROLL_THRESHOLD = 150;
 
   useEffect(() => {
-    const unsubscribe = converseController.subscribe(() => {
-      const newState = converseController.state;
-
-      if (newState.turns.length > prevTurnCountRef.current) {
-        const newestTurn = newState.turns[newState.turns.length - 1];
-        if (newestTurn && newState.activeTurnId !== newestTurn.id) {
-          converseController.selectTurn({id: newestTurn.id});
-        }
+    if (state.turns.length > prevTurnCountRef.current) {
+      const newestTurn = state.turns[state.turns.length - 1];
+      if (newestTurn && state.activeTurn?.id !== newestTurn.id) {
+        converseController.selectTurn({id: newestTurn.id});
       }
-      prevTurnCountRef.current = newState.turns.length;
-
-      setState(newState);
-    });
-    return unsubscribe;
-  }, []);
+    }
+    prevTurnCountRef.current = state.turns.length;
+  }, [state.turns]);
 
   const navigateToTurn = useCallback((direction: 'prev' | 'next') => {
     if (scrollCooldownRef.current) return;
-    const {turns, activeTurnId} = stateRef.current;
-    const currentIndex = turns.findIndex((t) => t.id === activeTurnId);
+    const {turns, activeTurn} = stateRef.current;
+    const currentIndex = turns.findIndex((t) => t.id === activeTurn?.id);
     if (currentIndex < 0) return;
 
     const targetIndex =
@@ -159,7 +127,7 @@ export function ConversePage() {
         {sidebarOpen && (
           <TurnsMenu
             turns={state.turns}
-            activeTurnId={state.activeTurnId}
+            activeTurnId={state.activeTurn?.id}
             onSelectTurn={handleSelectTurn}
           />
         )}
@@ -181,7 +149,7 @@ export function ConversePage() {
         </div>
         <div ref={contentRef} className={styles.content}>
           <ConversationArea
-            key={state.activeTurnId ?? 'empty'}
+            key={state.activeTurn?.id ?? 'empty'}
             turn={state.activeTurn}
             isStreaming={state.isStreaming}
             onRetry={handleRetry}

--- a/samples/thermidor/generative-react/src/hooks/use-controller.ts
+++ b/samples/thermidor/generative-react/src/hooks/use-controller.ts
@@ -3,7 +3,8 @@ import type {Controller} from '@coveo/thermidor';
 
 export function useController<T>(controller: Controller<T>): T {
   return useSyncExternalStore(
-    (onStoreChange) => controller.subscribe(() => onStoreChange()),
+    (onStoreChange) => controller.subscribe(onStoreChange),
+    () => controller.state,
     () => controller.state
   );
 }

--- a/samples/thermidor/generative-react/src/hooks/use-controller.ts
+++ b/samples/thermidor/generative-react/src/hooks/use-controller.ts
@@ -1,0 +1,9 @@
+import {useSyncExternalStore} from 'react';
+import type {Controller} from '@coveo/thermidor';
+
+export function useController<T>(controller: Controller<T>): T {
+  return useSyncExternalStore(
+    (onStoreChange) => controller.subscribe(() => onStoreChange()),
+    () => controller.state
+  );
+}

--- a/samples/thermidor/generative-react/tsconfig.json
+++ b/samples/thermidor/generative-react/tsconfig.json
@@ -10,7 +10,11 @@
     "moduleResolution": "Node16",
     "noEmit": true,
     "resolveJsonModule": true,
-    "types": ["vitest/globals", "vite/client"]
+    "types": ["vitest/globals", "vite/client"],
+    "paths": {
+      "@coveo/thermidor": ["../../../packages/thermidor/src/index.ts"],
+      "@/*": ["../../../packages/thermidor/*"]
+    }
   },
   "include": ["src", "vite.config.ts"]
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5883

The pattern used here https://github.com/coveo/ui-kit/pull/7994/changes#diff-ffdf174023504d8dd2ea92fe908f29a460e76bd25dce55558e788cbc16d11b7f is nice and clean. This PR applies the same pattern in the generative-react sample.

I also fixed some TS warnings and renamed the sample to something a bit more fitting.