### PR TITLE
ci: run publint on all public packages

### DIFF
--- a/.changeset/fix-atomic-hosted-page-entrypoints.md
+++ b/.changeset/fix-atomic-hosted-page-entrypoints.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic-hosted-page': patch
+---
+
+Fix package entrypoints to reference the files emitted by the current build.

--- a/packages/atomic-hosted-page/package.json
+++ b/packages/atomic-hosted-page/package.json
@@ -13,16 +13,15 @@
     "docs/"
   ],
   "type": "module",
-  "main": "dist/index.cjs.js",
+  "main": "dist/index.js",
   "module": "dist/index.js",
-  "types": "dist/types/components.d.ts",
-  "unpkg": "dist/atomic-page/atomic-hosted-page.esm.js",
+  "types": "dist/index.d.ts",
+  "unpkg": "dist/atomic-hosted-page.esm.js",
   "es2015": "dist/esm/index.mjs",
   "exports": {
     ".": {
-      "types": "./dist/types/components.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs.js"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./loader": {
       "import": "./loader/index.js"

--- a/scripts/ci/package-compatibility.mjs
+++ b/scripts/ci/package-compatibility.mjs
@@ -1,18 +1,81 @@
+import {execFile} from 'node:child_process';
+import {existsSync, readdirSync, readFileSync} from 'node:fs';
 import {EOL} from 'node:os';
+import {dirname, join} from 'node:path';
+import {promisify} from 'node:util';
 import {publint} from 'publint';
+
+const runCommand = promisify(execFile);
+
+const WORKSPACE_ROOTS = ['packages', 'samples', 'utils'];
+const EXCLUDED_PACKAGES = new Set(['@coveo/quantic']);
+const IGNORED_DIRECTORIES = new Set([
+  '.git',
+  '.next',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'publish',
+  'target',
+]);
+
+function findPublicPackages(rootDir) {
+  const packages = [];
+
+  for (const entry of readdirSync(rootDir, {withFileTypes: true})) {
+    if (entry.isDirectory()) {
+      if (!IGNORED_DIRECTORIES.has(entry.name)) {
+        packages.push(...findPublicPackages(join(rootDir, entry.name)));
+      }
+      continue;
+    }
+
+    if (entry.name !== 'package.json') {
+      continue;
+    }
+
+    const packageJsonPath = join(rootDir, entry.name);
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    if (pkg.name && !pkg.private && !EXCLUDED_PACKAGES.has(pkg.name)) {
+      packages.push({pkg, pkgDir: dirname(packageJsonPath)});
+    }
+  }
+
+  return packages;
+}
+
+async function getPublishedPackageDir({pkg, pkgDir}) {
+  const publishedPackageDir = pkg.publishConfig?.directory
+    ? join(pkgDir, pkg.publishConfig.directory)
+    : pkgDir;
+
+  if (pkg.publishConfig?.directory && pkg.scripts?.prepack) {
+    await runCommand('pnpm', ['run', 'prepack'], {cwd: pkgDir});
+  }
+
+  if (!existsSync(join(publishedPackageDir, 'package.json'))) {
+    throw new Error(`Unable to find the package artifact for ${pkg.name}.`);
+  }
+
+  return {
+    pack: pkg.publishConfig?.directory ? false : 'auto',
+    pkgDir: publishedPackageDir,
+  };
+}
+
+const packages = WORKSPACE_ROOTS.flatMap(findPublicPackages).sort((a, b) =>
+  a.pkgDir.localeCompare(b.pkgDir)
+);
+const packagesToScan = await Promise.all(packages.map(getPublishedPackageDir));
 
 let exitCode = 0;
 
-const pkgDirs = [
-  'packages/atomic',
-  'packages/headless',
-  'packages/atomic-react',
-  'packages/relay',
-];
-
 const issues = await Promise.all(
-  pkgDirs.map(async (pkgDir) => {
+  packagesToScan.map(async ({pack, pkgDir}) => {
     const {messages} = await publint({
+      pack,
       pkgDir,
       level: 'suggestion',
       strict: false,


### PR DESCRIPTION
## Problem
Publint only scanned four packages, leaving most published packages and all published sample templates without compatibility validation. Expanding coverage exposed stale entrypoint paths in `@coveo/atomic-hosted-page`.

## Solution
- Discover every named, non-private workspace package under `packages`, `samples`, and `utils`, excluding `@coveo/quantic`.
- Prepare and inspect each configured publish directory; sample artifacts run their existing `prepack` hook before Publint.
- Correct Atomic Hosted Page entrypoints to reference the ESM and type files its build emits, with a patch Changeset.