### PR TITLE
chore(ci): publish create-ui previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,6 +674,7 @@ jobs:
             './packages/create-atomic-component-project' \
             './packages/create-atomic-result-component' \
             './packages/create-atomic-rollup-plugin' \
+            './packages/create-ui' \
             './packages/headless' \
             './packages/headless-react' \
             './packages/relay' \


### PR DESCRIPTION
## Problem
`@coveo/create-ui` is not included in the explicit package list published to pkg.pr.new for pull requests, so its packed preview cannot be tested before release.

## Solution
Add `./packages/create-ui` to the pkg.pr.new publish command in the CI preview job.