### PR TITLE
docs(thermidor): add support for commerce_search_api_response routed interfaces in ng generative sample (take 2)

### DIFF
--- a/samples/thermidor/generative-angular/src/app/app.html
+++ b/samples/thermidor/generative-angular/src/app/app.html
@@ -10,6 +10,7 @@
       [reasoningText]="conversation.reasoningText()"
       [toolActivity]="conversation.toolActivity()"
       [surfaces]="conversation.surfaces()"
+      [routedInterface]="conversation.routedInterface()"
       [isStreaming]="conversation.busy()"
       [errorMessage]="conversation.activeTurnError()"
       [turnId]="conversation.activeTurnId() ?? ''"

--- a/samples/thermidor/generative-angular/src/app/components/pagination.component.ts
+++ b/samples/thermidor/generative-angular/src/app/components/pagination.component.ts
@@ -1,0 +1,112 @@
+import {ChangeDetectionStrategy, Component, input, output} from '@angular/core';
+
+const PAGE_SIZE_OPTIONS = [5, 10, 20, 50];
+
+@Component({
+  selector: 'app-pagination',
+  template: `
+    <div class="container">
+      <button
+        class="nav-button"
+        (click)="previous.emit()"
+        [disabled]="page() === 0"
+        aria-label="Previous page"
+      >
+        &larr; Previous
+      </button>
+      <span class="indicator">
+        Page {{ page() + 1 }} of {{ totalPages() }}
+      </span>
+      <button
+        class="nav-button"
+        (click)="next.emit()"
+        [disabled]="totalPages() <= 1 || page() === totalPages() - 1"
+        aria-label="Next page"
+      >
+        Next &rarr;
+      </button>
+      <select
+        class="page-size-select"
+        [value]="pageSize()"
+        (change)="onPageSizeChange($event)"
+        aria-label="Results per page"
+      >
+        @for (size of pageSizeOptions; track size) {
+          <option [value]="size" [selected]="size === pageSize()">
+            {{ size }} per page
+          </option>
+        }
+      </select>
+    </div>
+  `,
+  styles: [
+    `
+      .container {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 0;
+        flex-wrap: wrap;
+      }
+
+      .nav-button {
+        appearance: none;
+        border: 1px solid rgba(17, 35, 31, 0.12);
+        border-radius: 8px;
+        padding: 8px 14px;
+        background: rgba(255, 255, 255, 0.8);
+        color: #204f46;
+        cursor: pointer;
+        font: inherit;
+        font-size: 0.88rem;
+        transition:
+          background 150ms ease,
+          opacity 150ms ease;
+      }
+
+      .nav-button:hover:not(:disabled) {
+        background: rgba(215, 239, 231, 0.6);
+      }
+
+      .nav-button:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+
+      .indicator {
+        font-size: 0.88rem;
+        color: #516661;
+      }
+
+      .page-size-select {
+        margin-left: auto;
+        appearance: none;
+        border: 1px solid rgba(17, 35, 31, 0.12);
+        border-radius: 8px;
+        padding: 8px 12px;
+        background: rgba(255, 255, 255, 0.8);
+        color: #204f46;
+        font: inherit;
+        font-size: 0.85rem;
+        cursor: pointer;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PaginationComponent {
+  readonly page = input.required<number>();
+  readonly totalPages = input.required<number>();
+  readonly pageSize = input.required<number>();
+
+  readonly previous = output<void>();
+  readonly next = output<void>();
+  readonly pageSizeChange = output<number>();
+
+  protected readonly pageSizeOptions = PAGE_SIZE_OPTIONS;
+
+  protected onPageSizeChange(event: Event): void {
+    const value = Number((event.target as HTMLSelectElement).value);
+    this.pageSizeChange.emit(value);
+  }
+}

--- a/samples/thermidor/generative-angular/src/app/components/product-card.component.ts
+++ b/samples/thermidor/generative-angular/src/app/components/product-card.component.ts
@@ -1,0 +1,119 @@
+import {ChangeDetectionStrategy, Component, input} from '@angular/core';
+
+export interface ProductCardData {
+  id: string;
+  name: string;
+  brand?: string;
+  image?: string;
+  price?: number;
+  promoPrice?: number;
+  description?: string;
+  accent?: string;
+}
+
+@Component({
+  selector: 'app-product-card',
+  template: `
+    @if (product().image) {
+      <img
+        class="product-image"
+        [src]="product().image"
+        [alt]="product().name"
+        loading="lazy"
+      />
+    } @else {
+      <div
+        class="swatch"
+        [style.background]="
+          product().accent || 'linear-gradient(135deg, #e7d8c8, #c6a889)'
+        "
+      ></div>
+    }
+    <p class="brand">{{ product().brand }}</p>
+    <h4>{{ product().name }}</h4>
+    <p class="description">
+      {{ truncate(product().description || 'Barca Sports product', 80) }}
+    </p>
+    <div class="footer">
+      <strong>{{
+        formatPrice(product().promoPrice ?? product().price)
+      }}</strong>
+      <span>{{ product().promoPrice ? 'Sale price' : 'View details' }}</span>
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        display: flex;
+        flex-direction: column;
+        border-radius: 22px;
+        padding: 16px;
+        border: 1px solid rgba(17, 35, 31, 0.12);
+        background: rgba(255, 255, 255, 0.8);
+      }
+
+      .brand {
+        margin: 0 0 6px;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-size: 0.74rem;
+        color: #516661;
+      }
+
+      h4 {
+        margin: 0;
+      }
+
+      .product-image {
+        width: 100%;
+        height: 140px;
+        object-fit: cover;
+        border-radius: 16px;
+        margin-bottom: 12px;
+        background: #f0ece4;
+      }
+
+      .swatch {
+        width: 100%;
+        height: 140px;
+        border-radius: 16px;
+        margin-bottom: 12px;
+      }
+
+      .description {
+        margin: 12px 0;
+        color: #516661;
+        line-height: 1.5;
+      }
+
+      .footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-top: auto;
+      }
+
+      .footer span {
+        color: #204f46;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProductCardComponent {
+  readonly product = input.required<ProductCardData>();
+
+  protected formatPrice(value: number | undefined): string {
+    if (value === undefined) return '';
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      maximumFractionDigits: 0,
+    }).format(value);
+  }
+
+  protected truncate(text: string, max: number): string {
+    return text.length <= max ? text : text.slice(0, max).trimEnd() + '…';
+  }
+}

--- a/samples/thermidor/generative-angular/src/app/components/product-carousel.component.ts
+++ b/samples/thermidor/generative-angular/src/app/components/product-carousel.component.ts
@@ -1,8 +1,18 @@
-import {ChangeDetectionStrategy, Component, input} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
 import {ProductCarouselSurface} from '../models';
+import {
+  ProductCardComponent,
+  type ProductCardData,
+} from './product-card.component';
 
 @Component({
   selector: 'app-product-carousel',
+  imports: [ProductCardComponent],
   template: `
     <section class="surface">
       <header class="surface-header">
@@ -18,37 +28,8 @@ import {ProductCarouselSurface} from '../models';
         </div>
       } @else {
         <div class="carousel">
-          @for (item of surface().products; track item.ec_product_id) {
-            <article class="card">
-              @if (item.ec_image) {
-                <img
-                  class="product-image"
-                  [src]="item.ec_image"
-                  [alt]="item.ec_name"
-                  loading="lazy"
-                />
-              } @else {
-                <div
-                  class="swatch"
-                  [style.background]="
-                    item.accent || 'linear-gradient(135deg, #e7d8c8, #c6a889)'
-                  "
-                ></div>
-              }
-              <p class="brand">{{ item.ec_brand }}</p>
-              <h4>{{ item.ec_name }}</h4>
-              <p class="description">
-                {{ item.description || 'Barca Sports product' }}
-              </p>
-              <div class="footer">
-                <strong>{{
-                  formatPrice(item.ec_promo_price ?? item.ec_price)
-                }}</strong>
-                <span>{{
-                  item.ec_promo_price ? 'Sale price' : 'View details'
-                }}</span>
-              </div>
-            </article>
+          @for (card of cards(); track card.id) {
+            <app-product-card class="carousel-item" [product]="card" />
           }
         </div>
       }
@@ -60,9 +41,7 @@ import {ProductCarouselSurface} from '../models';
         margin-bottom: 16px;
       }
 
-      .surface-kicker,
-      .brand,
-      .meta {
+      .surface-kicker {
         margin: 0 0 6px;
         text-transform: uppercase;
         letter-spacing: 0.1em;
@@ -70,8 +49,7 @@ import {ProductCarouselSurface} from '../models';
         color: #516661;
       }
 
-      h3,
-      h4 {
+      h3 {
         margin: 0;
       }
 
@@ -84,18 +62,16 @@ import {ProductCarouselSurface} from '../models';
         padding-bottom: 8px;
       }
 
-      .card,
-      .loading-card {
+      .carousel-item {
         flex: 0 0 240px;
         scroll-snap-align: start;
-        border-radius: 22px;
-        padding: 16px;
-        border: 1px solid rgba(17, 35, 31, 0.12);
-        background: rgba(255, 255, 255, 0.8);
       }
 
       .loading-card {
+        flex: 0 0 240px;
+        scroll-snap-align: start;
         min-height: 220px;
+        border-radius: 22px;
         background: linear-gradient(
           90deg,
           rgba(231, 221, 209, 0.95),
@@ -104,46 +80,6 @@ import {ProductCarouselSurface} from '../models';
         );
         background-size: 200% 100%;
         animation: shimmer 1.25s linear infinite;
-      }
-
-      .product-image {
-        width: 100%;
-        height: 140px;
-        object-fit: cover;
-        border-radius: 16px;
-        margin-bottom: 12px;
-        background: #f0ece4;
-      }
-
-      .swatch {
-        width: 100%;
-        height: 140px;
-        border-radius: 16px;
-        margin-bottom: 12px;
-      }
-
-      .description {
-        margin: 12px 0;
-        color: #516661;
-        line-height: 1.5;
-      }
-
-      .meta {
-        display: flex;
-        gap: 10px;
-        flex-wrap: wrap;
-      }
-
-      .footer {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 12px;
-        margin-top: 12px;
-      }
-
-      .footer span {
-        color: #204f46;
       }
 
       @keyframes shimmer {
@@ -162,11 +98,16 @@ export class ProductCarouselComponent {
   protected readonly placeholders = Array.from({length: 3});
   readonly surface = input.required<ProductCarouselSurface>();
 
-  protected formatPrice(value: number): string {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      maximumFractionDigits: 0,
-    }).format(value);
-  }
+  protected readonly cards = computed<ProductCardData[]>(() =>
+    this.surface().products.map((p) => ({
+      id: p.ec_product_id,
+      name: p.ec_name,
+      brand: p.ec_brand,
+      image: p.ec_image,
+      price: p.ec_price,
+      promoPrice: p.ec_promo_price,
+      description: p.description,
+      accent: p.accent,
+    }))
+  );
 }

--- a/samples/thermidor/generative-angular/src/app/components/routed-commerce-results.component.ts
+++ b/samples/thermidor/generative-angular/src/app/components/routed-commerce-results.component.ts
@@ -1,0 +1,133 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  inject,
+  input,
+  OnInit,
+  signal,
+} from '@angular/core';
+import {
+  buildProductListController,
+  buildPaginationController,
+  type ProductListControllerState,
+  type PaginationControllerState,
+  type PaginationController,
+  type CommerceInterface,
+} from '@coveo/thermidor';
+import {
+  ProductCardComponent,
+  type ProductCardData,
+} from './product-card.component';
+import {PaginationComponent} from './pagination.component';
+
+@Component({
+  selector: 'app-routed-commerce-results',
+  imports: [ProductCardComponent, PaginationComponent],
+  template: `
+    @if (products().length === 0 && !isLoading()) {
+      <p class="empty">No products found.</p>
+    } @else {
+      <div class="grid">
+        @for (card of cards(); track card.id) {
+          <app-product-card [product]="card" />
+        }
+      </div>
+    }
+
+    @if (paginationState(); as pagination) {
+      <app-pagination
+        [page]="pagination.page"
+        [totalPages]="pagination.totalPages"
+        [pageSize]="pagination.pageSize"
+        (previous)="selectPage(pagination.page - 1)"
+        (next)="selectPage(pagination.page + 1)"
+        (pageSizeChange)="setPageSize($event)"
+      />
+    }
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+        gap: 14px;
+      }
+
+      .empty {
+        color: #516661;
+        font-size: 0.95rem;
+        text-align: center;
+        padding: 24px 0;
+      }
+    `,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RoutedCommerceResultsComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly commerceInterface = input.required<CommerceInterface>();
+
+  protected readonly products = signal<ProductListControllerState['products']>(
+    []
+  );
+  protected readonly paginationState = signal<PaginationControllerState | null>(
+    null
+  );
+  protected readonly isLoading = signal(true);
+
+  private paginationController: PaginationController | null = null;
+
+  protected readonly cards = computed<ProductCardData[]>(() =>
+    this.products().map((p) => ({
+      id: p.permanentid,
+      name: p.ec_name,
+      brand: p.ec_brand,
+      image: p.ec_thumbnails?.[0] ?? p.ec_images?.[0],
+      price: p.ec_price,
+      promoPrice: p.ec_promo_price,
+      description: p.ec_shortdesc ?? p.ec_description,
+    }))
+  );
+
+  ngOnInit(): void {
+    const iface = this.commerceInterface();
+
+    const productList = buildProductListController({interface: iface});
+    const pagination = buildPaginationController({interface: iface});
+
+    this.paginationController = pagination;
+
+    this.products.set(productList.state.products);
+    this.paginationState.set(pagination.state);
+    this.isLoading.set(productList.state.products.length === 0);
+
+    const unsubProducts = productList.subscribe(() => {
+      this.products.set(productList.state.products);
+      this.isLoading.set(false);
+    });
+
+    const unsubPagination = pagination.subscribe(() => {
+      this.paginationState.set(pagination.state);
+    });
+
+    this.destroyRef.onDestroy(() => {
+      unsubProducts();
+      unsubPagination();
+    });
+  }
+
+  protected selectPage(page: number): void {
+    this.paginationController?.selectPage(page);
+  }
+
+  protected setPageSize(size: number): void {
+    this.paginationController?.setPageSize(size);
+  }
+}

--- a/samples/thermidor/generative-angular/src/app/components/routed-commerce-results.component.ts
+++ b/samples/thermidor/generative-angular/src/app/components/routed-commerce-results.component.ts
@@ -120,6 +120,7 @@ export class RoutedCommerceResultsComponent implements OnInit {
     this.destroyRef.onDestroy(() => {
       unsubProducts();
       unsubPagination();
+      iface.dispose();
     });
   }
 

--- a/samples/thermidor/generative-angular/src/app/components/routed-commerce-results.component.ts
+++ b/samples/thermidor/generative-angular/src/app/components/routed-commerce-results.component.ts
@@ -3,9 +3,9 @@ import {
   Component,
   computed,
   DestroyRef,
+  effect,
   inject,
   input,
-  OnInit,
   signal,
 } from '@angular/core';
 import {
@@ -69,7 +69,7 @@ import {PaginationComponent} from './pagination.component';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RoutedCommerceResultsComponent implements OnInit {
+export class RoutedCommerceResultsComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   readonly commerceInterface = input.required<CommerceInterface>();
@@ -96,31 +96,43 @@ export class RoutedCommerceResultsComponent implements OnInit {
     }))
   );
 
-  ngOnInit(): void {
-    const iface = this.commerceInterface();
+  constructor() {
+    let cleanup: (() => void) | null = null;
 
-    const productList = buildProductListController({interface: iface});
-    const pagination = buildPaginationController({interface: iface});
+    effect(() => {
+      const iface = this.commerceInterface();
 
-    this.paginationController = pagination;
+      if (cleanup) {
+        cleanup();
+      }
 
-    this.products.set(productList.state.products);
-    this.paginationState.set(pagination.state);
-    this.isLoading.set(productList.state.products.length === 0);
+      const productList = buildProductListController({interface: iface});
+      const pagination = buildPaginationController({interface: iface});
 
-    const unsubProducts = productList.subscribe(() => {
+      this.paginationController = pagination;
+
       this.products.set(productList.state.products);
-      this.isLoading.set(false);
-    });
-
-    const unsubPagination = pagination.subscribe(() => {
       this.paginationState.set(pagination.state);
+      this.isLoading.set(productList.state.products.length === 0);
+
+      const unsubProducts = productList.subscribe(() => {
+        this.products.set(productList.state.products);
+        this.isLoading.set(false);
+      });
+
+      const unsubPagination = pagination.subscribe(() => {
+        this.paginationState.set(pagination.state);
+      });
+
+      cleanup = () => {
+        unsubProducts();
+        unsubPagination();
+        iface.dispose();
+      };
     });
 
     this.destroyRef.onDestroy(() => {
-      unsubProducts();
-      unsubPagination();
-      iface.dispose();
+      cleanup?.();
     });
   }
 

--- a/samples/thermidor/generative-angular/src/app/components/transcript-panel.component.ts
+++ b/samples/thermidor/generative-angular/src/app/components/transcript-panel.component.ts
@@ -8,8 +8,15 @@ import {
   PipeTransform,
 } from '@angular/core';
 import {marked} from 'marked';
-import type {RenderableCommerceSurface, ToolCall, Turn} from '../models';
+import type {
+  RenderableCommerceSurface,
+  RoutedInterface,
+  ToolCall,
+  Turn,
+} from '../models';
+import type {CommerceInterface} from '@coveo/thermidor';
 import {SurfaceOutletComponent} from './surface-outlet.component';
+import {RoutedCommerceResultsComponent} from './routed-commerce-results.component';
 
 marked.setOptions({breaks: true, gfm: true});
 
@@ -23,7 +30,11 @@ class MarkdownPipe implements PipeTransform {
 
 @Component({
   selector: 'app-transcript-panel',
-  imports: [SurfaceOutletComponent, MarkdownPipe],
+  imports: [
+    SurfaceOutletComponent,
+    RoutedCommerceResultsComponent,
+    MarkdownPipe,
+  ],
   template: `
     <header class="panel-header">
       <div>
@@ -116,7 +127,16 @@ class MarkdownPipe implements PipeTransform {
         </details>
       }
 
-      @if (surfaces().length > 0) {
+      @if (commerceInterface(); as iface) {
+        <article class="inline-surfaces">
+          <div class="inline-surfaces-head">
+            <p class="bubble-role">Assistant</p>
+            <span>Commerce results</span>
+          </div>
+
+          <app-routed-commerce-results [commerceInterface]="iface" />
+        </article>
+      } @else if (surfaces().length > 0) {
         <article class="inline-surfaces">
           <div class="inline-surfaces-head">
             <p class="bubble-role">Assistant</p>
@@ -142,12 +162,23 @@ export class TranscriptPanelComponent {
   readonly reasoningText = input('');
   readonly toolActivity = input<ToolCall[]>([]);
   readonly surfaces = input<RenderableCommerceSurface[]>([]);
+  readonly routedInterface = input<RoutedInterface | undefined>(undefined);
   readonly isStreaming = input(false);
   readonly errorMessage = input('');
   readonly turnId = input('');
   readonly resetConversation = output<void>();
   readonly quickAction = output<string>();
   readonly retryTurn = output<string>();
+
+  protected readonly commerceInterface = computed<CommerceInterface | null>(
+    () => {
+      const routed = this.routedInterface();
+      if (routed?.useCase === 'commerceSearch') {
+        return routed.interface;
+      }
+      return null;
+    }
+  );
 
   protected readonly hasProgress = computed(
     () => this.toolActivity().length > 0 || this.reasoningText().length > 0

--- a/samples/thermidor/generative-angular/src/app/models.ts
+++ b/samples/thermidor/generative-angular/src/app/models.ts
@@ -1,7 +1,12 @@
 // Shared frontend contract types for the Angular sample.
 // These types re-export Thermidor's canonical conversation types and define
 // the sample-specific commerce surface shapes used across the app.
-export type {Turn, A2UISurface, ToolCall} from '@coveo/thermidor';
+export type {
+  Turn,
+  A2UISurface,
+  ToolCall,
+  RoutedInterface,
+} from '@coveo/thermidor';
 
 export type ProductRecord = {
   ec_product_id: string;

--- a/samples/thermidor/generative-angular/src/app/services/conversation.service.ts
+++ b/samples/thermidor/generative-angular/src/app/services/conversation.service.ts
@@ -12,6 +12,7 @@ import {CONVERSATION_STORAGE_KEY} from '../constants';
 import type {
   A2UISurface,
   RenderableCommerceSurface,
+  RoutedInterface,
   ToolCall,
   Turn,
 } from '../models';
@@ -26,6 +27,7 @@ export class ConversationService {
   readonly reasoningText = signal('');
   readonly toolActivity = signal<ToolCall[]>([]);
   readonly surfaces = signal<RenderableCommerceSurface[]>([]);
+  readonly routedInterface = signal<RoutedInterface | undefined>(undefined);
   readonly activeTurnId = signal<string | undefined>(undefined);
   readonly activeTurnError = signal('');
 
@@ -68,6 +70,7 @@ export class ConversationService {
     this.turns.set(turns);
     this.activeTurnId.set(activeTurn?.id);
     this.surfaces.set(this.buildSurfaces(turns));
+    this.routedInterface.set(activeTurn?.routedInterface);
 
     if (activeTurn) {
       this.reasoningText.set(

--- a/samples/thermidor/generative-react/src/components/RoutedCommerceResults/RoutedCommerceResults.tsx
+++ b/samples/thermidor/generative-react/src/components/RoutedCommerceResults/RoutedCommerceResults.tsx
@@ -2,6 +2,7 @@ import {useState, useEffect, useRef} from 'react';
 import {
   buildProductListController,
   buildPaginationController,
+  type CommerceInterface,
   type ProductListControllerState,
   type PaginationControllerState,
   type PaginationController,
@@ -11,7 +12,7 @@ import {Pagination} from '../Pagination/Pagination.js';
 import styles from './RoutedCommerceResults.module.css';
 
 interface RoutedCommerceResultsProps {
-  interface: unknown;
+  interface: CommerceInterface;
 }
 
 export function RoutedCommerceResults(props: RoutedCommerceResultsProps) {
@@ -22,15 +23,11 @@ export function RoutedCommerceResults(props: RoutedCommerceResultsProps) {
 
   useEffect(() => {
     const controller = buildProductListController({
-      interface: props.interface as Parameters<
-        typeof buildProductListController
-      >[0]['interface'],
+      interface: props.interface,
     });
 
     const paginationCtrl = buildPaginationController({
-      interface: props.interface as Parameters<
-        typeof buildPaginationController
-      >[0]['interface'],
+      interface: props.interface,
     });
 
     paginationRef.current = paginationCtrl;
@@ -49,7 +46,7 @@ export function RoutedCommerceResults(props: RoutedCommerceResultsProps) {
     return () => {
       unsubscribeProducts();
       unsubscribePagination();
-      (props.interface as {dispose?: () => void}).dispose?.();
+      props.interface.dispose();
     };
   }, [props.interface]);
 

--- a/samples/thermidor/generative-react/src/components/RoutedCommerceResults/RoutedCommerceResults.tsx
+++ b/samples/thermidor/generative-react/src/components/RoutedCommerceResults/RoutedCommerceResults.tsx
@@ -49,6 +49,7 @@ export function RoutedCommerceResults(props: RoutedCommerceResultsProps) {
     return () => {
       unsubscribeProducts();
       unsubscribePagination();
+      (props.interface as {dispose?: () => void}).dispose?.();
     };
   }, [props.interface]);
 

--- a/samples/thermidor/generative-react/src/components/RoutedSearchResults/RoutedSearchResults.tsx
+++ b/samples/thermidor/generative-react/src/components/RoutedSearchResults/RoutedSearchResults.tsx
@@ -60,6 +60,7 @@ export function RoutedSearchResults(props: RoutedSearchResultsProps) {
     return () => {
       unsubscribeResults();
       unsubscribePagination();
+      (props.interface as {dispose?: () => void}).dispose?.();
     };
   }, [props.interface]);
 

--- a/samples/thermidor/generative-react/src/components/RoutedSearchResults/RoutedSearchResults.tsx
+++ b/samples/thermidor/generative-react/src/components/RoutedSearchResults/RoutedSearchResults.tsx
@@ -3,6 +3,7 @@ import {
   buildResultListController,
   buildPaginationController,
   loadSearchParametersActions,
+  type SearchInterface,
   type ResultListControllerState,
   type PaginationControllerState,
   type PaginationController,
@@ -12,7 +13,7 @@ import {Pagination} from '../Pagination/Pagination.js';
 import styles from './RoutedSearchResults.module.css';
 
 interface RoutedSearchResultsProps {
-  interface: unknown;
+  interface: SearchInterface;
 }
 
 export function RoutedSearchResults(props: RoutedSearchResultsProps) {
@@ -23,21 +24,15 @@ export function RoutedSearchResults(props: RoutedSearchResultsProps) {
 
   useEffect(() => {
     const controller = buildResultListController({
-      interface: props.interface as Parameters<
-        typeof buildResultListController
-      >[0]['interface'],
+      interface: props.interface,
     });
 
     const paginationCtrl = buildPaginationController({
-      interface: props.interface as Parameters<
-        typeof buildPaginationController
-      >[0]['interface'],
+      interface: props.interface,
     });
 
     const searchParams = loadSearchParametersActions({
-      interface: props.interface as Parameters<
-        typeof loadSearchParametersActions
-      >[0]['interface'],
+      interface: props.interface,
     });
 
     // Temporary hack: all information should be retrieved from the activity
@@ -60,7 +55,7 @@ export function RoutedSearchResults(props: RoutedSearchResultsProps) {
     return () => {
       unsubscribeResults();
       unsubscribePagination();
-      (props.interface as {dispose?: () => void}).dispose?.();
+      props.interface.dispose();
     };
   }, [props.interface]);
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5870

This PR is the same as #8008, which was accidentally based off / merged into test-tsdown.

I cherry-picked the commits to apply to this branch, and also put the ts-down branch back in a decent state.