### PR TITLE
fix(ci): serve prebuilt CDN artifacts in Playwright

### DIFF
--- a/packages/atomic-hosted-page/playwright.config.ts
+++ b/packages/atomic-hosted-page/playwright.config.ts
@@ -83,7 +83,7 @@ export default defineConfig({
       stderr: 'pipe',
     },
     isCDN && {
-      command: 'pnpm exec turbo start --filter=@coveo/cdn',
+      command: 'pnpm --filter @coveo/cdn start',
       timeout: 10 * 60e3,
       port: 3000,
       reuseExistingServer: !process.env.CI,

--- a/packages/atomic/playwright.config.ts
+++ b/packages/atomic/playwright.config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
   webServer: process.env.CI
     ? {
         command: isCDN
-          ? 'pnpm exec turbo start --filter=@coveo/cdn'
+          ? 'pnpm --filter @coveo/cdn start'
           : `pnpm exec turbo dev --filter=@coveo/atomic`,
         env: {
           STORYBOOK_INVOKED_BY: 'playwright',


### PR DESCRIPTION
## Problem
CDN Playwright checks run after CI has already built the CDN collection, but their `turbo start --filter=@coveo/cdn` web server command triggers the full CDN build graph again. Cache misses can exhaust the 120-second Playwright startup budget before the server begins listening.

## Solution
Serve the prebuilt CDN collection directly with `pnpm --filter @coveo/cdn start` in Atomic and Atomic Hosted Page CDN-mode Playwright configurations. Normal non-CDN startup behavior is unchanged.

## Validation
- `CI=1 DEPLOYMENT_ENVIRONMENT=CDN pnpm exec turbo build --filter=@coveo/cdn`
- Atomic CDN Playwright phase: 10 passed (7.71s wall time)
- Atomic Hosted Page CDN Playwright phase: 9 passed (15.99s wall time)
- `pnpm run lint:fix` completed Oxlint, Oxfmt, and Quantic lint-fix; its final CSpell phase exited `-7` (known non-code failure).