### PR TITLE
chore: leverage chromatic checks

### DIFF
--- a/packages/atomic/chromatic.config.json
+++ b/packages/atomic/chromatic.config.json
@@ -2,6 +2,7 @@
   "$schema": "https://www.chromatic.com/config-file.schema.json",
   "buildCommand": "turbo run build:storybook --filter=@coveo/atomic --",
   "outputDir": "dist-storybook",
+  "exitOnceUploaded": true,
   "untraced": ["/virtual:*"],
   "onlyChanged": true
 }


### PR DESCRIPTION
The idea is to leverage
<img width="807" height="137" alt="image" src="https://github.com/user-attachments/assets/b74d9593-3975-40a4-a6db-dc4fe859107a" />
instead of the GitHub action checks.
This will allow us to reuse snapshots needlessly when the UI changes are approved in Chromatic.