### PR TITLE
fix(thermidor): do not store serializable instances in redux state

### DIFF
--- a/packages/thermidor/src/index.ts
+++ b/packages/thermidor/src/index.ts
@@ -49,6 +49,7 @@ export type {
   AgentResponse,
   RoutedInterface,
   RoutedUseCase,
+  SerializableRoutedInterface,
   StateTurn,
   ToolCall,
   ToolCallStatus,

--- a/packages/thermidor/src/index.ts
+++ b/packages/thermidor/src/index.ts
@@ -49,6 +49,7 @@ export type {
   AgentResponse,
   RoutedInterface,
   RoutedUseCase,
+  StateTurn,
   ToolCall,
   ToolCallStatus,
   Turn,

--- a/packages/thermidor/src/internal/api/generative/generative-runtime.ts
+++ b/packages/thermidor/src/internal/api/generative/generative-runtime.ts
@@ -39,9 +39,6 @@ export interface GenerativeStatePort {
   ): void;
 }
 
-/**
- * Result of hydrating a sub-interface from a stream event or restored snapshot.
- */
 export interface HydrationResult<K extends RoutedUseCase = RoutedUseCase> {
   useCase: K;
   interface: UseCaseInterfaceMap[K];

--- a/packages/thermidor/src/internal/api/generative/generative-runtime.ts
+++ b/packages/thermidor/src/internal/api/generative/generative-runtime.ts
@@ -10,15 +10,16 @@ import {getOrCreateConfigurationSelectors} from '@/src/internal/features/configu
 import {generateId} from '@/src/internal/utils/index.js';
 import type {
   A2UISurface,
-  RoutedInterface,
+  RoutedUseCase,
   TurnStatus,
+  UseCaseInterfaceMap,
 } from '@/src/internal/features/generative/index.js';
 
 export interface GenerativeStatePort {
   createTurn(payload: {id: string; prompt: string; status: TurnStatus}): void;
   setActiveTurnId(id: string): void;
   replaceTurnId(oldId: string, newId: string): void;
-  setRoutedInterface(turnId: string, routedInterface: RoutedInterface): void;
+  setRoutedInterface(turnId: string, hydrationResult: HydrationResult): void;
   initAgentResponse(turnId: string): void;
   startMessage(turnId: string, role: string): void;
   appendMessageDelta(turnId: string, delta: string): void;
@@ -38,11 +39,21 @@ export interface GenerativeStatePort {
   ): void;
 }
 
+/**
+ * Result of hydrating a sub-interface from a stream event or restored snapshot.
+ */
+export interface HydrationResult<K extends RoutedUseCase = RoutedUseCase> {
+  useCase: K;
+  interface: UseCaseInterfaceMap[K];
+  snapshot: Record<string, unknown>;
+  query: string | undefined;
+}
+
 export type HydrateSubInterface = (
   activityType: string,
   content: unknown,
   query?: string
-) => RoutedInterface | null;
+) => HydrationResult | null;
 
 export interface GenerativeRuntimeConfig {
   statePort: GenerativeStatePort;
@@ -287,14 +298,14 @@ export class GenerativeRuntime {
       case 'commerce_search_api_response':
       case 'search_api_response': {
         const {type: _type, ...content} = event;
-        const routedInterface = this.hydrateSubInterface(
+        const hydrationResult = this.hydrateSubInterface(
           event.type,
           content,
           this.currentPrompt
         );
 
-        if (routedInterface) {
-          this.statePort.setRoutedInterface(turnId, routedInterface);
+        if (hydrationResult) {
+          this.statePort.setRoutedInterface(turnId, hydrationResult);
           return {turnId, isTerminal: true};
         }
 

--- a/packages/thermidor/src/internal/api/generative/index.ts
+++ b/packages/thermidor/src/internal/api/generative/index.ts
@@ -3,4 +3,5 @@ export type {
   GenerativeStatePort,
   GenerativeRuntimeConfig,
   HydrateSubInterface,
+  HydrationResult,
 } from './generative-runtime.js';

--- a/packages/thermidor/src/internal/features/generative/generative-actions.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-actions.ts
@@ -5,7 +5,7 @@ import type {InterfaceHandle} from '@/src/internal/utils/index.js';
 import type {
   A2UISurface,
   GenerativeState,
-  RoutedInterface,
+  RoutedUseCase,
   TurnStatus,
 } from './generative-types.js';
 
@@ -26,7 +26,7 @@ export function createGenerativeActions(interfaceId: string) {
     ),
     setRoutedInterface: createAction<{
       turnId: string;
-      routedInterface: RoutedInterface;
+      useCase: RoutedUseCase;
     }>(`${prefix}/setRoutedInterface`),
     initAgentResponse: createAction<{turnId: string}>(
       `${prefix}/initAgentResponse`

--- a/packages/thermidor/src/internal/features/generative/generative-hydration.test.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-hydration.test.ts
@@ -1,179 +1,301 @@
-import {describe, it, expect, beforeEach} from 'vitest';
+import {beforeEach, describe, it, expect, vi} from 'vitest';
+import {createTestEngine} from '@/src/test/test-utils.js';
 import {
-  Engine,
-  getFullEngine,
+  type Engine,
   type FullEngine,
+  getFullEngine,
 } from '@/src/internal/engine/index.js';
-import {getHandleInternals} from '@/src/internal/utils/index.js';
 import {
   createHydrateSubInterface,
-  getOrCreateHydrateFromSnapshotAction,
+  rehydrateRoutedInterfaces,
 } from './generative-hydration.js';
-import {getOrCreateProductListSlice} from '@/src/internal/features/product-list/index.js';
-import {getOrCreateResultsSlice} from '@/src/internal/features/result-list/index.js';
-import {buildSearchInterface} from '@/src/public/interfaces/search.js';
-
-function createTestEngine() {
-  return new Engine({
-    configuration: {
-      organizationId: 'test-org',
-      accessToken: 'test-token',
-      trackingId: 'test',
-      language: 'en',
-      country: 'US',
-      currency: 'USD',
-    },
-  });
-}
-
-describe('getOrCreateHydrateFromSnapshotAction', () => {
-  it('returns the same action for the same interfaceId', () => {
-    const engine = createTestEngine();
-    const iface = buildSearchInterface({engine, id: 'test-id'});
-    const action1 = getOrCreateHydrateFromSnapshotAction(iface);
-    const action2 = getOrCreateHydrateFromSnapshotAction(iface);
-    expect(action1).toBe(action2);
-  });
-
-  it('returns different actions for different interfaceIds', () => {
-    const engine = createTestEngine();
-    const ifaceA = buildSearchInterface({engine, id: 'id-a'});
-    const ifaceB = buildSearchInterface({engine, id: 'id-b'});
-    const action1 = getOrCreateHydrateFromSnapshotAction(ifaceA);
-    const action2 = getOrCreateHydrateFromSnapshotAction(ifaceB);
-    expect(action1).not.toBe(action2);
-  });
-
-  it('creates an action with the correct type pattern', () => {
-    const engine = createTestEngine();
-    const iface = buildSearchInterface({engine, id: 'my-interface'});
-    const action = getOrCreateHydrateFromSnapshotAction(iface);
-    expect(action.type).toBe('my-interface/hydrateFromSnapshot');
-  });
-});
+import {RoutedInterfaceRegistry} from './routed-interface-registry.js';
+import {CommerceInterfaceImpl} from '@/src/internal/interfaces/index.js';
+import {SearchInterfaceImpl} from '@/src/internal/interfaces/index.js';
+import type {HydrateSubInterface} from '@/src/internal/api/generative/index.js';
 
 describe('createHydrateSubInterface', () => {
+  let engine: Engine;
   let fullEngine: FullEngine;
 
   beforeEach(() => {
-    fullEngine = getFullEngine(createTestEngine());
+    engine = createTestEngine();
+    fullEngine = getFullEngine(engine);
   });
 
-  it('returns null for unrecognized activity types', () => {
+  it('returns null for an unknown activity type', () => {
     const hydrate = createHydrateSubInterface(fullEngine);
-    const result = hydrate('unknown-activity-type', {});
+
+    const result = hydrate('unknown_activity', {results: []});
+
     expect(result).toBeNull();
   });
 
-  it('returns a RoutedInterface for commerce_search_api_response', () => {
+  it('returns a CommerceInterfaceImpl for commerce_search_api_response', () => {
     const hydrate = createHydrateSubInterface(fullEngine);
-    const content = {
-      products: [
-        {
-          permanentid: 'p1',
-          ec_name: 'Product 1',
-          ec_price: 29.99,
-          clickUri: 'https://example.com/p1',
-        },
-      ],
-      pagination: {totalEntries: 1},
-      facets: [],
-    };
+    const content = {results: [{title: 'Shoes'}]};
 
-    const result = hydrate('commerce_search_api_response', content);
+    const result = hydrate('commerce_search_api_response', content, 'shoes');
+
     expect(result).not.toBeNull();
     expect(result!.useCase).toBe('commerceSearch');
-    expect(result!.interface).toBeDefined();
-    const {stateId} = getHandleInternals(result!.interface);
-    expect(stateId).toBeDefined();
+    expect(result!.interface).toBeInstanceOf(CommerceInterfaceImpl);
+    expect(result!.snapshot).toBe(content);
+    expect(result!.query).toBe('shoes');
   });
 
-  it('returns a RoutedInterface for search_api_response', () => {
+  it('returns a SearchInterfaceImpl for search_api_response', () => {
     const hydrate = createHydrateSubInterface(fullEngine);
-    const content = {
-      results: [
-        {
-          uniqueId: 'r1',
-          title: 'Result 1',
-          uri: 'https://example.com/r1',
-          printableUri: 'example.com/r1',
-          clickUri: 'https://example.com/r1',
-          raw: {},
-          score: 90,
-        },
-      ],
-      totalCount: 1,
-      facets: [],
-    };
+    const content = {results: [{title: 'Doc'}]};
 
-    const result = hydrate('search_api_response', content);
+    const result = hydrate('search_api_response', content, 'docs');
+
     expect(result).not.toBeNull();
     expect(result!.useCase).toBe('search');
-    expect(result!.interface).toBeDefined();
+    expect(result!.interface).toBeInstanceOf(SearchInterfaceImpl);
+    expect(result!.snapshot).toBe(content);
+    expect(result!.query).toBe('docs');
   });
 
-  it('stores hydration snapshot and hydrates products into the sub-interface', async () => {
+  it('uses queryCorrection.correctedQuery over the fallback query', () => {
     const hydrate = createHydrateSubInterface(fullEngine);
     const content = {
-      products: [
-        {
-          permanentid: 'p1',
-          ec_name: 'Test Product',
-          ec_price: 42.0,
-          clickUri: 'https://example.com/p1',
-        },
-      ],
-      pagination: {totalEntries: 1},
-      facets: [],
+      results: [],
+      queryCorrection: {correctedQuery: 'corrected'},
     };
 
-    const result = hydrate('commerce_search_api_response', content);
-    const subInterface = result!.interface;
+    const result = hydrate('commerce_search_api_response', content, 'typo');
 
-    const productSlice = getOrCreateProductListSlice(subInterface);
-    await fullEngine.adoptSlice(productSlice);
-    const productState = fullEngine.read(
-      (state: Record<string, unknown>) =>
-        state[productSlice.name] as {products: unknown[]}
-    );
-    expect(productState.products).toHaveLength(1);
-    expect(productState.products[0]).toMatchObject({
-      permanentid: 'p1',
-      ec_name: 'Test Product',
-    });
+    expect(result!.query).toBe('corrected');
   });
 
-  it('stores hydration snapshot and hydrates results into the sub-interface', async () => {
+  it('falls back to the provided query when queryCorrection is absent', () => {
     const hydrate = createHydrateSubInterface(fullEngine);
-    const content = {
-      results: [
-        {
-          uniqueId: 'r1',
-          title: 'Result 1',
-          uri: 'https://example.com/r1',
-          printableUri: 'example.com/r1',
-          clickUri: 'https://example.com/r1',
-          raw: {field1: 'value1'},
-          score: 95,
-        },
-      ],
-      totalCount: 42,
-      facets: [],
-    };
+    const content = {results: []};
+
+    const result = hydrate('search_api_response', content, 'fallback');
+
+    expect(result!.query).toBe('fallback');
+  });
+
+  it('returns undefined query when neither queryCorrection nor fallback are provided', () => {
+    const hydrate = createHydrateSubInterface(fullEngine);
+    const content = {results: []};
 
     const result = hydrate('search_api_response', content);
-    const subInterface = result!.interface;
 
-    const resultsSlice = getOrCreateResultsSlice(subInterface);
-    await fullEngine.adoptSlice(resultsSlice);
-    const resultState = fullEngine.read(
-      (state: Record<string, unknown>) =>
-        state[resultsSlice.name] as {results: unknown[]}
+    expect(result!.query).toBeUndefined();
+  });
+
+  it('ignores queryCorrection with null correctedQuery', () => {
+    const hydrate = createHydrateSubInterface(fullEngine);
+    const content = {
+      results: [],
+      queryCorrection: {correctedQuery: null},
+    };
+
+    const result = hydrate('commerce_search_api_response', content, 'original');
+
+    expect(result!.query).toBe('original');
+  });
+
+  it('stores the hydration snapshot on the engine', () => {
+    const spy = vi.spyOn(fullEngine, 'storeHydrationSnapshot');
+    const hydrate = createHydrateSubInterface(fullEngine);
+    const content = {results: []};
+
+    const result = hydrate('commerce_search_api_response', content);
+
+    expect(spy).toHaveBeenCalledWith(content, result!.interface);
+  });
+});
+
+describe('rehydrateRoutedInterfaces', () => {
+  let registry: RoutedInterfaceRegistry;
+  let mockHydrate: HydrateSubInterface;
+
+  beforeEach(() => {
+    registry = new RoutedInterfaceRegistry();
+    mockHydrate = vi.fn();
+  });
+
+  it('skips turns without routedInterface', () => {
+    const turns = [{id: 'turn-1'}];
+
+    rehydrateRoutedInterfaces(turns, registry, mockHydrate);
+
+    expect(mockHydrate).not.toHaveBeenCalled();
+    expect(registry.get('turn-1')).toBeUndefined();
+  });
+
+  it('skips turns where routedInterface has no snapshot', () => {
+    const turns = [
+      {id: 'turn-1', routedInterface: {useCase: 'commerceSearch'}},
+    ];
+
+    rehydrateRoutedInterfaces(turns, registry, mockHydrate);
+
+    expect(mockHydrate).not.toHaveBeenCalled();
+  });
+
+  it('skips turns with an unknown useCase', () => {
+    const turns = [
+      {
+        id: 'turn-1',
+        routedInterface: {
+          useCase: 'unknownUseCase',
+          snapshot: {results: []},
+        },
+      },
+    ];
+
+    rehydrateRoutedInterfaces(turns, registry, mockHydrate);
+
+    expect(mockHydrate).not.toHaveBeenCalled();
+  });
+
+  it('calls hydrateSubInterface with the correct activity type and snapshot for commerceSearch', () => {
+    const snapshot = {results: [{title: 'Product'}]};
+    const turns = [
+      {
+        id: 'turn-1',
+        routedInterface: {
+          useCase: 'commerceSearch',
+          snapshot,
+          query: 'shoes',
+        },
+      },
+    ];
+
+    const mockResult = {
+      useCase: 'commerceSearch' as const,
+      interface: {} as any,
+      snapshot,
+      query: 'shoes',
+    };
+    (mockHydrate as ReturnType<typeof vi.fn>).mockReturnValue(mockResult);
+
+    rehydrateRoutedInterfaces(turns, registry, mockHydrate);
+
+    expect(mockHydrate).toHaveBeenCalledWith(
+      'commerce_search_api_response',
+      snapshot,
+      'shoes'
     );
-    expect(resultState.results).toHaveLength(1);
-    expect(resultState.results[0]).toMatchObject({
-      uniqueId: 'r1',
-      title: 'Result 1',
+  });
+
+  it('calls hydrateSubInterface with the correct activity type for search', () => {
+    const snapshot = {results: []};
+    const turns = [
+      {
+        id: 'turn-1',
+        routedInterface: {useCase: 'search', snapshot, query: 'docs'},
+      },
+    ];
+
+    const mockResult = {
+      useCase: 'search' as const,
+      interface: {} as any,
+      snapshot,
+      query: 'docs',
+    };
+    (mockHydrate as ReturnType<typeof vi.fn>).mockReturnValue(mockResult);
+
+    rehydrateRoutedInterfaces(turns, registry, mockHydrate);
+
+    expect(mockHydrate).toHaveBeenCalledWith(
+      'search_api_response',
+      snapshot,
+      'docs'
+    );
+  });
+
+  it('registers the hydration result in the registry', () => {
+    const snapshot = {results: []};
+    const iface = {} as any;
+    const turns = [
+      {
+        id: 'turn-1',
+        routedInterface: {useCase: 'commerceSearch', snapshot, query: 'q'},
+      },
+    ];
+
+    (mockHydrate as ReturnType<typeof vi.fn>).mockReturnValue({
+      useCase: 'commerceSearch',
+      interface: iface,
+      snapshot,
+      query: 'q',
     });
+
+    rehydrateRoutedInterfaces(turns, registry, mockHydrate);
+
+    const entry = registry.get('turn-1');
+    expect(entry).toBeDefined();
+    expect(entry!.useCase).toBe('commerceSearch');
+    expect(entry!.interface).toBe(iface);
+    expect(entry!.snapshot).toBe(snapshot);
+    expect(entry!.query).toBe('q');
+  });
+
+  it('does not register when hydrateSubInterface returns null', () => {
+    const turns = [
+      {
+        id: 'turn-1',
+        routedInterface: {
+          useCase: 'commerceSearch',
+          snapshot: {results: []},
+        },
+      },
+    ];
+
+    (mockHydrate as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+    rehydrateRoutedInterfaces(turns, registry, mockHydrate);
+
+    expect(registry.get('turn-1')).toBeUndefined();
+  });
+
+  it('processes multiple turns independently', () => {
+    const snapshot1 = {results: [{title: 'A'}]};
+    const snapshot2 = {results: [{title: 'B'}]};
+    const iface1 = {id: 1} as any;
+    const iface2 = {id: 2} as any;
+
+    const turns = [
+      {
+        id: 'turn-1',
+        routedInterface: {
+          useCase: 'commerceSearch',
+          snapshot: snapshot1,
+          query: 'a',
+        },
+      },
+      {id: 'turn-2'}, // no routedInterface, should be skipped
+      {
+        id: 'turn-3',
+        routedInterface: {useCase: 'search', snapshot: snapshot2, query: 'b'},
+      },
+    ];
+
+    (mockHydrate as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce({
+        useCase: 'commerceSearch',
+        interface: iface1,
+        snapshot: snapshot1,
+        query: 'a',
+      })
+      .mockReturnValueOnce({
+        useCase: 'search',
+        interface: iface2,
+        snapshot: snapshot2,
+        query: 'b',
+      });
+
+    rehydrateRoutedInterfaces(turns, registry, mockHydrate);
+
+    expect(mockHydrate).toHaveBeenCalledTimes(2);
+    expect(registry.get('turn-1')!.interface).toBe(iface1);
+    expect(registry.get('turn-2')).toBeUndefined();
+    expect(registry.get('turn-3')!.interface).toBe(iface2);
   });
 });

--- a/packages/thermidor/src/internal/features/generative/generative-hydration.test.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-hydration.test.ts
@@ -128,16 +128,6 @@ describe('rehydrateRoutedInterfaces', () => {
     expect(registry.get('turn-1')).toBeUndefined();
   });
 
-  it('skips turns where routedInterface has no snapshot', () => {
-    const turns = [
-      {id: 'turn-1', routedInterface: {useCase: 'commerceSearch'}},
-    ];
-
-    rehydrateRoutedInterfaces(turns, registry, mockHydrate);
-
-    expect(mockHydrate).not.toHaveBeenCalled();
-  });
-
   it('skips turns with an unknown useCase', () => {
     const turns = [
       {
@@ -145,6 +135,7 @@ describe('rehydrateRoutedInterfaces', () => {
         routedInterface: {
           useCase: 'unknownUseCase',
           snapshot: {results: []},
+          query: undefined,
         },
       },
     ];
@@ -244,6 +235,7 @@ describe('rehydrateRoutedInterfaces', () => {
         routedInterface: {
           useCase: 'commerceSearch',
           snapshot: {results: []},
+          query: undefined,
         },
       },
     ];

--- a/packages/thermidor/src/internal/features/generative/generative-hydration.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-hydration.ts
@@ -117,15 +117,15 @@ export function rehydrateRoutedInterfaces(
     id: string;
     routedInterface?: {
       useCase: string;
-      snapshot?: Record<string, unknown>;
-      query?: string;
+      snapshot: Record<string, unknown>;
+      query: string | undefined;
     };
   }[],
   registry: RoutedInterfaceRegistry,
   hydrateSubInterface: HydrateSubInterface
 ): void {
   for (const turn of turns) {
-    if (!turn.routedInterface?.snapshot) {
+    if (!turn.routedInterface) {
       continue;
     }
 

--- a/packages/thermidor/src/internal/features/generative/generative-hydration.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-hydration.ts
@@ -4,8 +4,12 @@ import {getHandleInternals} from '@/src/internal/utils/index.js';
 import {generateId} from '@/src/internal/utils/index.js';
 import type {InterfaceHandle} from '@/src/internal/utils/index.js';
 import type {FullEngine} from '@/src/internal/engine/index.js';
-import type {RoutedInterface, RoutedUseCase} from './generative-types.js';
-import type {HydrateSubInterface} from '@/src/internal/api/generative/index.js';
+import type {RoutedUseCase} from './generative-types.js';
+import type {
+  HydrateSubInterface,
+  HydrationResult,
+} from '@/src/internal/api/generative/index.js';
+import type {RoutedInterfaceRegistry} from './routed-interface-registry.js';
 import {CommerceInterfaceImpl} from '@/src/internal/interfaces/index.js';
 import {SearchInterfaceImpl} from '@/src/internal/interfaces/index.js';
 import {getOrCreateSearchBoxActions} from '@/src/internal/features/search-box/index.js';
@@ -14,6 +18,11 @@ import {getOrCreateSearchBoxSlice} from '@/src/internal/features/search-box/inde
 const ACTIVITY_TYPE_TO_ROUTED_USE_CASE: Record<string, RoutedUseCase> = {
   commerce_search_api_response: 'commerceSearch',
   search_api_response: 'search',
+};
+
+const ROUTED_USE_CASE_TO_ACTIVITY_TYPE: Record<RoutedUseCase, string> = {
+  commerceSearch: 'commerce_search_api_response',
+  search: 'search_api_response',
 };
 
 type HydrateAction = ReturnType<typeof createHydrateAction>;
@@ -42,7 +51,7 @@ export function createHydrateSubInterface(
     activityType: string,
     content: unknown,
     query?: string
-  ): RoutedInterface | null => {
+  ): HydrationResult | null => {
     const routedUseCase = ACTIVITY_TYPE_TO_ROUTED_USE_CASE[activityType];
     if (!routedUseCase) {
       return null;
@@ -61,7 +70,12 @@ export function createHydrateSubInterface(
         const searchBoxActions = getOrCreateSearchBoxActions(subInterface);
         fullEngine.mutate(searchBoxActions.setQuery(effectiveQuery));
       }
-      return {useCase: 'commerceSearch' as const, interface: subInterface};
+      return {
+        useCase: 'commerceSearch' as const,
+        interface: subInterface,
+        snapshot: contentRecord,
+        query: effectiveQuery,
+      };
     }
 
     const subInterface = new SearchInterfaceImpl(fullEngine, generateId());
@@ -73,7 +87,12 @@ export function createHydrateSubInterface(
       const searchBoxActions = getOrCreateSearchBoxActions(subInterface);
       fullEngine.mutate(searchBoxActions.setQuery(effectiveQuery));
     }
-    return {useCase: 'search' as const, interface: subInterface};
+    return {
+      useCase: 'search' as const,
+      interface: subInterface,
+      snapshot: contentRecord,
+      query: effectiveQuery,
+    };
   };
 }
 
@@ -91,4 +110,50 @@ function extractEffectiveQuery(
   }
 
   return fallbackQuery;
+}
+
+/**
+ * Rehydrates routed interfaces from serialized snapshots and registers
+ * them in the registry. Used during restore/conversationToRestore.
+ */
+export function rehydrateRoutedInterfaces(
+  turns: {
+    id: string;
+    routedInterface?: {
+      useCase: string;
+      snapshot?: Record<string, unknown>;
+      query?: string;
+    };
+  }[],
+  registry: RoutedInterfaceRegistry,
+  hydrateSubInterface: HydrateSubInterface
+): void {
+  for (const turn of turns) {
+    if (!turn.routedInterface?.snapshot) {
+      continue;
+    }
+
+    const activityType =
+      ROUTED_USE_CASE_TO_ACTIVITY_TYPE[
+        turn.routedInterface.useCase as RoutedUseCase
+      ];
+    if (!activityType) {
+      continue;
+    }
+
+    const hydrationResult = hydrateSubInterface(
+      activityType,
+      turn.routedInterface.snapshot,
+      turn.routedInterface.query
+    );
+
+    if (hydrationResult) {
+      registry.register(turn.id, {
+        useCase: hydrationResult.useCase,
+        interface: hydrationResult.interface,
+        snapshot: hydrationResult.snapshot,
+        query: hydrationResult.query,
+      });
+    }
+  }
 }

--- a/packages/thermidor/src/internal/features/generative/generative-hydration.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-hydration.ts
@@ -112,10 +112,6 @@ function extractEffectiveQuery(
   return fallbackQuery;
 }
 
-/**
- * Rehydrates routed interfaces from serialized snapshots and registers
- * them in the registry. Used during restore/conversationToRestore.
- */
 export function rehydrateRoutedInterfaces(
   turns: {
     id: string;

--- a/packages/thermidor/src/internal/features/generative/generative-selectors.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-selectors.ts
@@ -4,7 +4,7 @@ import type {InterfaceHandle} from '@/src/internal/utils/index.js';
 import {createMemoizedStateSelector} from '@/src/internal/utils/index.js';
 import {createSelectSlice} from '@/src/internal/utils/index.js';
 import {initialGenerativeState} from './generative-slice.js';
-import type {Turn} from './generative-types.js';
+import type {StateTurn} from './generative-types.js';
 
 type GenerativeSelectors = ReturnType<typeof createGenerativeSelectors>;
 
@@ -21,7 +21,7 @@ export function createGenerativeSelectors(interfaceId: string) {
   return {
     getTurns: createMemoizedStateSelector(
       sliceSelector,
-      (state): Turn[] => state.turns
+      (state): StateTurn[] => state.turns
     ),
     getActiveTurnId: createMemoizedStateSelector(
       sliceSelector,

--- a/packages/thermidor/src/internal/features/generative/generative-slice.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-slice.ts
@@ -49,7 +49,7 @@ export function createGenerativeSlice(
         .addCase(actions.setRoutedInterface, (state, {payload}) => {
           const turn = state.turns.find((t) => t.id === payload.turnId);
           if (turn) {
-            turn.routedInterface = payload.routedInterface;
+            turn.routedInterface = {useCase: payload.useCase};
             turn.status = 'complete';
           }
         })

--- a/packages/thermidor/src/internal/features/generative/generative-types.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-types.ts
@@ -9,6 +9,47 @@ import type {SearchInterface} from '@/src/internal/utils/index.js';
 
 export type TurnStatus = 'streaming' | 'complete' | 'error';
 
+/**
+ * The store-level turn shape. Uses `SerializableRoutedInterface` to avoid
+ * storing non-serializable class instances in the store.
+ */
+export interface StateTurn {
+  /**
+   * The unique identifier of the turn (server-provided or temporary client-generated).
+   */
+  id: string;
+
+  /**
+   * The user-submitted prompt text for this turn.
+   */
+  prompt: string;
+
+  /**
+   * The current lifecycle status of this turn.
+   */
+  status: TurnStatus;
+
+  /**
+   * Present when the turn resulted in routing mode (serializable portion only).
+   */
+  routedInterface?: SerializableRoutedInterface;
+
+  /**
+   * Present when the turn resulted in agent mode.
+   */
+  agentResponse?: AgentResponse;
+
+  /**
+   * A human-readable error message when the turn is in error status.
+   */
+  error?: string;
+}
+
+/**
+ * The public-facing turn shape exposed to consumers.
+ * Contains the full `RoutedInterface` (with the non-serializable interface instance
+ * merged back from the registry).
+ */
 export interface Turn {
   /**
    * The unique identifier of the turn (server-provided or temporary client-generated).
@@ -46,14 +87,28 @@ export type UseCaseInterfaceMap = {
   search: SearchInterface;
 };
 
+export type RoutedUseCase = 'commerceSearch' | 'search';
+
+/**
+ * The serializable portion of a routed interface stored in state.
+ * Does NOT contain the non-serializable interface instance.
+ */
+export type SerializableRoutedInterface = {
+  [K in RoutedUseCase]: {
+    useCase: K;
+  };
+}[RoutedUseCase];
+
+/**
+ * The full routed interface exposed to public consumers.
+ * Contains the non-serializable interface instance merged back from the registry.
+ */
 export type RoutedInterface = {
   [K in RoutedUseCase]: {
     useCase: K;
     interface: UseCaseInterfaceMap[K];
   };
 }[RoutedUseCase];
-
-export type RoutedUseCase = 'commerceSearch' | 'search';
 
 export interface AgentResponse {
   /**
@@ -125,9 +180,9 @@ export type A2UISurface = Record<string, unknown>;
 
 export interface GenerativeState {
   /**
-   * The ordered turn history for this generative interface.
+   * The ordered turn history for this generative interface (serializable only).
    */
-  turns: Turn[];
+  turns: StateTurn[];
 
   /**
    * The id of the currently active turn, or undefined when no turns exist.

--- a/packages/thermidor/src/internal/features/generative/index.ts
+++ b/packages/thermidor/src/internal/features/generative/index.ts
@@ -4,7 +4,16 @@ export {getOrCreateGenerativeSelectors} from './generative-selectors.js';
 export {
   createHydrateSubInterface,
   getOrCreateHydrateFromSnapshotAction,
+  rehydrateRoutedInterfaces,
 } from './generative-hydration.js';
+export {
+  getOrCreateRoutedInterfaceRegistry,
+  mergeTurnsWithRegistry,
+} from './routed-interface-registry.js';
+export type {
+  RoutedInterfaceEntry,
+  RoutedInterfaceRegistry,
+} from './routed-interface-registry.js';
 export type {
   A2UISurface,
   AgentMessage,
@@ -12,6 +21,8 @@ export type {
   GenerativeState,
   RoutedInterface,
   RoutedUseCase,
+  SerializableRoutedInterface,
+  StateTurn,
   ToolCall,
   ToolCallStatus,
   Turn,

--- a/packages/thermidor/src/internal/features/generative/routed-interface-registry.test.ts
+++ b/packages/thermidor/src/internal/features/generative/routed-interface-registry.test.ts
@@ -1,0 +1,209 @@
+import {describe, it, expect} from 'vitest';
+import {
+  RoutedInterfaceRegistry,
+  mergeTurnsWithRegistry,
+} from './routed-interface-registry.js';
+import type {RoutedInterfaceEntry} from './routed-interface-registry.js';
+import type {StateTurn} from './generative-types.js';
+import type {
+  CommerceInterface,
+  SearchInterface,
+} from '@/src/internal/utils/index.js';
+
+function createEntry(
+  overrides: Partial<RoutedInterfaceEntry> = {}
+): RoutedInterfaceEntry {
+  return {
+    useCase: 'commerceSearch',
+    interface: {} as CommerceInterface,
+    snapshot: {results: []},
+    query: 'shoes',
+    ...overrides,
+  };
+}
+
+function createStateTurn(overrides: Partial<StateTurn> = {}): StateTurn {
+  return {
+    id: 'turn-1',
+    prompt: 'find shoes',
+    status: 'complete',
+    ...overrides,
+  };
+}
+
+describe('RoutedInterfaceRegistry', () => {
+  describe('register / get', () => {
+    it('stores and retrieves an entry by turnId', () => {
+      const registry = new RoutedInterfaceRegistry();
+      const entry = createEntry();
+
+      registry.register('turn-1', entry);
+
+      expect(registry.get('turn-1')).toBe(entry);
+    });
+
+    it('returns undefined for an unknown turnId', () => {
+      const registry = new RoutedInterfaceRegistry();
+
+      expect(registry.get('unknown')).toBeUndefined();
+    });
+
+    it('overwrites a previous entry for the same turnId', () => {
+      const registry = new RoutedInterfaceRegistry();
+      const first = createEntry({query: 'first'});
+      const second = createEntry({query: 'second'});
+
+      registry.register('turn-1', first);
+      registry.register('turn-1', second);
+
+      expect(registry.get('turn-1')).toBe(second);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes an existing entry', () => {
+      const registry = new RoutedInterfaceRegistry();
+      registry.register('turn-1', createEntry());
+
+      registry.remove('turn-1');
+
+      expect(registry.get('turn-1')).toBeUndefined();
+    });
+
+    it('is a no-op for an unknown turnId', () => {
+      const registry = new RoutedInterfaceRegistry();
+      registry.register('turn-1', createEntry());
+
+      registry.remove('unknown');
+
+      expect(registry.get('turn-1')).toBeDefined();
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all entries', () => {
+      const registry = new RoutedInterfaceRegistry();
+      registry.register('turn-1', createEntry());
+      registry.register('turn-2', createEntry({query: 'other'}));
+
+      registry.clear();
+
+      expect(registry.get('turn-1')).toBeUndefined();
+      expect(registry.get('turn-2')).toBeUndefined();
+    });
+  });
+
+  describe('entries', () => {
+    it('iterates over all registered entries', () => {
+      const registry = new RoutedInterfaceRegistry();
+      const e1 = createEntry({query: 'a'});
+      const e2 = createEntry({query: 'b'});
+      registry.register('turn-1', e1);
+      registry.register('turn-2', e2);
+
+      const result = [...registry.entries()];
+
+      expect(result).toEqual([
+        ['turn-1', e1],
+        ['turn-2', e2],
+      ]);
+    });
+  });
+});
+
+describe('mergeTurnsWithRegistry', () => {
+  it('passes through turns without routedInterface unchanged', () => {
+    const registry = new RoutedInterfaceRegistry();
+    const turn = createStateTurn();
+
+    const [merged] = mergeTurnsWithRegistry([turn], registry);
+
+    expect(merged).toEqual(turn);
+    expect(merged.routedInterface).toBeUndefined();
+  });
+
+  it('merges the registry interface into a turn that has routedInterface', () => {
+    const registry = new RoutedInterfaceRegistry();
+    const iface = {} as CommerceInterface;
+    registry.register('turn-1', createEntry({interface: iface}));
+
+    const turn = createStateTurn({
+      routedInterface: {useCase: 'commerceSearch'},
+    });
+
+    const [merged] = mergeTurnsWithRegistry([turn], registry);
+
+    expect(merged.routedInterface).toEqual({
+      useCase: 'commerceSearch',
+      interface: iface,
+    });
+  });
+
+  it('strips routedInterface when registry has no entry', () => {
+    const registry = new RoutedInterfaceRegistry();
+    const turn = createStateTurn({
+      routedInterface: {useCase: 'search'},
+    });
+
+    const [merged] = mergeTurnsWithRegistry([turn], registry);
+
+    expect(merged.routedInterface).toBeUndefined();
+  });
+
+  it('handles a mix of turns with and without routed interfaces', () => {
+    const registry = new RoutedInterfaceRegistry();
+    const iface = {} as SearchInterface;
+    registry.register(
+      'turn-2',
+      createEntry({
+        useCase: 'search',
+        interface: iface,
+      })
+    );
+
+    const turns: StateTurn[] = [
+      createStateTurn({id: 'turn-1', prompt: 'hello'}),
+      createStateTurn({
+        id: 'turn-2',
+        prompt: 'search docs',
+        routedInterface: {useCase: 'search'},
+      }),
+      createStateTurn({id: 'turn-3', prompt: 'thanks', status: 'streaming'}),
+    ];
+
+    const merged = mergeTurnsWithRegistry(turns, registry);
+
+    expect(merged).toHaveLength(3);
+    expect(merged[0].routedInterface).toBeUndefined();
+    expect(merged[1].routedInterface).toEqual({
+      useCase: 'search',
+      interface: iface,
+    });
+    expect(merged[2].routedInterface).toBeUndefined();
+  });
+
+  it('preserves all non-routedInterface fields from the state turn', () => {
+    const registry = new RoutedInterfaceRegistry();
+    registry.register('turn-1', createEntry());
+
+    const turn = createStateTurn({
+      id: 'turn-1',
+      prompt: 'find shoes',
+      status: 'complete',
+      routedInterface: {useCase: 'commerceSearch'},
+      agentResponse: {
+        messages: [{content: 'here', role: 'assistant'}],
+        surfaces: [],
+        toolCalls: [],
+        reasoningContent: '',
+      },
+    });
+
+    const [merged] = mergeTurnsWithRegistry([turn], registry);
+
+    expect(merged.id).toBe('turn-1');
+    expect(merged.prompt).toBe('find shoes');
+    expect(merged.status).toBe('complete');
+    expect(merged.agentResponse?.messages[0].content).toBe('here');
+  });
+});

--- a/packages/thermidor/src/internal/features/generative/routed-interface-registry.ts
+++ b/packages/thermidor/src/internal/features/generative/routed-interface-registry.ts
@@ -1,0 +1,111 @@
+import {type CacheKey, createCacheKey} from '@/src/internal/utils/index.js';
+import {getHandleInternals} from '@/src/internal/utils/index.js';
+import type {InterfaceHandle} from '@/src/internal/utils/index.js';
+import type {
+  RoutedInterface,
+  RoutedUseCase,
+  StateTurn,
+  Turn,
+  UseCaseInterfaceMap,
+} from './generative-types.js';
+
+/**
+ * Entry stored in the routed interface registry.
+ * Contains the non-serializable interface instance alongside the
+ * serialization-friendly snapshot data needed for restore.
+ */
+export interface RoutedInterfaceEntry {
+  useCase: RoutedUseCase;
+  interface: UseCaseInterfaceMap[RoutedUseCase];
+  /** The raw API response content used to hydrate the sub-interface. */
+  snapshot: Record<string, unknown>;
+  /** The query that was active when the routed interface was created. */
+  query: string | undefined;
+}
+
+/**
+ * A side-registry that holds non-serializable routed interface instances
+ * outside the store.
+ *
+ * Keyed by turnId. Scoped per generative interface via the cacheRegistry pattern.
+ */
+export class RoutedInterfaceRegistry {
+  #entries = new Map<string, RoutedInterfaceEntry>();
+
+  register(turnId: string, entry: RoutedInterfaceEntry): void {
+    this.#entries.set(turnId, entry);
+  }
+
+  get(turnId: string): RoutedInterfaceEntry | undefined {
+    return this.#entries.get(turnId);
+  }
+
+  remove(turnId: string): void {
+    this.#entries.delete(turnId);
+  }
+
+  clear(): void {
+    this.#entries.clear();
+  }
+
+  entries(): IterableIterator<[string, RoutedInterfaceEntry]> {
+    return this.#entries.entries();
+  }
+}
+
+/**
+ * Merges serializable state turns with the registry to produce
+ * full turns containing non-serializable interface instances.
+ */
+export function mergeTurnsWithRegistry(
+  stateTurns: StateTurn[],
+  registry: RoutedInterfaceRegistry
+): Turn[] {
+  return stateTurns.map((stateTurn): Turn => {
+    if (!stateTurn.routedInterface) {
+      return stateTurn as Turn;
+    }
+
+    const entry = registry.get(stateTurn.id);
+    if (!entry) {
+      // Registry entry not available (e.g. restored without snapshot).
+      // Strip routedInterface to avoid exposing an incomplete object
+      // without the required `interface` field.
+      const {routedInterface: _, ...rest} = stateTurn;
+      return rest as Turn;
+    }
+
+    return {
+      ...stateTurn,
+      routedInterface: buildRoutedInterface(entry),
+    };
+  });
+}
+
+function buildRoutedInterface(entry: RoutedInterfaceEntry): RoutedInterface {
+  switch (entry.useCase) {
+    case 'commerceSearch':
+      return {
+        useCase: 'commerceSearch',
+        interface: entry.interface as UseCaseInterfaceMap['commerceSearch'],
+      };
+    case 'search':
+      return {
+        useCase: 'search',
+        interface: entry.interface as UseCaseInterfaceMap['search'],
+      };
+  }
+}
+
+const CACHE_KEY: CacheKey<RoutedInterfaceRegistry> =
+  createCacheKey<RoutedInterfaceRegistry>('generative/routedInterfaceRegistry');
+
+export function getOrCreateRoutedInterfaceRegistry(
+  iface: InterfaceHandle
+): RoutedInterfaceRegistry {
+  const {cacheRegistry} = getHandleInternals(iface);
+  return cacheRegistry.getOrCreate(
+    CACHE_KEY,
+    () => new RoutedInterfaceRegistry()
+  );
+}

--- a/packages/thermidor/src/internal/features/generative/routed-interface-registry.ts
+++ b/packages/thermidor/src/internal/features/generative/routed-interface-registry.ts
@@ -9,26 +9,13 @@ import type {
   UseCaseInterfaceMap,
 } from './generative-types.js';
 
-/**
- * Entry stored in the routed interface registry.
- * Contains the non-serializable interface instance alongside the
- * serialization-friendly snapshot data needed for restore.
- */
 export interface RoutedInterfaceEntry {
   useCase: RoutedUseCase;
   interface: UseCaseInterfaceMap[RoutedUseCase];
-  /** The raw API response content used to hydrate the sub-interface. */
   snapshot: Record<string, unknown>;
-  /** The query that was active when the routed interface was created. */
   query: string | undefined;
 }
 
-/**
- * A side-registry that holds non-serializable routed interface instances
- * outside the store.
- *
- * Keyed by turnId. Scoped per generative interface via the cacheRegistry pattern.
- */
 export class RoutedInterfaceRegistry {
   #entries = new Map<string, RoutedInterfaceEntry>();
 
@@ -53,10 +40,6 @@ export class RoutedInterfaceRegistry {
   }
 }
 
-/**
- * Merges serializable state turns with the registry to produce
- * full turns containing non-serializable interface instances.
- */
 export function mergeTurnsWithRegistry(
   stateTurns: StateTurn[],
   registry: RoutedInterfaceRegistry
@@ -68,9 +51,6 @@ export function mergeTurnsWithRegistry(
 
     const entry = registry.get(stateTurn.id);
     if (!entry) {
-      // Registry entry not available (e.g. restored without snapshot).
-      // Strip routedInterface to avoid exposing an incomplete object
-      // without the required `interface` field.
       const {routedInterface: _, ...rest} = stateTurn;
       return rest as Turn;
     }

--- a/packages/thermidor/src/public/controllers/converse/converse-controller-serialization.test.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller-serialization.test.ts
@@ -102,7 +102,11 @@ describe('deserializeToGenerativeState', () => {
     const serialized = createSerializedState({
       turns: [
         createSerializedTurn({
-          routedInterface: {useCase: 'commerceSearch'},
+          routedInterface: {
+            useCase: 'commerceSearch',
+            snapshot: {results: []},
+            query: undefined,
+          },
         }),
       ],
     });

--- a/packages/thermidor/src/public/controllers/converse/converse-controller-serialization.test.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller-serialization.test.ts
@@ -1,0 +1,201 @@
+import {describe, it, expect} from 'vitest';
+import {
+  deserializeToGenerativeState,
+  type SerializedConverseState,
+  type SerializedTurn,
+} from './converse-controller-serialization.js';
+
+function createSerializedTurn(
+  overrides: Partial<SerializedTurn> = {}
+): SerializedTurn {
+  return {
+    id: 'turn-1',
+    prompt: 'hello',
+    status: 'complete',
+    ...overrides,
+  };
+}
+
+function createSerializedState(
+  overrides: Partial<SerializedConverseState> = {}
+): SerializedConverseState {
+  return {
+    name: 'test conversation',
+    timestamp: 1000,
+    turns: [],
+    activeTurnId: undefined,
+    ...overrides,
+  };
+}
+
+describe('deserializeToGenerativeState', () => {
+  it('maps basic fields from serialized state', () => {
+    const serialized = createSerializedState({
+      activeTurnId: 'turn-1',
+      conversationSessionId: 'session-abc',
+      conversationToken: 'token-xyz',
+      turns: [createSerializedTurn()],
+    });
+
+    const result = deserializeToGenerativeState(serialized);
+
+    expect(result.activeTurnId).toBe('turn-1');
+    expect(result.conversationSessionId).toBe('session-abc');
+    expect(result.conversationToken).toBe('token-xyz');
+    expect(result.turns).toHaveLength(1);
+  });
+
+  it('preserves turn id, prompt, and status', () => {
+    const serialized = createSerializedState({
+      turns: [
+        createSerializedTurn({
+          id: 'abc',
+          prompt: 'find shoes',
+          status: 'complete',
+        }),
+      ],
+    });
+
+    const result = deserializeToGenerativeState(serialized);
+
+    expect(result.turns[0].id).toBe('abc');
+    expect(result.turns[0].prompt).toBe('find shoes');
+    expect(result.turns[0].status).toBe('complete');
+  });
+
+  it('marks streaming turns as error with an interruption message', () => {
+    const serialized = createSerializedState({
+      turns: [createSerializedTurn({status: 'streaming'})],
+    });
+
+    const result = deserializeToGenerativeState(serialized);
+
+    expect(result.turns[0].status).toBe('error');
+    expect(result.turns[0].error).toBe('Stream was interrupted');
+  });
+
+  it('does not modify turns that are already in error status', () => {
+    const serialized = createSerializedState({
+      turns: [
+        createSerializedTurn({status: 'error', error: 'Something broke'}),
+      ],
+    });
+
+    const result = deserializeToGenerativeState(serialized);
+
+    expect(result.turns[0].status).toBe('error');
+    expect(result.turns[0].error).toBe('Something broke');
+  });
+
+  it('does not modify complete turns', () => {
+    const serialized = createSerializedState({
+      turns: [createSerializedTurn({status: 'complete'})],
+    });
+
+    const result = deserializeToGenerativeState(serialized);
+
+    expect(result.turns[0].status).toBe('complete');
+    expect(result.turns[0].error).toBeUndefined();
+  });
+
+  it('maps routedInterface useCase into the state turn', () => {
+    const serialized = createSerializedState({
+      turns: [
+        createSerializedTurn({
+          routedInterface: {useCase: 'commerceSearch'},
+        }),
+      ],
+    });
+
+    const result = deserializeToGenerativeState(serialized);
+
+    expect(result.turns[0].routedInterface).toEqual({
+      useCase: 'commerceSearch',
+    });
+  });
+
+  it('omits routedInterface when not present in the serialized turn', () => {
+    const serialized = createSerializedState({
+      turns: [createSerializedTurn()],
+    });
+
+    const result = deserializeToGenerativeState(serialized);
+
+    expect(result.turns[0].routedInterface).toBeUndefined();
+  });
+
+  it('strips snapshot and query from routedInterface (state only holds useCase)', () => {
+    const serialized = createSerializedState({
+      turns: [
+        createSerializedTurn({
+          routedInterface: {
+            useCase: 'search',
+            snapshot: {results: []},
+            query: 'docs',
+          },
+        }),
+      ],
+    });
+
+    const result = deserializeToGenerativeState(serialized);
+
+    expect(result.turns[0].routedInterface).toEqual({useCase: 'search'});
+    expect((result.turns[0].routedInterface as any).snapshot).toBeUndefined();
+    expect((result.turns[0].routedInterface as any).query).toBeUndefined();
+  });
+
+  it('preserves agentResponse data through deserialization', () => {
+    const agentResponse = {
+      messages: [{content: 'Here are your results', role: 'assistant'}],
+      surfaces: [],
+      toolCalls: [],
+      reasoningContent: 'thinking...',
+    };
+
+    const serialized = createSerializedState({
+      turns: [createSerializedTurn({agentResponse})],
+    });
+
+    const result = deserializeToGenerativeState(serialized);
+
+    expect(result.turns[0].agentResponse).toEqual(agentResponse);
+  });
+
+  it('handles an empty turns array', () => {
+    const serialized = createSerializedState({turns: []});
+
+    const result = deserializeToGenerativeState(serialized);
+
+    expect(result.turns).toEqual([]);
+  });
+
+  it('handles multiple turns with mixed statuses', () => {
+    const serialized = createSerializedState({
+      turns: [
+        createSerializedTurn({id: 't1', status: 'complete'}),
+        createSerializedTurn({id: 't2', status: 'streaming'}),
+        createSerializedTurn({id: 't3', status: 'error', error: 'fail'}),
+      ],
+    });
+
+    const result = deserializeToGenerativeState(serialized);
+
+    expect(result.turns[0].status).toBe('complete');
+    expect(result.turns[1].status).toBe('error');
+    expect(result.turns[1].error).toBe('Stream was interrupted');
+    expect(result.turns[2].status).toBe('error');
+    expect(result.turns[2].error).toBe('fail');
+  });
+
+  it('handles undefined conversationSessionId and conversationToken', () => {
+    const serialized = createSerializedState({
+      conversationSessionId: undefined,
+      conversationToken: undefined,
+    });
+
+    const result = deserializeToGenerativeState(serialized);
+
+    expect(result.conversationSessionId).toBeUndefined();
+    expect(result.conversationToken).toBeUndefined();
+  });
+});

--- a/packages/thermidor/src/public/controllers/converse/converse-controller-serialization.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller-serialization.ts
@@ -20,11 +20,6 @@ export interface SerializedConverseState {
 
 export interface SerializedRoutedInterface {
   useCase: string;
-  /**
-   * The raw API response content used to rehydrate the sub-interface on restore.
-   * Can be large (full commerce/search response). Consumers persisting
-   * `SerializedConverseState` should be mindful of storage budgets.
-   */
   snapshot?: Record<string, unknown>;
   query?: string;
 }
@@ -33,11 +28,6 @@ export interface SerializedTurn extends Omit<StateTurn, 'routedInterface'> {
   routedInterface?: SerializedRoutedInterface | undefined;
 }
 
-/**
- * Converts a `SerializedConverseState` into the internal `GenerativeState`
- * shape suitable for store hydration. Handles edge cases like marking
- * interrupted streams as errors.
- */
 export function deserializeToGenerativeState(
   serialized: SerializedConverseState
 ): GenerativeState {

--- a/packages/thermidor/src/public/controllers/converse/converse-controller-serialization.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller-serialization.ts
@@ -1,4 +1,13 @@
-import type {Turn} from '@/src/internal/features/generative/index.js';
+import type {
+  GenerativeState,
+  RoutedUseCase,
+  StateTurn,
+} from '@/src/internal/features/generative/index.js';
+
+const VALID_USE_CASES: Set<string> = new Set<string>([
+  'commerceSearch',
+  'search',
+]);
 
 export interface SerializedConverseState {
   name: string;
@@ -9,6 +18,51 @@ export interface SerializedConverseState {
   activeTurnId: string | undefined;
 }
 
-export type SerializedTurn = Omit<Turn, 'routedInterface'> & {
-  routedInterface?: {useCase: string} | undefined;
-};
+export interface SerializedRoutedInterface {
+  useCase: string;
+  /**
+   * The raw API response content used to rehydrate the sub-interface on restore.
+   * Can be large (full commerce/search response). Consumers persisting
+   * `SerializedConverseState` should be mindful of storage budgets.
+   */
+  snapshot?: Record<string, unknown>;
+  query?: string;
+}
+
+export interface SerializedTurn extends Omit<StateTurn, 'routedInterface'> {
+  routedInterface?: SerializedRoutedInterface | undefined;
+}
+
+/**
+ * Converts a `SerializedConverseState` into the internal `GenerativeState`
+ * shape suitable for store hydration. Handles edge cases like marking
+ * interrupted streams as errors.
+ */
+export function deserializeToGenerativeState(
+  serialized: SerializedConverseState
+): GenerativeState {
+  const turns: StateTurn[] = serialized.turns.map((serializedTurn) => {
+    const {routedInterface, ...rest} = serializedTurn;
+    const turn: StateTurn = {...rest};
+
+    if (turn.status === 'streaming') {
+      turn.status = 'error';
+      turn.error = 'Stream was interrupted';
+    }
+
+    if (routedInterface && VALID_USE_CASES.has(routedInterface.useCase)) {
+      turn.routedInterface = {
+        useCase: routedInterface.useCase as RoutedUseCase,
+      };
+    }
+
+    return turn;
+  });
+
+  return {
+    turns,
+    activeTurnId: serialized.activeTurnId,
+    conversationSessionId: serialized.conversationSessionId,
+    conversationToken: serialized.conversationToken,
+  };
+}

--- a/packages/thermidor/src/public/controllers/converse/converse-controller-serialization.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller-serialization.ts
@@ -1,5 +1,6 @@
 import type {
   GenerativeState,
+  RoutedInterfaceRegistry,
   RoutedUseCase,
   StateTurn,
 } from '@/src/internal/features/generative/index.js';
@@ -28,8 +29,17 @@ export interface SerializedTurn extends Omit<StateTurn, 'routedInterface'> {
   routedInterface?: SerializedRoutedInterface | undefined;
 }
 
+/**
+ * Converts a `SerializedConverseState` into the internal `GenerativeState`
+ * shape suitable for store hydration. Handles edge cases like marking
+ * interrupted streams as errors.
+ *
+ * Only populates `routedInterface` on a turn when the registry has a
+ * corresponding entry, ensuring store and registry stay in sync.
+ */
 export function deserializeToGenerativeState(
-  serialized: SerializedConverseState
+  serialized: SerializedConverseState,
+  registry?: RoutedInterfaceRegistry
 ): GenerativeState {
   const turns: StateTurn[] = serialized.turns.map((serializedTurn) => {
     const {routedInterface, ...rest} = serializedTurn;
@@ -40,7 +50,11 @@ export function deserializeToGenerativeState(
       turn.error = 'Stream was interrupted';
     }
 
-    if (routedInterface && VALID_USE_CASES.has(routedInterface.useCase)) {
+    if (
+      routedInterface &&
+      VALID_USE_CASES.has(routedInterface.useCase) &&
+      (!registry || registry.get(turn.id))
+    ) {
       turn.routedInterface = {
         useCase: routedInterface.useCase as RoutedUseCase,
       };

--- a/packages/thermidor/src/public/controllers/converse/converse-controller-serialization.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller-serialization.ts
@@ -20,8 +20,8 @@ export interface SerializedConverseState {
 
 export interface SerializedRoutedInterface {
   useCase: string;
-  snapshot?: Record<string, unknown>;
-  query?: string;
+  snapshot: Record<string, unknown>;
+  query: string | undefined;
 }
 
 export interface SerializedTurn extends Omit<StateTurn, 'routedInterface'> {

--- a/packages/thermidor/src/public/controllers/converse/converse-controller.test.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller.test.ts
@@ -313,7 +313,7 @@ describe('buildConverseController', () => {
       expect(result.activeTurnId).toBe('turn-1');
     });
 
-    it('reduces routedInterface to {useCase} only', () => {
+    it('serializes routedInterface with useCase, snapshot, and query (without the live interface instance)', () => {
       const controller = buildController();
       const actions = getOrCreateGenerativeActions(generativeInterface);
       const registry = getOrCreateRoutedInterfaceRegistry(generativeInterface);

--- a/packages/thermidor/src/public/controllers/converse/converse-controller.test.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller.test.ts
@@ -5,7 +5,10 @@ import {
   type FullEngine,
   getFullEngine,
 } from '@/src/internal/engine/index.js';
-import {getOrCreateGenerativeActions} from '@/src/internal/features/generative/index.js';
+import {
+  getOrCreateGenerativeActions,
+  getOrCreateRoutedInterfaceRegistry,
+} from '@/src/internal/features/generative/index.js';
 import {
   buildGenerativeInterface,
   type GenerativeInterface,
@@ -313,6 +316,7 @@ describe('buildConverseController', () => {
     it('reduces routedInterface to {useCase} only', () => {
       const controller = buildController();
       const actions = getOrCreateGenerativeActions(generativeInterface);
+      const registry = getOrCreateRoutedInterfaceRegistry(generativeInterface);
 
       fullEngine.mutate(
         actions.createTurn({
@@ -321,13 +325,16 @@ describe('buildConverseController', () => {
           status: 'streaming',
         })
       );
+      registry.register('turn-1', {
+        useCase: 'commerceSearch',
+        interface: {} as never,
+        snapshot: {results: []},
+        query: 'shoes',
+      });
       fullEngine.mutate(
         actions.setRoutedInterface({
           turnId: 'turn-1',
-          routedInterface: {
-            useCase: 'commerceSearch',
-            interface: {} as never,
-          },
+          useCase: 'commerceSearch',
         })
       );
       fullEngine.mutate(actions.completeTurn({turnId: 'turn-1'}));
@@ -336,6 +343,8 @@ describe('buildConverseController', () => {
 
       expect(result.turns[0].routedInterface).toEqual({
         useCase: 'commerceSearch',
+        snapshot: {results: []},
+        query: 'shoes',
       });
     });
 

--- a/packages/thermidor/src/public/controllers/converse/converse-controller.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller.ts
@@ -172,11 +172,13 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
       const serialized: SerializedTurn = {...rest};
       if (routedInterface) {
         const entry = this.#registry.get(turn.id);
-        serialized.routedInterface = {
-          useCase: routedInterface.useCase,
-          snapshot: entry?.snapshot,
-          query: entry?.query,
-        };
+        if (entry) {
+          serialized.routedInterface = {
+            useCase: routedInterface.useCase,
+            snapshot: entry.snapshot,
+            query: entry.query,
+          };
+        }
       }
       return serialized;
     });

--- a/packages/thermidor/src/public/controllers/converse/converse-controller.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller.ts
@@ -43,15 +43,16 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
     const hydrateSubInterface = createHydrateSubInterface(fullEngine);
 
     if (options.conversationToRestore) {
-      const hydratedState = deserializeToGenerativeState(
-        options.conversationToRestore
-      );
-      fullEngine.mutate(actions.hydrateState(hydratedState));
       rehydrateRoutedInterfaces(
         options.conversationToRestore.turns,
         registry,
         hydrateSubInterface
       );
+      const hydratedState = deserializeToGenerativeState(
+        options.conversationToRestore,
+        registry
+      );
+      fullEngine.mutate(actions.hydrateState(hydratedState));
     }
 
     const controllerState = createMemoizedStateSelector(
@@ -199,13 +200,13 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
 
   restore(state: SerializedConverseState): void {
     this.#registry.clear();
-    const hydratedState = deserializeToGenerativeState(state);
-    this.engine.mutate(this.#actions.hydrateState(hydratedState));
     rehydrateRoutedInterfaces(
       state.turns,
       this.#registry,
       this.#hydrateSubInterface
     );
+    const hydratedState = deserializeToGenerativeState(state, this.#registry);
+    this.engine.mutate(this.#actions.hydrateState(hydratedState));
   }
 
   clear(): void {

--- a/packages/thermidor/src/public/controllers/converse/converse-controller.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller.ts
@@ -1,17 +1,28 @@
 import type {
-  GenerativeState,
+  RoutedInterfaceRegistry,
   Turn,
 } from '@/src/internal/features/generative/index.js';
-import {GenerativeRuntime} from '@/src/internal/api/generative/index.js';
-import {createHydrateSubInterface} from '@/src/internal/features/generative/index.js';
-import {BaseController} from '@/src/internal/utils/index.js';
-import {createMemoizedStateSelector} from '@/src/internal/utils/index.js';
-import {getHandleInternals} from '@/src/internal/utils/index.js';
-import {getOrCreateGenerativeActions} from '@/src/internal/features/generative/index.js';
-import {getOrCreateGenerativeSelectors} from '@/src/internal/features/generative/index.js';
-import type {GenerativeInterface} from '@/src/internal/utils/index.js';
-import type {Controller} from '@/src/internal/utils/index.js';
 import {
+  createHydrateSubInterface,
+  getOrCreateGenerativeActions,
+  getOrCreateGenerativeSelectors,
+  getOrCreateRoutedInterfaceRegistry,
+  mergeTurnsWithRegistry,
+  rehydrateRoutedInterfaces,
+} from '@/src/internal/features/generative/index.js';
+import {GenerativeRuntime} from '@/src/internal/api/generative/index.js';
+import type {HydrateSubInterface} from '@/src/internal/api/generative/index.js';
+import {
+  BaseController,
+  createMemoizedStateSelector,
+  getHandleInternals,
+} from '@/src/internal/utils/index.js';
+import type {
+  GenerativeInterface,
+  Controller,
+} from '@/src/internal/utils/index.js';
+import {
+  deserializeToGenerativeState,
   SerializedConverseState,
   SerializedTurn,
 } from './converse-controller-serialization.js';
@@ -20,38 +31,50 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
   #runtime: GenerativeRuntime;
   #actions: ReturnType<typeof getOrCreateGenerativeActions>;
   #selectors: ReturnType<typeof getOrCreateGenerativeSelectors>;
+  #registry: RoutedInterfaceRegistry;
+  #hydrateSubInterface: HydrateSubInterface;
 
   constructor(options: ConverseControllerOptions) {
-    const {engine: fullEngine} = getHandleInternals(options.interface);
+    const {engine: fullEngine, stateId} = getHandleInternals(options.interface);
 
     const actions = getOrCreateGenerativeActions(options.interface);
     const selectors = getOrCreateGenerativeSelectors(options.interface);
+    const registry = getOrCreateRoutedInterfaceRegistry(options.interface);
+    const hydrateSubInterface = createHydrateSubInterface(fullEngine);
 
     if (options.conversationToRestore) {
-      const hydratedState = hydrateFromSerializedState(
+      const hydratedState = deserializeToGenerativeState(
         options.conversationToRestore
       );
       fullEngine.mutate(actions.hydrateState(hydratedState));
+      rehydrateRoutedInterfaces(
+        options.conversationToRestore.turns,
+        registry,
+        hydrateSubInterface
+      );
     }
-
-    const {stateId} = getHandleInternals(options.interface);
 
     const controllerState = createMemoizedStateSelector(
       selectors.getTurns,
       selectors.getActiveTurnId,
-      (turns, activeTurnId): ConverseControllerState => ({
-        turns,
-        activeTurn: activeTurnId
-          ? turns.find((t) => t.id === activeTurnId)
-          : undefined,
-        isStreaming: turns.some((t) => t.status === 'streaming'),
-      })
+      (stateTurns, activeTurnId): ConverseControllerState => {
+        const turns = mergeTurnsWithRegistry(stateTurns, registry);
+        return {
+          turns,
+          activeTurn: activeTurnId
+            ? turns.find((t) => t.id === activeTurnId)
+            : undefined,
+          isStreaming: turns.some((t) => t.status === 'streaming'),
+        };
+      }
     );
 
     super(fullEngine, controllerState);
 
     this.#actions = actions;
     this.#selectors = selectors;
+    this.#registry = registry;
+    this.#hydrateSubInterface = hydrateSubInterface;
     this.#runtime = GenerativeRuntime.getInstance(fullEngine, stateId, {
       generativeInterface: options.interface,
       cartInterface: options.interface,
@@ -63,11 +86,20 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
           this.engine.mutate(this.#actions.setActiveTurnId(id));
         },
         replaceTurnId: (oldId, newId) => {
+          const entry = this.#registry.get(oldId);
+          if (entry) {
+            this.#registry.remove(oldId);
+            this.#registry.register(newId, entry);
+          }
           this.engine.mutate(this.#actions.replaceTurnId({oldId, newId}));
         },
-        setRoutedInterface: (turnId, routedInterface) => {
+        setRoutedInterface: (turnId, hydrationResult) => {
+          this.#registry.register(turnId, hydrationResult);
           this.engine.mutate(
-            this.#actions.setRoutedInterface({turnId, routedInterface})
+            this.#actions.setRoutedInterface({
+              turnId,
+              useCase: hydrationResult.useCase,
+            })
           );
         },
         initAgentResponse: (turnId) => {
@@ -108,6 +140,7 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
           this.engine.mutate(this.#actions.failTurn({turnId, error}));
         },
         clearTurnResponse: (turnId) => {
+          this.#registry.remove(turnId);
           this.engine.mutate(this.#actions.clearTurnResponse({turnId}));
         },
         startReasoning: (turnId) => {
@@ -127,7 +160,7 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
           );
         },
       },
-      hydrateSubInterface: createHydrateSubInterface(fullEngine),
+      hydrateSubInterface,
     });
   }
 
@@ -138,7 +171,12 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
       const {routedInterface, ...rest} = turn;
       const serialized: SerializedTurn = {...rest};
       if (routedInterface) {
-        serialized.routedInterface = {useCase: routedInterface.useCase};
+        const entry = this.#registry.get(turn.id);
+        serialized.routedInterface = {
+          useCase: routedInterface.useCase,
+          snapshot: entry?.snapshot,
+          query: entry?.query,
+        };
       }
       return serialized;
     });
@@ -158,11 +196,18 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
   }
 
   restore(state: SerializedConverseState): void {
-    const hydratedState = hydrateFromSerializedState(state);
+    this.#registry.clear();
+    const hydratedState = deserializeToGenerativeState(state);
     this.engine.mutate(this.#actions.hydrateState(hydratedState));
+    rehydrateRoutedInterfaces(
+      state.turns,
+      this.#registry,
+      this.#hydrateSubInterface
+    );
   }
 
   clear(): void {
+    this.#registry.clear();
     this.engine.mutate(
       this.#actions.hydrateState({
         turns: [],
@@ -223,27 +268,4 @@ export interface ConverseControllerOptions {
   interface: GenerativeInterface;
   conversationToRestore?: SerializedConverseState;
   onSurfaceOperation?: (operations: unknown[]) => void;
-}
-
-function hydrateFromSerializedState(
-  serialized: SerializedConverseState
-): GenerativeState {
-  const turns: Turn[] = serialized.turns.map((serializedTurn) => {
-    const {routedInterface: _routedInterface, ...rest} = serializedTurn;
-    const turn: Turn = {...rest};
-
-    if (turn.status === 'streaming') {
-      turn.status = 'error';
-      turn.error = 'Stream was interrupted';
-    }
-
-    return turn;
-  });
-
-  return {
-    turns,
-    activeTurnId: serialized.activeTurnId,
-    conversationSessionId: serialized.conversationSessionId,
-    conversationToken: serialized.conversationToken,
-  };
 }

--- a/packages/thermidor/src/public/controllers/index.ts
+++ b/packages/thermidor/src/public/controllers/index.ts
@@ -28,6 +28,7 @@ export type {
 } from './converse/converse-controller.js';
 export type {
   SerializedConverseState,
+  SerializedRoutedInterface,
   SerializedTurn,
 } from './converse/converse-controller-serialization.js';
 export {buildProductListController} from './product-list/product-list-controller.js';

--- a/samples/thermidor/generative-react/src/components/ConversationArea/ConversationArea.tsx
+++ b/samples/thermidor/generative-react/src/components/ConversationArea/ConversationArea.tsx
@@ -1,27 +1,9 @@
+import type {Turn} from '@coveo/thermidor';
 import {UserPrompt} from '../UserPrompt/UserPrompt.js';
 import {AgentResponse} from '../AgentResponse/AgentResponse.js';
 import {RoutedCommerceResults} from '../RoutedCommerceResults/RoutedCommerceResults.js';
 import {RoutedSearchResults} from '../RoutedSearchResults/RoutedSearchResults.js';
 import styles from './ConversationArea.module.css';
-
-interface Turn {
-  id: string;
-  prompt: string;
-  status: 'streaming' | 'complete' | 'error';
-  routedInterface?: {useCase: string; interface: unknown};
-  agentResponse?: {
-    messages: {content: string; role: string}[];
-    surfaces: Record<string, unknown>[];
-    toolCalls: {
-      id: string;
-      name: string;
-      args: string;
-      result?: string;
-      status: 'calling' | 'completed';
-    }[];
-  };
-  error?: string;
-}
 
 export interface ConversationAreaProps {
   turn: Turn | undefined;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5896

## Problem

The converse feature stored `CommerceInterfaceImpl` and `SearchInterfaceImpl` class instances directly in the store (at `turns[N].routedInterface.interface`), triggering serialization warnings on every dispatch involving routed interfaces.

## Solution

Introduced a `RoutedInterfaceRegistry`: a per-interface side-map (`Map<turnId, entry>`) that holds the non-serializable instances outside the store. The store now only keeps `{useCase} (serializable)`, and the controller's state selector merges the registry data back at read time so consumers still see the full `Turn` with `routedInterface.interface` populated.

Additionally, routed interfaces are now rehydrated on restore: `serialize()` persists the API response snapshot alongside the `useCase`, and `restore()` recreates live sub-interface instances from those snapshots (fixing a bug where restored conversations lost their routed interfaces.).

## Note

`SerializedRoutedInterface` `.snapshot` and `.query` are now required fields. Previously serialized conversations without these fields will not restore routed interfaces. Internal samples are adjusted in this PR.

This is acceptable since Thermidor is still in early development and no external consumers will be affected by this breaking API change.

## Tests

Added unit tests for:

- `RoutedInterfaceRegistry`
- `mergeTurnsWithRegistry`
- `rehydrateRoutedInterfaces`
- `deserializeToGenerativeState`