### PR TITLE
chore: clean up recommended vscode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,11 +2,9 @@
   "recommendations": [
     "oxc.oxc-vscode",
     "streetsidesoftware.code-spell-checker",
-    "github.copilot-chat",
     "runem.lit-plugin",
     "unifiedjs.vscode-mdx",
     "ms-playwright.playwright",
     "bradlc.vscode-tailwindcss",
-    "vitest.explorer"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,6 @@
     "runem.lit-plugin",
     "unifiedjs.vscode-mdx",
     "ms-playwright.playwright",
-    "bradlc.vscode-tailwindcss",
+    "bradlc.vscode-tailwindcss"
   ]
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5900

Removed:
- Vitest (it's buggy)
- GH Copilot chat (no longer useful)