### PR TITLE
chore(agents): auto-generate AGENTS.md package list and fill missing descriptions

### DIFF
--- a/.github/workflows/agents-md-check.yml
+++ b/.github/workflows/agents-md-check.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check for uncommitted changes
         run: |
           if [ -n "$(git status --porcelain AGENTS.md)" ]; then
-            echo "::error::AGENTS.md packages list is out of date. Run 'node scripts/generate-agents-md-packages.mjs' and commit the results."
+            echo "::error::AGENTS.md packages list is out of date. Run 'pnpm run generate:agents-md-packages' and commit the results."
             git diff --stat
             exit 1
           fi

--- a/.github/workflows/agents-md-check.yml
+++ b/.github/workflows/agents-md-check.yml
@@ -1,0 +1,34 @@
+name: Agents.md Packages Check
+on:
+  pull_request:
+    paths:
+      - 'packages/**/package.json'
+      - 'AGENTS.md'
+      - 'scripts/generate-agents-md-packages.mjs'
+      - 'scripts/packages.mjs'
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  check-agents-md:
+    name: 'Verify AGENTS.md packages list is up to date'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: '.nvmrc'
+      - run: node scripts/generate-agents-md-packages.mjs
+      - name: Check for uncommitted changes
+        run: |
+          if [ -n "$(git status --porcelain AGENTS.md)" ]; then
+            echo "::error::AGENTS.md packages list is out of date. Run 'node scripts/generate-agents-md-packages.mjs' and commit the results."
+            git diff --stat
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 ### Public
 
 - [`@coveo/atomic`](packages/atomic/): A web-component library for building modern UIs interfacing with the Coveo platform
-- [`@coveo/atomic-angular`](packages/atomic-angular/projects/atomic-angular/)
+- [`@coveo/atomic-angular`](packages/atomic-angular/projects/atomic-angular/): An Angular component library for building modern UIs interfacing with the Coveo platform, wrapping the core Atomic web components
 - [`@coveo/atomic-hosted-page`](packages/atomic-hosted-page/): Web Component used to inject a Coveo Hosted Search Page in the DOM.
 - [`@coveo/atomic-legacy`](packages/atomic-legacy/): Package used internally by @coveo/atomic for components using legacy technologies (e.g., Stencil). This package is not intended for public use.
 - [`@coveo/atomic-react`](packages/atomic-react/): React specific wrapper for the Atomic component library
@@ -42,14 +42,14 @@
 ### Private
 
 - [`@coveo/atomic-a11y`](packages/atomic-a11y/): Accessibility utilities and tools for Coveo Atomic components
-- [`@coveo/atomic-angular-builder`](packages/atomic-angular/)
+- [`@coveo/atomic-angular-builder`](packages/atomic-angular/): Angular workspace used to build and publish the @coveo/atomic-angular package
 - [`@coveo/atomic-cdn-smoke`](packages/atomic-cdn-smoke/): CDN visual smoke tests for Atomic components using Playwright + Chromatic
-- [`@coveo/create-atomic-template`](packages/create-atomic-template/): {{titleCase project}} project
-- [`@coveo/documentation`](packages/documentation/)
-- [`@coveo/mock-converse-api`](packages/mock-converse-api/)
-- [`@coveo/pkg-new-template`](packages/pkg-new-template/)
+- [`@coveo/create-atomic-template`](packages/create-atomic-template/): Template project scaffolded by @coveo/create-atomic when generating a new Atomic search page
+- [`@coveo/documentation`](packages/documentation/): Typedoc plugin enforcing Coveo's documentation styling and navigation conventions across the monorepo
+- [`@coveo/mock-converse-api`](packages/mock-converse-api/): HTTP server exposing mock Converse API endpoints, built on @coveo/platform-mock-api, for local development and testing
+- [`@coveo/pkg-new-template`](packages/pkg-new-template/): Preview app used by pkg.pr.new to let reviewers try out Atomic and Headless builds from a pull request
 - [`@coveo/platform-mock-api`](packages/platform-mock-api/): Coveo Platform API mock layer for testing (search, commerce, insight, recommendations)
-- [`@coveo/relay-playground`](packages/relay-playground/)
+- [`@coveo/relay-playground`](packages/relay-playground/): Next.js playground app for manually testing and exploring the @coveo/relay analytics library
 
 ## Technology
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,25 +13,43 @@
 - **Fix linting errors across the monorepo**: `pnpm run lint:fix`
 - **Add a changeset**: `pnpm changeset`
 
-## Structure
+## Packages
 
-These are the public packages in the monorepo:
+<!-- AUTO-GENERATED: run `pnpm run generate:agents-md-packages` to update this section. Do not edit by hand. -->
 
-- `packages/atomic/`: Web-component library for building modern UIs interfacing with the Coveo platform; built on top of headless
-- `packages/atomic-react/`: React wrapper for the Atomic component library
-- `packages/atomic-hosted-page/`: Web component for injecting a Coveo Hosted Search Page in the DOM
-- `packages/atomic-legacy/`: Internal package used by `@coveo/atomic` for legacy Stencil components
-- `packages/auth/`: Functions to help authenticate with the Coveo platform
-- `packages/bueno/`: Value validation library
-- `packages/headless/`: Redux-based headless library; built on top of the Coveo REST APIs
-- `packages/headless-react/`: React utilities for SSR with headless
-- `packages/quantic/`: Salesforce Lightning Web Component library; built on top of headless
-- `packages/shopify/`: Coveo integration for Shopify storefronts
-- `packages/create-atomic/`: Generator for new Atomic projects
-- `packages/create-atomic-component/`: Generator for new Atomic components
-- `packages/create-atomic-component-project/`: Generator for new Atomic component library projects
-- `packages/create-atomic-result-component/`: Generator for new Atomic result components
-- `packages/create-atomic-rollup-plugin/`: Rollup plugin for resolving Atomic dependencies from CDN or npm
+### Public
+
+- [`@coveo/atomic`](packages/atomic/): A web-component library for building modern UIs interfacing with the Coveo platform
+- [`@coveo/atomic-angular`](packages/atomic-angular/projects/atomic-angular/)
+- [`@coveo/atomic-hosted-page`](packages/atomic-hosted-page/): Web Component used to inject a Coveo Hosted Search Page in the DOM.
+- [`@coveo/atomic-legacy`](packages/atomic-legacy/): Package used internally by @coveo/atomic for components using legacy technologies (e.g., Stencil). This package is not intended for public use.
+- [`@coveo/atomic-react`](packages/atomic-react/): React specific wrapper for the Atomic component library
+- [`@coveo/auth`](packages/auth/): Functions to help authenticate with the Coveo platform.
+- [`@coveo/bueno`](packages/bueno/): A simple validator
+- [`@coveo/create-atomic`](packages/create-atomic/): Coveo Atomic Generator
+- [`@coveo/create-atomic-component`](packages/create-atomic-component/): Initialize a Coveo Atomic Component
+- [`@coveo/create-atomic-component-project`](packages/create-atomic-component-project/): Initialize a Coveo Atomic Library Project
+- [`@coveo/create-atomic-result-component`](packages/create-atomic-result-component/): Initialize a Coveo Atomic Result Component
+- [`@coveo/create-atomic-rollup-plugin`](packages/create-atomic-rollup-plugin/): Rollup plugin for resolving Coveo Atomic dependencies from CDN or npm
+- [`@coveo/create-ui`](packages/create-ui/): Scaffold a Coveo UI project (Atomic or Headless) from the official samples.
+- [`@coveo/headless`](packages/headless/): A headless library for building search experiences on the Coveo platform
+- [`@coveo/headless-react`](packages/headless-react/): React utilities for SSR (Server Side Rendering) with headless
+- [`@coveo/quantic`](packages/quantic/): A Salesforce Lightning Web Component (LWC) library for building modern UIs interfacing with the Coveo platform
+- [`@coveo/relay`](packages/relay/): A library for sending analytics events using Coveo's Event protocol.
+- [`@coveo/shopify`](packages/shopify/): Utilities to integrate Shopify with Coveo's commerce engine
+- [`@coveo/thermidor`](packages/thermidor/): Experimental package for a unified, framework-agnostic headless engine for search and conversational experiences
+
+### Private
+
+- [`@coveo/atomic-a11y`](packages/atomic-a11y/): Accessibility utilities and tools for Coveo Atomic components
+- [`@coveo/atomic-angular-builder`](packages/atomic-angular/)
+- [`@coveo/atomic-cdn-smoke`](packages/atomic-cdn-smoke/): CDN visual smoke tests for Atomic components using Playwright + Chromatic
+- [`@coveo/create-atomic-template`](packages/create-atomic-template/): {{titleCase project}} project
+- [`@coveo/documentation`](packages/documentation/)
+- [`@coveo/mock-converse-api`](packages/mock-converse-api/)
+- [`@coveo/pkg-new-template`](packages/pkg-new-template/)
+- [`@coveo/platform-mock-api`](packages/platform-mock-api/): Coveo Platform API mock layer for testing (search, commerce, insight, recommendations)
+- [`@coveo/relay-playground`](packages/relay-playground/)
 
 ## Technology
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "notify:docs": "node ./scripts/notify-docs/published-ui-kit.mjs",
     "release": "pnpm run build && changeset publish",
     "knip": "knip",
-    "generate:catalog-info": "node scripts/generate-catalog-info.mjs"
+    "generate:catalog-info": "node scripts/generate-catalog-info.mjs",
+    "generate:agents-md-packages": "node scripts/generate-agents-md-packages.mjs"
   },
   "devDependencies": {
     "@actions/github": "9.1.1",

--- a/packages/atomic-angular/package.json
+++ b/packages/atomic-angular/package.json
@@ -2,6 +2,7 @@
   "name": "@coveo/atomic-angular-builder",
   "version": "0.0.0",
   "private": true,
+  "description": "Angular workspace used to build and publish the @coveo/atomic-angular package",
   "scripts": {
     "ng": "ng",
     "dev": "ng serve",

--- a/packages/atomic-angular/projects/atomic-angular/package.json
+++ b/packages/atomic-angular/projects/atomic-angular/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@coveo/atomic-angular",
   "version": "3.11.16",
+  "description": "An Angular component library for building modern UIs interfacing with the Coveo platform, wrapping the core Atomic web components",
   "license": "Apache-2.0",
   "repository": {
     "url": "https://github.com/coveo/ui-kit"

--- a/packages/create-atomic-template/package.json
+++ b/packages/create-atomic-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coveo/create-atomic-template",
-  "description": "Template project scaffolded by @coveo/create-atomic when generating a new Atomic search page",
+  "description": "{{titleCase project}} project",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/packages/create-atomic-template/package.json
+++ b/packages/create-atomic-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coveo/create-atomic-template",
-  "description": "{{titleCase project}} project",
+  "description": "Template project scaffolded by @coveo/create-atomic when generating a new Atomic search page",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -2,6 +2,7 @@
   "name": "@coveo/documentation",
   "version": "1.0.0",
   "private": true,
+  "description": "Typedoc plugin enforcing Coveo's documentation styling and navigation conventions across the monorepo",
   "files": [
     "dist",
     "configs",

--- a/packages/mock-converse-api/package.json
+++ b/packages/mock-converse-api/package.json
@@ -2,6 +2,7 @@
   "name": "@coveo/mock-converse-api",
   "version": "0.1.0",
   "private": true,
+  "description": "HTTP server exposing mock Converse API endpoints, built on @coveo/platform-mock-api, for local development and testing",
   "type": "module",
   "scripts": {
     "start": "node dist/server.js",

--- a/packages/pkg-new-template/package.json
+++ b/packages/pkg-new-template/package.json
@@ -2,6 +2,7 @@
   "name": "@coveo/pkg-new-template",
   "version": "0.0.0",
   "private": true,
+  "description": "Preview app used by pkg.pr.new to let reviewers try out Atomic and Headless builds from a pull request",
   "type": "module",
   "scripts": {
     "dev": "node ./scripts/copyResources.mjs && vite",

--- a/packages/relay-playground/package.json
+++ b/packages/relay-playground/package.json
@@ -2,6 +2,7 @@
   "name": "@coveo/relay-playground",
   "version": "3.1.1",
   "private": true,
+  "description": "Next.js playground app for manually testing and exploring the @coveo/relay analytics library",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/scripts/generate-agents-md-packages.mjs
+++ b/scripts/generate-agents-md-packages.mjs
@@ -209,10 +209,4 @@ function main() {
   );
 }
 
-// Guard so importing this module (e.g. from the test file, which imports
-// individual functions for unit testing) never triggers `main()` as a
-// side effect: only run it when this file is executed directly via
-// `node scripts/generate-agents-md-packages.mjs`.
-if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
-}
+main();

--- a/scripts/generate-agents-md-packages.mjs
+++ b/scripts/generate-agents-md-packages.mjs
@@ -1,0 +1,218 @@
+/**
+ * Generates the `## Packages` section of the root `AGENTS.md` file from the
+ * `name`, `description`, and `private` fields of every package's
+ * `package.json`.
+ *
+ * Usage:
+ *   node scripts/generate-agents-md-packages.mjs
+ */
+
+import {readFileSync, writeFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {
+  getAllPackageDirs,
+  getPackageManifestFromPackagePath,
+  getPackagePathFromPackageDir,
+} from './packages.mjs';
+
+const rootDir = resolve(fileURLToPath(import.meta.url), '..', '..');
+const agentsMdPath = resolve(rootDir, 'AGENTS.md');
+
+/**
+ * @typedef PackageEntry
+ * @property {string} dir - Relative path under `packages/`, e.g. `atomic`.
+ * @property {string} name - Value of the manifest's `name` field.
+ * @property {string} description - Value of the manifest's `description`
+ *   field, or `''` if absent.
+ * @property {boolean} isPrivate - `true` when the manifest's `private`
+ *   field is exactly `true`, `false` otherwise (including when absent).
+ */
+
+/**
+ * Builds a `PackageEntry` from a directory path and an already-parsed
+ * manifest, applying the `description` and `private` defaulting rules.
+ * This is a pure function with no file-system access, kept separate from
+ * `readPackageEntry` so it can be exercised directly against arbitrary
+ * manifests.
+ *
+ * @param {string} dir Relative path under `packages/`, e.g. `atomic` or
+ *   `atomic-angular/projects/atomic-angular`.
+ * @param {Record<string, unknown>} manifest Parsed `package.json` content.
+ * @returns {PackageEntry}
+ */
+export function buildPackageEntryFromManifest(dir, manifest) {
+  return {
+    dir,
+    name: manifest.name,
+    description: manifest.description ?? '',
+    isPrivate: manifest.private === true,
+  };
+}
+
+/**
+ * Reads the `name`, `description`, and `private` fields from the
+ * `package.json` of the given package directory.
+ *
+ * @param {string} dir Relative path under `packages/`, e.g. `atomic` or
+ *   `atomic-angular/projects/atomic-angular`.
+ * @returns {PackageEntry}
+ */
+function readPackageEntry(dir) {
+  const fullPath = getPackagePathFromPackageDir(dir);
+  const manifest = getPackageManifestFromPackagePath(fullPath);
+  return buildPackageEntryFromManifest(dir, manifest);
+}
+
+/**
+ * Renders a single Markdown list item for a package entry: a link whose
+ * text is the manifest name in inline code and whose target is the
+ * package directory, followed by the description (omitted when empty).
+ *
+ * @param {PackageEntry} entry
+ * @returns {string}
+ */
+export function renderPackageEntry(entry) {
+  const link = `packages/${entry.dir}/`;
+  const descriptionSuffix = entry.description ? `: ${entry.description}` : '';
+  return `- [\`${entry.name}\`](${link})${descriptionSuffix}`;
+}
+
+const AUTO_GENERATED_MARKER =
+  '<!-- AUTO-GENERATED: run `pnpm run generate:agents-md-packages` to update this section. Do not edit by hand. -->';
+
+/**
+ * Compares two package entries by their `dir` field using standard string
+ * comparison, for use as an alphabetical `Array#sort` comparator.
+ *
+ * @param {PackageEntry} a
+ * @param {PackageEntry} b
+ * @returns {number}
+ */
+function byDir(a, b) {
+  if (a.dir < b.dir) return -1;
+  if (a.dir > b.dir) return 1;
+  return 0;
+}
+
+/**
+ * Renders a `### Public` or `### Private` subsection heading followed by
+ * its entries, one per line. Entries are sorted alphabetically by `dir`
+ * before rendering.
+ *
+ * @param {string} heading `### Public` or `### Private`.
+ * @param {PackageEntry[]} entries
+ * @returns {string[]} Lines to append to the section, including a leading
+ *   blank line separating this subsection from the previous content.
+ */
+function renderSubsection(heading, entries) {
+  const sorted = [...entries].sort(byDir);
+  return ['', heading, '', ...sorted.map(renderPackageEntry)];
+}
+
+/**
+ * Renders the full replacement content for the `## Packages` section,
+ * including heading, auto-generated marker, and Public/Private
+ * subsections. Entries are partitioned by `isPrivate`: entries with
+ * `isPrivate === false` render under `### Public`, entries with
+ * `isPrivate === true` render under `### Private`, with `### Public`
+ * always rendered before `### Private`. A subsection with no entries is
+ * omitted entirely (its heading is not rendered).
+ *
+ * @param {PackageEntry[]} entries
+ * @returns {string}
+ */
+export function renderPackagesSection(entries) {
+  const publicEntries = entries.filter((entry) => !entry.isPrivate);
+  const privateEntries = entries.filter((entry) => entry.isPrivate);
+
+  const lines = ['## Packages', '', AUTO_GENERATED_MARKER];
+
+  if (publicEntries.length > 0) {
+    lines.push(...renderSubsection('### Public', publicEntries));
+  }
+
+  if (privateEntries.length > 0) {
+    lines.push(...renderSubsection('### Private', privateEntries));
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * Replaces the `## Packages` section of `AGENTS.md` content with
+ * `newSection`, leaving every other line unchanged. The section is defined
+ * as starting at the line beginning with `## Packages` (inclusive) and
+ * ending immediately before the next line beginning with `## ` (or at the
+ * end of the file if no such line follows). Exactly one blank line is kept
+ * between `newSection` and the next `## `-prefixed heading (or, when there
+ * is no following heading, after `newSection`), matching the blank-line
+ * convention used between sections elsewhere in `AGENTS.md`.
+ *
+ * @param {string} agentsMdContent
+ * @param {string} newSection
+ * @returns {string}
+ */
+export function replacePackagesSection(agentsMdContent, newSection) {
+  const lines = agentsMdContent.split('\n');
+  const headingIndex = lines.findIndex((line) =>
+    line.startsWith('## Packages')
+  );
+
+  if (headingIndex === -1) {
+    throw new Error('Could not find "## Packages" heading in AGENTS.md');
+  }
+
+  let nextHeadingIndex = -1;
+  for (let i = headingIndex + 1; i < lines.length; i++) {
+    if (lines[i].startsWith('## ')) {
+      nextHeadingIndex = i;
+      break;
+    }
+  }
+
+  const before = lines.slice(0, headingIndex);
+  const after = nextHeadingIndex === -1 ? [] : lines.slice(nextHeadingIndex);
+
+  const newSectionLines = newSection.split('\n');
+  if (newSectionLines[newSectionLines.length - 1] === '') {
+    newSectionLines.pop();
+  }
+
+  const resultLines =
+    after.length === 0
+      ? [...before, ...newSectionLines, '']
+      : [...before, ...newSectionLines, '', ...after];
+
+  return resultLines.join('\n');
+}
+
+/**
+ * Discovers every package directory, builds its `PackageEntry`, and
+ * rewrites the `## Packages` section of the root `AGENTS.md` file with the
+ * regenerated content.
+ */
+function main() {
+  const dirs = getAllPackageDirs();
+  const entries = dirs.map(readPackageEntry);
+
+  const newSection = renderPackagesSection(entries);
+
+  const agentsMdContent = readFileSync(agentsMdPath, 'utf-8');
+  const updatedContent = replacePackagesSection(agentsMdContent, newSection);
+  writeFileSync(agentsMdPath, updatedContent);
+
+  const publicCount = entries.filter((entry) => !entry.isPrivate).length;
+  const privateCount = entries.length - publicCount;
+  console.log(
+    `Updated: AGENTS.md (${entries.length} packages: ${publicCount} public, ${privateCount} private)`
+  );
+}
+
+// Guard so importing this module (e.g. from the test file, which imports
+// individual functions for unit testing) never triggers `main()` as a
+// side effect: only run it when this file is executed directly via
+// `node scripts/generate-agents-md-packages.mjs`.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/generate-agents-md-packages.mjs
+++ b/scripts/generate-agents-md-packages.mjs
@@ -30,6 +30,19 @@ const agentsMdPath = resolve(rootDir, 'AGENTS.md');
  */
 
 /**
+ * Package metadata to use in `AGENTS.md` instead of the corresponding
+ * manifest values. Keys are package directories relative to `packages/`.
+ *
+ * @type {Record<string, Partial<PackageEntry>>}
+ */
+const overrides = {
+  '@coveo/create-atomic-template': {
+    description:
+      'Template project scaffolded by @coveo/create-atomic when generating a new Atomic search page',
+  },
+};
+
+/**
  * Builds a `PackageEntry` from a directory path and an already-parsed
  * manifest, applying the `description` and `private` defaulting rules.
  * This is a pure function with no file-system access, kept separate from
@@ -61,7 +74,11 @@ export function buildPackageEntryFromManifest(dir, manifest) {
 function readPackageEntry(dir) {
   const fullPath = getPackagePathFromPackageDir(dir);
   const manifest = getPackageManifestFromPackagePath(fullPath);
-  return buildPackageEntryFromManifest(dir, manifest);
+  const entry = buildPackageEntryFromManifest(dir, manifest);
+  return {
+    ...entry,
+    ...(overrides[entry.name] ?? {}),
+  };
 }
 
 /**

--- a/scripts/packages.mjs
+++ b/scripts/packages.mjs
@@ -1,4 +1,4 @@
-import {existsSync, readFileSync} from 'node:fs';
+import {existsSync, readdirSync, readFileSync} from 'node:fs';
 import {resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -7,6 +7,8 @@ export const workspacesRoot = resolve(
   '..',
   '..'
 );
+
+const nestedAtomicAngularPackageDir = 'atomic-angular/projects/atomic-angular';
 
 export const packageDirsNpmTag = /** @type {const} */ ([
   'atomic',
@@ -56,4 +58,43 @@ export function getPackageDefinitionFromPackageDir(packageDir) {
   }
   const {name, version} = getPackageManifestFromPackagePath(fullPath);
   return {name, version, packageDir};
+}
+
+/**
+ * Returns the relative path (from the `packages/` directory) of every
+ * package directory in the monorepo, including the nested Angular project
+ * directory at `atomic-angular/projects/atomic-angular`.
+ *
+ * A directory is considered a package directory when it contains a
+ * `package.json` file. Directories under `packages/` are scanned one level
+ * deep; the nested Angular project directory is checked explicitly rather
+ * than through recursion, so its `dist` output directory is never visited.
+ *
+ * @param {string} [rootDir] Directory containing the `packages/` folder to
+ *   scan. Defaults to the monorepo's workspaces root, and is otherwise only
+ *   intended to be overridden by tests that exercise this function against
+ *   a synthetic directory tree.
+ * @returns {string[]} Relative paths such as `atomic`, `bueno`,
+ *   `atomic-angular/projects/atomic-angular`.
+ */
+export function getAllPackageDirs(rootDir = workspacesRoot) {
+  const packagesRoot = resolve(rootDir, 'packages');
+  const topLevelPackageDirs = readdirSync(packagesRoot, {
+    withFileTypes: true,
+  })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(resolve(packagesRoot, name, 'package.json')));
+
+  const packageDirs = [...topLevelPackageDirs];
+
+  if (
+    existsSync(
+      resolve(packagesRoot, nestedAtomicAngularPackageDir, 'package.json')
+    )
+  ) {
+    packageDirs.push(nestedAtomicAngularPackageDir);
+  }
+
+  return packageDirs;
 }


### PR DESCRIPTION
## Summary

Automates the `## Packages` section of the root `AGENTS.md` and fills in
missing or low-quality `description` fields across the monorepo's
package.json files.

- Add `scripts/generate-agents-md-packages.mjs` (plus shared helpers in   `scripts/packages.mjs`) to regenerate the `## Packages` section of `AGENTS.md` from each package's `name`, `description`, and `private` fields, exposed as `pnpm run generate:agents-md-packages`.
- Add a CI workflow (`agents-md-check.yml`) to fail if `AGENTS.md` drifts from the generated output.
- Add or correct `description` fields for packages that had none or a placeholder value: `@coveo/atomic-angular`, `@coveo/atomic-angular-builder`, `@coveo/create-atomic-template` (was the literal Handlebars template string `{{titleCase project}} project`), `@coveo/documentation`, `@coveo/mock-converse-api`, `@coveo/pkg-new-template`, and `@coveo/relay-playground`.
- Regenerate `AGENTS.md` to reflect the new descriptions.

⚠️ Package descriptions were AI generated and I’m not super familiar with them, please review carefully

---

I tried to instead just create a command that outputs just the markdown of the packages and instructing the agent via AGENTS.md and steering files to run the command as needed, but after testing a few variations of prompts, it only really did that if I asked "give me a list of all packages". 

Something like "tell me more about thermidor" didn't trigger it and therefore it had to figure it out by itself via a bunch of `find`/`grep`.

Committing to AGENTS.md is more reliable and I think it's short enough to avoid polluting the context.