### PR TITLE
fix(ci): continue releases after partial Changesets publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,6 +47,7 @@ jobs:
           cache-retention-days: 7
       - name: Create release PR or publish
         id: changesets
+        continue-on-error: true
         uses: step-security/changeset-action@6ddf46283ed49170eb6ca2179818f7d2a0ae687c # v1.9.0
         with:
           version: pnpm changeset version
@@ -56,6 +57,11 @@ jobs:
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - name: Fail if publishing made no progress
+        if: ${{ steps.changesets.outcome == 'failure' && steps.changesets.outputs.published != 'true' }}
+        run: |
+          echo "The publish command failed before any package was published." >&2
+          exit 1
       - name: Update release/v3 bookmark
         if: ${{ steps.changesets.outputs.published == 'true' }}
         run: |


### PR DESCRIPTION
## Problem
A partial npm publish makes the Changesets action exit with code 1. That fails the `release` job and blocks the release bookmark, post-publish jobs, and CDN release even when one or more packages were successfully published.

## Solution
Allow the Changesets step to continue after an error. Add a guard that fails the workflow only if the step failed and did not publish any package. Partial publishes can therefore continue through the release and CDN flow, while no-progress failures remain blocking.

## Validation
- `pnpm run lint:fix`
- `pnpm exec oxfmt --check .github/workflows/cd.yml`
- `git diff --check`