### PR TITLE
chore: enroll more Stories into Chromatic 

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,9 +6,6 @@ on:
 permissions:
   contents: read
 
-env:
-  CHROMATIC_ALL: ${{ vars.CHROMATIC_ALL }}
-
 jobs:
   release:
     concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
 permissions:
   contents: read
 
-
 jobs:
   pr-report:
     if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
 permissions:
   contents: read
 
-env:
-  CHROMATIC_ALL: ${{ vars.CHROMATIC_ALL }}
 
 jobs:
   pr-report:

--- a/packages/atomic/.storybook/main.ts
+++ b/packages/atomic/.storybook/main.ts
@@ -171,10 +171,6 @@ const config: StorybookConfig = {
     name: '@storybook/web-components-vite',
     options: {},
   },
-  env: (config) => ({
-    ...config,
-    CHROMATIC_ALL: process.env.CHROMATIC_ALL ?? '',
-  }),
   async viteFinal(config, {configType}) {
     const {default: tailwindcss} = await import('@tailwindcss/vite');
     const version = getPackageVersion();

--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -97,7 +97,6 @@ const preview: Preview = {
         textColor: '#282829',
       }),
     },
-    chromatic: {disableSnapshot: import.meta.env.CHROMATIC_ALL !== 'true'},
   },
   beforeEach({canvasElement, canvas}) {
     Object.assign(canvas, {...within(canvasElement)});

--- a/packages/atomic/.storybook/vite-env.d.ts
+++ b/packages/atomic/.storybook/vite-env.d.ts
@@ -5,10 +5,6 @@ declare module '*.css' {
   export default content;
 }
 
-interface ImportMetaEnv {
-  readonly CHROMATIC_ALL: string
-}
-
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }

--- a/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-breadbox/atomic-commerce-breadbox.new.stories.tsx
@@ -98,7 +98,6 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-    chromatic: {disableSnapshot: true},
     layout: 'fullscreen',
     actions: {
       handles: events,

--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.new.stories.tsx
@@ -49,7 +49,6 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-    chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-did-you-mean/atomic-commerce-did-you-mean.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-did-you-mean/atomic-commerce-did-you-mean.new.stories.tsx
@@ -41,7 +41,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.new.stories.tsx
@@ -50,7 +50,6 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-    chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.new.stories.tsx
@@ -44,7 +44,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facets/atomic-commerce-facets.new.stories.tsx
@@ -44,7 +44,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.new.stories.tsx
@@ -22,7 +22,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-layout/atomic-commerce-layout.new.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-load-more-products/atomic-commerce-load-more-products.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-load-more-products/atomic-commerce-load-more-products.new.stories.tsx
@@ -34,7 +34,6 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-load-more-products/atomic-commerce-load-more-products.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-load-more-products/atomic-commerce-load-more-products.new.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.new.stories.tsx
@@ -46,7 +46,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-no-products/atomic-commerce-no-products.new.stories.tsx
@@ -46,7 +46,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
@@ -50,7 +50,7 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-numeric-facet/atomic-commerce-numeric-facet.new.stories.tsx
@@ -50,7 +50,6 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.new.stories.tsx
@@ -34,7 +34,6 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-pager/atomic-commerce-pager.new.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.new.stories.tsx
@@ -76,7 +76,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.new.stories.tsx
@@ -76,7 +76,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.new.stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-products-per-page/atomic-commerce-products-per-page.new.stories.tsx
@@ -35,7 +35,6 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.new.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-query-summary/atomic-commerce-query-summary.new.stories.tsx
@@ -25,7 +25,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.new.stories.tsx
@@ -58,7 +58,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.new.stories.tsx
@@ -58,7 +58,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.new.stories.tsx
@@ -41,7 +41,6 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-refine-toggle/atomic-commerce-refine-toggle.new.stories.tsx
@@ -41,7 +41,7 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.new.stories.tsx
@@ -26,7 +26,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-query-suggestions/atomic-commerce-search-box-query-suggestions.new.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.new.stories.tsx
@@ -26,7 +26,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-recent-queries/atomic-commerce-search-box-recent-queries.new.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.new.stories.tsx
@@ -32,7 +32,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-sort-dropdown/atomic-commerce-sort-dropdown.new.stories.tsx
@@ -32,7 +32,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-text/atomic-commerce-text.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-text/atomic-commerce-text.new.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-text/atomic-commerce-text.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-text/atomic-commerce-text.new.stories.tsx
@@ -25,7 +25,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.new.stories.tsx
@@ -60,7 +60,6 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-timeframe-facet/atomic-commerce-timeframe-facet.new.stories.tsx
@@ -60,7 +60,7 @@ const meta: Meta = {
     msw: {
       handlers: [...commerceApiHarness.handlers],
     },
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-children/atomic-product-children.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-children/atomic-product-children.new.stories.tsx
@@ -62,7 +62,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-children/atomic-product-children.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-children/atomic-product-children.new.stories.tsx
@@ -62,7 +62,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-description/atomic-product-description.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-description/atomic-product-description.new.stories.tsx
@@ -48,7 +48,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-description/atomic-product-description.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-description/atomic-product-description.new.stories.tsx
@@ -48,7 +48,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.new.stories.tsx
@@ -48,7 +48,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-excerpt/atomic-product-excerpt.new.stories.tsx
@@ -48,7 +48,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.new.stories.tsx
@@ -43,7 +43,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.new.stories.tsx
@@ -43,7 +43,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-image/atomic-product-image.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-image/atomic-product-image.new.stories.tsx
@@ -73,7 +73,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-image/atomic-product-image.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-image/atomic-product-image.new.stories.tsx
@@ -73,7 +73,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.new.stories.tsx
@@ -53,7 +53,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-link/atomic-product-link.new.stories.tsx
@@ -53,7 +53,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.new.stories.tsx
@@ -50,7 +50,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-multi-value-text/atomic-product-multi-value-text.new.stories.tsx
@@ -50,7 +50,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-numeric-field-value/atomic-product-numeric-field-value.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-numeric-field-value/atomic-product-numeric-field-value.new.stories.tsx
@@ -61,7 +61,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-numeric-field-value/atomic-product-numeric-field-value.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-numeric-field-value/atomic-product-numeric-field-value.new.stories.tsx
@@ -61,7 +61,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-price/atomic-product-price.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-price/atomic-product-price.new.stories.tsx
@@ -78,7 +78,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-price/atomic-product-price.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-price/atomic-product-price.new.stories.tsx
@@ -78,7 +78,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.new.stories.tsx
@@ -58,7 +58,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-rating/atomic-product-rating.new.stories.tsx
@@ -58,7 +58,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-actions/atomic-product-section-actions.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-actions/atomic-product-section-actions.new.stories.tsx
@@ -38,7 +38,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-actions/atomic-product-section-actions.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-actions/atomic-product-section-actions.new.stories.tsx
@@ -38,7 +38,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-badges/atomic-product-section-badges.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-badges/atomic-product-section-badges.new.stories.tsx
@@ -37,7 +37,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-badges/atomic-product-section-badges.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-badges/atomic-product-section-badges.new.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-bottom-metadata/atomic-product-section-bottom-metadata.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-bottom-metadata/atomic-product-section-bottom-metadata.new.stories.tsx
@@ -36,7 +36,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-bottom-metadata/atomic-product-section-bottom-metadata.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-bottom-metadata/atomic-product-section-bottom-metadata.new.stories.tsx
@@ -36,7 +36,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-children/atomic-product-section-children.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-children/atomic-product-section-children.new.stories.tsx
@@ -36,7 +36,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-children/atomic-product-section-children.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-children/atomic-product-section-children.new.stories.tsx
@@ -36,7 +36,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-description/atomic-product-section-description.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-description/atomic-product-section-description.new.stories.tsx
@@ -37,7 +37,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-description/atomic-product-section-description.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-description/atomic-product-section-description.new.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-emphasized/atomic-product-section-emphasized.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-emphasized/atomic-product-section-emphasized.new.stories.tsx
@@ -36,7 +36,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-emphasized/atomic-product-section-emphasized.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-emphasized/atomic-product-section-emphasized.new.stories.tsx
@@ -36,7 +36,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-metadata/atomic-product-section-metadata.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-metadata/atomic-product-section-metadata.new.stories.tsx
@@ -36,7 +36,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-metadata/atomic-product-section-metadata.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-metadata/atomic-product-section-metadata.new.stories.tsx
@@ -36,7 +36,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-name/atomic-product-section-name.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-name/atomic-product-section-name.new.stories.tsx
@@ -37,7 +37,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-name/atomic-product-section-name.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-name/atomic-product-section-name.new.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.new.stories.tsx
@@ -36,7 +36,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-section-visual/atomic-product-section-visual.new.stories.tsx
@@ -36,7 +36,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.new.stories.tsx
@@ -81,7 +81,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.new.stories.tsx
+++ b/packages/atomic/src/components/commerce/atomic-product-text/atomic-product-text.new.stories.tsx
@@ -81,7 +81,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...commerceApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/common/atomic-aria-live/atomic-aria-live.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-aria-live/atomic-aria-live.new.stories.tsx
@@ -24,7 +24,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...searchApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/common/atomic-aria-live/atomic-aria-live.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-aria-live/atomic-aria-live.new.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...searchApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/common/atomic-component-error/atomic-component-error.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-component-error/atomic-component-error.new.stories.tsx
@@ -27,7 +27,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...searchApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/common/atomic-component-error/atomic-component-error.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-component-error/atomic-component-error.new.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...searchApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/common/atomic-layout-section/atomic-layout-section.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-layout-section/atomic-layout-section.new.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...searchApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/common/atomic-layout-section/atomic-layout-section.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-layout-section/atomic-layout-section.new.stories.tsx
@@ -21,7 +21,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...searchApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/common/atomic-numeric-range/atomic-numeric-range.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-numeric-range/atomic-numeric-range.new.stories.tsx
@@ -24,7 +24,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...searchApiHarness.handlers]},
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/common/atomic-numeric-range/atomic-numeric-range.new.stories.tsx
+++ b/packages/atomic/src/components/common/atomic-numeric-range/atomic-numeric-range.new.stories.tsx
@@ -24,7 +24,7 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...searchApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.new.stories.tsx
@@ -21,7 +21,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-edit-toggle/atomic-insight-edit-toggle.new.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/insight/atomic-insight-full-search-button/atomic-insight-full-search-button.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-full-search-button/atomic-insight-full-search-button.new.stories.tsx
@@ -21,7 +21,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/insight/atomic-insight-full-search-button/atomic-insight-full-search-button.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-full-search-button/atomic-insight-full-search-button.new.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/insight/atomic-insight-generate-answer-button/atomic-insight-generate-answer-button.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-generate-answer-button/atomic-insight-generate-answer-button.new.stories.tsx
@@ -21,7 +21,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/insight/atomic-insight-generate-answer-button/atomic-insight-generate-answer-button.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-generate-answer-button/atomic-insight-generate-answer-button.new.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.new.stories.tsx
@@ -77,7 +77,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-interface/atomic-insight-interface.new.stories.tsx
@@ -77,7 +77,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/insight/atomic-insight-layout/atomic-insight-layout.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/atomic-insight-layout.new.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/insight/atomic-insight-layout/atomic-insight-layout.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-layout/atomic-insight-layout.new.stories.tsx
@@ -29,7 +29,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/insight/atomic-insight-tab/atomic-insight-tab.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-tab/atomic-insight-tab.new.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     actions: {},
     msw: {
       handlers: [...mockedInsightApi.handlers],

--- a/packages/atomic/src/components/insight/atomic-insight-tab/atomic-insight-tab.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-tab/atomic-insight-tab.new.stories.tsx
@@ -29,7 +29,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     actions: {},
     msw: {
       handlers: [...mockedInsightApi.handlers],

--- a/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.new.stories.tsx
@@ -41,7 +41,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-button/atomic-ipx-button.new.stories.tsx
@@ -41,7 +41,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-modal/atomic-ipx-modal.new.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta = {
   ],
   parameters: {
     ...commonParameters,
-    chromatic: {disableSnapshot: true},
+
     layout: 'centered',
     docs: {
       ...commonParameters.docs,

--- a/packages/atomic/src/components/ipx/atomic-ipx-tab/atomic-ipx-tab.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-tab/atomic-ipx-tab.new.stories.tsx
@@ -29,7 +29,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     actions: {},
     msw: {
       handlers: [...mockSearchApi.handlers],

--- a/packages/atomic/src/components/ipx/atomic-ipx-tab/atomic-ipx-tab.new.stories.tsx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-tab/atomic-ipx-tab.new.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     actions: {},
     msw: {
       handlers: [...mockSearchApi.handlers],

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.new.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-breadbox/atomic-breadbox.new.stories.tsx
@@ -37,7 +37,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
@@ -49,7 +49,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-facet/atomic-facet.new.stories.tsx
@@ -49,7 +49,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-html/atomic-html.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-html/atomic-html.new.stories.tsx
@@ -21,7 +21,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-html/atomic-html.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-html/atomic-html.new.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
@@ -26,7 +26,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-pager/atomic-pager.new.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
@@ -31,7 +31,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-query-summary/atomic-query-summary.new.stories.tsx
@@ -31,7 +31,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
@@ -36,7 +36,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
@@ -36,7 +36,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
@@ -35,7 +35,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-refine-toggle/atomic-refine-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-toggle/atomic-refine-toggle.new.stories.tsx
@@ -33,7 +33,6 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-refine-toggle/atomic-refine-toggle.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-refine-toggle/atomic-refine-toggle.new.stories.tsx
@@ -33,7 +33,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-result-children-template/atomic-result-children-template.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-children-template/atomic-result-children-template.new.stories.tsx
@@ -127,7 +127,6 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-result-children-template/atomic-result-children-template.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-children-template/atomic-result-children-template.new.stories.tsx
@@ -127,7 +127,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-result-html/atomic-result-html.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-html/atomic-result-html.new.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-result-html/atomic-result-html.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-html/atomic-result-html.new.stories.tsx
@@ -34,7 +34,6 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
-
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
@@ -28,6 +28,7 @@ import '@/src/components/search/atomic-result-template/atomic-result-template.js
 import '@/src/components/search/atomic-result-text/atomic-result-text.js';
 import '@/src/components/search/atomic-table-element/atomic-table-element.js';
 import '@/src/components/search/atomic-text/atomic-text.js';
+import {SearchResponse} from '@coveo/platform-mock-api/search/search-response';
 
 const defaultTemplateContent = `<atomic-result-template>
   <template>
@@ -120,12 +121,20 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {handlers: [...searchApiHarness.handlers]},
     layout: 'fullscreen',
     actions: {
       handles: events,
     },
+  },
+  beforeEach: async (context) => {
+    searchApiHarness.searchEndpoint.clear();
+    searchApiHarness.searchEndpoint.mock((response) => ({
+      ...response,
+      results: (response as SearchResponse).results.slice(0, 20),
+      numberOfResults: 20,
+    }));
   },
   args: {
     ...args,

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.new.stories.tsx
@@ -121,7 +121,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-
     msw: {handlers: [...searchApiHarness.handlers]},
     layout: 'fullscreen',
     actions: {

--- a/packages/atomic/src/components/search/atomic-result-number/atomic-result-number.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-number/atomic-result-number.new.stories.tsx
@@ -38,7 +38,6 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
-
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-result-number/atomic-result-number.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-number/atomic-result-number.new.stories.tsx
@@ -38,7 +38,7 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-result-rating/atomic-result-rating.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-rating/atomic-result-rating.new.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-result-rating/atomic-result-rating.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-rating/atomic-result-rating.new.stories.tsx
@@ -37,7 +37,6 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
-
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-result-section-actions/atomic-result-section-actions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-actions/atomic-result-section-actions.new.stories.tsx
@@ -34,7 +34,6 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-section-actions/atomic-result-section-actions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-actions/atomic-result-section-actions.new.stories.tsx
@@ -9,6 +9,7 @@ import {
 import {MockSearchApi} from '@coveo/platform-mock-api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-actions/atomic-result-section-actions.js';
+import {SearchResponse} from '@coveo/platform-mock-api/search/search-response';
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-actions',
@@ -16,16 +17,13 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const searchApiHarness = new MockSearchApi();
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...(response as SearchResponse),
+  results: (response as SearchResponse).results.slice(0, 1),
+  numberOfResults: 1,
+}));
 
 const {play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-  },
   includeCodeRoot: false,
 });
 
@@ -36,7 +34,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-section-badges/atomic-result-section-badges.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-badges/atomic-result-section-badges.new.stories.tsx
@@ -9,6 +9,7 @@ import {
 import {MockSearchApi} from '@coveo/platform-mock-api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-badges/atomic-result-section-badges.js';
+import {SearchResponse} from '@coveo/platform-mock-api/search/search-response';
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-badges',
@@ -16,16 +17,13 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const searchApiHarness = new MockSearchApi();
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...(response as SearchResponse),
+  results: (response as SearchResponse).results.slice(0, 1),
+  numberOfResults: 1,
+}));
 
 const {play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-  },
   includeCodeRoot: false,
 });
 const meta: Meta = {
@@ -35,7 +33,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-section-badges/atomic-result-section-badges.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-badges/atomic-result-section-badges.new.stories.tsx
@@ -33,7 +33,6 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.new.stories.tsx
@@ -33,7 +33,6 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.new.stories.tsx
@@ -9,6 +9,7 @@ import {
 import {MockSearchApi} from '@coveo/platform-mock-api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-bottom-metadata/atomic-result-section-bottom-metadata.js';
+import {SearchResponse} from '@coveo/platform-mock-api/search/search-response';
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-bottom-metadata',
@@ -16,16 +17,13 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const searchApiHarness = new MockSearchApi();
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...(response as SearchResponse),
+  results: (response as SearchResponse).results.slice(0, 1),
+  numberOfResults: 1,
+}));
 
 const {play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-  },
   includeCodeRoot: false,
 });
 const meta: Meta = {
@@ -35,7 +33,7 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
+
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-section-children/atomic-result-section-children.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-children/atomic-result-section-children.new.stories.tsx
@@ -9,6 +9,7 @@ import {
 import {MockSearchApi} from '@coveo/platform-mock-api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-children/atomic-result-section-children.js';
+import {SearchResponse} from '@coveo/platform-mock-api/search/search-response';
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-children',
@@ -16,18 +17,16 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const searchApiHarness = new MockSearchApi();
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...(response as SearchResponse),
+  results: (response as SearchResponse).results.slice(0, 1),
+  numberOfResults: 1,
+}));
 
 const {play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-  },
   includeCodeRoot: false,
 });
+
 const meta: Meta = {
   component: 'atomic-result-section-children',
   title: 'Search/Result Sections',
@@ -35,7 +34,6 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-section-emphasized/atomic-result-section-emphasized.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-emphasized/atomic-result-section-emphasized.new.stories.tsx
@@ -9,6 +9,7 @@ import {
 import {MockSearchApi} from '@coveo/platform-mock-api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-emphasized/atomic-result-section-emphasized.js';
+import {SearchResponse} from '@coveo/platform-mock-api/search/search-response';
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-emphasized',
@@ -16,16 +17,13 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const searchApiHarness = new MockSearchApi();
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...(response as SearchResponse),
+  results: (response as SearchResponse).results.slice(0, 1),
+  numberOfResults: 1,
+}));
 
 const {play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-  },
   includeCodeRoot: false,
 });
 const meta: Meta = {
@@ -35,7 +33,6 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-section-excerpt/atomic-result-section-excerpt.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-excerpt/atomic-result-section-excerpt.new.stories.tsx
@@ -9,18 +9,16 @@ import {
 import {MockSearchApi} from '@coveo/platform-mock-api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-excerpt/atomic-result-section-excerpt.js';
+import {SearchResponse} from '@coveo/platform-mock-api/search/search-response';
 
 const searchApiHarness = new MockSearchApi();
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...(response as SearchResponse),
+  results: (response as SearchResponse).results.slice(0, 1),
+  numberOfResults: 1,
+}));
 
 const {play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-  },
   includeCodeRoot: false,
 });
 
@@ -36,7 +34,6 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-section-title-metadata/atomic-result-section-title-metadata.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-title-metadata/atomic-result-section-title-metadata.new.stories.tsx
@@ -9,6 +9,7 @@ import {
 import {MockSearchApi} from '@coveo/platform-mock-api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-title-metadata/atomic-result-section-title-metadata.js';
+import {SearchResponse} from '@coveo/platform-mock-api/search/search-response';
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-title-metadata',
@@ -16,18 +17,16 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const searchApiHarness = new MockSearchApi();
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...(response as SearchResponse),
+  results: (response as SearchResponse).results.slice(0, 1),
+  numberOfResults: 1,
+}));
 
 const {play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-  },
   includeCodeRoot: false,
 });
+
 const meta: Meta = {
   component: 'atomic-result-section-title-metadata',
   title: 'Search/Result Sections',
@@ -35,7 +34,6 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-section-title/atomic-result-section-title.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-title/atomic-result-section-title.new.stories.tsx
@@ -9,6 +9,7 @@ import {
 import {MockSearchApi} from '@coveo/platform-mock-api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-title/atomic-result-section-title.js';
+import {SearchResponse} from '@coveo/platform-mock-api/search/search-response';
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-title',
@@ -16,16 +17,13 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const searchApiHarness = new MockSearchApi();
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...(response as SearchResponse),
+  results: (response as SearchResponse).results.slice(0, 1),
+  numberOfResults: 1,
+}));
 
 const {play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-  },
   includeCodeRoot: false,
 });
 
@@ -36,7 +34,6 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-section-visual/atomic-result-section-visual.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-section-visual/atomic-result-section-visual.new.stories.tsx
@@ -9,6 +9,7 @@ import {
 import {MockSearchApi} from '@coveo/platform-mock-api/search/mock';
 import {wrapInSearchInterface} from '@/storybook-utils/search/search-interface-wrapper';
 import '@/src/components/search/atomic-result-section-visual/atomic-result-section-visual.js';
+import {SearchResponse} from '@coveo/platform-mock-api/search/search-response';
 
 const {events, args, argTypes, template} = getStorybookHelpers(
   'atomic-result-section-visual',
@@ -16,18 +17,16 @@ const {events, args, argTypes, template} = getStorybookHelpers(
 );
 
 const searchApiHarness = new MockSearchApi();
+searchApiHarness.searchEndpoint.mock((response) => ({
+  ...(response as SearchResponse),
+  results: (response as SearchResponse).results.slice(0, 1),
+  numberOfResults: 1,
+}));
 
 const {play} = wrapInSearchInterface({
-  config: {
-    preprocessRequest: (request) => {
-      const parsed = JSON.parse(request.body as string);
-      parsed.numberOfResults = 1;
-      request.body = JSON.stringify(parsed);
-      return request;
-    },
-  },
   includeCodeRoot: false,
 });
+
 const meta: Meta = {
   component: 'atomic-result-section-visual',
   title: 'Search/Result Sections',
@@ -35,7 +34,6 @@ const meta: Meta = {
   render: (args) => template(args),
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-result-text/atomic-result-text.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-result-text/atomic-result-text.new.stories.tsx
@@ -34,7 +34,6 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-results-per-page/atomic-results-per-page.new.stories.tsx
@@ -28,7 +28,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box-query-suggestions/atomic-search-box-query-suggestions.new.stories.tsx
@@ -36,7 +36,6 @@ const meta: Meta = {
   ],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-search-box-recent-queries/atomic-search-box-recent-queries.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-box-recent-queries/atomic-search-box-recent-queries.new.stories.tsx
@@ -33,7 +33,6 @@ const meta: Meta = {
   decorators: [searchBoxDecorator, searchInterfaceDecorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.new.stories.tsx
@@ -38,7 +38,6 @@ const meta: Meta = {
   decorators: [(story) => html`<div id="code-root">${story()}</div>`],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-search-layout/atomic-search-layout.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-search-layout/atomic-search-layout.new.stories.tsx
@@ -20,7 +20,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-smart-snippet-suggestions/atomic-smart-snippet-suggestions.new.stories.tsx
@@ -181,7 +181,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-sort-dropdown/atomic-sort-dropdown.new.stories.tsx
@@ -27,7 +27,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-tab/atomic-tab.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-tab/atomic-tab.new.stories.tsx
@@ -30,7 +30,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/src/components/search/atomic-table-element/atomic-table-element.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-table-element/atomic-table-element.new.stories.tsx
@@ -27,7 +27,6 @@ const meta: Meta = {
   parameters: {
     ...parameters,
     msw: {handlers: [...searchApiHarness.handlers]},
-    chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-text/atomic-text.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-text/atomic-text.new.stories.tsx
@@ -23,7 +23,6 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
-    chromatic: {disableSnapshot: true},
     msw: {handlers: [...searchApiHarness.handlers]},
     actions: {
       handles: events,

--- a/packages/atomic/turbo.json
+++ b/packages/atomic/turbo.json
@@ -30,7 +30,7 @@
     "build:storybook": {
       "dependsOn": ["^build", "pre:storybook"],
       "outputs": ["./dist-storybook/**"],
-      "env": ["STORYBOOK_INVOKED_BY", "CHROMATIC_ALL"]
+      "env": ["STORYBOOK_INVOKED_BY"]
     },
     "chromatic": {
       "dependsOn": [],
@@ -39,8 +39,7 @@
         "CHROMATIC_PROJECT_TOKEN",
         "CHROMATIC_SHA",
         "CHROMATIC_BRANCH",
-        "CHROMATIC_SLUG",
-        "CHROMATIC_ALL"
+        "CHROMATIC_SLUG"
       ]
     },
     "build:cem": {


### PR DESCRIPTION
- Remove `CHROMATIC_ALL`, it seems to be bugged -> I think we prefer to see "all" then revert/cut it off if needed
- Remove per-story skip for story that are now MSWed