### PR TITLE
refactor(headless): inject answer generation analytics client to listener middleware

### DIFF
--- a/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/answer-agent-runner.test.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/answer-agent-runner.test.ts
@@ -62,6 +62,10 @@ describe('createAnswerRunner', () => {
   };
   const navigatorProvider = vi.fn(() => navigatorContext);
   const exampleStrategy = {onRunStartedEvent: () => {}};
+  const analytics = {
+    logGeneratedAnswerStreamEnd: vi.fn(),
+    logGeneratedAnswerResponseLinked: vi.fn(),
+  } as any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -86,8 +90,8 @@ describe('createAnswerRunner', () => {
     const runner = buildRunner();
 
     await Promise.all([
-      runner.run(state, dispatch, navigatorProvider),
-      runner.run(state, dispatch, navigatorProvider),
+      runner.run(state, dispatch, navigatorProvider, analytics),
+      runner.run(state, dispatch, navigatorProvider, analytics),
     ]);
 
     expect(abortRunMock).toHaveBeenCalledTimes(1);
@@ -96,7 +100,7 @@ describe('createAnswerRunner', () => {
   it('creates the agent using configuration selectors', async () => {
     const runner = buildRunner();
 
-    await runner.run(state, dispatch, navigatorProvider);
+    await runner.run(state, dispatch, navigatorProvider, analytics);
 
     expect(createAnswerAgent).toHaveBeenCalledWith(
       'agent-123',
@@ -108,9 +112,9 @@ describe('createAnswerRunner', () => {
   it('builds the strategy and executes the agent with forwarded props', async () => {
     const runner = buildRunner();
 
-    await runner.run(state, dispatch, navigatorProvider);
+    await runner.run(state, dispatch, navigatorProvider, analytics);
 
-    expect(createHeadAnswerStrategy).toHaveBeenCalledWith(dispatch);
+    expect(createHeadAnswerStrategy).toHaveBeenCalledWith(dispatch, analytics);
     expect(constructGenerateHeadAnswerParams).toHaveBeenCalledWith(
       state,
       navigatorContext
@@ -132,7 +136,7 @@ describe('createAnswerRunner', () => {
     vi.mocked(selectDebugAgentSession).mockReturnValue(true);
     const runner = buildRunner();
 
-    await runner.run(state, dispatch, navigatorProvider);
+    await runner.run(state, dispatch, navigatorProvider, analytics);
 
     expect(mockAgent.runAgent).toHaveBeenCalledWith(
       {
@@ -149,7 +153,7 @@ describe('createAnswerRunner', () => {
   it('exposes an abortRun helper that cancels the active agent', async () => {
     const runner = buildRunner();
 
-    await runner.run(state, dispatch, navigatorProvider);
+    await runner.run(state, dispatch, navigatorProvider, analytics);
     runner.abortRun();
 
     expect(abortRunMock).toHaveBeenCalledTimes(1);
@@ -158,7 +162,7 @@ describe('createAnswerRunner', () => {
   it('sets isRunning to false on the agent when abortRun is called', async () => {
     const runner = buildRunner();
 
-    await runner.run(state, dispatch, navigatorProvider);
+    await runner.run(state, dispatch, navigatorProvider, analytics);
     mockAgent.isRunning = true;
     runner.abortRun();
 
@@ -168,7 +172,7 @@ describe('createAnswerRunner', () => {
   it('dispatches the loading state when a run starts', async () => {
     const runner = buildRunner();
 
-    await runner.run(state, dispatch, navigatorProvider);
+    await runner.run(state, dispatch, navigatorProvider, analytics);
 
     expect(dispatch).toHaveBeenCalledWith(setIsLoading(true));
   });
@@ -179,7 +183,7 @@ describe('createAnswerRunner', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     runAgentMock.mockRejectedValueOnce(error);
 
-    await runner.run(state, dispatch, navigatorProvider);
+    await runner.run(state, dispatch, navigatorProvider, analytics);
 
     expect(dispatch).toHaveBeenCalledWith(setIsLoading(true));
     expect(dispatch).toHaveBeenCalledWith(

--- a/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/answer-agent-runner.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/answer-agent-runner.ts
@@ -1,5 +1,6 @@
 import type {Dispatch} from '@reduxjs/toolkit';
 import type {NavigatorContext} from '../../../../../app/navigator-context-provider.js';
+import type {AnswerGenerationAnalyticsClient} from '../../../../../features/generated-answer/answer-generation-analytics-client.js';
 import {
   selectAccessToken,
   selectAgentId,
@@ -39,7 +40,8 @@ export const createAnswerRunner = () => {
   const run = async (
     state: StateNeededForHeadAnswerParams,
     dispatch: Dispatch,
-    getNavigatorContext: () => NavigatorContext
+    getNavigatorContext: () => NavigatorContext,
+    analytics: AnswerGenerationAnalyticsClient
   ) => {
     abortRun();
 
@@ -53,7 +55,7 @@ export const createAnswerRunner = () => {
 
     currentAgent = agent;
 
-    const strategy = createHeadAnswerStrategy(dispatch);
+    const strategy = createHeadAnswerStrategy(dispatch, analytics);
     const params = constructGenerateHeadAnswerParams(
       state,
       getNavigatorContext()

--- a/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/head-answer-strategy.test.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/head-answer-strategy.test.ts
@@ -24,13 +24,16 @@ import {
   updateError,
   updateMessage,
 } from '../../../../../features/generated-answer/generated-answer-actions.js';
-import * as generatedAnswerAnalyticsActions from '../../../../../features/generated-answer/generated-answer-analytics-actions.js';
 import {GeneratedAnswerSseErrorCode} from '../../../../../features/generated-answer/sse-generated-answer-errors.js';
 import {createHeadAnswerStrategy} from './head-answer-strategy.js';
 
 describe('createHeadAnswerStrategy', () => {
   let dispatch: ReturnType<typeof vi.fn> & Dispatch;
   let strategy: AgentSubscriber;
+  let analytics: {
+    logGeneratedAnswerStreamEnd: ReturnType<typeof vi.fn>;
+    logGeneratedAnswerResponseLinked: ReturnType<typeof vi.fn>;
+  };
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -38,7 +41,11 @@ describe('createHeadAnswerStrategy', () => {
 
   beforeEach(() => {
     dispatch = vi.fn() as unknown as ReturnType<typeof vi.fn> & Dispatch;
-    strategy = createHeadAnswerStrategy(dispatch);
+    analytics = {
+      logGeneratedAnswerStreamEnd: vi.fn(),
+      logGeneratedAnswerResponseLinked: vi.fn(),
+    };
+    strategy = createHeadAnswerStrategy(dispatch, analytics as any);
   });
 
   it('initializes identifiers and streaming state when a run starts', () => {
@@ -154,14 +161,11 @@ describe('createHeadAnswerStrategy', () => {
   it('finalizes the run with the answer generation result', () => {
     const streamEndAction = vi.fn() as any;
     const responseLinkedAction = vi.fn() as any;
-    const streamEndSpy = vi
-      .spyOn(generatedAnswerAnalyticsActions, 'logGeneratedAnswerStreamEnd')
-      .mockReturnValue(streamEndAction);
-    vi.spyOn(
-      generatedAnswerAnalyticsActions,
-      'logGeneratedAnswerResponseLinked'
-    ).mockReturnValue(responseLinkedAction);
-    strategy = createHeadAnswerStrategy(dispatch);
+    analytics.logGeneratedAnswerStreamEnd.mockReturnValue(streamEndAction);
+    analytics.logGeneratedAnswerResponseLinked.mockReturnValue(
+      responseLinkedAction
+    );
+    strategy = createHeadAnswerStrategy(dispatch, analytics as any);
     strategy.onRunStartedEvent!({
       event: {runId: 'run-001', threadId: 'thread-007'},
     } as any);
@@ -180,7 +184,11 @@ describe('createHeadAnswerStrategy', () => {
     expect(dispatch).toHaveBeenNthCalledWith(1, setIsAnswerGenerated(true));
     expect(dispatch).toHaveBeenNthCalledWith(2, setCannotAnswer(false));
     expect(dispatch).toHaveBeenNthCalledWith(3, setIsStreaming(false));
-    expect(streamEndSpy).toHaveBeenCalledWith(true, 'run-001', true);
+    expect(analytics.logGeneratedAnswerStreamEnd).toHaveBeenCalledWith(
+      true,
+      'run-001',
+      true
+    );
     expect(dispatch).toHaveBeenNthCalledWith(4, streamEndAction);
     expect(dispatch).toHaveBeenNthCalledWith(5, responseLinkedAction);
   });
@@ -188,14 +196,11 @@ describe('createHeadAnswerStrategy', () => {
   it('disables answer flags when no answer was generated', () => {
     const streamEndAction = vi.fn() as any;
     const responseLinkedAction = vi.fn() as any;
-    const streamEndSpy = vi
-      .spyOn(generatedAnswerAnalyticsActions, 'logGeneratedAnswerStreamEnd')
-      .mockReturnValue(streamEndAction);
-    vi.spyOn(
-      generatedAnswerAnalyticsActions,
-      'logGeneratedAnswerResponseLinked'
-    ).mockReturnValue(responseLinkedAction);
-    strategy = createHeadAnswerStrategy(dispatch);
+    analytics.logGeneratedAnswerStreamEnd.mockReturnValue(streamEndAction);
+    analytics.logGeneratedAnswerResponseLinked.mockReturnValue(
+      responseLinkedAction
+    );
+    strategy = createHeadAnswerStrategy(dispatch, analytics as any);
     strategy.onRunStartedEvent!({
       event: {runId: 'run-001', threadId: 'thread-007'},
     } as any);
@@ -214,7 +219,11 @@ describe('createHeadAnswerStrategy', () => {
     expect(dispatch).toHaveBeenNthCalledWith(1, setIsAnswerGenerated(false));
     expect(dispatch).toHaveBeenNthCalledWith(2, setCannotAnswer(true));
     expect(dispatch).toHaveBeenNthCalledWith(3, setIsStreaming(false));
-    expect(streamEndSpy).toHaveBeenCalledWith(false, 'run-001', undefined);
+    expect(analytics.logGeneratedAnswerStreamEnd).toHaveBeenCalledWith(
+      false,
+      'run-001',
+      undefined
+    );
     expect(dispatch).toHaveBeenNthCalledWith(4, streamEndAction);
     expect(dispatch).toHaveBeenNthCalledWith(5, responseLinkedAction);
   });

--- a/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/head-answer-strategy.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/answer-agent/head-answer-strategy.ts
@@ -22,10 +22,7 @@ import {
   updateError,
   updateMessage,
 } from '../../../../../features/generated-answer/generated-answer-actions.js';
-import {
-  logGeneratedAnswerResponseLinked,
-  logGeneratedAnswerStreamEnd,
-} from '../../../../../features/generated-answer/generated-answer-analytics-actions.js';
+import type {AnswerGenerationAnalyticsClient} from '../../../../../features/generated-answer/answer-generation-analytics-client.js';
 import type {
   GenerationStepName,
   GenerationToolCallArgsGeneric,
@@ -37,7 +34,8 @@ import {mapRunErrorCode} from '../../../../../features/generated-answer/sse-gene
  * Creates an AgentSubscriber that handles answer streaming events
  */
 export const createHeadAnswerStrategy = (
-  dispatch: ThunkDispatch<unknown, unknown, UnknownAction>
+  dispatch: ThunkDispatch<unknown, unknown, UnknownAction>,
+  analytics: AnswerGenerationAnalyticsClient
 ): AgentSubscriber => {
   let runId = '';
   let answerHasText = false;
@@ -191,9 +189,13 @@ export const createHeadAnswerStrategy = (
       dispatch(setCannotAnswer(!answerGenerated));
       dispatch(setIsStreaming(false));
       dispatch(
-        logGeneratedAnswerStreamEnd(answerGenerated, runId, answerTextIsEmpty)
+        analytics.logGeneratedAnswerStreamEnd(
+          answerGenerated,
+          runId,
+          answerTextIsEmpty
+        )
       );
-      dispatch(logGeneratedAnswerResponseLinked());
+      dispatch(analytics.logGeneratedAnswerResponseLinked());
     },
   };
 };

--- a/packages/headless/src/api/knowledge/answer-generation/agents/follow-up-agent/follow-up-answer-strategy.test.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/follow-up-agent/follow-up-answer-strategy.test.ts
@@ -18,13 +18,16 @@ import {
   setFollowUpIsLoading,
   setFollowUpIsStreaming,
 } from '../../../../../features/follow-up-answers/follow-up-answers-actions.js';
-import * as generatedAnswerAnalyticsActions from '../../../../../features/generated-answer/generated-answer-analytics-actions.js';
 import {GeneratedAnswerSseErrorCode} from '../../../../../features/generated-answer/sse-generated-answer-errors.js';
 import {createFollowUpStrategy} from './follow-up-answer-strategy.js';
 
 describe('createFollowUpStrategy', () => {
   let dispatch: ReturnType<typeof vi.fn> & Dispatch;
   let strategy: AgentSubscriber;
+  let analytics: {
+    logGeneratedAnswerStreamEnd: ReturnType<typeof vi.fn>;
+    logGeneratedAnswerResponseLinked: ReturnType<typeof vi.fn>;
+  };
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -34,7 +37,11 @@ describe('createFollowUpStrategy', () => {
 
   beforeEach(() => {
     dispatch = vi.fn() as unknown as ReturnType<typeof vi.fn> & Dispatch;
-    strategy = createFollowUpStrategy(dispatch);
+    analytics = {
+      logGeneratedAnswerStreamEnd: vi.fn(),
+      logGeneratedAnswerResponseLinked: vi.fn(),
+    };
+    strategy = createFollowUpStrategy(dispatch, analytics as any);
     strategy.onRunStartedEvent!({event: {runId}} as any);
     vi.clearAllMocks();
   });
@@ -154,7 +161,7 @@ describe('createFollowUpStrategy', () => {
   });
 
   it('records turn limit failures using the input run id when no run was started', () => {
-    strategy = createFollowUpStrategy(dispatch);
+    strategy = createFollowUpStrategy(dispatch, analytics as any);
 
     strategy.onRunErrorEvent!({
       input: {runId: 'run-456'},
@@ -225,16 +232,11 @@ describe('createFollowUpStrategy', () => {
   it('dispatches stream end and response linked analytics when a run finishes', () => {
     const streamEndAction = vi.fn() as any;
     const responseLinkedAction = vi.fn() as any;
-    const streamEndSpy = vi
-      .spyOn(generatedAnswerAnalyticsActions, 'logGeneratedAnswerStreamEnd')
-      .mockReturnValue(streamEndAction);
-    const responseLinkedSpy = vi
-      .spyOn(
-        generatedAnswerAnalyticsActions,
-        'logGeneratedAnswerResponseLinked'
-      )
-      .mockReturnValue(responseLinkedAction);
-    strategy = createFollowUpStrategy(dispatch);
+    analytics.logGeneratedAnswerStreamEnd.mockReturnValue(streamEndAction);
+    analytics.logGeneratedAnswerResponseLinked.mockReturnValue(
+      responseLinkedAction
+    );
+    strategy = createFollowUpStrategy(dispatch, analytics as any);
     strategy.onRunStartedEvent!({event: {runId}} as any);
     vi.clearAllMocks();
 
@@ -249,8 +251,14 @@ describe('createFollowUpStrategy', () => {
       1,
       followUpCompleted({answerId: runId, cannotAnswer: false})
     );
-    expect(streamEndSpy).toHaveBeenCalledWith(true, runId, true);
-    expect(responseLinkedSpy).toHaveBeenCalledWith(runId);
+    expect(analytics.logGeneratedAnswerStreamEnd).toHaveBeenCalledWith(
+      true,
+      runId,
+      true
+    );
+    expect(analytics.logGeneratedAnswerResponseLinked).toHaveBeenCalledWith(
+      runId
+    );
     expect(dispatch).toHaveBeenNthCalledWith(2, streamEndAction);
     expect(dispatch).toHaveBeenNthCalledWith(3, responseLinkedAction);
   });

--- a/packages/headless/src/api/knowledge/answer-generation/agents/follow-up-agent/follow-up-answer-strategy.ts
+++ b/packages/headless/src/api/knowledge/answer-generation/agents/follow-up-agent/follow-up-answer-strategy.ts
@@ -15,10 +15,7 @@ import {
   setFollowUpIsLoading,
   setFollowUpIsStreaming,
 } from '../../../../../features/follow-up-answers/follow-up-answers-actions.js';
-import {
-  logGeneratedAnswerResponseLinked,
-  logGeneratedAnswerStreamEnd,
-} from '../../../../../features/generated-answer/generated-answer-analytics-actions.js';
+import type {AnswerGenerationAnalyticsClient} from '../../../../../features/generated-answer/answer-generation-analytics-client.js';
 import type {
   GenerationStepName,
   GenerationToolCallArgsGeneric,
@@ -30,7 +27,8 @@ import {mapRunErrorCode} from '../../../../../features/generated-answer/sse-gene
  * Creates an AgentSubscriber that handles follow-up answer streaming events
  */
 export const createFollowUpStrategy = (
-  dispatch: ThunkDispatch<unknown, unknown, UnknownAction>
+  dispatch: ThunkDispatch<unknown, unknown, UnknownAction>,
+  analytics: AnswerGenerationAnalyticsClient
 ): AgentSubscriber => {
   let runId = '';
   let answerHasText = false;
@@ -184,9 +182,13 @@ export const createFollowUpStrategy = (
         })
       );
       dispatch(
-        logGeneratedAnswerStreamEnd(answerGenerated, runId, answerTextIsEmpty)
+        analytics.logGeneratedAnswerStreamEnd(
+          answerGenerated,
+          runId,
+          answerTextIsEmpty
+        )
       );
-      dispatch(logGeneratedAnswerResponseLinked(runId));
+      dispatch(analytics.logGeneratedAnswerResponseLinked(runId));
       runId = '';
       answerHasText = false;
     },

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -26,7 +26,7 @@ import type {
 } from '../features/configuration/configuration-state.js';
 import {versionReducer as version} from '../features/debug/version-slice.js';
 import type {AnswerGenerationAnalyticsClient} from '../features/generated-answer/answer-generation-analytics-client.js';
-import {searchAnswerGenerationAnalyticsClient} from '../features/generated-answer/generated-answer-analytics-actions.js';
+import {generatedAnswerAnalyticsClient} from '../features/generated-answer/generated-answer-analytics-actions.js';
 import type {SearchParametersState} from '../state/search-app-state.js';
 import {doNotTrack} from '../utils/utils.js';
 import {analyticsMiddleware} from './analytics-middleware.js';
@@ -380,7 +380,7 @@ function createMiddleware<Reducers extends ReducersMapObject>(
   const generateAnswerListener = createGenerateAnswerListener({
     getNavigatorContext,
     generationAnalyticsClient:
-      generationAnalyticsClient ?? searchAnswerGenerationAnalyticsClient,
+      generationAnalyticsClient ?? generatedAnswerAnalyticsClient,
   });
 
   return [

--- a/packages/headless/src/app/engine.ts
+++ b/packages/headless/src/app/engine.ts
@@ -25,6 +25,8 @@ import type {
   CoreConfigurationState,
 } from '../features/configuration/configuration-state.js';
 import {versionReducer as version} from '../features/debug/version-slice.js';
+import type {AnswerGenerationAnalyticsClient} from '../features/generated-answer/answer-generation-analytics-client.js';
+import {searchAnswerGenerationAnalyticsClient} from '../features/generated-answer/generated-answer-analytics-actions.js';
 import type {SearchParametersState} from '../state/search-app-state.js';
 import {doNotTrack} from '../utils/utils.js';
 import {analyticsMiddleware} from './analytics-middleware.js';
@@ -351,7 +353,8 @@ function createStore<
   const middlewares = createMiddleware(
     options,
     thunkExtraArguments.logger,
-    () => thunkExtraArguments.navigatorContext
+    () => thunkExtraArguments.navigatorContext,
+    thunkExtraArguments.answerGenerationAnalyticsClient
   );
 
   return configureStore({
@@ -366,7 +369,8 @@ function createStore<
 function createMiddleware<Reducers extends ReducersMapObject>(
   options: EngineOptions<Reducers>,
   logger: Logger,
-  getNavigatorContext: () => NavigatorContext
+  getNavigatorContext: () => NavigatorContext,
+  generationAnalyticsClient?: AnswerGenerationAnalyticsClient
 ) {
   const {renewAccessToken} = options.configuration;
   const renewTokenMiddleware = createRenewAccessTokenMiddleware(
@@ -375,6 +379,8 @@ function createMiddleware<Reducers extends ReducersMapObject>(
   );
   const generateAnswerListener = createGenerateAnswerListener({
     getNavigatorContext,
+    generationAnalyticsClient:
+      generationAnalyticsClient ?? searchAnswerGenerationAnalyticsClient,
   });
 
   return [

--- a/packages/headless/src/app/listener-middleware/generate-answer-listener-middleware.test.ts
+++ b/packages/headless/src/app/listener-middleware/generate-answer-listener-middleware.test.ts
@@ -67,6 +67,11 @@ describe('generateAnswerListener', () => {
               getDefaultMiddleware().prepend(
                 createGenerateAnswerListener({
                   getNavigatorContext: buildMockNavigatorContextProvider(),
+                  generationAnalyticsClient: {
+                    logGeneratedAnswerStreamEnd: vi.fn(),
+                    logGeneratedAnswerResponseLinked: vi.fn(),
+                    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- unit test
+                  } as any,
                   // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- unit test
                 }).middleware as Middleware<{}, any>
               ),
@@ -109,6 +114,11 @@ describe('generateAnswerListener', () => {
               getDefaultMiddleware().prepend(
                 createGenerateAnswerListener({
                   getNavigatorContext: buildMockNavigatorContextProvider(),
+                  generationAnalyticsClient: {
+                    logGeneratedAnswerStreamEnd: vi.fn(),
+                    logGeneratedAnswerResponseLinked: vi.fn(),
+                    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- unit test
+                  } as any,
                   // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- unit test
                 }).middleware as Middleware<{}, any>
               ),
@@ -181,6 +191,11 @@ describe('generateAnswerListener', () => {
             getDefaultMiddleware().prepend(
               createGenerateAnswerListener({
                 getNavigatorContext: buildMockNavigatorContextProvider(),
+                generationAnalyticsClient: {
+                  logGeneratedAnswerStreamEnd: vi.fn(),
+                  logGeneratedAnswerResponseLinked: vi.fn(),
+                  // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- unit test
+                } as any,
                 // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- unit test
               }).middleware as Middleware<{}, any>
             ),
@@ -218,6 +233,11 @@ describe('generateAnswerListener', () => {
             getDefaultMiddleware().prepend(
               createGenerateAnswerListener({
                 getNavigatorContext: buildMockNavigatorContextProvider(),
+                generationAnalyticsClient: {
+                  logGeneratedAnswerStreamEnd: vi.fn(),
+                  logGeneratedAnswerResponseLinked: vi.fn(),
+                  // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- unit test
+                } as any,
                 // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- unit test
               }).middleware as Middleware<{}, any>
             ),

--- a/packages/headless/src/app/listener-middleware/generate-answer-listener-middleware.ts
+++ b/packages/headless/src/app/listener-middleware/generate-answer-listener-middleware.ts
@@ -2,6 +2,7 @@ import {createListenerMiddleware, type Dispatch} from '@reduxjs/toolkit';
 import {createAnswerRunner} from '../../api/knowledge/answer-generation/agents/answer-agent/answer-agent-runner.js';
 import {resetFollowUpAnswers} from '../../features/follow-up-answers/follow-up-answers-actions.js';
 import {resetAnswer} from '../../features/generated-answer/generated-answer-actions.js';
+import type {AnswerGenerationAnalyticsClient} from '../../features/generated-answer/answer-generation-analytics-client.js';
 import type {StateNeededForHeadAnswerParams} from '../../features/generated-answer/generated-answer-request.js';
 import {isGeneratedAnswerFeatureEnabledWithAgentAPI} from '../../features/generated-answer/generated-answer-selectors.js';
 import {selectQuery} from '../../features/query/query-selectors.js';
@@ -10,11 +11,15 @@ import type {NavigatorContext} from '../navigator-context-provider.js';
 
 export const createGenerateAnswerListener = (extra: {
   getNavigatorContext: () => NavigatorContext;
+  generationAnalyticsClient: AnswerGenerationAnalyticsClient;
 }) => {
   const generateAnswerListener = createListenerMiddleware<
     StateNeededForHeadAnswerParams,
     Dispatch,
-    {getNavigatorContext: () => NavigatorContext}
+    {
+      getNavigatorContext: () => NavigatorContext;
+      generationAnalyticsClient: AnswerGenerationAnalyticsClient;
+    }
   >({extra});
   const answerRunner = createAnswerRunner();
 
@@ -41,7 +46,12 @@ export const createGenerateAnswerListener = (extra: {
         return;
       }
 
-      answerRunner.run(state, listenerApi.dispatch, extra.getNavigatorContext);
+      answerRunner.run(
+        state,
+        listenerApi.dispatch,
+        extra.getNavigatorContext,
+        extra.generationAnalyticsClient
+      );
     },
   });
 

--- a/packages/headless/src/app/search-engine/search-engine.ts
+++ b/packages/headless/src/app/search-engine/search-engine.ts
@@ -23,6 +23,7 @@ import {
 } from '../../features/configuration/configuration-actions.js';
 import type {ConfigurationState} from '../../features/configuration/configuration-state.js';
 import {debugReducer as debug} from '../../features/debug/debug-slice.js';
+import {searchAnswerGenerationAnalyticsClient} from '../../features/generated-answer/generated-answer-analytics-actions.js';
 import {pipelineReducer as pipeline} from '../../features/pipeline/pipeline-slice.js';
 import {executeSearch} from '../../features/search/search-actions.js';
 import {firstSearchExecutedSelector} from '../../features/search/search-selectors.js';
@@ -137,6 +138,7 @@ export function buildSearchEngine(options: SearchEngineOptions): SearchEngine {
     ...buildThunkExtraArguments(configuration, logger),
     apiClient: searchAPIClient,
     streamingClient: generatedAnswerClient,
+    answerGenerationAnalyticsClient: searchAnswerGenerationAnalyticsClient,
   };
 
   const augmentedOptions: EngineOptions<SearchEngineReducers> = {

--- a/packages/headless/src/app/search-engine/search-engine.ts
+++ b/packages/headless/src/app/search-engine/search-engine.ts
@@ -23,7 +23,7 @@ import {
 } from '../../features/configuration/configuration-actions.js';
 import type {ConfigurationState} from '../../features/configuration/configuration-state.js';
 import {debugReducer as debug} from '../../features/debug/debug-slice.js';
-import {searchAnswerGenerationAnalyticsClient} from '../../features/generated-answer/generated-answer-analytics-actions.js';
+import {generatedAnswerAnalyticsClient} from '../../features/generated-answer/generated-answer-analytics-actions.js';
 import {pipelineReducer as pipeline} from '../../features/pipeline/pipeline-slice.js';
 import {executeSearch} from '../../features/search/search-actions.js';
 import {firstSearchExecutedSelector} from '../../features/search/search-selectors.js';
@@ -138,7 +138,7 @@ export function buildSearchEngine(options: SearchEngineOptions): SearchEngine {
     ...buildThunkExtraArguments(configuration, logger),
     apiClient: searchAPIClient,
     streamingClient: generatedAnswerClient,
-    answerGenerationAnalyticsClient: searchAnswerGenerationAnalyticsClient,
+    answerGenerationAnalyticsClient: generatedAnswerAnalyticsClient,
   };
 
   const augmentedOptions: EngineOptions<SearchEngineReducers> = {

--- a/packages/headless/src/app/thunk-extra-arguments.ts
+++ b/packages/headless/src/app/thunk-extra-arguments.ts
@@ -2,6 +2,7 @@ import type {Relay} from '@coveo/relay';
 import type {AnalyticsClientSendEventHook} from 'coveo.analytics';
 import type {Logger} from 'pino';
 import type {GeneratedAnswerAPIClient} from '../api/generated-answer/generated-answer-client.js';
+import type {AnswerGenerationAnalyticsClient} from '../features/generated-answer/answer-generation-analytics-client.js';
 import {
   NoopPreprocessRequest,
   type PreprocessRequest,
@@ -25,6 +26,7 @@ export interface ThunkExtraArguments {
   analyticsClientMiddleware: AnalyticsClientSendEventHook;
   logger: Logger;
   validatePayload: typeof validatePayloadAndThrow;
+  answerGenerationAnalyticsClient?: AnswerGenerationAnalyticsClient;
 }
 
 export function buildThunkExtraArguments(

--- a/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
+++ b/packages/headless/src/controllers/core/generated-answer/headless-core-generated-answer.ts
@@ -3,6 +3,7 @@ import type {
   CustomAction,
   LegacySearchAction,
 } from '../../../features/analytics/analytics-utils.js';
+import type {AnswerGenerationAnalyticsClient} from '../../../features/generated-answer/answer-generation-analytics-client.js';
 import {
   closeGeneratedAnswerFeedbackModal,
   collapseGeneratedAnswer,
@@ -134,7 +135,7 @@ export interface GeneratedAnswer extends Controller {
   ): void;
 }
 
-export interface GeneratedAnswerAnalyticsClient {
+export interface GeneratedAnswerAnalyticsClient extends AnswerGenerationAnalyticsClient {
   /** @deprecated */
   logLikeGeneratedAnswer(): CustomAction;
   logLikeGeneratedAnswer(answerId?: string): CustomAction;

--- a/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
@@ -1,10 +1,7 @@
 import type {GeneratedAnswerCitation} from '../../api/generated-answer/generated-answer-event-payload.js';
 import {warnIfUsingNextAnalyticsModeForServiceFeature} from '../../app/engine.js';
 import type {SearchEngine} from '../../app/search-engine/search-engine.js';
-import {
-  generatedAnswerAnalyticsClient,
-  searchAnswerGenerationAnalyticsClient,
-} from '../../features/generated-answer/generated-answer-analytics-actions.js';
+import {generatedAnswerAnalyticsClient} from '../../features/generated-answer/generated-answer-analytics-actions.js';
 import type {
   GeneratedAnswerBase,
   GeneratedAnswerState,
@@ -70,7 +67,6 @@ export function buildGeneratedAnswer(
     controller = buildGeneratedAnswerWithFollowUps(
       engine,
       generatedAnswerAnalyticsClient,
-      searchAnswerGenerationAnalyticsClient,
       {...props, agentId: props.agentId}
     );
   } else if (

--- a/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
+++ b/packages/headless/src/controllers/generated-answer/headless-generated-answer.ts
@@ -1,7 +1,10 @@
 import type {GeneratedAnswerCitation} from '../../api/generated-answer/generated-answer-event-payload.js';
 import {warnIfUsingNextAnalyticsModeForServiceFeature} from '../../app/engine.js';
 import type {SearchEngine} from '../../app/search-engine/search-engine.js';
-import {generatedAnswerAnalyticsClient} from '../../features/generated-answer/generated-answer-analytics-actions.js';
+import {
+  generatedAnswerAnalyticsClient,
+  searchAnswerGenerationAnalyticsClient,
+} from '../../features/generated-answer/generated-answer-analytics-actions.js';
 import type {
   GeneratedAnswerBase,
   GeneratedAnswerState,
@@ -67,6 +70,7 @@ export function buildGeneratedAnswer(
     controller = buildGeneratedAnswerWithFollowUps(
       engine,
       generatedAnswerAnalyticsClient,
+      searchAnswerGenerationAnalyticsClient,
       {...props, agentId: props.agentId}
     );
   } else if (

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
@@ -19,6 +19,7 @@ import {
   logLikeGeneratedAnswer,
   logOpenGeneratedAnswerFollowUpSource,
   logOpenGeneratedAnswerSource,
+  searchAnswerGenerationAnalyticsClient,
 } from '../../../features/generated-answer/generated-answer-analytics-actions.js';
 import {getGeneratedAnswerInitialState} from '../../../features/generated-answer/generated-answer-state.js';
 import type {SearchAppState} from '../../../index.js';
@@ -106,6 +107,7 @@ describe('GeneratedAnswerWithFollowUps', () => {
     buildGeneratedAnswerWithFollowUps(
       engine,
       generatedAnswerAnalyticsClient,
+      searchAnswerGenerationAnalyticsClient,
       props
     );
 
@@ -196,7 +198,10 @@ describe('GeneratedAnswerWithFollowUps', () => {
       'org-123',
       'prod'
     );
-    expect(mockCreateFollowUpStrategy).toHaveBeenCalledWith(engine.dispatch);
+    expect(mockCreateFollowUpStrategy).toHaveBeenCalledWith(
+      engine.dispatch,
+      searchAnswerGenerationAnalyticsClient
+    );
   });
 
   describe('state getter', () => {
@@ -297,7 +302,8 @@ describe('GeneratedAnswerWithFollowUps', () => {
       expect(mockAnswerRunner.run).toHaveBeenCalledWith(
         engine.state,
         engine.dispatch,
-        expect.any(Function)
+        expect.any(Function),
+        searchAnswerGenerationAnalyticsClient
       );
       const navigatorContextProvider = mockAnswerRunner.run.mock.calls[0][2];
       expect(navigatorContextProvider()).toBe(engine.navigatorContext);

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.test.ts
@@ -19,7 +19,6 @@ import {
   logLikeGeneratedAnswer,
   logOpenGeneratedAnswerFollowUpSource,
   logOpenGeneratedAnswerSource,
-  searchAnswerGenerationAnalyticsClient,
 } from '../../../features/generated-answer/generated-answer-analytics-actions.js';
 import {getGeneratedAnswerInitialState} from '../../../features/generated-answer/generated-answer-state.js';
 import type {SearchAppState} from '../../../index.js';
@@ -107,7 +106,6 @@ describe('GeneratedAnswerWithFollowUps', () => {
     buildGeneratedAnswerWithFollowUps(
       engine,
       generatedAnswerAnalyticsClient,
-      searchAnswerGenerationAnalyticsClient,
       props
     );
 
@@ -200,7 +198,7 @@ describe('GeneratedAnswerWithFollowUps', () => {
     );
     expect(mockCreateFollowUpStrategy).toHaveBeenCalledWith(
       engine.dispatch,
-      searchAnswerGenerationAnalyticsClient
+      generatedAnswerAnalyticsClient
     );
   });
 
@@ -303,7 +301,7 @@ describe('GeneratedAnswerWithFollowUps', () => {
         engine.state,
         engine.dispatch,
         expect.any(Function),
-        searchAnswerGenerationAnalyticsClient
+        generatedAnswerAnalyticsClient
       );
       const navigatorContextProvider = mockAnswerRunner.run.mock.calls[0][2];
       expect(navigatorContextProvider()).toBe(engine.navigatorContext);

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
@@ -19,7 +19,6 @@ import {
 import {followUpAnswersReducer as followUpAnswers} from '../../../features/follow-up-answers/follow-up-answers-slice.js';
 import type {FollowUpAnswersState} from '../../../features/follow-up-answers/follow-up-answers-state.js';
 import {generativeQuestionAnsweringIdSelector} from '../../../features/generated-answer/generated-answer-selectors.js';
-import type {AnswerGenerationAnalyticsClient} from '../../../features/generated-answer/answer-generation-analytics-client.js';
 import {withGeneratedAnswerSseErrorHelpers} from '../../../features/generated-answer/sse-generated-answer-errors.js';
 import type {GeneratedAnswerState} from '../../../index.js';
 import type {
@@ -103,7 +102,6 @@ export type GeneratedAnswerWithFollowUpsProps = GeneratedAnswerProps &
 export function buildGeneratedAnswerWithFollowUps(
   engine: SearchEngine | InsightEngine,
   analyticsClient: GeneratedAnswerAnalyticsClient,
-  generationAnalyticsClient: AnswerGenerationAnalyticsClient,
   props: GeneratedAnswerWithFollowUpsProps
 ): GeneratedAnswerWithFollowUps {
   if (!props.agentId || props.agentId.trim() === '') {
@@ -129,7 +127,7 @@ export function buildGeneratedAnswerWithFollowUps(
   );
   const followUpStrategy = createFollowUpStrategy(
     engine.dispatch,
-    generationAnalyticsClient
+    analyticsClient
   );
   const answerRunner = createAnswerRunner();
 
@@ -159,7 +157,7 @@ export function buildGeneratedAnswerWithFollowUps(
         engine.state,
         engine.dispatch,
         () => engine.navigatorContext,
-        generationAnalyticsClient
+        analyticsClient
       );
     },
 

--- a/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
+++ b/packages/headless/src/controllers/knowledge/generated-answer/headless-generated-answer-with-follow-ups.ts
@@ -19,6 +19,7 @@ import {
 import {followUpAnswersReducer as followUpAnswers} from '../../../features/follow-up-answers/follow-up-answers-slice.js';
 import type {FollowUpAnswersState} from '../../../features/follow-up-answers/follow-up-answers-state.js';
 import {generativeQuestionAnsweringIdSelector} from '../../../features/generated-answer/generated-answer-selectors.js';
+import type {AnswerGenerationAnalyticsClient} from '../../../features/generated-answer/answer-generation-analytics-client.js';
 import {withGeneratedAnswerSseErrorHelpers} from '../../../features/generated-answer/sse-generated-answer-errors.js';
 import type {GeneratedAnswerState} from '../../../index.js';
 import type {
@@ -102,6 +103,7 @@ export type GeneratedAnswerWithFollowUpsProps = GeneratedAnswerProps &
 export function buildGeneratedAnswerWithFollowUps(
   engine: SearchEngine | InsightEngine,
   analyticsClient: GeneratedAnswerAnalyticsClient,
+  generationAnalyticsClient: AnswerGenerationAnalyticsClient,
   props: GeneratedAnswerWithFollowUpsProps
 ): GeneratedAnswerWithFollowUps {
   if (!props.agentId || props.agentId.trim() === '') {
@@ -125,7 +127,10 @@ export function buildGeneratedAnswerWithFollowUps(
     organizationId,
     environment
   );
-  const followUpStrategy = createFollowUpStrategy(engine.dispatch);
+  const followUpStrategy = createFollowUpStrategy(
+    engine.dispatch,
+    generationAnalyticsClient
+  );
   const answerRunner = createAnswerRunner();
 
   return {
@@ -153,7 +158,8 @@ export function buildGeneratedAnswerWithFollowUps(
       answerRunner.run(
         engine.state,
         engine.dispatch,
-        () => engine.navigatorContext
+        () => engine.navigatorContext,
+        generationAnalyticsClient
       );
     },
 

--- a/packages/headless/src/features/generated-answer/answer-generation-analytics-client.ts
+++ b/packages/headless/src/features/generated-answer/answer-generation-analytics-client.ts
@@ -1,0 +1,24 @@
+import type {
+  CustomAction,
+  InsightAction,
+} from '../analytics/analytics-utils.js';
+
+/**
+ * Analytics client for the answer generation lifecycle events.
+ *
+ * These events are dispatched from the answer generation machinery (the answer
+ * generation listener middleware and the answer/follow-up streaming strategies)
+ * rather than from the controller itself. Injecting this client allows each use
+ * case (search, insight, ...) to log the generation lifecycle with its own
+ * analytics implementation instead of being hardcoded to a single use case.
+ */
+export interface AnswerGenerationAnalyticsClient {
+  logGeneratedAnswerStreamEnd(
+    answerGenerated: boolean,
+    answerId?: string,
+    answerTextIsEmpty?: boolean
+  ): CustomAction | InsightAction;
+  logGeneratedAnswerResponseLinked(
+    answerId?: string
+  ): CustomAction | InsightAction;
+}

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
@@ -10,6 +10,7 @@ import {
 import {SearchPageEvents} from '../analytics/search-action-cause.js';
 import type {SearchAction} from '../search/search-actions.js';
 import type {InlineLink} from '../../utils/inline-link.js';
+import type {AnswerGenerationAnalyticsClient} from './answer-generation-analytics-client.js';
 import {
   citationSourceSelector,
   generativeQuestionAnsweringIdSelector,
@@ -329,6 +330,12 @@ export const logGeneratedAnswerResponseLinked = (
       };
     },
   });
+
+export const searchAnswerGenerationAnalyticsClient: AnswerGenerationAnalyticsClient =
+  {
+    logGeneratedAnswerStreamEnd,
+    logGeneratedAnswerResponseLinked,
+  };
 
 export const logGeneratedAnswerShowAnswers = (): CustomAction =>
   makeAnalyticsAction({

--- a/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-analytics-actions.ts
@@ -10,7 +10,6 @@ import {
 import {SearchPageEvents} from '../analytics/search-action-cause.js';
 import type {SearchAction} from '../search/search-actions.js';
 import type {InlineLink} from '../../utils/inline-link.js';
-import type {AnswerGenerationAnalyticsClient} from './answer-generation-analytics-client.js';
 import {
   citationSourceSelector,
   generativeQuestionAnsweringIdSelector,
@@ -331,12 +330,6 @@ export const logGeneratedAnswerResponseLinked = (
     },
   });
 
-export const searchAnswerGenerationAnalyticsClient: AnswerGenerationAnalyticsClient =
-  {
-    logGeneratedAnswerStreamEnd,
-    logGeneratedAnswerResponseLinked,
-  };
-
 export const logGeneratedAnswerShowAnswers = (): CustomAction =>
   makeAnalyticsAction({
     prefix: 'analytics/generatedAnswer/show',
@@ -501,6 +494,7 @@ export const generatedAnswerAnalyticsClient = {
   logGeneratedAnswerHideAnswers,
   logGeneratedAnswerShowAnswers,
   logGeneratedAnswerStreamEnd,
+  logGeneratedAnswerResponseLinked,
   logGeneratedAnswerFeedback,
   logDislikeGeneratedAnswer,
   logLikeGeneratedAnswer,

--- a/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
+++ b/packages/headless/src/features/generated-answer/generated-answer-insight-analytics-actions.ts
@@ -418,6 +418,7 @@ export const generatedAnswerInsightAnalyticsClient = {
   logGeneratedAnswerHideAnswers,
   logGeneratedAnswerShowAnswers,
   logGeneratedAnswerStreamEnd,
+  logGeneratedAnswerResponseLinked,
   logGeneratedAnswerFeedback,
   logDislikeGeneratedAnswer,
   logLikeGeneratedAnswer,


### PR DESCRIPTION
## The problem

Most Headless controllers ship in two flavors for two use cases: search and insight. Take the pager: both versions consume the same core pager controller, and the only real difference is the analytics client they use — one dispatches search analytics actions, the other insight analytics actions. Each version is then exported under the same name but from a different bundle, so importing from `@coveo/headless` gives you the search controller and importing from the insight bundle gives you the insight one. Clean, and it works well across basically every controller.

The `GeneratedAnswerWithFollowUps` controller is the odd one out. This controller is **not** the thing that generates the answer. The answer is generated by a listener middleware that reacts to search queries and does the streaming work. So even though the controller could own a use-case-specific analytics client, it isn't the one actually producing the answer — which makes it tricky to log the right analytics for the right use case. In practice the generation lifecycle events (`logGeneratedAnswerStreamEnd`, `logGeneratedAnswerResponseLinked`) were just hardcoded to the **search** analytics actions inside the streaming strategies, so there was no way for insight to ever log them correctly.

## The fix

Instead of hardcoding, we introduce an `AnswerGenerationAnalyticsClient` and inject it. The key insight is **where** it gets injected: as an extra argument at engine build time (`ThunkExtraArguments`).

That's what makes this scale to both use cases in the future. The generation middleware is registered once for every engine, so it can't know on its own whether it's serving search or insight. But each engine builder already knows exactly which use case it is:

- `buildSearchEngine` injects the **search** generation analytics client.
- Later, `buildInsightEngine` can inject the **insight** one.

The middleware just reads whatever client the engine put in `ThunkExtraArguments` and hands it to the streaming strategy. So the same global generation machinery ends up logging search analytics inside a search engine and insight analytics inside an insight engine — no branching, no use-case detection, just the client the engine was built with. The follow-ups controller gets the same client through its constructor (for `retry()` and follow-up streaming), fed from the same per-use-case constant.

## Scope

- **Search only for now.** Insight is intentionally left out; the interface return type is already widened (`CustomAction | InsightAction`) so dropping in an insight client later is a one-liner in the insight engine + bundle.
- Search behavior is unchanged — it's the same two action creators, now passed by reference instead of imported directly.