### PR TITLE
Updating atomic-result-link info

### DIFF
--- a/packages/atomic/src/components/search/atomic-result-link/atomic-result-link.ts
+++ b/packages/atomic/src/components/search/atomic-result-link/atomic-result-link.ts
@@ -23,7 +23,7 @@ import '@/src/components/search/atomic-result-text/atomic-result-text';
 import styles from './atomic-result-link.tw.css';
 
 /**
- * The `atomic-result-link` component automatically transforms a search result title into a clickable link that points to the original item.
+ * The `atomic-result-link` component automatically converts a search result title into a clickable link to the original item. When users click the link, the component logs a click analytics event.
  * @slot default - Lets you display alternative content inside the link
  * @slot attributes - Lets you pass [attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attributes) down to the link element, overriding other attributes, to be used exclusively with an "a" tag such as `<a slot="attributes" target="_blank" download></a>`.
  */

--- a/packages/atomic/src/components/search/atomic-result-link/atomic-result-link.usage.mdx
+++ b/packages/atomic/src/components/search/atomic-result-link/atomic-result-link.usage.mdx
@@ -1,5 +1,5 @@
 
-The `atomic-result-link` component automatically transforms a search result **title** into a clickable link that points to the original item. This component is used within `atomic-result-template` components inside the result list:
+The `atomic-result-link` component automatically converts a search result **title** into a clickable link to the original item. This component is used within `atomic-result-template` components inside the result list:
 
 ```html
 <atomic-search-interface>


### PR DESCRIPTION
See https://coveord.atlassian.net/browse/DOC-19931

This PR and [this public docs PR](https://github.com/coveo/doc_jekyll-public-site/pull/16681) are both associated with this doc update request.

**NOTE**: This is my first adventure in this repo. Let me know if there are things I'm missing.