### PR TITLE
fix(headless): logGeneratedAnswerStreamEnd never used insight use-case

### DIFF
--- a/.changeset/insight-generated-answer-stream-end.md
+++ b/.changeset/insight-generated-answer-stream-end.md
@@ -1,0 +1,5 @@
+---
+"@coveo/headless": patch
+---
+
+Fixed `logGeneratedAnswerStreamEnd` always logging the Search analytics event, even when the `GeneratedAnswer` controller is built on an Insight engine. The Insight-specific `logGeneratedAnswerStreamEnd` action is now correctly invoked for Insight use cases, and its signature was aligned with the Search version (`answerGenerated`, `answerId?`, `answerTextIsEmpty?`) so callers must now explicitly provide `answerTextIsEmpty` in both cases.

--- a/.changeset/insight-generated-answer-stream-end.md
+++ b/.changeset/insight-generated-answer-stream-end.md
@@ -2,4 +2,4 @@
 "@coveo/headless": patch
 ---
 
-Fixed `logGeneratedAnswerStreamEnd` always logging the Search analytics event, even when the `GeneratedAnswer` controller is built on an Insight engine. The Insight-specific `logGeneratedAnswerStreamEnd` action is now correctly invoked for Insight use cases, and its signature was aligned with the Search version (`answerGenerated`, `answerId?`, `answerTextIsEmpty?`) so callers must now explicitly provide `answerTextIsEmpty` in both cases.
+Fixed `logGeneratedAnswerStreamEnd` always logging the Search analytics event, even when the `GeneratedAnswer` controller is built on an Insight engine. The Insight-specific `logGeneratedAnswerStreamEnd` action is now correctly invoked for Insight use cases, and its signature was aligned with the Search version (`answerGenerated`, `answerId?`, `answerTextIsEmpty?`).

--- a/packages/headless/src/api/knowledge/stream-answer-api.ts
+++ b/packages/headless/src/api/knowledge/stream-answer-api.ts
@@ -8,10 +8,8 @@ import {
   updateCitations,
   updateMessage,
 } from '../../features/generated-answer/generated-answer-actions.js';
-import {
-  logGeneratedAnswerResponseLinked,
-  logGeneratedAnswerStreamEnd,
-} from '../../features/generated-answer/generated-answer-analytics-actions.js';
+import {logGeneratedAnswerResponseLinked} from '../../features/generated-answer/generated-answer-analytics-actions.js';
+import type {GeneratedAnswerAnalyticsClient} from '../../features/generated-answer/generated-answer-analytics-client.js';
 import type {AnswerApiQueryParams} from '../../features/generated-answer/generated-answer-request.js';
 import {fetchEventSource} from '../../utils/fetch-event-source/fetch.js';
 import type {EventSourceMessage} from '../../utils/fetch-event-source/parse.js';
@@ -108,7 +106,8 @@ const handleError = (
 export const updateCacheWithEvent = (
   event: EventSourceMessage,
   draft: GeneratedAnswerStream,
-  dispatch: ThunkDispatch<StreamAnswerAPIState, unknown, UnknownAction>
+  dispatch: ThunkDispatch<StreamAnswerAPIState, unknown, UnknownAction>,
+  analyticsClient?: GeneratedAnswerAnalyticsClient
 ) => {
   const message: Required<MessageType> = JSON.parse(event.data);
   if (message.finishReason === 'ERROR' && message.errorMessage) {
@@ -145,13 +144,15 @@ export const updateCacheWithEvent = (
       const answerTextIsEmpty = answerGenerated
         ? !draft.answer?.trim()
         : undefined;
-      dispatch(
-        logGeneratedAnswerStreamEnd(
-          answerGenerated,
-          answerId,
-          answerTextIsEmpty
-        )
-      );
+      if (analyticsClient) {
+        dispatch(
+          analyticsClient.logGeneratedAnswerStreamEnd(
+            answerGenerated,
+            answerId,
+            answerTextIsEmpty
+          )
+        );
+      }
       dispatch(logGeneratedAnswerResponseLinked());
       break;
     }
@@ -192,11 +193,15 @@ export const answerApi = answerSlice.injectEndpoints({
       serializeQueryArgs: ({endpointName, queryArgs}) => {
         // RTK Query serialize our endpoints and they're serialized state arguments as the key in the store.
         // Keys must match, because if anything in the query changes, it's not the same query anymore.
-        // Analytics data is excluded entirely as it contains volatile fields that change during streaming.
-        const {analytics: _analytics, ...queryArgsWithoutAnalytics} = queryArgs;
+        // `analyticsClient` is excluded entirely as it holds a non-serializable callback that is not
+        // part of the actual API request payload and doesn't affect the resulting cached answer.
+        const {
+          analyticsClient: _analyticsClient,
+          ...queryArgsWithoutAnalyticsClient
+        } = queryArgs;
 
-        // Standard RTK key, with analytics excluded
-        return `${endpointName}(${JSON.stringify(queryArgsWithoutAnalytics)})`;
+        // Standard RTK key, with analyticsClient excluded
+        return `${endpointName}(${JSON.stringify(queryArgsWithoutAnalyticsClient)})`;
       },
       async onCacheEntryAdded(
         args,
@@ -222,10 +227,11 @@ export const answerApi = answerSlice.injectEndpoints({
           generatedAnswer.answerConfigurationId!,
           insightConfiguration?.insightId
         );
+        const {analyticsClient: _analyticsClient, ...requestBody} = args;
 
         await fetchEventSource(answerEndpoint, {
           method: 'POST',
-          body: JSON.stringify(args),
+          body: JSON.stringify(requestBody),
           headers: {
             Authorization: `Bearer ${accessToken}`,
             Accept: 'application/json',
@@ -244,7 +250,12 @@ export const answerApi = answerSlice.injectEndpoints({
           },
           onmessage: (event) => {
             updateCachedData((draft) => {
-              updateCacheWithEvent(event, draft, dispatch);
+              updateCacheWithEvent(
+                event,
+                draft,
+                dispatch,
+                args.analyticsClient
+              );
             });
           },
           onerror: (error) => {

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
@@ -205,7 +205,7 @@ describe('#streamAnswerApi', () => {
           answerGenerated: true,
         },
       });
-      const draft = buildDefaultDraft({answer: 'some answer'});
+      const draft = buildDefaultDraft({answer: 'some answer', answerId: '1'});
 
       updateCacheWithEvent(event, draft, dispatch);
 
@@ -229,6 +229,63 @@ describe('#streamAnswerApi', () => {
       expect(draft).toHaveProperty('generated', false);
       expect(draft).toHaveProperty('isStreaming', false);
       expect(dispatch).toHaveBeenCalled();
+    });
+
+    it('should invoke the provided analyticsClient.logGeneratedAnswerStreamEnd with the right arguments', () => {
+      const dispatch = vi.fn();
+      const logGeneratedAnswerStreamEnd = vi.fn().mockReturnValue({
+        type: 'analytics/generatedAnswer/streamEnd',
+      });
+      const analyticsClient = {
+        logLikeGeneratedAnswer: vi.fn(),
+        logDislikeGeneratedAnswer: vi.fn(),
+        logGeneratedAnswerFeedback: vi.fn(),
+        logOpenGeneratedAnswerSource: vi.fn(),
+        logHoverCitation: vi.fn(),
+        logGeneratedAnswerShowAnswers: vi.fn(),
+        logGeneratedAnswerHideAnswers: vi.fn(),
+        logCopyGeneratedAnswer: vi.fn(),
+        logRetryGeneratedAnswer: vi.fn(),
+        logGeneratedAnswerExpand: vi.fn(),
+        logGeneratedAnswerCollapse: vi.fn(),
+        logGeneratedAnswerStreamEnd,
+      };
+      const event = buildSuccessEvent({
+        payloadType: 'genqa.endOfStreamType',
+        payload: {
+          answerGenerated: true,
+        },
+      });
+      const draft = buildDefaultDraft({answer: 'some answer', answerId: '1'});
+
+      updateCacheWithEvent(event, draft, dispatch, analyticsClient);
+
+      expect(logGeneratedAnswerStreamEnd).toHaveBeenCalledWith(
+        true,
+        '1',
+        false
+      );
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'analytics/generatedAnswer/streamEnd',
+      });
+    });
+
+    it('should not throw and should not dispatch a streamEnd analytics action when analytics is not provided', () => {
+      const dispatch = vi.fn();
+      const event = buildSuccessEvent({
+        payloadType: 'genqa.endOfStreamType',
+        payload: {
+          answerGenerated: true,
+        },
+      });
+      const draft = buildDefaultDraft({answer: 'some answer', answerId: '1'});
+
+      expect(() => updateCacheWithEvent(event, draft, dispatch)).not.toThrow();
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'analytics/generatedAnswer/streamEnd',
+        })
+      );
     });
   });
 

--- a/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
+++ b/packages/headless/src/api/knowledge/tests/stream-answer-api.test.ts
@@ -231,7 +231,7 @@ describe('#streamAnswerApi', () => {
       expect(dispatch).toHaveBeenCalled();
     });
 
-    it('should invoke the provided analyticsClient.logGeneratedAnswerStreamEnd with the right arguments', () => {
+    it('should invoke the provided analyticsClient.logGeneratedAnswerStreamEnd with the right arguments when a genqa.endOfStreamType event is received', () => {
       const dispatch = vi.fn();
       const logGeneratedAnswerStreamEnd = vi.fn().mockReturnValue({
         type: 'analytics/generatedAnswer/streamEnd',

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -1,8 +1,4 @@
 import type {CoreEngine} from '../../../app/engine.js';
-import type {
-  CustomAction,
-  LegacySearchAction,
-} from '../../../features/analytics/analytics-utils.js';
 import {
   closeGeneratedAnswerFeedbackModal,
   collapseGeneratedAnswer,
@@ -17,6 +13,7 @@ import {
   updateResponseFormat,
 } from '../../../features/generated-answer/generated-answer-actions.js';
 import type {GeneratedAnswerFeedback} from '../../../features/generated-answer/generated-answer-analytics-actions.js';
+import type {GeneratedAnswerAnalyticsClient} from '../../../features/generated-answer/generated-answer-analytics-client.js';
 import {generatedAnswerReducer as generatedAnswer} from '../../../features/generated-answer/generated-answer-slice.js';
 import type {GeneratedAnswerState} from '../../../features/generated-answer/generated-answer-state.js';
 import type {GeneratedResponseFormat} from '../../../features/generated-answer/generated-response-format.js';
@@ -132,46 +129,6 @@ export interface GeneratedAnswer extends Controller {
     citationHoverTimeMs: number,
     answerId: string
   ): void;
-}
-
-export interface GeneratedAnswerAnalyticsClient {
-  /** @deprecated */
-  logLikeGeneratedAnswer(): CustomAction;
-  logLikeGeneratedAnswer(answerId?: string): CustomAction;
-  /** @deprecated */
-  logDislikeGeneratedAnswer(): CustomAction;
-  logDislikeGeneratedAnswer(answerId?: string): CustomAction;
-  logGeneratedAnswerFeedback: (
-    feedback: GeneratedAnswerFeedback
-  ) => CustomAction;
-  /** @deprecated */
-  logOpenGeneratedAnswerSource(citationId: string): CustomAction;
-  logOpenGeneratedAnswerSource(
-    citationId: string,
-    answerId?: string
-  ): CustomAction;
-  logOpenGeneratedAnswerFollowUpSource?(
-    citationId: string,
-    answerId: string
-  ): CustomAction;
-  /** @deprecated */
-  logHoverCitation(
-    citationId: string,
-    citationHoverTimeMs: number
-  ): CustomAction;
-  logHoverCitation(
-    citationId: string,
-    citationHoverTimeMs: number,
-    answerId?: string
-  ): CustomAction;
-  logGeneratedAnswerShowAnswers: () => CustomAction;
-  logGeneratedAnswerHideAnswers: () => CustomAction;
-  /** @deprecated */
-  logCopyGeneratedAnswer(): CustomAction;
-  logCopyGeneratedAnswer(answerId?: string): CustomAction;
-  logRetryGeneratedAnswer: () => LegacySearchAction;
-  logGeneratedAnswerExpand: () => CustomAction;
-  logGeneratedAnswerCollapse: () => CustomAction;
 }
 
 export interface GeneratedAnswerPropsInitialState {

--- a/packages/headless/src/controllers/core/generated-answer/headless-searchapi-generated-answer.test.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-searchapi-generated-answer.test.ts
@@ -318,7 +318,10 @@ describe('searchapi-generated-answer', () => {
         },
       };
 
-      subscribeStateManagerMock.subscribeToSearchRequests(engine);
+      subscribeStateManagerMock.subscribeToSearchRequests(
+        engine,
+        generatedAnswerAnalyticsClient
+      );
     };
 
     beforeEach(() => {
@@ -346,6 +349,19 @@ describe('searchapi-generated-answer', () => {
       listener();
 
       expect(streamAnswer).toHaveBeenCalled();
+    });
+
+    it('should pass the analytics client into streamAnswer', () => {
+      setupEngine(true);
+
+      const listener = engine.subscribe.mock.calls[0][0];
+      listener();
+
+      expect(streamAnswer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          analyticsClient: generatedAnswerAnalyticsClient,
+        })
+      );
     });
 
     it('should not stream answer when generated answer is disabled', () => {

--- a/packages/headless/src/controllers/core/generated-answer/headless-searchapi-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-searchapi-generated-answer.ts
@@ -22,9 +22,9 @@ import {randomID} from '../../../utils/utils.js';
 import {
   buildCoreGeneratedAnswer,
   type GeneratedAnswer,
-  type GeneratedAnswerAnalyticsClient,
   type GeneratedAnswerProps,
 } from './headless-core-generated-answer.js';
+import type {GeneratedAnswerAnalyticsClient} from '../../../features/generated-answer/generated-answer-analytics-client.js';
 
 interface SearchAPIGeneratedAnswer extends GeneratedAnswer {}
 
@@ -44,7 +44,8 @@ interface SubscribeStateManager {
       GeneratedAnswerSection & SearchSection & DebugSection,
       ClientThunkExtraArguments<GeneratedAnswerAPIClient>,
       ConfigurationState
-    >
+    >,
+    analyticsClient: GeneratedAnswerAnalyticsClient
   ) => Unsubscribe;
 }
 
@@ -67,7 +68,7 @@ export const subscribeStateManager: SubscribeStateManager = {
     return true;
   },
 
-  subscribeToSearchRequests: (engine) => {
+  subscribeToSearchRequests: (engine, analyticsClient) => {
     const strictListener = () => {
       const state = engine.state;
       const requestId = state.search.requestId;
@@ -103,6 +104,7 @@ export const subscribeStateManager: SubscribeStateManager = {
           streamAnswer({
             setAbortControllerRef: (ref: AbortController) =>
               subscribeStateManager.setAbortControllerRef(ref, genQaEngineId),
+            analyticsClient,
           })
         );
       }
@@ -157,7 +159,7 @@ export function buildSearchAPIGeneratedAnswer(
     };
   }
 
-  subscribeStateManager.subscribeToSearchRequests(engine);
+  subscribeStateManager.subscribeToSearchRequests(engine, analyticsClient);
 
   const isSearchEngine = (
     engine: SearchEngine | InsightEngine

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.test.ts
@@ -523,6 +523,22 @@ describe('knowledge-generated-answer', () => {
           expect(mockGenerateAnswer).toHaveBeenCalledTimes(1);
         });
 
+        it('should pass the generatedAnswerAnalyticsClient into generateAnswer', () => {
+          mockSelectAnswerTriggerParams.mockReturnValue({
+            q: 'test query',
+            requestId: 'new-request',
+            cannotAnswer: false,
+            analyticsMode: 'legacy',
+            actionCause: 'searchboxSubmit',
+          });
+
+          listener();
+
+          expect(mockGenerateAnswer).toHaveBeenCalledWith({
+            analyticsClient: generatedAnswerAnalyticsClient,
+          });
+        });
+
         it('should call generateAnswer for each new request with query', () => {
           mockSelectAnswerTriggerParams
             .mockReturnValueOnce({

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-answerapi-generated-answer.ts
@@ -35,9 +35,9 @@ import {loadReducerError} from '../../../utils/errors.js';
 import {
   buildCoreGeneratedAnswer,
   type GeneratedAnswer,
-  type GeneratedAnswerAnalyticsClient,
   type GeneratedAnswerProps,
 } from '../../core/generated-answer/headless-core-generated-answer.js';
+import type {GeneratedAnswerAnalyticsClient} from '../../../features/generated-answer/generated-answer-analytics-client.js';
 
 interface AnswerApiGeneratedAnswer extends Omit<
   GeneratedAnswer,
@@ -99,7 +99,8 @@ const parseEvaluationArguments = ({
 });
 
 const subscribeToSearchRequest = (
-  engine: SearchEngine<StreamAnswerAPIState>
+  engine: SearchEngine<StreamAnswerAPIState>,
+  analyticsClient: SearchAPIGeneratedAnswerAnalyticsClient
 ) => {
   let lastRequestId = '';
 
@@ -119,7 +120,11 @@ const subscribeToSearchRequest = (
       }
 
       if (triggerParams.q?.length > 0) {
-        engine.dispatch(generateAnswer());
+        engine.dispatch(
+          generateAnswer({
+            analyticsClient,
+          })
+        );
       }
     }
   };
@@ -157,7 +162,10 @@ export function buildAnswerApiGeneratedAnswer(
   const getState = () => engine.state;
   engine.dispatch(updateAnswerConfigurationId(props.answerConfigurationId!));
 
-  subscribeToSearchRequest(engine as SearchEngine<StreamAnswerAPIState>);
+  subscribeToSearchRequest(
+    engine as SearchEngine<StreamAnswerAPIState>,
+    analyticsClient
+  );
 
   return {
     ...controller,

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
@@ -29,9 +29,9 @@ import {loadReducerError} from '../../../utils/errors.js';
 import {
   buildCoreGeneratedAnswer,
   type GeneratedAnswer,
-  type GeneratedAnswerAnalyticsClient,
   type GeneratedAnswerProps,
 } from '../../core/generated-answer/headless-core-generated-answer.js';
+import type {GeneratedAnswerAnalyticsClient} from '../../../features/generated-answer/generated-answer-analytics-client.js';
 
 export interface GeneratedAnswerWithFollowUpsState extends GeneratedAnswerState {
   followUpAnswers: FollowUpAnswersState;

--- a/packages/headless/src/features/generated-answer/generated-answer-actions.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-actions.test.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any -- unit tests */
 import {buildMockCitation} from '../../test/mock-citation.js';
+import {generatedAnswerAnalyticsClient} from './generated-answer-analytics-actions.js';
 import {
   generateAnswer,
   registerFieldsToIncludeInCitations,
@@ -12,6 +13,7 @@ import {
   updateMessage,
   updateResponseFormat,
 } from './generated-answer-actions.js';
+import {constructAnswerAPIQueryParams} from './generated-answer-request.js';
 import {
   type GeneratedContentFormat,
   generatedContentFormat,
@@ -221,6 +223,44 @@ describe('generated answer', () => {
         expect.stringContaining(
           'Missing answerConfigurationId in engine configuration'
         )
+      );
+    });
+
+    it('should default to the Search analytics client when called without arguments (backward compatibility)', async () => {
+      const thunk = generateAnswer();
+      await expect(
+        thunk(mockDispatch, mockGetState, mockExtra)
+      ).resolves.not.toThrow();
+
+      expect(constructAnswerAPIQueryParams).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        generatedAnswerAnalyticsClient
+      );
+    });
+
+    it('should thread the provided analyticsClient into constructAnswerAPIQueryParams', async () => {
+      const analyticsClient = {
+        logLikeGeneratedAnswer: vi.fn(),
+        logDislikeGeneratedAnswer: vi.fn(),
+        logGeneratedAnswerFeedback: vi.fn(),
+        logOpenGeneratedAnswerSource: vi.fn(),
+        logHoverCitation: vi.fn(),
+        logGeneratedAnswerShowAnswers: vi.fn(),
+        logGeneratedAnswerHideAnswers: vi.fn(),
+        logCopyGeneratedAnswer: vi.fn(),
+        logRetryGeneratedAnswer: vi.fn(),
+        logGeneratedAnswerExpand: vi.fn(),
+        logGeneratedAnswerCollapse: vi.fn(),
+        logGeneratedAnswerStreamEnd: vi.fn(),
+      };
+      const thunk = generateAnswer({analyticsClient});
+      await thunk(mockDispatch, mockGetState, mockExtra);
+
+      expect(constructAnswerAPIQueryParams).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        analyticsClient
       );
     });
 

--- a/packages/headless/src/features/generated-answer/generated-answer-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-actions.ts
@@ -21,6 +21,8 @@ import type {StreamAnswerAPIState} from '../../api/knowledge/stream-answer-api-s
 import type {AsyncThunkOptions} from '../../app/async-thunk-options.js';
 import type {SearchThunkExtraArguments} from '../../app/search-thunk-extra-arguments.js';
 import type {AnswerApiQueryParams} from '../../features/generated-answer/generated-answer-request.js';
+import {generatedAnswerAnalyticsClient} from './generated-answer-analytics-actions.js';
+import type {GeneratedAnswerAnalyticsClient} from './generated-answer-analytics-client.js';
 import type {
   ConfigurationSection,
   DebugSection,
@@ -32,10 +34,7 @@ import {
   requiredNonEmptyString,
   validatePayload,
 } from '../../utils/validate-payload.js';
-import {
-  logGeneratedAnswerResponseLinked,
-  logGeneratedAnswerStreamEnd,
-} from './generated-answer-analytics-actions.js';
+import {logGeneratedAnswerResponseLinked} from './generated-answer-analytics-actions.js';
 import {
   buildStreamingRequest,
   constructAnswerAPIQueryParams,
@@ -293,6 +292,11 @@ export const toolCallArgs = createAction(
 
 interface StreamAnswerArgs {
   setAbortControllerRef: (ref: AbortController) => void;
+  /**
+   * The analytics client used to log analytics events with the behavior appropriate for the
+   * current use case (e.g., Search vs Insight).
+   */
+  analyticsClient: GeneratedAnswerAnalyticsClient;
 }
 
 export const streamAnswer = createAsyncThunk<
@@ -305,7 +309,7 @@ export const streamAnswer = createAsyncThunk<
   const {search} = getState();
   const {queryExecuted} = search;
 
-  const {setAbortControllerRef} = params;
+  const {setAbortControllerRef, analyticsClient} = params;
 
   const request = await buildStreamingRequest(state);
 
@@ -345,7 +349,7 @@ export const streamAnswer = createAsyncThunk<
         dispatch(setIsStreaming(false));
         dispatch(setIsAnswerGenerated(isAnswerGenerated));
         dispatch(
-          logGeneratedAnswerStreamEnd(
+          analyticsClient.logGeneratedAnswerStreamEnd(
             isAnswerGenerated,
             answerId,
             isAnswerGenerated ? isAnswerTextEmpty : undefined
@@ -419,13 +423,24 @@ export const streamAnswer = createAsyncThunk<
  * 2. Construct the Answer API query parameters based on the current state.
  * 3. Fetch a new answer from the Answer API using the provided configuration.
  */
+export interface GenerateAnswerArgs {
+  /**
+   * The analytics client used to log analytics events with the behavior appropriate for the
+   * current use case (e.g., Search vs Insight).
+   *
+   * Defaults to the Search analytics client when not provided.
+   */
+  analyticsClient?: GeneratedAnswerAnalyticsClient;
+}
+
 export const generateAnswer = createAsyncThunk<
   void,
-  void,
+  GenerateAnswerArgs | void,
   AsyncThunkOptions<StreamAnswerAPIState, SearchThunkExtraArguments>
 >(
   'generatedAnswer/generateAnswer',
-  async (_, {getState, dispatch, extra: {navigatorContext, logger}}) => {
+  async (args, {getState, dispatch, extra: {navigatorContext, logger}}) => {
+    const {analyticsClient = generatedAnswerAnalyticsClient} = args ?? {};
     dispatch(resetAnswer());
 
     const state = getState() as StreamAnswerAPIState;
@@ -440,7 +455,8 @@ export const generateAnswer = createAsyncThunk<
     if (state.generatedAnswer.answerConfigurationId) {
       const answerApiQueryParams = constructAnswerAPIQueryParams(
         state,
-        navigatorContext
+        navigatorContext,
+        analyticsClient
       );
       // TODO: SVCC-5178 Refactor multiple sequential dispatches into single action
       dispatch(setAnswerApiQueryParams(answerApiQueryParams));

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-client.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-client.ts
@@ -1,0 +1,61 @@
+import type {
+  CustomAction,
+  LegacySearchAction,
+} from '../analytics/analytics-utils.js';
+import type {GeneratedAnswerFeedback} from './generated-answer-analytics-actions.js';
+
+/**
+ * Defines the analytics actions that a `GeneratedAnswer` controller needs to log
+ * analytics events for generated answers.
+ *
+ * This interface is implemented separately for each use case (e.g., `generatedAnswerAnalyticsClient`
+ * for Search, `generatedAnswerInsightAnalyticsClient` for Insight), and the appropriate
+ * implementation is resolved and passed down at controller-build time.
+ *
+ * @group Controllers
+ * @category GeneratedAnswer
+ */
+export interface GeneratedAnswerAnalyticsClient {
+  /** @deprecated */
+  logLikeGeneratedAnswer(): CustomAction;
+  logLikeGeneratedAnswer(answerId?: string): CustomAction;
+  /** @deprecated */
+  logDislikeGeneratedAnswer(): CustomAction;
+  logDislikeGeneratedAnswer(answerId?: string): CustomAction;
+  logGeneratedAnswerFeedback: (
+    feedback: GeneratedAnswerFeedback
+  ) => CustomAction;
+  /** @deprecated */
+  logOpenGeneratedAnswerSource(citationId: string): CustomAction;
+  logOpenGeneratedAnswerSource(
+    citationId: string,
+    answerId?: string
+  ): CustomAction;
+  logOpenGeneratedAnswerFollowUpSource?(
+    citationId: string,
+    answerId: string
+  ): CustomAction;
+  /** @deprecated */
+  logHoverCitation(
+    citationId: string,
+    citationHoverTimeMs: number
+  ): CustomAction;
+  logHoverCitation(
+    citationId: string,
+    citationHoverTimeMs: number,
+    answerId?: string
+  ): CustomAction;
+  logGeneratedAnswerShowAnswers: () => CustomAction;
+  logGeneratedAnswerHideAnswers: () => CustomAction;
+  /** @deprecated */
+  logCopyGeneratedAnswer(): CustomAction;
+  logCopyGeneratedAnswer(answerId?: string): CustomAction;
+  logRetryGeneratedAnswer: () => LegacySearchAction;
+  logGeneratedAnswerExpand: () => CustomAction;
+  logGeneratedAnswerCollapse: () => CustomAction;
+  logGeneratedAnswerStreamEnd(
+    answerGenerated: boolean,
+    answerId?: string,
+    answerTextIsEmpty?: boolean
+  ): CustomAction;
+}

--- a/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.test.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.test.ts
@@ -289,18 +289,18 @@ describe('generated answer insight analytics actions', () => {
     });
 
     [false, true].map((answerGenerated) => {
-      it('should log #logGeneratedAnswerStreamEnd with the right payload', async () => {
-        await logGeneratedAnswerStreamEnd(answerGenerated)()(
-          engine.dispatch,
-          () => engine.state,
-          {} as ThunkExtraArguments
-        );
+      it(`should log #logGeneratedAnswerStreamEnd with ${answerGenerated ? 'generated' : 'not generated'} and 'empty' answer`, async () => {
+        await logGeneratedAnswerStreamEnd(
+          answerGenerated,
+          undefined,
+          answerGenerated ? true : undefined
+        )()(engine.dispatch, () => engine.state, {} as ThunkExtraArguments);
 
         const mockToUse = mockLogGeneratedAnswerStreamEnd;
         const expectedMetadata = {
           generativeQuestionAnsweringId: exampleGenerativeQuestionAnsweringId,
           answerGenerated,
-          answerTextIsEmpty: answerGenerated || undefined,
+          answerTextIsEmpty: answerGenerated ? true : undefined,
         };
 
         expect(mockToUse).toHaveBeenCalledTimes(1);
@@ -309,6 +309,27 @@ describe('generated answer insight analytics actions', () => {
           expectedCaseContext
         );
       });
+    });
+
+    it('should use a provided answerTextIsEmpty value', async () => {
+      await logGeneratedAnswerStreamEnd(true, undefined, false)()(
+        engine.dispatch,
+        () => engine.state,
+        {} as ThunkExtraArguments
+      );
+
+      const mockToUse = mockLogGeneratedAnswerStreamEnd;
+      const expectedMetadata = {
+        generativeQuestionAnsweringId: exampleGenerativeQuestionAnsweringId,
+        answerGenerated: true,
+        answerTextIsEmpty: false,
+      };
+
+      expect(mockToUse).toHaveBeenCalledTimes(1);
+      expect(mockToUse).toHaveBeenCalledWith(
+        expectedMetadata,
+        expectedCaseContext
+      );
     });
 
     it('should log #logGeneratedAnswerShowAnswers with the right payload', async () => {

--- a/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
@@ -217,18 +217,19 @@ export const logGeneratedAnswerFeedback = (
     },
   });
 
-//TODO: SFINT-5435
+// TODO: SFINT-5435
+// TODO: In the next major version, make `answerId` required and remove the fallback
+// to `generativeQuestionAnsweringIdSelector(state)`.
 export const logGeneratedAnswerStreamEnd = (
-  answerGenerated: boolean
+  answerGenerated: boolean,
+  answerId?: string,
+  answerTextIsEmpty?: boolean
 ): InsightAction =>
   makeInsightAnalyticsActionFactory(SearchPageEvents.generatedAnswerStreamEnd)({
     prefix: 'analytics/generatedAnswer/streamEnd',
     __legacy__getBuilder: (client, state) => {
       const generativeQuestionAnsweringId =
-        generativeQuestionAnsweringIdSelector(state);
-      const answerTextIsEmpty = answerGenerated
-        ? !state.generatedAnswer?.answer?.trim()
-        : undefined;
+        answerId ?? generativeQuestionAnsweringIdSelector(state);
       if (!generativeQuestionAnsweringId) {
         return null;
       }
@@ -244,7 +245,7 @@ export const logGeneratedAnswerStreamEnd = (
     analyticsType: 'Rga.AnswerReceived',
     analyticsPayloadBuilder: (state): Rga.AnswerReceived | undefined => {
       const generativeQuestionAnsweringId =
-        generativeQuestionAnsweringIdSelector(state);
+        answerId ?? generativeQuestionAnsweringIdSelector(state);
       return {
         answerId: generativeQuestionAnsweringId ?? '',
         answerGenerated,

--- a/packages/headless/src/features/generated-answer/generated-answer-request.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-request.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../api/search/search-api-params.js';
 import type {CaseContextParam} from '../../api/service/insight/query/query-request.js';
 import type {NavigatorContext} from '../../app/navigator-context-provider.js';
+import type {GeneratedAnswerAnalyticsClient} from './generated-answer-analytics-client.js';
 import {selectAdvancedSearchQueries} from '../../features/advanced-search-queries/advanced-search-query-selectors.js';
 import {fromAnalyticsStateToAnalyticsParams} from '../../features/configuration/analytics-params.js';
 import {selectContext} from '../../features/context/context-selector.js';
@@ -68,7 +69,14 @@ export interface AnswerApiQueryParams
       SearchRequest,
       keyof (BaseParam & AuthenticationParam & AutomaticFacetsParams)
     >,
-    CaseContextParam {}
+    CaseContextParam {
+  /**
+   * The analytics client used to log analytics events with the behavior appropriate for the
+   * current use case (e.g., Search vs Insight). Excluded from the RTK Query cache key since
+   * it is not part of the actual API request payload.
+   */
+  analyticsClient?: GeneratedAnswerAnalyticsClient;
+}
 
 export const buildStreamingRequest = async (
   state: StateNeededByGeneratedAnswerStream
@@ -85,7 +93,8 @@ export const buildStreamingRequest = async (
 
 export const constructAnswerAPIQueryParams = (
   state: StreamAnswerAPIState,
-  navigatorContext: NavigatorContext
+  navigatorContext: NavigatorContext,
+  analyticsClient?: GeneratedAnswerAnalyticsClient
 ): AnswerApiQueryParams => {
   const q = selectQuery(state)?.q;
 
@@ -170,6 +179,7 @@ export const constructAnswerAPIQueryParams = (
     ...(state.insightCaseContext?.caseContext && {
       caseContext: state.insightCaseContext?.caseContext,
     }),
+    ...(analyticsClient && {analyticsClient}),
   };
 };
 


### PR DESCRIPTION
### SFINT-6870 

proposal to fix insight generatedAnswerStreamEnd by adding an optional Analytics Client pass-through to the streaming client so they can properly dispatch the right analytics action.