### PR TITLE
fix(create-ui): support npm binary invocation

### DIFF
--- a/.changeset/fix-create-ui-npm-bin.md
+++ b/.changeset/fix-create-ui-npm-bin.md
@@ -1,0 +1,5 @@
+---
+'@coveo/create-ui': patch
+---
+
+Fix execution through npm-installed binaries.

--- a/packages/create-ui/package.json
+++ b/packages/create-ui/package.json
@@ -30,7 +30,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node ./dist/index.js",
-    "test": "vitest run",
+    "test": "vitest run && pnpm test:pack",
+    "test:pack": "node ./scripts/test-packed-bin.mjs",
     "test:watch": "vitest",
     "clean": "node ../../utils/ci/rm-rf.mjs dist"
   },

--- a/packages/create-ui/scripts/test-packed-bin.mjs
+++ b/packages/create-ui/scripts/test-packed-bin.mjs
@@ -1,0 +1,42 @@
+import {execFileSync} from 'node:child_process';
+import {mkdir, mkdtemp, readdir, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const tempDir = await mkdtemp(join(tmpdir(), 'create-ui-pack-'));
+const installDir = join(tempDir, 'install');
+
+await mkdir(installDir);
+
+try {
+  execFileSync('pnpm', ['pack', '--pack-destination', tempDir], {
+    cwd: packageDir,
+    stdio: 'inherit',
+  });
+
+  const packageFile = (await readdir(tempDir)).find((file) =>
+    file.endsWith('.tgz')
+  );
+  if (packageFile === undefined) {
+    throw new Error('pnpm pack did not produce a package tarball.');
+  }
+
+  execFileSync(
+    'npm',
+    [
+      'install',
+      '--ignore-scripts',
+      '--no-package-lock',
+      join(tempDir, packageFile),
+    ],
+    {cwd: installDir, stdio: 'inherit'}
+  );
+  execFileSync('npm', ['exec', '--no', '--', 'create-ui', '--help'], {
+    cwd: installDir,
+    stdio: 'inherit',
+  });
+} finally {
+  await rm(tempDir, {recursive: true, force: true});
+}

--- a/packages/create-ui/src/index.ts
+++ b/packages/create-ui/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import {Command, CommanderError} from 'commander';
+import {realpathSync} from 'node:fs';
 import {mkdir, mkdtemp, rm} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join, resolve} from 'node:path';
@@ -281,7 +282,8 @@ export async function main(rawArgs: string[]): Promise<number> {
 }
 
 const isDirectRun =
-  argv[1] !== undefined && fileURLToPath(import.meta.url) === argv[1];
+  argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === realpathSync(argv[1]);
 
 if (isDirectRun) {
   process.on('uncaughtException', (err) => {


### PR DESCRIPTION
## Problem
The published `@coveo/create-ui` CLI exits successfully without running when npm invokes its `.bin` shim. The direct-run guard compares the shim path with the resolved module path as literal strings.

## Solution
Resolve the invoked executable path before comparing it to the CLI module path. Add a normal-test packed-artifact smoke test that runs `pnpm pack`, installs the tarball in a fresh npm project, and verifies `npm exec create-ui --help` through the installed bin.