### PR TITLE
feat(thermidor): rewrite path aliases at build time to emit a self-contained dist/

### DIFF
--- a/packages/thermidor/package.json
+++ b/packages/thermidor/package.json
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --project ./tsconfig.build.json",
+    "build": "tsc --project ./tsconfig.build.json && node scripts/resolve-path-aliases.mjs",
     "clean": "node ../../utils/ci/rm-rf.mjs dist",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/thermidor/scripts/resolve-path-aliases.mjs
+++ b/packages/thermidor/scripts/resolve-path-aliases.mjs
@@ -1,0 +1,46 @@
+/**
+ * Rewrites `@/src/...` path aliases to relative paths in compiled output.
+ *
+ * TypeScript does not rewrite tsconfig `paths` aliases in emitted JS or .d.ts
+ * files. This script runs after `tsc` and replaces every `@/src/X` import
+ * specifier with the correct relative path based on the importing file's
+ * location within `dist/`.
+ */
+
+import {readdir, readFile, writeFile} from 'node:fs/promises';
+import {dirname, join, relative} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const distDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist');
+
+const ALIAS_RE = /(?<quote>['"])@\/src\/(?<path>[^'"]+)\k<quote>/g;
+
+async function collectFiles(dir) {
+  const entries = await readdir(dir, {withFileTypes: true, recursive: true});
+  return entries
+    .filter((e) => e.isFile() && /\.(js|d\.[cm]?ts)$/.test(e.name))
+    .map((e) => join(e.parentPath, e.name));
+}
+
+function toRelative(importPath, fromFile) {
+  const target = join(distDir, importPath);
+  const rel = relative(dirname(fromFile), target);
+  return rel.startsWith('.') ? rel : `./${rel}`;
+}
+
+async function processFile(filePath) {
+  const content = await readFile(filePath, 'utf-8');
+  const result = content.replace(ALIAS_RE, (_, quote, path) => {
+    return `${quote}${toRelative(path, filePath)}${quote}`;
+  });
+  if (result === content) return false;
+  await writeFile(filePath, result);
+  return true;
+}
+
+const files = await collectFiles(distDir);
+let changed = 0;
+for (const file of files) {
+  if (await processFile(file)) changed++;
+}
+console.log(`resolve-path-aliases: rewrote imports in ${changed} file(s)`);

--- a/packages/thermidor/scripts/resolve-path-aliases.mjs
+++ b/packages/thermidor/scripts/resolve-path-aliases.mjs
@@ -24,7 +24,7 @@ async function collectFiles(dir) {
 
 function toRelative(importPath, fromFile) {
   const target = join(distDir, importPath);
-  const rel = relative(dirname(fromFile), target);
+  const rel = relative(dirname(fromFile), target).replaceAll('\\', '/');
   return rel.startsWith('.') ? rel : `./${rel}`;
 }
 

--- a/samples/thermidor/generative-angular/tsconfig.app.json
+++ b/samples/thermidor/generative-angular/tsconfig.app.json
@@ -6,11 +6,7 @@
     "outDir": "./out-tsc/app",
     "types": [],
     "noPropertyAccessFromIndexSignature": false,
-    "importHelpers": false,
-    "paths": {
-      "@coveo/thermidor": ["../../../packages/thermidor/src/index.ts"],
-      "@/*": ["../../../packages/thermidor/*"]
-    }
+    "importHelpers": false
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.spec.ts"]

--- a/samples/thermidor/generative-react/tsconfig.json
+++ b/samples/thermidor/generative-react/tsconfig.json
@@ -10,11 +10,7 @@
     "moduleResolution": "Node16",
     "noEmit": true,
     "resolveJsonModule": true,
-    "types": ["vitest/globals", "vite/client"],
-    "paths": {
-      "@coveo/thermidor": ["../../../packages/thermidor/src/index.ts"],
-      "@/*": ["../../../packages/thermidor/*"]
-    }
+    "types": ["vitest/globals", "vite/client"]
   },
   "include": ["src", "vite.config.ts"]
 }

--- a/samples/thermidor/generative-react/vite.config.ts
+++ b/samples/thermidor/generative-react/vite.config.ts
@@ -1,14 +1,7 @@
 import react from '@vitejs/plugin-react';
-import path from 'node:path';
-import {fileURLToPath} from 'node:url';
 import {defineConfig, loadEnv} from 'vite';
 
 type PlatformEnvironment = 'prod' | 'dev' | 'stg' | 'hipaa';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const thermidorRoot = path.resolve(__dirname, '../../../packages/thermidor');
-const thermidorSourceEntry = path.resolve(thermidorRoot, 'src/index.ts');
 
 function parseBoolean(value: string | undefined): boolean | undefined {
   if (!value) {
@@ -82,12 +75,6 @@ export default defineConfig(({mode}) => {
 
   return {
     plugins: [react()],
-    resolve: {
-      alias: {
-        '@coveo/thermidor': thermidorSourceEntry,
-        '@': thermidorRoot,
-      },
-    },
     server: {
       open: true,
       ...(useProxy && targets

--- a/samples/thermidor/search-react/tsconfig.json
+++ b/samples/thermidor/search-react/tsconfig.json
@@ -10,11 +10,7 @@
     "moduleResolution": "Node16",
     "noEmit": true,
     "resolveJsonModule": true,
-    "types": ["vitest/globals", "vite/client"],
-    "paths": {
-      "@coveo/thermidor": ["../../../packages/thermidor/src/index.ts"],
-      "@/*": ["../../../packages/thermidor/*"]
-    }
+    "types": ["vitest/globals", "vite/client"]
   },
   "include": ["src", "vite.config.ts"]
 }

--- a/samples/thermidor/search-react/vite.config.ts
+++ b/samples/thermidor/search-react/vite.config.ts
@@ -1,14 +1,7 @@
 import react from '@vitejs/plugin-react';
-import path from 'node:path';
-import {fileURLToPath} from 'node:url';
 import {defineConfig, loadEnv} from 'vite';
 
 type PlatformEnvironment = 'prod' | 'dev' | 'stg' | 'hipaa';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const thermidorRoot = path.resolve(__dirname, '../../../packages/thermidor');
-const thermidorSourceEntry = path.resolve(thermidorRoot, 'src/index.ts');
 
 function parseBoolean(value: string | undefined): boolean | undefined {
   if (!value) {
@@ -72,12 +65,6 @@ export default defineConfig(({mode}) => {
 
   return {
     plugins: [react()],
-    resolve: {
-      alias: {
-        '@coveo/thermidor': thermidorSourceEntry,
-        '@': thermidorRoot,
-      },
-    },
     server: {
       open: true,
       ...(useProxy && targets


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5885

Thermidor's `dist/` ships with unresolved `@/src/...` path aliases because tsc doesn't rewrite them. This breaks any consumer that doesn't manually configure matching aliases.

This PR adds a small post-build script to rewrite those aliases to relative paths, and removes the source-pointing workarounds from the samples so they consume `dist/` like a real consumer would.