### PR TITLE
chore(coveo.analytics): snapshot legacy source

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -17,6 +17,7 @@
     "**/packages/atomic/stencil-proxy/**/*",
     "**/packages/documentation/**/assets/**/*",
     "**/packages/headless/**/coveo.analytics/**/*",
+    "**/packages/coveo-analytics/**/*",
     "**/samples/headless/rga-angular/**/*.html",
     "**/*.hbs",
     "**/*.handlebars",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -24,7 +24,8 @@
     "**/packages/atomic/**/*.d.ts",
     "**/packages/atomic/stencil-proxy/**",
     "**/packages/documentation/**/assets/**",
-    "**/packages/headless/**/coveo.analytics/**"
+    "**/packages/headless/**/coveo.analytics/**",
+    "**/packages/coveo-analytics/**"
   ],
   "overrides": [
     {

--- a/knip.js
+++ b/knip.js
@@ -8,6 +8,8 @@ export default {
   ignoreDependencies: ['semver'],
   ignore: [
     'packages/quantic/**',
+    // Temporary until CAJS package activation supplies package metadata and entry points.
+    'packages/coveo-analytics/**',
     'samples/headless/rga-react/src/components/Quickstart.tsx',
     'samples/headless/rga-react/src/components/Citation.tsx',
     'samples/headless/rga-react/src/components/CitationsList.tsx',

--- a/packages/coveo-analytics/LICENSE
+++ b/packages/coveo-analytics/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Coveo <http://www.coveo.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/coveo-analytics/README.md
+++ b/packages/coveo-analytics/README.md
@@ -39,7 +39,7 @@ Since calls to the coveo analytics service need to be authenticated, the library
 
 ## Available actions
 
-After the library has loaded sucessfully, you can interact with coveoua through the global `coveoua` function. Any interaction with the library happens through this function by supplying both a action name, followed by an optional series of action arguments. The following actions are available:
+After the library has loaded successfully, you can interact with coveoua through the global `coveoua` function. Any interaction with the library happens through this function by supplying both a action name, followed by an optional series of action arguments. The following actions are available:
 
 ### Initialization
 

--- a/packages/coveo-analytics/README.md
+++ b/packages/coveo-analytics/README.md
@@ -1,0 +1,252 @@
+# ![coveo.analytics](./assets/coveo.analytics.js.png)
+
+[![Build Status](https://travis-ci.org/coveo/coveo.analytics.js.svg?branch=master)](https://travis-ci.org/coveo/coveo.analytics.js)
+[![Coverage Status](https://coveralls.io/repos/github/coveo/coveo.analytics.js/badge.svg?branch=master)](https://coveralls.io/github/coveo/coveo.analytics.js?branch=master)
+[![TypeScript](https://badges.frapsoft.com/typescript/code/typescript.png?v=100)](https://github.com/ellerbrock/typescript-badges/)
+
+# Coveo Analytics JavaScript client
+
+The Coveo analytics javascript client, also called coveo.analytics.js or coveoua for short, is responsible for logging analytics events to the Coveo platform. Analytics events may include basic Coveo web events such as clicks or searches. For specific usecases, such as commerce and service, dedicated events may be defined and logged.
+
+The analytics library is bundled with all Coveo provided UI components. Integrations which exclusively rely on these components, generally don't have to interact with coveoua directly. For Coveo integrations which integrate with an already existing UI and do not use headless, coveoua will be required to ensure events are logged correctly.
+
+## Loading and initializing the library in the browser
+
+In order to ensure the tracking code is available on your webpage, the following code snippet needs to be added to the top of each page on which analytics are required. This will load the latest major version of coveo.analytics.js from a Coveo CDN. As of writing, the current major version is 2.
+
+```html
+<script>
+    (function (c, o, v, e, O, u, a) {
+        a = 'coveoua';
+        c[a] =
+            c[a] ||
+            function () {
+                (c[a].q = c[a].q || []).push(arguments);
+            };
+        c[a].t = Date.now();
+        u = o.createElement(v);
+        u.async = 1;
+        u.src = e;
+        O = o.getElementsByTagName(v)[0];
+        O.parentNode.insertBefore(u, O);
+    })(window, document, 'script', 'https://static.cloud.coveo.com/coveo.analytics.js/2/coveoua.js');
+</script>
+
+coveoua('init', #COVEO_API_KEY); // Replace #COVEO_API_KEY with your api key
+```
+
+Since calls to the coveo analytics service need to be authenticated, the library needs to be initialized with a Coveo api key which has push access to the [Analytics Data Domain](https://docs.coveo.com/en/1707/cloud-v2-administrators/privilege-reference#analytics-data-domain). You can create an API key from the [administration console](https://platform.cloud.coveo.com/admin/#/organization/api-access/) selecting the **Push** option box for the **Analytics Data** domain (see [Adding and Managing API Keys](https://docs.coveo.com/en/1718/cloud-v2-administrators/adding-and-managing-api-keys)).
+
+## Available actions
+
+After the library has loaded sucessfully, you can interact with coveoua through the global `coveoua` function. Any interaction with the library happens through this function by supplying both a action name, followed by an optional series of action arguments. The following actions are available:
+
+### Initialization
+
+-   `coveoua('version')`: Returns the current version of the tracking library.
+-   `coveoua('init', <COVEO_API_KEY>, <ENDPOINT>)`: Initializes the library with the given api key and endpoint. The following parameters are accepted
+    -   COVEO_API_KEY (mandatory): A valid api key.
+    -   ENDPOINT (optional): A string specifying the desired analytics endpoint. The default value is https://analytics.cloud.coveo.com/rest/ua. In case your organization is HIPAA enabled, you should override with https://analyticshipaa.cloud.coveo.com/rest/ua.
+-   `coveoua('init', <COVEO_API_KEY>, {endpoint: <ENDPOINT>, isCustomEndpoint: <IS_CUSTOM_ENDPOINT>, plugins: <PLUGINS>})`: Initializes the library with the given api key, endpoint, isCustomEndpoint option and plugins. The following parameters are accepted
+    -   COVEO_API_KEY (mandatory): A valid api key.
+    -   ENDPOINT (optional): An object string specifying the desired analytics endpoint. The default value is https://analytics.cloud.coveo.com/rest/ua. In case your organization is HIPAA enabled, you should override with https://analyticshipaa.cloud.coveo.com/rest/ua.
+    -   IS_CUSTOM_ENDPOINT (optional): An boolean specifying if the desired analytics endpoint is custom. This means the library will not try to add any prefix logic like /rest/ua at the end of the provided endpoint. This can be useful when implementing analytics through a reverse-proxy solution like cloudfront.
+    -   PLUGINS (optional): An array of known plugin names. See [plugins](#plugins) for more information.
+-   `coveoua('set', <NAME>, <VALUE>)`: Attempts to inject an attribute with given name and value on every logged event, overriding any existing value. Some payloads may reject attributes they do not support.
+-   `coveoua('set', <OBJECT>)`: Attempts to inject all attributes and values of the given object on every logged event, overriding any existing value. Some payloads may reject attributes they do not support.
+-   `coveoua('set', 'custom', <OBJECT>)`: Attempts to inject all attributes and values of the given object in the custom section of an object, overriding any existing value. Use this call to pass customer specific parameters on the payload.
+-   `coveoua('onLoad', <CALLBACK>)`: Calls the specified function immediately, library initialization is not required.
+-   `coveoua('reset')`: Resets the state of the logger to the state before initialization.
+
+### Sending events
+
+-   `coveoua('send', <EVENT_NAME>, <EVENT_PAYLOAD>)`: Sends an event with a given name and payload to the analytics endpoint.
+
+### Plugin control
+
+-   `coveoua('provide', <PLUGIN_NAME>, <PLUGINCLASS>)`: Registers a given pluginClass with the analytics library under the provided name.
+-   `coveoua('require', <PLUGIN_NAME>)`: Explicitly loads the plugin with the given name.
+-   `coveoua('callPlugin', <PLUGIN_NAME>, <FUNCTION>, <PARAMS>)`: Executes the specified function with given arguments on the given plugin name. Can be shorthanded using a plugin action prefix `coveoua(<PLUGINNAME>:<FUNCTION>, <PARAMS>)`.
+
+## Plugins
+
+Coveoua is set up in a modular way with different plugins providing functionality that may be specific to a given usecase. This allows you to customize some of its behavior dynamically. By default, the following plugins are loaded at library initialization:
+
+-   `ec`: eCommerce plugin which takes care of sending eCommerce specific events.
+-   `svc`: Service plugin which takes care of sending customer service specific events.
+
+Plugin actions extend the set of available actions. They can be executed either via the `callPlugin` action above, or via the shorthand. For example, to call the function `addImpression` on the `ec` plugin, you'd specify `coveoua('ec:addImpression', ...)`.
+
+It is possible to disable loading of any plugins by explicitly initializing the library with an empty list of plugins using `coveoua('init', <API_KEY>, {plugins:[]})`.
+
+## Sending basic usage analytics events
+
+In most common integration usecases, you will be using Coveo pre-wired components (e.g. jsui, headless or atomic) to handle communication with the Coveo backend. These components have their own specific apis to handle event logging.
+
+When you are not using any specific Coveo web component, you need to send these events payloads explicitly, use the `send` action to transmit an assembled payload to the usage analytics backend. See the [Usage Analytics Events](https://docs.coveo.com/en/2949/analyze-usage-data/usage-analytics-events) documentation for description of the payload contents. The following event types are supported in coveoua:
+
+-   `search`: sends a [client side search](https://docs.coveo.com/en/1502/build-a-search-ui/log-search-events) event.
+-   `click`: sends a [click event](https://docs.coveo.com/en/2064/build-a-search-ui/log-click-events).
+-   `view`: sends a [view event](https://docs.coveo.com/en/2651/build-a-search-ui/log-view-events).
+-   `custom`: sends a [custom event](https://docs.coveo.com/en/2650/build-a-search-ui/log-custom-events).
+-   `collect`: sends a [collect event](https://docs.coveo.com/en/l41i0031/build-a-search-ui/log-collect-events) payload. We strongly recommend you use the simplified api in the ecommerce plugin [to send these events instead](#sending-commerce-specific-events).
+
+For example, in order to send a click event after a user has interacted with a Coveo provided result, first initialize the library with an api key and then send a click event with the appropriate payload. Refer to the [click event documentation](https://docs.coveo.com/en/2064/build-a-search-ui/log-click-events) for up to date information on event payloads.
+
+```js
+coveoua('send', 'click', {...});
+```
+
+You should be able to observe the click event being transmitted to the Coveo backend at `https://analytics.cloud.coveo.com/rest/ua/click` in the Developer tool's **Network** tab of your browser of choice.
+
+## Sending commerce specific events
+
+Commerce specific events such as product selections, shopping cart modifications and transactions are sent to Coveo in the compact [collect protocol](https://docs.coveo.com/en/l41i0031/build-a-search-ui/log-collect-events). Rather than explicitly assembling these payloads by hand, the eCommerce plugin provides APIs to assemble and transmit the payloads. The `event` is specific to the eCommerce plugin:
+
+-   `event`: An event, which has been assembled through different plugin actions.
+
+The eCommerce plugin supports adding product data (`ec:addProduct`) as well as setting the [appropriate event action](https://docs.coveo.com/en/l29e0540/coveo-for-commerce/commerce-events-reference#product-action-type-reference) through `ec:setAction`. These calls can be used in series to assemble different types of payloads:
+
+-   A [product detail view](https://docs.coveo.com/en/l2pd0522)
+-   [Cart modification events](https://docs.coveo.com/en/n39h1594/)
+-   A [cart purchase](https://docs.coveo.com/en/l39m0327/coveo-for-commerce/measure-a-purchase)
+-   An [event on a search-driven listing-page](https://docs.coveo.com/en/l41a1037/coveo-for-commerce/measure-events-on-a-listing-or-search-page)
+
+As a sample, here is how a [cart modification event](https://docs.coveo.com/en/l3jg0266/coveo-for-commerce/measure-cart-page-events#measure-an-increase-in-item-quantity-in-cart) is assembled:
+
+1. First use the `ec:addProduct` action to include the [relevant product data](https://docs.coveo.com/en/l29e0540/coveo-for-commerce/commerce-events-reference#product-data-fields-reference) in the event you’re about to send
+    ```js
+    coveoua('ec:addProduct', <PRODUCT_DATA>);
+    ```
+2. Then use the `ec:setAction` action to specify that the [action done on this data](https://docs.coveo.com/en/l29e0540/coveo-for-commerce/commerce-events-reference#product-action-type-reference) is an addition to the cart.
+    ```js
+    coveoua('ec:setAction', 'add');
+    ```
+3. Finally, use the `send` action to send the generic event to Coveo Usage Analytics. The payload is implicit in this case, and has been generated by the plugin.
+    ```js
+    coveoua('send', 'event');
+    ```
+
+## Linking clientIds across different domains using a URL parameter
+
+To help track a visitor across different domains, the library offers functionality to initialize a clientId from a URL query parameter. The query parameter is named `cvo_cid` with value `<clientid>.<timestamp>`. The clientId is encoded without dashes and the timestamp is encoded in seconds since epoch, both to save space in the url. Both are separated by a period. A sample parameter could be `cvo_cid=c0b48880743e484f8044d7c37910c55b.1676298678`. This query parameter will be picked up by the target page if the following conditions hold:
+
+-   The target page has a equal or greater version of coveo.analytics.js loaded.
+-   The current URL contains a `cvo_cid` query parameter
+-   The parameter contains a valid uuid.
+-   The parameter contains a valid timestamp, and that timestamp is no more than 120 seconds in the past.
+-   The receiving page has specified a list of valid referrers and the current referrer host matches that list, using wildcards, including ports, specified using `coveoua('link:acceptFrom', [<referrers>])`.
+
+Given that you want to ensure the clientId remains consistent when you navigate from a source page on http://foo.com/index.html to a target page http://bar.com/index.html, the following steps are needed.
+
+1. Ensure coveo.analytics.js is loaded on the source page.
+2. Modify the source page such that whenever a link to the target page is clicked, its `href` is replaced by `coveoua('link:decorate', 'http://bar.com/index.html')`. For example, by creating an onClick event listener on the element or on the page. It's important that the decorated link is generated at the moment the link is clicked, as it will be valid only for a short time after generation.
+
+```html
+<script>
+    async function decorate(element) {
+        element.href = await coveoua('link:decorate', element.href);
+    }
+</script>
+<a onclick="decorate(this)" href="http://bar.com/index.html">Navigate</a>>
+```
+
+3. Ensure coveo.analytics.js is loaded on the target page.
+4. Ensure that the target page allows reception of links from the source page by adding `coveoua('link:acceptFrom', ['foo.com']);` immediately after script load.
+
+# Developer information
+
+Information for contributors or Coveo developers developing or integrating coveoua.
+
+## Setup
+
+```bash
+git clone
+npm install
+npm run build
+```
+
+## Running and observing the code
+
+There are two ways to run your code locally:
+
+1. Run `npm run start` and open your browser on http://localhost:9001
+
+2. Debugging through VSCode debugger with the `Debug: Start Debugging` command, using the `Launch Chrome` configuration.
+
+To test out your changes, add `coveoua` function calls in the `public/index.html` file and check the payload in the `Developer Console` section of your browser.
+
+## Running tests
+
+1. From the command line through `npm run test`.
+2. Debugging through VSCode debugger with the `Debug: Start Debugging` command, using the `Jest All` configuration.
+
+## Storage and persistence
+
+Coveo.analytics.js tracks interactions from the same browser client, through a client side provided uuid called a `clientId`. This clientId is initialized on first use and there are multiple options for persisting it's value:
+
+-   Cookie storage, which supports top level domain storage. This means that the clientId for a.foo.com will be identical to the one on b.foo.com.
+-   Local storage, which allows to store much more information client side, but has the drawback of not being able to access data across multiple top level domains.
+-   Session storage, which has roughly the same limitation and capability as Local storage, except that it is cleared when the web browser tab is closed.
+
+By default, coveoua will use both local storage and cookie storage to persist its clientId. If your environment does not support local persistence, it's possible to write your own storage abstraction.
+
+## Using coveo.analytics.js with React Native
+
+Since React Native does not run inside a browser, it cannot use cookies or the local/session storage that modern browsers provide. You must provide your own Storage implementation. Thankfully, there exist multiple packages to store data:
+
+-   [React native community AsyncStorage](https://github.com/react-native-async-storage/async-storage) (recommended)
+-   [React native AsyncStorage](https://reactnative.dev/docs/asyncstorage) (deprecated)
+-   [Expo Secure Store](https://docs.expo.dev/versions/latest/sdk/securestore/)
+
+A sample React native storage class implementation could look as follows
+
+```js
+import {CoveoAnalyticsClient, ReactNativeRuntime} from 'coveo.analytics/react-native';
+// Use any React native storage library or implement your own.
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// Sample storage class
+class ReactNativeStorage implements WebStorage {
+    async getItem(key: string) {
+        return AsyncStorage.getItem(key);
+    }
+    async setItem(key: string, data: string) {
+        return AsyncStorage.setItem(key, data);
+    }
+    async removeItem(key: string) {
+        AsyncStorage.removeItem(key);
+    }
+}
+
+// Create an API client with a specific runtime
+const client = new CoveoAnalyticsClient({
+    token: 'YOUR_API_KEY',
+    runtimeEnvironment: new ReactNativeRuntime({
+        token: 'YOUR_API_KEY',
+        storage: new ReactNativeStorage(),
+    }),
+});
+
+// Send your event
+client.sendCustomEvent({
+    eventType: 'dog',
+    eventValue: 'Hello! Yes! This is Dog!',
+    language: 'en',
+});
+```
+
+## Conformance
+
+Chrome, Firefox, Safari, Edge. IE11 support on a reasonable-effort basis.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## License
+
+MIT license (see [LICENSE](LICENSE)).
+
+[![forthebadge](https://forthebadge.com/images/badges/built-with-love.svg)](https://forthebadge.com)
+[![coveo](./assets/by-coveo.png)](https://www.coveo.com)

--- a/packages/coveo-analytics/bundle/browser-fetch.ts
+++ b/packages/coveo-analytics/bundle/browser-fetch.ts
@@ -1,0 +1,3 @@
+// This file is to prevent including a fetch polyfill from the "cross-fetch" dependency when building for a browser target.
+// Major browsers today provide fetch on the window object, so including a polyfill would needlessly increase the size of the bundle.
+export const fetch = window.fetch;

--- a/packages/coveo-analytics/docs/technical-overview.md
+++ b/packages/coveo-analytics/docs/technical-overview.md
@@ -1,0 +1,146 @@
+# Technical Overview of coveo.analytics.js
+
+Here is a brief document explaining some design decisions in the project.
+
+## Replicating the Google Measurement Protocol
+
+When Coveo wanted to start tracking Commerce events, we decided to stick to an existing format instead of designing our own. This lead to the usage of Google's [Measurement Protocol](https://developers.google.com/analytics/devguides/collection/protocol/v1/reference) with the "Enhanced ECommerce" capabilities.
+
+The idea was to allow people that already use this format to very quickly switch (or use with) the coveo.analytics.js library for commerce tracking.
+
+On the Coveo Usage Analytics side, a new endpoint was created to accept this format and is called the `collect` endpoint.
+
+## Project Structure
+
+### src/client
+
+The client section holds the analytics client that can be constructed and used as a standard client.
+
+The "runtime" is a small wrapper around features that are only available in NodeJS or in the Browser
+
+The "fetchClient" is using a standard "fetch" to send the event.
+
+The "beaconClient" is used to send "beacons" from the navigator. This "beacon" has _no response validation from the browser_ (send and forget), so it is especially useful when the event is sent on an outgoing click.
+
+Everything related to "Measurement Protocol Mapping" contain all the logic to map human-readable attribute to the Measurement Protocol condensed format.
+
+The `analytics.ts` file is the one wrapping everything into a neatly usable client.
+
+### src/coveoua
+
+This section holds the library that is compiled for browser usage. It wraps the "client" (see previous section) into an easy to use `coveoua()` queue.
+
+`simpleanalytics.ts` holds the logic of processing one event from the queue.
+
+`browser.ts` holds the logic of assigning the global variable in the browser.
+
+`plugins.ts` allows registering an external plugin (such as `ec` and `svc`, but both of them are included by default for convenience). See the plugins section for more details.
+
+### src/formatting
+
+This sections holds some formatting methods for metadata.
+
+### src/hook
+
+This section holds "hooks" that are executed on sending a new event. It is mostly used to centralise a specific logic that modifies the event in some way.
+
+`addDefaultValues.ts` ensures that some values are always included
+
+`enhanceViewEvent.ts` ensures that view events include the location, referrer, and also adds the event to the history store.
+
+### src/plugins
+
+This section contains plugins that add specific features and new actions to the standard protocol. E.g. `ec:addProduct`.
+
+`BasePlugin.ts` contains the main logic of updating the `location` and `referrer` on a new `coveoua("send", "pageview")` event, adding some other default values that are required for the Measurement Protocol, and managing the action data.
+
+`ec.ts` and `svc.ts` both register the actions that should use the measurement protocol with `this.client.addEventTypeMapping`, and also register some hooks to properly add some properties with `this.client.registerBeforeSendEventHook`. They also take care of holding some values (such as `products` that are added with `ec:addProduct`) until an event or pageview is sent to the Collect endpoint.
+
+### src/react-native
+
+This section holds the objects related to react-native runtime.
+
+### src/searchPage
+
+`searchPageClient` is a wrapper around the main client that is strongly typed for Search Page events.
+
+### functional
+
+This section holds tests that mimic real user behavior. Some methods are available to get back the request and the response for each call. The goal here is to have as many "real use cases" tests.
+
+### Cypress
+
+This section holds an e2e test that loads the page and sends a pageview. The purpose of this is to monitor that the `coveoua` script can be called from the browser by using the static endpoint at any time.
+
+## Quirks in the Project
+
+### Plugins
+
+The reasons there are "plugins" in the project is to mimic what is done in the `ga.js` library. (In the end, we include our 2 plugins all the time, so maybe this was unnecessary)
+
+### Client Hooks
+
+Since we are using plugins, we needed a way to inject some logic into the main event processing. This was done in a "pipeline" fashion, where multiple processors receive the event from the previous processor and can alter it in any way.
+
+#### resolveParameters
+
+In the `analytics.ts` file, the `resolveParameters` method is used to transform the current parameters, e.g. with `coveoua("send", "event", { page: 'X' })`, you need to process the `{ page: 'X' }` parameters into a specific way depending on the event.
+
+The `processVariableArgumentsNamesStep` is parsing the "variable arguments" of the command. For instance, the `coveoua("send", "event")` can accept multiple optional variables which must be mapped to values. These mappings are added with hooks from the plugins with the `addEventTypeMapping` method. Given the following code:
+
+```ts
+this.client.addEventTypeMapping(ECPluginEventTypes.event, {
+    newEventType: EventType.collect,
+    variableLengthArgumentsNames: ['eventCategory', 'eventAction', 'eventLabel', 'eventValue'],
+    addVisitorIdParameter: true,
+    usesMeasurementProtocol: true,
+});
+```
+
+This tells the client that an `event` (`coveoua("send", "event)`) can accept 4 parameters (`eventCategory`, and so on).
+
+`addVisitorIdParameter` tells the script to append the visitorId, and `useMeasurementProtocol` tells to map use the measurement protocol mapper.
+
+So in the end, `coveoua("send", "event", "category", "action")` will be mapped into the following parameters: `{ eventCategory: "category", eventAction: "action" }`.
+
+The next steps are `addVisitorIdStep`, `setAnonymousUserStep`, which pretty self-explanatory.
+
+The last one is `processBeforeSendHooksStep`, this steps is it's own "pipeline" where every `beforeSendHooks` will accept the payload and return a new one. You can technically register any event in this hook to preprocess it. The plugins append their own data by using these (see `registerBeforeSendEventHook` references)
+
+If you try to use `client.getParameters()`, it will return the current parameters for the call you plan on sending. At this point, you can observe all the `location`, `visitorId`, and everything else that are currently set by the method calls.
+
+But this data is not yet ready to be sent to the Usage Analytics endpoint, which is why we must process it into a _payload_.
+
+#### resolvePayload
+
+The job here is to take the current parameter and process them for the endpoint.
+
+It functions in a similar "pipeline" way, where each function processes the payload in some way.
+
+We first `cleanPayloadStep` to remove empty values, then `validateParams` to validate the parameters that only accept a couple of values, then we convert the parameters into the measurement protocol format with `processMeasurementProtocolConversionStep`. We validate that those values all follow the measurement protocol format with `removeUnknownParameters`. The `processCustomParameters` then takes care of "unfolding" any `custom` value in the payload.
+
+The `client.getPayload()` method will give you the result of this step, which should have (almost) all keys in the Measurement Protocol format (the exception being the "Coveo Extension Keys", see section related to that)
+
+#### afterSendHooks
+
+After the event is sent, you can use your own hook to do something with the payload. The `registerAfterSendEventHook` method is there for you.
+
+### Key Mapping, and Coveo Extensions
+
+Some keys are part of the Measurement Protocol and are carefully separated for clarity.
+
+The `baseMeasurementProtocolMapper` includes the mappings to be done for every plugin. `coveoExtensionsKeys` are keys that are "passthrough", meaning that sending `coveoua("send", "event", { "tab": 'x'})` will result in `tab: 'x'` in the final payload.
+
+`commerceMeasurementProtocolMapper` contains all the data to map product, impressions and other commerce keys. It also has the regex validators to ensure that only valid measurement protocol keys are sent as a payload.
+
+`serviceMeasurementProtocolMapper` is similar, but contains stuff for the Service use case.
+
+### Beacon VS Fetch, and the buffer
+
+If you try to send an event with `fetch` and a redirection happens, the event will get canceled because the browser waits for the response and it will never actually send the event. To fix this, you need to use `navigator.sendBeacon`.
+
+To simplify the whole thing, we introduce a mini-buffer that holds the event.".
+
+The trick here is to flush the buffer with a `setTimeout(flush, 0)` so that the event is sent as soon as the thread is available. But on a `beforeunload` event, triggered when a redirection happen, flush the events with the `beacon`.
+
+This ensures that we use `beacon` on the right occasion, and `fetch` for the rest of the times.

--- a/packages/coveo-analytics/docs/technical-overview.md
+++ b/packages/coveo-analytics/docs/technical-overview.md
@@ -42,7 +42,7 @@ This sections holds some formatting methods for metadata.
 
 ### src/hook
 
-This section holds "hooks" that are executed on sending a new event. It is mostly used to centralise a specific logic that modifies the event in some way.
+This section holds "hooks" that are executed on sending a new event. It is mostly used to centralize a specific logic that modifies the event in some way.
 
 `addDefaultValues.ts` ensures that some values are always included
 

--- a/packages/coveo-analytics/functional/ec-events.spec.ts
+++ b/packages/coveo-analytics/functional/ec-events.spec.ts
@@ -1,0 +1,1073 @@
+import {DefaultEventResponse} from '../src/events';
+import type {getCurrentClient} from '../src/coveoua/library';
+import coveoua from '../src/coveoua/browser';
+import {mockFetch} from '../tests/fetchMock';
+
+declare const self: any;
+const getClient: typeof getCurrentClient = (self.coveoanalytics as any).getCurrentClient;
+const {fetchMock, fetchMockBeforeEach} = mockFetch();
+
+describe('ec events', () => {
+    const initialLocation = `${window.location}`;
+    const aToken = 'token';
+    const anEndpoint = 'http://bloup';
+
+    const guidFormat = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+
+    const defaultContextValues = {
+        dl: `${location.protocol}//${location.hostname}${
+            location.pathname.indexOf('/') === 0 ? location.pathname : `/${location.pathname}`
+        }${location.search}`,
+        sr: `${screen.width}x${screen.height}`,
+        sd: `${screen.colorDepth}-bit`,
+        ul: navigator.language,
+        ua: navigator.userAgent,
+        dr: document.referrer,
+        dt: document.title,
+        de: document.characterSet,
+        pid: expect.stringMatching(guidFormat),
+        cid: expect.stringMatching(guidFormat),
+        tm: expect.any(Number),
+        z: expect.stringMatching(guidFormat),
+    };
+
+    let client: ReturnType<typeof getClient>;
+
+    beforeEach(() => {
+        fetchMockBeforeEach();
+
+        changeDocumentLocation(initialLocation);
+        const address = new RegExp('/rest/v15/analytics');
+        fetchMock.reset();
+        fetchMock.post(address, (url, {body}) => {
+            const parsedBody = JSON.parse(body!.toString());
+            const visitorId = parsedBody.cid;
+            return {
+                visitId: 'firsttimevisiting',
+                visitorId,
+            } as DefaultEventResponse;
+        });
+        coveoua('reset');
+        coveoua('init', aToken, anEndpoint);
+        client = getClient();
+    });
+
+    it('can set custom data at the root level and send a page view event', async () => {
+        await coveoua('set', 'custom', {
+            verycustom: 'value',
+        });
+        await coveoua('send', 'pageview');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            verycustom: 'value',
+        });
+    });
+
+    it('can set custom data as a customData object and send a click event', async () => {
+        await coveoua('set', 'custom', {
+            verycustom: 'value',
+        });
+        await coveoua('send', 'click');
+
+        const [body] = getParsedBody();
+
+        expect(body).toHaveProperty('customData.verycustom', 'value');
+    });
+
+    it('should lowercase the properties of custom objects', async () => {
+        await coveoua('set', 'custom', {
+            camelCase: 'camel',
+            snake_case: 'snake',
+            PascalCase: 'pascal',
+            UPPER_CASE_SNAKE: 'upper snake',
+        });
+        await coveoua('send', 'pageview');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            camelcase: 'camel',
+            snake_case: 'snake',
+            pascalcase: 'pascal',
+            upper_case_snake: 'upper snake',
+        });
+    });
+
+    it('will not include the product or action when sending a pageview event', async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
+        await coveoua('send', 'pageview');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+        });
+    });
+
+    it('will include the product and action only when sending a detail event', async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
+        coveoua('send', 'pageview');
+        await coveoua('send', 'event');
+
+        coveoua('ec:addProduct', {name: 'wow2', id: 'something2', brand: 'brand2'});
+        coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
+        coveoua('send', 'event');
+        await coveoua('send', 'pageview');
+
+        const [pageviewBody, eventBody, eventBody2, pageviewBody2] = getParsedBody();
+
+        expect(pageviewBody.pa).toBeUndefined();
+        expect(pageviewBody.pr1nm).toBeUndefined();
+        expect(pageviewBody.pr1id).toBeUndefined();
+        expect(pageviewBody.pr1br).toBeUndefined();
+
+        expect(eventBody.pa).toEqual('detail');
+        expect(eventBody.pr1nm).toEqual('wow');
+        expect(eventBody.pr1id).toEqual('something');
+        expect(eventBody.pr1br).toEqual('brand');
+
+        expect(eventBody2.pa).toEqual('detail');
+        expect(eventBody2.pr1nm).toEqual('wow2');
+        expect(eventBody2.pr1id).toEqual('something2');
+        expect(eventBody2.pr1br).toEqual('brand2');
+
+        expect(pageviewBody2.pa).toBeUndefined();
+        expect(pageviewBody2.pr1nm).toBeUndefined();
+        expect(pageviewBody2.pr1id).toBeUndefined();
+        expect(pageviewBody2.pr1br).toBeUndefined();
+    });
+
+    it('can send a product detail view event', async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        coveoua('ec:setAction', 'detail', {storeid: 'amazing'});
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            pr1nm: 'wow',
+            pr1id: 'something',
+            pr1br: 'brand',
+            pa: 'detail',
+        });
+    });
+
+    it('can send a product detail view event with custom values', async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand'});
+        coveoua('ec:setAction', 'detail', {storeid: 'amazing', custom: {verycustom: 'value'}});
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            pr1nm: 'wow',
+            pr1id: 'something',
+            pr1br: 'brand',
+            pa: 'detail',
+            verycustom: 'value',
+        });
+    });
+
+    it('can send a product impression event', async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        coveoua('ec:setAction', 'impression');
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            pr1nm: 'wow',
+            pr1id: 'something',
+            pr1br: 'brand',
+            pa: 'impression',
+        });
+    });
+
+    it('can send a product quickview event', async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        coveoua('ec:setAction', 'quickview');
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            pr1nm: 'wow',
+            pr1id: 'something',
+            pr1br: 'brand',
+            pa: 'quickview',
+        });
+    });
+
+    it('can send a product bookmark add event', async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        coveoua('ec:setAction', 'bookmark_add');
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            pr1nm: 'wow',
+            pr1id: 'something',
+            pr1br: 'brand',
+            pa: 'bookmark_add',
+        });
+    });
+
+    it('can send a product bookmark remove event', async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        coveoua('ec:setAction', 'bookmark_remove');
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            pr1nm: 'wow',
+            pr1id: 'something',
+            pr1br: 'brand',
+            pa: 'bookmark_remove',
+        });
+    });
+
+    it('can send a pageview event with options', async () => {
+        await coveoua('send', 'pageview', 'page', {
+            title: 'wow',
+            location: 'http://right.here',
+        });
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            dp: 'page',
+            dt: 'wow',
+            dl: 'http://right.here',
+        });
+    });
+
+    it('can send a pageview event with options containing custom values', async () => {
+        await coveoua('send', 'pageview', 'page', {
+            title: 'wow',
+            location: 'http://right.here',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            dp: 'page',
+            dt: 'wow',
+            dl: 'http://right.here',
+            verycustom: 'value',
+        });
+    });
+
+    it("doesn't crash when sending an unknown action", async () => {
+        coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        coveoua('ec:setAction', 'bloup');
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            pr1nm: 'wow',
+            pr1id: 'something',
+            pr1br: 'brand',
+        });
+    });
+
+    it('should change the pageViewId only when sending a second page view event', async () => {
+        await coveoua('send', 'event');
+        await coveoua('send', 'event');
+        await coveoua('send', 'pageview');
+        await coveoua('send', 'event');
+        await coveoua('send', 'pageview');
+        await coveoua('send', 'event');
+
+        const [event, secondEvent, pageView, thirdEvent, secondPageView, afterSecondPageView] = getParsedBody();
+
+        [event, secondEvent, pageView, thirdEvent, secondPageView, afterSecondPageView]
+            .map((e) => e.pid)
+            .forEach((pid) => expect(pid).toMatch(guidFormat));
+
+        expect(event.pid).toBe(secondEvent.pid);
+        expect(event.pid).toBe(pageView.pid);
+        expect(event.pid).toBe(thirdEvent.pid);
+        expect(event.pid).not.toBe(secondPageView.pid);
+        expect(secondPageView.pid).toBe(afterSecondPageView.pid);
+    });
+
+    it('should update the current location and referrer on a second page view', async () => {
+        const secondLocation = 'http://very.new/';
+
+        await coveoua('send', 'pageview');
+        await coveoua('send', 'event', '1');
+        changeDocumentLocation(secondLocation);
+        await coveoua('send', 'pageview');
+        await coveoua('send', 'event', '2');
+
+        const [pageView, afterFirst, secondPageView, afterSecond] = getParsedBody();
+
+        expect(pageView.dl).toBe(initialLocation);
+        expect(pageView.dr).toBe(document.referrer);
+        expect(afterFirst.dl).toBe(initialLocation);
+        expect(afterFirst.dr).toBe(document.referrer);
+
+        expect(secondPageView.dl).toBe(secondLocation);
+        expect(secondPageView.dr).toBe(initialLocation);
+        expect(afterSecond.dl).toBe(secondLocation);
+        expect(afterSecond.dr).toBe(initialLocation);
+    });
+
+    it('should only update the current location and referrer on the first page view (COM-1372)', async () => {
+        const secondLocation = 'http://very.new/';
+
+        await coveoua('send', 'event', '1');
+        await coveoua('send', 'pageview');
+        changeDocumentLocation(secondLocation);
+        await coveoua('send', 'event', '2');
+        await coveoua('send', 'pageview');
+        await coveoua('send', 'event', '3');
+
+        const [firstEvent, firstPageView, secondEvent, secondPageView, thirdEvent] = getParsedBody();
+
+        expect(firstEvent.dl).toBe(initialLocation);
+        expect(firstEvent.dr).toBe(document.referrer);
+        expect(firstPageView.dl).toBe(initialLocation);
+        expect(firstPageView.dr).toBe(document.referrer);
+        expect(secondEvent.dl).toBe(initialLocation);
+        expect(secondEvent.dr).toBe(document.referrer);
+
+        expect(secondPageView.dl).toBe(secondLocation);
+        expect(secondPageView.dr).toBe(initialLocation);
+        expect(thirdEvent.dl).toBe(secondLocation);
+        expect(thirdEvent.dr).toBe(initialLocation);
+    });
+
+    it('should return the same payload', async () => {
+        const secondLocation = 'http://very.new/';
+
+        const firstPayload = await client!.getPayload('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+        const secondPayload = await client!.getPayload('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+        await coveoua('send', 'pageview');
+        changeDocumentLocation(secondLocation);
+        const firstAfterPayload = await client!.getPayload('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+        const secondAfterPayload = await client!.getPayload('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+
+        const firstPayloadToCompare = returnCommonAttributes(firstPayload, ['tm', 'z']);
+        const secondPayloadToCompare = returnCommonAttributes(secondPayload, ['tm', 'z']);
+        const firstAfterPayloadToCompare = returnCommonAttributes(firstAfterPayload, ['tm', 'z']);
+        const secondAfterPayloadToCompare = returnCommonAttributes(secondAfterPayload, ['tm', 'z']);
+
+        expect(firstPayloadToCompare).toEqual(secondPayloadToCompare);
+        expect(firstPayloadToCompare.dl).toBe(initialLocation);
+        expect(firstPayloadToCompare.dr).toBe(document.referrer);
+
+        expect(firstAfterPayloadToCompare).toEqual(secondAfterPayloadToCompare);
+        expect(firstAfterPayloadToCompare.dl).toBe(secondLocation);
+        expect(firstAfterPayloadToCompare.dr).toBe(initialLocation);
+    });
+
+    it('should return the same parameters', async () => {
+        const secondLocation = 'http://very.new/';
+
+        const firstParameters = await client!.getParameters('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+        const secondParameters = await client!.getParameters('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+        await coveoua('send', 'pageview');
+        changeDocumentLocation(secondLocation);
+        const firstAfterParameters = await client!.getParameters('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+        const secondAfterParameters = await client!.getParameters('pageview', {
+            title: 'wow',
+            custom: {
+                verycustom: 'value',
+            },
+        });
+
+        const firstParametersToCompare = returnCommonAttributes(firstParameters, ['time', 'eventId']);
+        const secondParametersToCompare = returnCommonAttributes(secondParameters, ['time', 'eventId']);
+        const firstAfterParametersToCompare = returnCommonAttributes(firstAfterParameters, ['time', 'eventId']);
+        const secondAfterParametersToCompare = returnCommonAttributes(secondAfterParameters, ['time', 'eventId']);
+
+        expect(firstParametersToCompare).toEqual(secondParametersToCompare);
+        expect(firstParametersToCompare.location).toBe(initialLocation);
+        expect(firstParametersToCompare.referrer).toBe(document.referrer);
+
+        expect(firstAfterParametersToCompare).toEqual(secondAfterParametersToCompare);
+        expect(firstAfterParametersToCompare.location).toBe(secondLocation);
+        expect(firstAfterParametersToCompare.referrer).toBe(initialLocation);
+    });
+
+    it('should return similar parameters and payload', async () => {
+        const parameters = await client!.getParameters('pageview', {});
+        const payload = await client!.getPayload('pageview', {});
+
+        const firstParametersToCompare = returnCommonAttributes(parameters, ['time', 'eventId']);
+
+        expect(firstParametersToCompare).toEqual({
+            hitType: payload.t,
+            pageViewId: payload.pid,
+            encoding: payload.de,
+            location: payload.dl,
+            referrer: payload.dr,
+            screenColor: payload.sd,
+            screenResolution: payload.sr,
+            title: payload.dt,
+            userAgent: payload.ua,
+            language: payload.ul,
+            visitorId: payload.cid,
+        });
+    });
+
+    it('should return similar parameters and send', async () => {
+        const firstParameters = await client!.getParameters('pageview', {});
+        await coveoua('send', 'pageview');
+        const secondParameters = await client!.getParameters('pageview', {});
+        await coveoua('send', 'pageview');
+
+        const [pageView, secondPageView] = getParsedBody();
+
+        const firstParametersToCompare = returnCommonAttributes(firstParameters, ['time', 'eventId']);
+        const secondParametersToCompare = returnCommonAttributes(secondParameters, ['time', 'eventId']);
+
+        expect(firstParametersToCompare).toEqual({
+            hitType: pageView.t,
+            pageViewId: pageView.pid,
+            encoding: pageView.de,
+            location: pageView.dl,
+            referrer: pageView.dr,
+            screenColor: pageView.sd,
+            screenResolution: pageView.sr,
+            title: pageView.dt,
+            userAgent: pageView.ua,
+            language: pageView.ul,
+            visitorId: pageView.cid,
+        });
+
+        expect(secondParametersToCompare).toEqual({
+            hitType: secondPageView.t,
+            pageViewId: secondPageView.pid,
+            encoding: secondPageView.de,
+            location: secondPageView.dl,
+            referrer: secondPageView.dr,
+            screenColor: secondPageView.sd,
+            screenResolution: secondPageView.sr,
+            title: secondPageView.dt,
+            userAgent: secondPageView.ua,
+            language: secondPageView.ul,
+            visitorId: secondPageView.cid,
+        });
+    });
+
+    it('should return similar payload and send', async () => {
+        const firstPayload = await client!.getPayload('pageview', {});
+        await coveoua('send', 'pageview');
+        const secondPayload = await client!.getPayload('pageview', {});
+        await coveoua('send', 'pageview');
+
+        const [pageView, secondPageView] = getParsedBody();
+
+        const firstPayloadToCompare = returnCommonAttributes(firstPayload, ['tm', 'z']);
+        const secondPayloadToCompare = returnCommonAttributes(secondPayload, ['tm', 'z']);
+
+        const pageViewToCompare = returnCommonAttributes(pageView, ['tm', 'z']);
+
+        const secondPageViewToCompare = returnCommonAttributes(secondPageView, ['tm', 'z']);
+
+        expect(firstPayloadToCompare).toEqual(pageViewToCompare);
+        expect(secondPayloadToCompare).toEqual(secondPageViewToCompare);
+    });
+
+    it('should update the current location when a pageview is sent with the page parameter and keep it', async () => {
+        await coveoua('send', 'pageview', '/page');
+        await coveoua('send', 'event', '1');
+
+        const [event, secondEvent] = getParsedBody();
+
+        expect(event.dl).toBe(`${initialLocation}page`);
+        expect(secondEvent.dl).toBe(`${initialLocation}page`);
+    });
+
+    it('should keep the current location when a pageview is sent with the page parameter', async () => {
+        await coveoua('send', 'pageview', '/page');
+
+        const [event] = getParsedBody();
+
+        expect(event.dl).toBe(`${initialLocation}page`);
+    });
+
+    it('should be able to set the userId', async () => {
+        const aUser = '👴';
+        await coveoua('set', 'userId', aUser);
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            uid: aUser,
+        });
+    });
+
+    it('should be able to set trackingId using set action', async () => {
+        const trackingId = 'tracksite';
+        await coveoua('set', 'trackingId', trackingId);
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            trackingId: trackingId,
+        });
+    });
+
+    it('should be able to set trackingId with context_website for collect event', async () => {
+        const contextWebsite = 'tracksite';
+        await coveoua('set', 'custom', {context_website: contextWebsite});
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            trackingId: contextWebsite,
+            context_website: contextWebsite,
+        });
+    });
+
+    it('should be able to set trackingId with context_website for non-collect event', async () => {
+        const contextWebsite = 'tracksite';
+        await coveoua('set', 'custom', {context_website: contextWebsite});
+        await coveoua('send', 'view');
+
+        const [event] = getParsedBody();
+
+        expect(event).toHaveProperty('trackingId', contextWebsite);
+        expect(event).toHaveProperty('customData.context_website', contextWebsite);
+    });
+
+    it('context_website does not overwrite trackingId', async () => {
+        const contextWebsite = 'tracksite';
+        const trackingId = 'trackingid';
+        await coveoua('set', 'custom', {context_website: contextWebsite});
+        await coveoua('set', 'trackingId', trackingId);
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            trackingId: trackingId,
+            context_website: contextWebsite,
+        });
+    });
+
+    it('should be able to set trackingId with siteName on collect event', async () => {
+        const website = 'tracksite';
+        await coveoua('set', 'custom', {siteName: website});
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            trackingId: website,
+            sitename: website,
+        });
+    });
+
+    it('should be able to set trackingId with siteName on non-collect event', async () => {
+        const website = 'tracksite';
+        await coveoua('set', 'custom', {siteName: website});
+        await coveoua('send', 'view');
+
+        const [event] = getParsedBody();
+
+        expect(event).toHaveProperty('trackingId', website);
+        expect(event).toHaveProperty('customData.sitename', website);
+    });
+
+    it('siteName does not overwrite trackingId', async () => {
+        const website = 'tracksite';
+        const trackingId = 'trackingid';
+        await coveoua('set', 'custom', {siteName: website});
+        await coveoua('set', 'trackingId', trackingId);
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            trackingId: trackingId,
+            sitename: website,
+        });
+    });
+
+    describe('with auto-detection of userId', () => {
+        describe('with API key', () => {
+            beforeEach(() => {
+                coveoua('init', 'xxapikey', anEndpoint);
+            });
+
+            it('should set userId to anonymous', async () => {
+                await coveoua('send', 'pageview');
+
+                const [event] = getParsedBody();
+
+                expect(event).toEqual({
+                    ...defaultContextValues,
+                    t: 'pageview',
+                    uid: 'anonymous',
+                });
+            });
+            it('should not overwrite existing userId', async () => {
+                const aUser = '👴';
+                await coveoua('set', 'userId', aUser);
+                await coveoua('send', 'pageview');
+
+                const [event] = getParsedBody();
+
+                expect(event).toEqual({
+                    ...defaultContextValues,
+                    t: 'pageview',
+                    uid: aUser,
+                });
+            });
+        });
+        describe('with Search Token', () => {
+            beforeEach(() => {
+                const searchToken =
+                    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' +
+                    'eyJ1cmwiOiJodHRwczovL3d3dy55b3V0dWJlLmNvb' +
+                    'S93YXRjaD92PW9IZzVTSllSSEEwIiwidXNlcklkIj' +
+                    'oiUmljayBBc3RsZXkiLCJleHAiOjE1MTYyMzkwMjJ9.' +
+                    'gOxUfMZuwMFw-QK-q0xOKJ-23YgGwFJbncCIHgIxjcc';
+                coveoua('init', searchToken, anEndpoint);
+            });
+
+            it('should not set the user id', async () => {
+                await coveoua('send', 'pageview');
+
+                const [event] = getParsedBody();
+
+                expect(Object.keys(event)).not.toContain('uid');
+            });
+            it('should not overwrite existing userId', async () => {
+                const steveJobs = 'steve@apple.com';
+                await coveoua('set', 'userId', steveJobs);
+                await coveoua('send', 'pageview');
+
+                const [event] = getParsedBody();
+
+                expect(event).toEqual({
+                    ...defaultContextValues,
+                    t: 'pageview',
+                    uid: steveJobs,
+                });
+            });
+        });
+    });
+
+    it('should be able to set the anonymizeIp', async () => {
+        await coveoua('set', 'anonymizeIp', true);
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            aip: 1,
+        });
+    });
+
+    it('should be able to set the anonymizeIp with "true" string', async () => {
+        await coveoua('set', 'anonymizeIp', 'true');
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            aip: 1,
+        });
+    });
+
+    it('should be able to set the anonymizeIp to false', async () => {
+        await coveoua('set', 'anonymizeIp', false);
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+        });
+    });
+
+    it('should be able to set the anonymizeIp to false for undefined value', async () => {
+        await coveoua('set', 'anonymizeIp');
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+        });
+    });
+
+    it('should be able to set the anonymizeIp to true for anything in between', async () => {
+        await coveoua('set', 'anonymizeIp', 'pôtato');
+        await coveoua('send', 'pageview');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            aip: 1,
+        });
+    });
+
+    it('should remove unknown measurement protocol keys', async () => {
+        await coveoua('set', 'unknownParam', 'unknown');
+        await coveoua('send', 'pageview');
+
+        const [body] = getParsedBody();
+
+        expect(Object.keys(body)).not.toContain('unknownParam');
+    });
+
+    it('should remove unknown measurement protocol product keys', async () => {
+        await coveoua('ec:addProduct', {name: 'wow', id: 'something', brand: 'brand', unknown: 'ok'});
+        await coveoua('send', 'pageview');
+
+        const [body] = getParsedBody();
+
+        expect(Object.keys(body)).not.toContain('pr1unknown');
+    });
+
+    it('should append custom values to product', async () => {
+        var partialProduct = {name: 'wow', custom: {verycustom: 'value'}};
+        await coveoua('ec:addProduct', partialProduct);
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            pr1nm: partialProduct.name,
+            pr1verycustom: partialProduct.custom.verycustom,
+        });
+    });
+
+    it('should be able to follow the complete addToCart flow', async () => {
+        // https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#add-remove-cart
+        const product = {
+            id: 'id',
+            name: 'name',
+            category: 'category',
+            brand: 'brand',
+            variant: 'variant',
+            price: 0,
+            quantity: 0,
+        };
+        await coveoua('set', 'currencyCode', 'EUR');
+        await coveoua('ec:addProduct', product);
+        await coveoua('ec:setAction', 'add');
+        await coveoua('send', 'event', 'UX', 'click', 'add to cart');
+
+        const [event] = getParsedBody();
+
+        // Event directly extracted from `ca.js` with the same sequence of event.
+        expect(event).toEqual({
+            pid: expect.stringMatching(guidFormat), // Key changed from `a`
+            cid: expect.stringMatching(guidFormat),
+            cu: 'EUR',
+            de: defaultContextValues.de,
+            dl: defaultContextValues.dl,
+            dr: defaultContextValues.dr,
+            dt: defaultContextValues.dt,
+            ea: 'click',
+            ec: 'UX',
+            el: 'add to cart',
+            pa: 'add',
+            pr1br: product.brand,
+            pr1ca: product.category,
+            pr1id: product.id,
+            pr1nm: product.name,
+            pr1va: product.variant,
+            pr1pr: product.price,
+            pr1qt: product.quantity,
+            sd: defaultContextValues.sd,
+            sr: defaultContextValues.sr,
+            t: 'event',
+            tm: expect.any(Number),
+            ua: defaultContextValues.ua, // Added
+            ul: defaultContextValues.ul,
+            // v: 1, removed, we don't send version as of now.
+            z: expect.stringMatching(guidFormat),
+        });
+    });
+
+    it('should be able to follow the complete addImpression flow', async () => {
+        // https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#product-impression
+        const productImpression1 = {
+            id: 'P12345',
+            name: 'Android Warhol T-Shirt',
+            category: 'Apparel/T-Shirts',
+            brand: 'Google',
+            variant: 'black',
+            list: 'Search Results',
+            position: 1,
+        };
+        const productImpression2 = {
+            id: 'P67890',
+            name: 'YouTube Organic T-Shirt',
+            category: 'Apparel/T-Shirts',
+            brand: 'YouTube',
+            variant: 'gray',
+            list: 'Search Results',
+            position: 2,
+        };
+
+        await coveoua('ec:addImpression', productImpression1);
+        await coveoua('ec:addImpression', productImpression2);
+        await coveoua('send', 'event');
+
+        const [event] = getParsedBody();
+
+        expect(event).toEqual({
+            pid: expect.stringMatching(guidFormat),
+            cid: expect.stringMatching(guidFormat),
+            de: defaultContextValues.de,
+            dl: defaultContextValues.dl,
+            dr: defaultContextValues.dr,
+            dt: defaultContextValues.dt,
+            il1nm: productImpression1.list,
+            il1pi1id: productImpression1.id,
+            il1pi1nm: productImpression1.name,
+            il1pi1ca: productImpression1.category,
+            il1pi1br: productImpression1.brand,
+            il1pi1va: productImpression1.variant,
+            il1pi1ps: productImpression1.position,
+            il1pi2id: productImpression2.id,
+            il1pi2nm: productImpression2.name,
+            il1pi2ca: productImpression2.category,
+            il1pi2br: productImpression2.brand,
+            il1pi2va: productImpression2.variant,
+            il1pi2ps: productImpression2.position,
+            sd: defaultContextValues.sd,
+            sr: defaultContextValues.sr,
+            t: 'event',
+            tm: expect.any(Number),
+            ua: defaultContextValues.ua,
+            ul: defaultContextValues.ul,
+            z: expect.stringMatching(guidFormat),
+        });
+    });
+
+    it('ignores properties that are specific to another action', async () => {
+        await coveoua('ec:setAction', 'purchase', {
+            id: 'something',
+            rating: '5/7',
+        });
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+
+        expect(body).toEqual({
+            ...defaultContextValues,
+            pa: 'purchase',
+            t: 'event',
+            ti: 'something',
+        });
+    });
+
+    describe('with the coveo extensions', () => {
+        it('can send a quote event with a specific id and affiliation', async () => {
+            await coveoua('ec:setAction', 'quote', {
+                id: 'something',
+                affiliation: 'my super store',
+            });
+            await coveoua('send', 'event');
+
+            const [body] = getParsedBody();
+
+            expect(body).toEqual({
+                ...defaultContextValues,
+                pa: 'quote',
+                t: 'event',
+                quoteId: 'something',
+                quoteAffiliation: 'my super store',
+            });
+        });
+
+        it('can set an affiliation before defining the quote action', async () => {
+            coveoua('set', 'affiliation', 'super store');
+            await coveoua('ec:setAction', 'quote');
+            await coveoua('send', 'event');
+
+            const [body] = getParsedBody();
+
+            expect(body).toEqual({
+                ...defaultContextValues,
+                pa: 'quote',
+                t: 'event',
+                quoteAffiliation: 'super store',
+            });
+        });
+
+        it('can send a review event with a specific id and reviewRating', async () => {
+            await coveoua('ec:setAction', 'review', {
+                id: 'something',
+                reviewRating: 5,
+            });
+            await coveoua('send', 'event');
+
+            const [body] = getParsedBody();
+
+            expect(body).toEqual({
+                ...defaultContextValues,
+                pa: 'review',
+                t: 'event',
+                reviewId: 'something',
+                reviewRating: 5,
+            });
+        });
+
+        it('can send a product with the group property', async () => {
+            await coveoua('ec:addProduct', {
+                id: 'something',
+                group: 'nsync',
+            });
+            await coveoua('send', 'event');
+
+            const [body] = getParsedBody();
+
+            expect(body).toEqual({
+                ...defaultContextValues,
+                t: 'event',
+                pr1id: 'something',
+                pr1group: 'nsync',
+            });
+        });
+
+        it('can send an event with base extension keys', async () => {
+            await coveoua('send', 'event', {
+                contentId: 123,
+                contentIdKey: 'bloup',
+                contentType: 'fish',
+                searchHub: 'searchhub',
+                tab: 'tab',
+                searchUid: 'searchuid',
+                permanentId: 'somethingsomething',
+                contentLocale: 'en-us',
+                invalidOne: 'nope',
+            });
+
+            const [body] = getParsedBody();
+
+            expect(body).toEqual({
+                ...defaultContextValues,
+                t: 'event',
+                contentId: 123,
+                contentIdKey: 'bloup',
+                contentType: 'fish',
+                searchHub: 'searchhub',
+                tab: 'tab',
+                searchUid: 'searchuid',
+                permanentId: 'somethingsomething',
+                contentLocale: 'en-us',
+            });
+        });
+    });
+
+    const getParsedBody = (): any[] => {
+        return fetchMock.calls().map(([, {body}]: any) => JSON.parse(body.toString()));
+    };
+
+    const changeDocumentLocation = (url: string) => {
+        // @ts-ignore
+        delete window.location;
+        // @ts-ignore
+        // Ooommmpf... JSDOM does not support any form of navigation, so let's overwrite the whole thing 💥.
+        window.location = new URL(url);
+    };
+
+    const returnCommonAttributes = <T>(payload: T, attributesToRemove: Array<keyof T>) => {
+        attributesToRemove.forEach((attribute) => delete payload[attribute]);
+        return payload;
+    };
+});

--- a/packages/coveo-analytics/functional/svc-events.spec.ts
+++ b/packages/coveo-analytics/functional/svc-events.spec.ts
@@ -1,0 +1,119 @@
+import {DefaultEventResponse} from '../src/events';
+import coveoua from '../src/coveoua/browser';
+import {mockFetch} from '../tests/fetchMock';
+
+const {fetchMock, fetchMockBeforeEach} = mockFetch();
+
+describe('svc events', () => {
+    const initialLocation = `${window.location}`;
+    const aToken = 'token';
+    const anEndpoint = 'http://bloup';
+
+    const guidFormat = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+
+    const defaultContextValues = {
+        dl: `${location.protocol}//${location.hostname}${
+            location.pathname.indexOf('/') === 0 ? location.pathname : `/${location.pathname}`
+        }${location.search}`,
+        sr: `${screen.width}x${screen.height}`,
+        sd: `${screen.colorDepth}-bit`,
+        ul: navigator.language,
+        ua: navigator.userAgent,
+        dr: document.referrer,
+        dt: document.title,
+        de: document.characterSet,
+        pid: expect.stringMatching(guidFormat),
+        cid: expect.stringMatching(guidFormat),
+        tm: expect.any(Number),
+        z: expect.stringMatching(guidFormat),
+    };
+
+    beforeEach(() => {
+        fetchMockBeforeEach();
+
+        changeDocumentLocation(initialLocation);
+        const address = `${anEndpoint}/rest/v15/analytics/collect`;
+        fetchMock.reset();
+        fetchMock.post(address, (url, {body}) => {
+            const parsedBody = JSON.parse(body!.toString());
+            const visitorId = parsedBody.cid;
+            return {
+                visitId: 'firsttimevisiting',
+                visitorId,
+            } as DefaultEventResponse;
+        });
+        coveoua('reset');
+        coveoua('init', aToken, anEndpoint);
+    });
+
+    it('can send a pageview with a simple action and without ticket data', async () => {
+        coveoua('svc:setAction', 'ticket_create_start');
+
+        await coveoua('send', 'pageview');
+
+        const [body] = getParsedBody();
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'pageview',
+            svc_action: 'ticket_create_start',
+        });
+    });
+
+    it('can send an event with a complex action and ticket data', async () => {
+        coveoua('svc:setAction', 'ticket_classification_click', {classificationId: 'someId', requestID: 'someReqId'});
+        coveoua('svc:setTicket', {
+            subject: 'super subject',
+            description: 'some description',
+            category: 'some smort category',
+            custom: {verycustom: 'value'},
+        });
+
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            svc_action: 'ticket_classification_click',
+            svc_action_data: {classificationId: 'someId', requestID: 'someReqId'},
+            svc_ticket_subject: 'super subject',
+            svc_ticket_description: 'some description',
+            svc_ticket_category: 'some smort category',
+            svc_ticket_custom: {verycustom: 'value'},
+        });
+    });
+
+    it('should remove unknown measurement protocol ticket keys', async () => {
+        await coveoua('svc:setTicket', {
+            subject: 'super subject',
+            description: 'some description',
+            category: 'some smort category',
+            custom: {verycustom: 'value'},
+            unknown: 'ok',
+        });
+
+        await coveoua('send', 'event');
+
+        const [body] = getParsedBody();
+        expect(body).toEqual({
+            ...defaultContextValues,
+            t: 'event',
+            svc_ticket_subject: 'super subject',
+            svc_ticket_description: 'some description',
+            svc_ticket_category: 'some smort category',
+            svc_ticket_custom: {verycustom: 'value'},
+        });
+    });
+
+    const getParsedBody = (): any[] => {
+        return fetchMock.calls().map(([, {body}]: any) => JSON.parse(body.toString()));
+    };
+
+    const changeDocumentLocation = (url: string) => {
+        // @ts-ignore
+        delete window.location;
+        // @ts-ignore
+        // Ooommmpf... JSDOM does not support any form of navigation, so let's overwrite the whole thing 💥.
+        window.location = new URL(url);
+    };
+});

--- a/packages/coveo-analytics/src/caseAssist/caseAssistActions.ts
+++ b/packages/coveo-analytics/src/caseAssist/caseAssistActions.ts
@@ -1,0 +1,90 @@
+import {TicketProperties} from '../plugins/svc';
+
+export enum CaseAssistEvents {
+    click = 'click',
+    flowStart = 'flowStart',
+}
+
+export enum CaseAssistActions {
+    enterInterface = 'ticket_create_start',
+    fieldUpdate = 'ticket_field_update',
+    fieldSuggestionClick = 'ticket_classification_click',
+    suggestionClick = 'suggestion_click',
+    suggestionRate = 'suggestion_rate',
+    nextCaseStep = 'ticket_next_stage',
+    caseCancelled = 'ticket_cancel',
+    caseSolved = 'ticket_cancel',
+    caseCreated = 'ticket_create',
+}
+
+export enum CaseCancelledReasons {
+    quit = 'Quit',
+    solved = 'Solved',
+}
+
+export interface EnterInterfaceMetadata {
+    ticket: TicketProperties;
+}
+
+export interface UpdateCaseFieldMetadata {
+    fieldName: string;
+    ticket: TicketProperties;
+}
+
+export interface SelectFieldSuggestionMetadata {
+    suggestion: FieldSuggestion;
+    ticket: TicketProperties;
+}
+
+export interface SelectDocumentSuggestionMetadata {
+    suggestion: DocumentSuggestion;
+    ticket: TicketProperties;
+}
+
+export interface RateDocumentSuggestionMetadata {
+    rating: number;
+    suggestion: DocumentSuggestion;
+    ticket: TicketProperties;
+}
+
+export interface MoveToNextCaseStepMetadata {
+    ticket: TicketProperties;
+    stage?: string;
+}
+
+export interface CaseCancelledMetadata {
+    ticket: TicketProperties;
+}
+
+export interface CaseSolvedMetadata {
+    ticket: TicketProperties;
+}
+
+export interface CaseCreatedMetadata {
+    ticket: TicketProperties;
+}
+
+export interface FieldSuggestion {
+    classificationId: string;
+    responseId: string;
+    fieldName: string;
+    classification: {
+        value: string;
+        confidence: number;
+    };
+    autoSelection?: boolean;
+}
+
+export interface DocumentSuggestion {
+    suggestionId: string;
+    responseId: string;
+    suggestion: {
+        documentUri: string;
+        documentUriHash: string;
+        documentTitle: string;
+        documentUrl: string;
+        documentPosition: number;
+    };
+    fromQuickview?: boolean;
+    openDocument?: boolean;
+}

--- a/packages/coveo-analytics/src/caseAssist/caseAssistClient.spec.ts
+++ b/packages/coveo-analytics/src/caseAssist/caseAssistClient.spec.ts
@@ -1,0 +1,338 @@
+import {CaseAssistClient, CaseAssistClientProvider} from './caseAssistClient';
+import {
+    CaseAssistActions,
+    CaseAssistEvents,
+    CaseCancelledReasons,
+    DocumentSuggestion,
+    FieldSuggestion,
+} from './caseAssistActions';
+import {mockFetch, lastCallBody} from '../../tests/fetchMock';
+import {TicketProperties} from '../plugins/svc';
+const {fetchMock, fetchMockBeforeEach} = mockFetch();
+import doNotTrack from '../donottrack';
+import {Cookie} from '../cookieutils';
+jest.mock('../donottrack', () => {
+    return {
+        default: jest.fn(),
+        doNotTrack: jest.fn(),
+    };
+});
+
+describe('CaseAssistClient', () => {
+    const defaultSearchHub = 'origin-level-1';
+    let client: CaseAssistClient;
+
+    const provider: CaseAssistClientProvider = {
+        getOriginLevel1: () => defaultSearchHub,
+    };
+
+    beforeEach(() => {
+        fetchMockBeforeEach();
+
+        client = initClient();
+        fetchMock.mock(/.*/, {
+            visitorId: 'visitor-id',
+        });
+    });
+
+    afterEach(() => {
+        fetchMock.reset();
+    });
+
+    const initClient = () => {
+        return new CaseAssistClient(
+            {
+                enableAnalytics: true,
+            },
+            provider
+        );
+    };
+
+    const noTicket: Record<string, unknown> = undefined;
+    const noActionData: Record<string, unknown> = undefined;
+    const emptyTicket: TicketProperties = {};
+
+    const fakeTicket: TicketProperties = {
+        id: 'the-ticket-id',
+        subject: 'the ticket subject',
+        description: 'the ticket description',
+        category: 'ticket-category',
+        productId: 'some-product-id',
+        custom: {
+            customA: 'custom-a-value',
+            customB: 'custom-b-value',
+        },
+    };
+
+    const fakeFieldSuggestion = (): FieldSuggestion => {
+        return {
+            classification: {
+                value: 'some-field-value',
+                confidence: 0.5,
+            },
+            classificationId: 'field-suggestion-id',
+            fieldName: 'some-field',
+            responseId: 'field-suggestion-response-id',
+        };
+    };
+
+    const fakeDocumentSuggestion = (): DocumentSuggestion => {
+        return {
+            responseId: 'document-suggestion-response-id',
+            suggestionId: 'document-suggestion-id',
+            suggestion: {
+                documentPosition: 0,
+                documentTitle: 'the document title',
+                documentUri: 'some-document-uri',
+                documentUriHash: 'documenturihash',
+                documentUrl: 'some-document-url',
+            },
+        };
+    };
+
+    const expectMatchPayload = (actionName: CaseAssistActions, actionData: Object, ticket: TicketProperties) => {
+        const body: string = lastCallBody(fetchMock);
+        const content = JSON.parse(body);
+
+        expectMatchActionPayload(content, actionName, actionData);
+        expectMatchTicketPayload(content, ticket);
+        expectMatchProperty(content, 'searchHub', defaultSearchHub);
+    };
+
+    const expectMatchActionPayload = (
+        content: Record<string, unknown>,
+        actionName: CaseAssistActions,
+        actionData: Object
+    ) => {
+        expectMatchProperty(content, 'ec', 'svc');
+        expectMatchProperty(content, 'svc_action', actionName);
+        expectMatchProperty(content, 'svc_action_data', actionData);
+
+        const expectedEvent =
+            actionName === CaseAssistActions.enterInterface ? CaseAssistEvents.flowStart : CaseAssistEvents.click;
+        expectMatchProperty(content, 'ea', expectedEvent);
+    };
+
+    const expectMatchTicketPayload = (content: Record<string, unknown>, ticket?: TicketProperties) => {
+        expectMatchProperty(content, 'svc_ticket_id', ticket?.id);
+        expectMatchProperty(content, 'svc_ticket_subject', ticket?.subject);
+        expectMatchProperty(content, 'svc_ticket_description', ticket?.description);
+        expectMatchProperty(content, 'svc_ticket_category', ticket?.category);
+        expectMatchProperty(content, 'svc_ticket_product_id', ticket?.productId);
+        expectMatchProperty(content, 'svc_ticket_custom', ticket?.custom);
+    };
+
+    const expectMatchProperty = (content: Record<string, unknown>, propName: string, propValue: unknown) => {
+        if (typeof propValue !== 'undefined') {
+            if (typeof propValue === 'object') {
+                expect(content).toHaveProperty(propName);
+                expect(content[propName]).toMatchObject(propValue as object);
+            } else {
+                expect(content).toHaveProperty(propName, propValue);
+            }
+        } else {
+            expect(content).not.toHaveProperty(propName);
+        }
+    };
+
+    it('should have #enableAnalytics default to #true', async () => {
+        client = new CaseAssistClient({});
+
+        await client.logEnterInterface({
+            ticket: emptyTicket,
+        });
+
+        expect(fetchMock.called()).toBe(true);
+    });
+
+    it('should not send events when #enableAnalytics option is #false', async () => {
+        client = new CaseAssistClient({
+            enableAnalytics: false,
+        });
+
+        await client.logEnterInterface({
+            ticket: emptyTicket,
+        });
+
+        expect(fetchMock.called()).toBe(false);
+    });
+
+    it('should not send events when doNotTrack is enabled', async () => {
+        (doNotTrack as jest.Mock).mockImplementationOnce(() => true);
+
+        client = new CaseAssistClient({});
+
+        await client.logEnterInterface({
+            ticket: emptyTicket,
+        });
+
+        expect(fetchMock.called()).toBe(false);
+    });
+
+    it('should not send events after #disable function is called', async () => {
+        client.disable();
+
+        await client.logEnterInterface({
+            ticket: emptyTicket,
+        });
+
+        expect(fetchMock.called()).toBe(false);
+    });
+
+    it('disabling does not delete the visitorId', () => {
+        const visitorId = 'uuid';
+        Cookie.set('coveo_visitorId', visitorId);
+
+        expect(Cookie.get('coveo_visitorId')).toBe(visitorId);
+        client.disable();
+        expect(Cookie.get('coveo_visitorId')).toBe(visitorId);
+    });
+
+    it('should send events after #enable function is called', async () => {
+        client = new CaseAssistClient({
+            enableAnalytics: false,
+        });
+
+        client.enable();
+
+        await client.logEnterInterface({
+            ticket: emptyTicket,
+        });
+
+        expect(fetchMock.called()).toBe(true);
+    });
+
+    it('should send proper payload for #logEnterInterface', async () => {
+        await client.logEnterInterface({
+            ticket: emptyTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.enterInterface, noActionData, noTicket);
+    });
+
+    it('should send proper payload for #logUpdateCaseField', async () => {
+        await client.logUpdateCaseField({
+            fieldName: 'subject',
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.fieldUpdate, {fieldName: 'subject'}, fakeTicket);
+    });
+
+    it('should send proper payload for #logSelectFieldSuggestion', async () => {
+        await client.logSelectFieldSuggestion({
+            suggestion: fakeFieldSuggestion(),
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.fieldSuggestionClick, fakeFieldSuggestion(), fakeTicket);
+    });
+
+    it('should send proper payload for #logSelectFieldSuggestion when the autoSelection property is set to true', async () => {
+        const myFakeFieldSuggestion = fakeFieldSuggestion();
+        myFakeFieldSuggestion.autoSelection = true;
+        await client.logSelectFieldSuggestion({
+            suggestion: myFakeFieldSuggestion,
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.fieldSuggestionClick, myFakeFieldSuggestion, fakeTicket);
+    });
+
+    it('should send proper payload for #logSelectDocumentSuggestion', async () => {
+        await client.logSelectDocumentSuggestion({
+            suggestion: fakeDocumentSuggestion(),
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.suggestionClick, fakeDocumentSuggestion(), fakeTicket);
+    });
+
+    it('should send proper payload for #logSelectDocumentSuggestion when the fromQuickview property is set to true', async () => {
+        const myFakeDocumentSuggestion = fakeDocumentSuggestion();
+        myFakeDocumentSuggestion.fromQuickview = true;
+        await client.logSelectDocumentSuggestion({
+            suggestion: myFakeDocumentSuggestion,
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.suggestionClick, myFakeDocumentSuggestion, fakeTicket);
+    });
+
+    it('should send proper payload for #logSelectDocumentSuggestion when the openDocument property is set to true', async () => {
+        const myFakeDocumentSuggestion = fakeDocumentSuggestion();
+        myFakeDocumentSuggestion.openDocument = true;
+        await client.logSelectDocumentSuggestion({
+            suggestion: myFakeDocumentSuggestion,
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.suggestionClick, myFakeDocumentSuggestion, fakeTicket);
+    });
+
+    it('should send proper payload for #logRateDocumentSuggestion', async () => {
+        const rating = 0.8;
+
+        await client.logRateDocumentSuggestion({
+            rating,
+            suggestion: fakeDocumentSuggestion(),
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(
+            CaseAssistActions.suggestionRate,
+            {
+                ...fakeDocumentSuggestion(),
+                rate: rating,
+            },
+            fakeTicket
+        );
+    });
+
+    it('should send proper payload for #logMoveToNextCaseStep', async () => {
+        const stageName = 'stage 1';
+
+        await client.logMoveToNextCaseStep({
+            ticket: fakeTicket,
+            stage: stageName,
+        });
+
+        expectMatchPayload(CaseAssistActions.nextCaseStep, {stage: stageName}, fakeTicket);
+    });
+
+    it('should send proper payload for #logCaseCancelled', async () => {
+        await client.logCaseCancelled({
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(
+            CaseAssistActions.caseCancelled,
+            {
+                reason: CaseCancelledReasons.quit,
+            },
+            fakeTicket
+        );
+    });
+
+    it('should send proper payload for #logCaseSolved', async () => {
+        await client.logCaseSolved({
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(
+            CaseAssistActions.caseSolved,
+            {
+                reason: CaseCancelledReasons.solved,
+            },
+            fakeTicket
+        );
+    });
+
+    it('should send proper payload for #logCaseCreated', async () => {
+        await client.logCaseCreated({
+            ticket: fakeTicket,
+        });
+
+        expectMatchPayload(CaseAssistActions.caseCreated, noActionData, fakeTicket);
+    });
+});

--- a/packages/coveo-analytics/src/caseAssist/caseAssistClient.ts
+++ b/packages/coveo-analytics/src/caseAssist/caseAssistClient.ts
@@ -1,0 +1,139 @@
+import CoveoAnalyticsClient, {AnalyticsClient, ClientOptions} from '../client/analytics';
+import {NoopAnalytics} from '../client/noopAnalytics';
+import doNotTrack from '../donottrack';
+import {SVCPlugin} from '../plugins/svc';
+import {
+    CaseAssistActions,
+    CaseAssistEvents,
+    CaseCancelledMetadata,
+    CaseCancelledReasons,
+    CaseCreatedMetadata,
+    CaseSolvedMetadata,
+    EnterInterfaceMetadata,
+    MoveToNextCaseStepMetadata,
+    RateDocumentSuggestionMetadata,
+    SelectDocumentSuggestionMetadata,
+    SelectFieldSuggestionMetadata,
+    UpdateCaseFieldMetadata,
+} from './caseAssistActions';
+
+export interface CaseAssistClientProvider {
+    getOriginLevel1: () => string;
+}
+
+export interface CaseAssistClientOptions extends ClientOptions {
+    enableAnalytics?: boolean;
+}
+
+export class CaseAssistClient {
+    public coveoAnalyticsClient: AnalyticsClient;
+    private svc: SVCPlugin;
+
+    constructor(private options: Partial<CaseAssistClientOptions>, private provider?: CaseAssistClientProvider) {
+        const analyticsEnabled = (options.enableAnalytics ?? true) && !doNotTrack();
+
+        this.coveoAnalyticsClient = analyticsEnabled ? new CoveoAnalyticsClient(options) : new NoopAnalytics();
+        this.svc = new SVCPlugin({client: this.coveoAnalyticsClient});
+    }
+
+    public disable() {
+        this.coveoAnalyticsClient = new NoopAnalytics();
+        this.svc = new SVCPlugin({client: this.coveoAnalyticsClient});
+    }
+
+    public enable() {
+        this.coveoAnalyticsClient = new CoveoAnalyticsClient(this.options);
+        this.svc = new SVCPlugin({client: this.coveoAnalyticsClient});
+    }
+
+    public logEnterInterface(meta: EnterInterfaceMetadata) {
+        this.svc.setAction(CaseAssistActions.enterInterface);
+        this.svc.setTicket(meta.ticket);
+        return this.sendFlowStartEvent();
+    }
+
+    public logUpdateCaseField(meta: UpdateCaseFieldMetadata) {
+        this.svc.setAction(CaseAssistActions.fieldUpdate, {
+            fieldName: meta.fieldName,
+        });
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logSelectFieldSuggestion(meta: SelectFieldSuggestionMetadata) {
+        this.svc.setAction(CaseAssistActions.fieldSuggestionClick, meta.suggestion);
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logSelectDocumentSuggestion(meta: SelectDocumentSuggestionMetadata) {
+        this.svc.setAction(CaseAssistActions.suggestionClick, meta.suggestion);
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logRateDocumentSuggestion(meta: RateDocumentSuggestionMetadata) {
+        this.svc.setAction(CaseAssistActions.suggestionRate, {
+            rate: meta.rating,
+            ...meta.suggestion,
+        });
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logMoveToNextCaseStep(meta: MoveToNextCaseStepMetadata) {
+        this.svc.setAction(CaseAssistActions.nextCaseStep, {
+            stage: meta?.stage,
+        });
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logCaseCancelled(meta: CaseCancelledMetadata) {
+        this.svc.setAction(CaseAssistActions.caseCancelled, {
+            reason: CaseCancelledReasons.quit,
+        });
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logCaseSolved(meta: CaseSolvedMetadata) {
+        this.svc.setAction(CaseAssistActions.caseSolved, {
+            reason: CaseCancelledReasons.solved,
+        });
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    public logCaseCreated(meta: CaseCreatedMetadata) {
+        this.svc.setAction(CaseAssistActions.caseCreated);
+        this.svc.setTicket(meta.ticket);
+        return this.sendClickEvent();
+    }
+
+    private sendFlowStartEvent() {
+        return this.coveoAnalyticsClient.sendEvent(
+            'event',
+            'svc',
+            CaseAssistEvents.flowStart,
+            this.provider
+                ? {
+                      searchHub: this.provider.getOriginLevel1(),
+                  }
+                : null
+        );
+    }
+
+    private sendClickEvent() {
+        return this.coveoAnalyticsClient.sendEvent(
+            'event',
+            'svc',
+            CaseAssistEvents.click,
+            this.provider
+                ? {
+                      searchHub: this.provider.getOriginLevel1(),
+                  }
+                : null
+        );
+    }
+}

--- a/packages/coveo-analytics/src/client/analytics.spec.ts
+++ b/packages/coveo-analytics/src/client/analytics.spec.ts
@@ -1,0 +1,837 @@
+import {
+    ClickEventRequest,
+    CustomEventRequest,
+    DefaultEventResponse,
+    EventType,
+    SearchEventRequest,
+    ViewEventRequest,
+} from '../events';
+import {CoveoAnalyticsClient} from './analytics';
+import {IAnalyticsRequestOptions} from './analyticsRequestClient';
+import {CookieAndLocalStorage, CookieStorage, NullStorage} from '../storage';
+import HistoryStore from '../history';
+import {mockFetch} from '../../tests/fetchMock';
+import {BrowserRuntime, NoopRuntime} from './runtimeEnvironment';
+import * as doNotTrack from '../donottrack';
+import {Cookie} from '../cookieutils';
+import {CoveoLinkParam} from '../plugins/link';
+import {NoopAnalytics} from './noopAnalytics';
+
+const aVisitorId = '123';
+jest.mock('uuid', () => ({
+    v4: () => aVisitorId,
+    validate: jest.requireActual('uuid').validate,
+    v5: jest.requireActual('uuid').v5,
+}));
+
+const {fetchMock, fetchMockBeforeEach} = mockFetch();
+
+describe('Analytics', () => {
+    const aToken = 'token';
+    const anEndpoint = 'http://bloup';
+    const A_VERSION = 'v1337';
+
+    const viewEvent: ViewEventRequest = {
+        location: 'here',
+        contentIdKey: 'key',
+        contentIdValue: 'value',
+        language: 'en',
+    };
+    const searchEvent: SearchEventRequest = {
+        searchQueryUid: 'sqUid',
+        actionCause: 'interfaceLoad',
+        queryText: 'test',
+        responseTime: 50,
+    };
+    const clickEvent: ClickEventRequest = {
+        searchQueryUid: 'sqUid',
+        actionCause: 'documentOpen',
+        documentPosition: 1,
+        documentUriHash: 'docUriHash',
+        sourceName: 'source',
+    };
+    const customEvent: CustomEventRequest = {
+        eventType: 'custom',
+        eventValue: 'value',
+    };
+
+    const eventResponse: DefaultEventResponse = {
+        visitId: 'firsttimevisiting',
+        visitorId: aVisitorId,
+    };
+
+    const endpointForEventType = (eventType: EventType, endpoint: string = `${anEndpoint}/rest`) =>
+        `${endpoint}/${A_VERSION}/analytics/${eventType}?visitor=${aVisitorId}`;
+    const mockFetchRequestForEventType = (eventType: EventType) => {
+        const address = endpointForEventType(eventType);
+        fetchMock.post(address, eventResponse);
+    };
+
+    let client: CoveoAnalyticsClient;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        fetchMockBeforeEach();
+
+        new CookieStorage().removeItem('visitorId');
+        localStorage.clear();
+        fetchMock.reset();
+
+        client = new CoveoAnalyticsClient({
+            token: aToken,
+            endpoint: anEndpoint,
+            version: A_VERSION,
+        });
+    });
+
+    it('should add /rest if not present in endpoint', async () => {
+        const legacyEndpoint = 'https://usageanalytics.com';
+
+        client = new CoveoAnalyticsClient({
+            token: aToken,
+            endpoint: legacyEndpoint,
+            version: A_VERSION,
+        });
+
+        fetchMock.post(endpointForEventType(EventType.custom, `${legacyEndpoint}/rest`), eventResponse);
+        const response = await client.sendEvent(EventType.custom);
+        expect(response).toEqual(eventResponse);
+    });
+
+    it('should not add /rest if /rest present in endpoint', async () => {
+        const legacyEndpoint = 'https://usageanalytics.com/rest';
+
+        client = new CoveoAnalyticsClient({
+            token: aToken,
+            endpoint: legacyEndpoint,
+            version: A_VERSION,
+        });
+
+        fetchMock.post(endpointForEventType(EventType.custom, legacyEndpoint), eventResponse);
+        const response = await client.sendEvent(EventType.custom);
+        expect(response).toEqual(eventResponse);
+    });
+
+    it('should not add /rest if /rest/ua present in endpoint', async () => {
+        const legacyEndpoint = 'https://usageanalytics.com/rest/ua';
+
+        client = new CoveoAnalyticsClient({
+            token: aToken,
+            endpoint: legacyEndpoint,
+            version: A_VERSION,
+        });
+
+        fetchMock.post(endpointForEventType(EventType.custom, legacyEndpoint), eventResponse);
+        const response = await client.sendEvent(EventType.custom);
+        expect(response).toEqual(eventResponse);
+    });
+
+    it('should remove trailing slash in endpoint', async () => {
+        const legacyEndpoint = 'https://usageanalytics.com';
+
+        client = new CoveoAnalyticsClient({
+            token: aToken,
+            endpoint: legacyEndpoint + '/',
+            version: A_VERSION,
+        });
+
+        fetchMock.post(endpointForEventType(EventType.custom, `${legacyEndpoint}/rest`), eventResponse);
+        const response = await client.sendEvent(EventType.custom);
+        expect(response).toEqual(eventResponse);
+    });
+
+    it('should allow reverse-proxy endpoint', async () => {
+        const aReverseProxyEndpoint = 'https://12364734.cloudfront.net/analytics';
+
+        client = new CoveoAnalyticsClient({
+            token: aToken,
+            endpoint: aReverseProxyEndpoint,
+            isCustomEndpoint: true,
+            version: A_VERSION,
+        });
+
+        fetchMock.post(endpointForEventType(EventType.custom, aReverseProxyEndpoint), eventResponse);
+        const response = await client.sendEvent(EventType.custom);
+        expect(response).toEqual(eventResponse);
+    });
+
+    it('should call fetch with the parameters', async () => {
+        mockFetchRequestForEventType(EventType.view);
+
+        const response = await client.sendViewEvent(viewEvent);
+        expect(response).toEqual(eventResponse);
+
+        expect(fetchMock.called()).toBe(true);
+
+        const [path, {headers, body}]: any = fetchMock.lastCall();
+        expect(path).toBe(endpointForEventType(EventType.view));
+
+        const h = headers as Record<string, string>;
+        expect(h['Authorization']).toBe(`Bearer ${aToken}`);
+        expect(h['Content-Type']).toBe('application/json');
+
+        expect(body).not.toBeUndefined();
+
+        const parsedBody = JSON.parse(body.toString());
+        expect(parsedBody).toMatchObject(viewEvent);
+    });
+
+    it('should append default values to the view event', async () => {
+        mockFetchRequestForEventType(EventType.view);
+
+        await client.sendViewEvent(viewEvent);
+
+        const [body] = getParsedBodyCalls();
+
+        expect(body).toMatchObject({
+            clientId: '123',
+            userAgent: navigator.userAgent,
+        });
+    });
+
+    it('should append default values to the search event', async () => {
+        mockFetchRequestForEventType(EventType.search);
+
+        await client.sendSearchEvent(searchEvent);
+
+        const [body] = getParsedBodyCalls();
+
+        expect(body).toMatchObject({
+            clientId: '123',
+            userAgent: navigator.userAgent,
+        });
+    });
+
+    it('should append default values to the click event', async () => {
+        mockFetchRequestForEventType(EventType.click);
+
+        await client.sendClickEvent(clickEvent);
+
+        const [body] = getParsedBodyCalls();
+
+        expect(body).toMatchObject({
+            clientId: '123',
+            userAgent: navigator.userAgent,
+        });
+    });
+
+    it('should append default values to the custom event', async () => {
+        mockFetchRequestForEventType(EventType.custom);
+
+        await client.sendCustomEvent(customEvent);
+
+        const [body] = getParsedBodyCalls();
+
+        expect(body).toMatchObject({
+            clientId: '123',
+            userAgent: navigator.userAgent,
+        });
+    });
+
+    it('should send the events in the order they were called', async () => {
+        mockFetchRequestForEventType(EventType.view);
+        const firstRequest = client.sendViewEvent({
+            ...viewEvent,
+            customData: {
+                index: 0,
+            },
+        });
+        const secondRequest = client.sendViewEvent({
+            ...viewEvent,
+            customData: {
+                index: 1,
+            },
+        });
+        const thirdRequest = client.sendViewEvent({
+            ...viewEvent,
+            customData: {
+                index: 2,
+            },
+        });
+
+        await Promise.all([firstRequest, secondRequest, thirdRequest]);
+
+        const assertResponseHasCustomDataWithIndex = (response: RequestInit | undefined, index: number) => {
+            const parsedBody = JSON.parse(response!.body!.toString());
+            expect(parsedBody.customData.index).toBe(index);
+        };
+        const [[, firstResponse], [, secondResponse], [, thirdResponse]] = fetchMock.calls();
+        assertResponseHasCustomDataWithIndex(firstResponse, 0);
+        assertResponseHasCustomDataWithIndex(secondResponse, 1);
+        assertResponseHasCustomDataWithIndex(thirdResponse, 2);
+    });
+
+    it('should should only clean null, undefined, and empty string values', async () => {
+        mockFetchRequestForEventType(EventType.view);
+        await client.sendEvent(EventType.view, {
+            fine: 1,
+            ok: 0,
+            notok: '',
+            invalid: null,
+            ohno: undefined,
+        });
+
+        const [body] = getParsedBodyCalls();
+
+        expect(body).toMatchObject({
+            fine: 1,
+            ok: 0,
+        });
+    });
+
+    describe('should truncate the maxlength for URL parameters at 128 characters for ua events', () => {
+        const desiredMax: number = 128;
+        const longUrl: string = 'http://coveo.com/?q=' + 'a'.repeat(desiredMax);
+        expect(longUrl.length).toBeGreaterThan(desiredMax);
+        async function testEventType(type: EventType, url: string) {
+            mockFetchRequestForEventType(type);
+            await client.sendEvent(type, {
+                location: type == EventType.view ? url : undefined,
+                originLevel3: url,
+            });
+            const [body] = getParsedBodyCalls();
+            if (type == EventType.view) expect(body.location.length).toBeLessThanOrEqual(desiredMax);
+            expect(body.originLevel3.length).toBeLessThanOrEqual(desiredMax);
+        }
+        it('for view events', () => testEventType(EventType.view, longUrl));
+        it('for click events', () => testEventType(EventType.click, longUrl));
+        it('for search events', () => testEventType(EventType.search, longUrl));
+        it('for custom events', () => testEventType(EventType.custom, longUrl));
+    });
+
+    describe('url truncation is null safe', () => {
+        async function testAttributeTruncation(url: any) {
+            mockFetchRequestForEventType(EventType.view);
+            await client.sendEvent(EventType.view, {
+                location: url,
+                originLevel3: url,
+            });
+            const [body] = getParsedBodyCalls();
+            expect(body.location).toBe(url == null ? undefined : url);
+            expect(body.originLevel3).toBe(url == null ? undefined : url);
+        }
+        it('for undefined urls', () => testAttributeTruncation(undefined));
+        it('for null urls', () => testAttributeTruncation(null));
+        it('for non-string urls', () => testAttributeTruncation(12345));
+    });
+
+    it('should not remove #queryText for search events even if empty', async () => {
+        mockFetchRequestForEventType(EventType.search);
+        await client.sendEvent(EventType.search, {
+            queryText: '',
+        });
+
+        const [body] = getParsedBodyCalls();
+
+        expect(body).toMatchObject({
+            queryText: '',
+        });
+    });
+
+    describe('with event type mapping with variable arguments', () => {
+        const specialEventType = '🌟special🌟';
+        const argumentNames = ['eventCategory', 'eventAction', 'eventLabel', 'eventValue'];
+        beforeEach(() => {
+            mockFetchRequestForEventType(EventType.custom);
+            client.addEventTypeMapping(specialEventType, {
+                newEventType: EventType.custom,
+                variableLengthArgumentsNames: argumentNames,
+            });
+        });
+
+        it('should properly parse empty arguments', async () => {
+            await client.sendEvent(specialEventType);
+
+            const [path, {body}]: any = fetchMock.lastCall();
+            expect(path).toBe(endpointForEventType(EventType.custom));
+
+            const parsedBody = JSON.parse(body.toString());
+            expect(parsedBody).toEqual({});
+        });
+
+        it('should properly parse 1 argument', async () => {
+            await client.sendEvent(specialEventType, 'Video');
+
+            const [body] = getParsedBodyCalls();
+
+            expect(body).toEqual({
+                [argumentNames[0]]: 'Video',
+            });
+        });
+
+        it('should properly parse all arguments', async () => {
+            await client.sendEvent(specialEventType, 'Video', 'play', 'campaign');
+
+            const [body] = getParsedBodyCalls();
+
+            expect(body).toEqual({
+                [argumentNames[0]]: 'Video',
+                [argumentNames[1]]: 'play',
+                [argumentNames[2]]: 'campaign',
+            });
+        });
+
+        it('should properly handle a finished object argument', async () => {
+            await client.sendEvent(specialEventType, 'Video', {
+                nonInteraction: true,
+            });
+
+            const [body] = getParsedBodyCalls();
+
+            expect(body).toEqual({
+                [argumentNames[0]]: 'Video',
+                nonInteraction: true,
+            });
+        });
+    });
+
+    describe('with event type mapping activating context values', () => {
+        const specialEventType = '🌟special🌟';
+        beforeEach(() => {
+            mockFetchRequestForEventType(EventType.custom);
+            client.addEventTypeMapping(specialEventType, {
+                newEventType: EventType.custom,
+                addVisitorIdParameter: true,
+            });
+        });
+
+        it('should properly add visitorId key', async () => {
+            await client.sendEvent(specialEventType);
+
+            const [body] = getParsedBodyCalls();
+
+            expect(body).toHaveProperty('visitorId');
+        });
+    });
+
+    describe('with an endpoint set to the coveo platform proxy', () => {
+        const endpointWithRest = 'http://someendpoint.cloud.coveo.com/rest/ua';
+        beforeEach(() => {
+            client = new CoveoAnalyticsClient({
+                token: aToken,
+                endpoint: endpointWithRest,
+                version: A_VERSION,
+            });
+
+            fetchMock.post(endpointForEventType(EventType.custom, endpointWithRest), eventResponse);
+        });
+
+        it('should properly send the event without appending an extra /rest', async () => {
+            const response = await client.sendEvent(EventType.custom);
+            expect(response).toEqual(eventResponse);
+        });
+    });
+
+    describe('with userId auto-detection', () => {
+        const eventType = '🛂';
+
+        const expectUserId = (userId: {[key: string]: string}) => {
+            const [body] = getParsedBodyCalls();
+            expect(body).toMatchObject(userId);
+        };
+
+        describe('for API keys', () => {
+            beforeEach(() => {
+                client = new CoveoAnalyticsClient({
+                    token: 'xxapikey',
+                    endpoint: anEndpoint,
+                    version: A_VERSION,
+                });
+                mockFetchRequestForEventType(EventType.custom);
+            });
+            describe('with measurement protocol', () => {
+                beforeEach(() => {
+                    client.addEventTypeMapping(eventType, {
+                        newEventType: EventType.custom,
+                        usesMeasurementProtocol: true,
+                    });
+                });
+
+                it('should set the absent userId to anonymous', async () => {
+                    await client.sendEvent(eventType);
+                    expectUserId({uid: 'anonymous'});
+                });
+
+                it('should leave existing userIds', async () => {
+                    await client.sendEvent(eventType, {userId: 'bob'});
+                    expectUserId({uid: 'bob'});
+                });
+            });
+
+            describe('without measurement protocol', () => {
+                beforeEach(() => {
+                    client.addEventTypeMapping(eventType, {
+                        newEventType: EventType.custom,
+                        usesMeasurementProtocol: false,
+                    });
+                });
+
+                it('should do nothing with absent userId', async () => {
+                    await client.sendEvent(eventType);
+                    expectUserId({});
+                });
+
+                it('should leave existing userIds', async () => {
+                    await client.sendEvent(eventType, {userId: 'bob'});
+                    expectUserId({userId: 'bob'});
+                });
+            });
+        });
+
+        describe('for OAuth Tokens', () => {
+            beforeEach(() => {
+                client = new CoveoAnalyticsClient({
+                    token: 'xtoken',
+                    endpoint: anEndpoint,
+                    version: A_VERSION,
+                });
+                mockFetchRequestForEventType(EventType.custom);
+                client.addEventTypeMapping(eventType, {
+                    newEventType: EventType.custom,
+                    usesMeasurementProtocol: true,
+                });
+            });
+
+            it('should do nothing with absent userId', async () => {
+                await client.sendEvent(eventType);
+                expectUserId({});
+            });
+
+            it('should leave existing userIds', async () => {
+                await client.sendEvent(eventType, {userId: 'bob'});
+                expectUserId({uid: 'bob'});
+            });
+        });
+    });
+
+    describe('with context_website is set in customData', () => {
+        const contextWebsite = 'yourbestfriend.com';
+        const trackingId = 'yourfavoritefood.ca ';
+        beforeEach(() => {
+            client = new CoveoAnalyticsClient({
+                token: 'xtoken',
+                endpoint: anEndpoint,
+                version: A_VERSION,
+            });
+            mockFetchRequestForEventType(EventType.view);
+        });
+
+        it('should set trackingId when trackingId is not specified', async () => {
+            await client.sendEvent(EventType.view, {customData: {context_website: contextWebsite}});
+            const [body] = getParsedBodyCalls();
+            expect(body.trackingId).toBe(contextWebsite);
+        });
+
+        it('should not overwrite trackingId when trackingId is specified', async () => {
+            await client.sendEvent(EventType.view, {
+                trackingId: trackingId,
+                customData: {context_website: contextWebsite},
+            });
+            const [body] = getParsedBodyCalls();
+            expect(body.trackingId).toBe(trackingId);
+        });
+    });
+
+    describe('with siteName is set in customData', () => {
+        const website = 'yourbestfriend.com';
+        const trackingId = 'yourfavoritefood.ca ';
+        beforeEach(() => {
+            client = new CoveoAnalyticsClient({
+                token: 'xtoken',
+                endpoint: anEndpoint,
+                version: A_VERSION,
+            });
+            mockFetchRequestForEventType(EventType.view);
+        });
+
+        it('should set trackingId when trackingId is not specified', async () => {
+            await client.sendEvent(EventType.view, {customData: {siteName: website}});
+            const [body] = getParsedBodyCalls();
+            expect(body.trackingId).toBe(website);
+        });
+
+        it('should not overwrite trackingId when trackingId is specified', async () => {
+            await client.sendEvent(EventType.view, {trackingId: trackingId, customData: {siteName: website}});
+            const [body] = getParsedBodyCalls();
+            expect(body.trackingId).toBe(trackingId);
+        });
+    });
+
+    it('should support clearing cookies for visitorId and historyStore', () => {
+        const visitorId = 'foo';
+        const history = {name: 'foo', time: '123', value: 'bar'};
+        const storage = new CookieStorage();
+        const historyStore = new HistoryStore();
+
+        client.currentVisitorId = visitorId;
+        historyStore.addElement(history);
+
+        expect(storage.getItem('visitorId')).toBe('foo');
+        expect(historyStore.getMostRecentElement()).toEqual(history);
+
+        client.clear();
+        expect(storage.getItem('visitorId')).toBeNull();
+        expect(historyStore.getMostRecentElement()).toBeUndefined();
+    });
+
+    it('should support clearing cookies for visitorId and historyStore async', async () => {
+        const visitorId = 'foo';
+        const history = {name: 'foo', time: '123', value: 'bar'};
+        const storage = new CookieStorage();
+        const historyStore = new HistoryStore();
+
+        await client.setCurrentVisitorId(visitorId);
+        await historyStore.addElementAsync(history);
+
+        expect(await storage.getItem('visitorId')).toBe('foo');
+        expect(historyStore.getMostRecentElement()).toEqual(history);
+
+        client.clear();
+        expect(storage.getItem('visitorId')).toBeNull();
+        expect(historyStore.getMostRecentElement()).toBeUndefined();
+    });
+
+    it('should execute before send hooks passed as option', async () => {
+        mockFetchRequestForEventType(EventType.search);
+        const spy = jest.fn((_, p) => p);
+        const searchEventPayload = {queryText: 'potato'};
+        await new CoveoAnalyticsClient({
+            token: aToken,
+            endpoint: anEndpoint,
+            version: A_VERSION,
+            beforeSendHooks: [spy],
+        }).sendEvent(EventType.search, searchEventPayload);
+        expect(spy).toHaveBeenLastCalledWith(EventType.search, expect.objectContaining(searchEventPayload));
+    });
+
+    it('should preprocess the request with the preprocessRequest', async () => {
+        let clientOrigin: string;
+        let processedRequest: IAnalyticsRequestOptions = {
+            url: 'https://www.myownanalytics.com/endpoint',
+            headers: {
+                Age: '24',
+            },
+            method: 'PUT',
+            body: JSON.stringify({
+                test: 'custom',
+            }),
+        };
+        fetchMock.put(processedRequest.url, eventResponse);
+        const searchEventPayload = {queryText: 'potato'};
+        await new CoveoAnalyticsClient({
+            token: aToken,
+            endpoint: anEndpoint,
+            version: A_VERSION,
+            preprocessRequest: (request, type) => {
+                clientOrigin = type;
+                processedRequest = {
+                    ...request,
+                    ...processedRequest,
+                };
+                return processedRequest;
+            },
+        }).sendEvent(EventType.search, searchEventPayload);
+
+        const call = fetchMock.calls()[0];
+        const url = call[0];
+        const options: RequestInit | undefined = call[1];
+
+        const {url: expectedUrl, ...expectedOptions} = processedRequest;
+        expect(clientOrigin!).toBe('analyticsFetch');
+        expect(url).toBe(expectedUrl);
+        expect(options).toEqual(expectedOptions);
+    });
+
+    const getParsedBodyCalls = (): any[] => {
+        return fetchMock.calls().map(([, {body}]: any) => {
+            return JSON.parse(body.toString());
+        });
+    };
+});
+
+describe('doNotTrack', () => {
+    it('should do business as usual if doNotTrack returns false', () => {
+        jest.spyOn(doNotTrack, 'doNotTrack').mockImplementation(() => false);
+
+        let client = new CoveoAnalyticsClient({});
+
+        expect(client.runtime).toBeInstanceOf(BrowserRuntime);
+        expect(client.runtime.storage).toBeInstanceOf(CookieAndLocalStorage);
+    });
+
+    it('should honor doNotTrack', () => {
+        jest.spyOn(doNotTrack, 'doNotTrack').mockImplementation(() => true);
+
+        let client = new CoveoAnalyticsClient({});
+
+        expect(client.runtime).toBeInstanceOf(NoopRuntime);
+        expect(client.runtime.storage).toBeInstanceOf(NullStorage);
+    });
+
+    it('should not clear existing cookies', async () => {
+        jest.spyOn(doNotTrack, 'doNotTrack').mockImplementation(() => true);
+        Cookie.set('coveo_visitorId', aVisitorId);
+        expect(Cookie.get('coveo_visitorId')).toBe(aVisitorId);
+
+        new CoveoAnalyticsClient({});
+
+        expect(Cookie.get('coveo_visitorId')).toBe(aVisitorId);
+    });
+});
+
+describe('custom clientId', () => {
+    it('allows setting of a custom clientId', async () => {
+        const client = new CoveoAnalyticsClient({});
+        client.setClientId('c7d57b22-4aa8-487a-a106-be5243885f0a');
+        expect(await client.getCurrentVisitorId()).toBe('c7d57b22-4aa8-487a-a106-be5243885f0a');
+    });
+
+    it('persists clientId in lowercase', async () => {
+        const client = new CoveoAnalyticsClient({});
+        client.setClientId('C7D57B22-4AA8-487A-A106-BE5243885F0A');
+        expect(await client.getCurrentVisitorId()).toBe('c7d57b22-4aa8-487a-a106-be5243885f0a');
+    });
+
+    it('allows setting a custom consistent clientId given a string', async () => {
+        const client = new CoveoAnalyticsClient({});
+        client.setClientId('somestring', 'testNameSpace');
+        //uuid v5 specific uuid generation
+        expect(await client.getCurrentVisitorId()).toBe('2c356915-8223-5773-acb8-e2a34404a559');
+        //check for consistent ids
+        client.setClientId('somestring', 'testNameSpace');
+        expect(await client.getCurrentVisitorId()).toBe('2c356915-8223-5773-acb8-e2a34404a559');
+        client.setClientId('otherstring', 'testNameSpace');
+        expect(await client.getCurrentVisitorId()).not.toBe('2c356915-8223-5773-acb8-e2a34404a559');
+        client.setClientId('somestring', 'otherNameSpace');
+        expect(await client.getCurrentVisitorId()).not.toBe('2c356915-8223-5773-acb8-e2a34404a559');
+    });
+
+    it('errors when not providing a namespace', async () => {
+        const client = new CoveoAnalyticsClient({});
+        expect.assertions(1);
+        await expect(client.setClientId('somestring')).rejects.toEqual(
+            Error('Cannot generate uuid client id without a specific namespace string.')
+        );
+        //uuid v5 specific uuid generation
+    });
+});
+
+describe('clientId from link', () => {
+    // note: referrer is set as http://somewhere.over/thereferrer in setup.js
+    let client: CoveoAnalyticsClient;
+    const forcedUUID: string = 'c0b48880-743e-484f-8044-d7c37910c55b';
+
+    function navigateTo(url: string) {
+        // @ts-ignore
+        delete window.location;
+        // @ts-ignore
+        window.location = new URL(url);
+    }
+
+    beforeEach(() => {
+        client = new CoveoAnalyticsClient({});
+        // need to clear existing clientIds
+        client.clear();
+        jest.spyOn(doNotTrack, 'doNotTrack').mockImplementation(() => false);
+    });
+
+    it('will extract a clientId from a query param if the referrer matches all and it is not expired', async () => {
+        client.setAcceptedLinkReferrers(['*']);
+        const linkString = new CoveoLinkParam(forcedUUID, Date.now());
+        navigateTo('http://my.receivingdomain.com/?cvo_cid=' + linkString.toString());
+        expect(await client.getCurrentVisitorId()).toBe(forcedUUID);
+    });
+
+    it('will extract a clientId from a query param if the referrer matches the current referrer exactly and it is not expired', async () => {
+        client.setAcceptedLinkReferrers(['somewhere.over']);
+        const linkString = new CoveoLinkParam(forcedUUID, Date.now());
+        navigateTo('http://my.receivingdomain.com/?cvo_cid=' + linkString.toString());
+        expect(await client.getCurrentVisitorId()).toBe(forcedUUID);
+    });
+
+    it('will extract a clientId from a query param if the referrer matches the current referrer with wildcard and it is not expired', async () => {
+        client.setAcceptedLinkReferrers(['*.over']);
+        const linkString = new CoveoLinkParam(forcedUUID, Date.now());
+        navigateTo('http://my.receivingdomain.com/?cvo_cid=' + linkString.toString());
+        expect(await client.getCurrentVisitorId()).toBe(forcedUUID);
+    });
+
+    it('will extract a clientId from a query param if one of the referrer matches the current referrer and it is not expired', async () => {
+        client.setAcceptedLinkReferrers(['*.mydomain.com', '*.over']);
+        const linkString = new CoveoLinkParam(forcedUUID, Date.now());
+        navigateTo('http://my.receivingdomain.com/?cvo_cid=' + linkString.toString());
+        expect(await client.getCurrentVisitorId()).toBe(forcedUUID);
+    });
+
+    it('will not extract a clientId from a query param if the referrer matches and it is expired', async () => {
+        client.setAcceptedLinkReferrers(['*']);
+        const linkString = new CoveoLinkParam(forcedUUID, Date.now() - 180000);
+        navigateTo('http://my.receivingdomain.com/?cvo_cid=' + linkString.toString());
+        expect(await client.getCurrentVisitorId()).not.toBe(null);
+        expect(await client.getCurrentVisitorId()).toBe(aVisitorId);
+    });
+
+    it('will not extract a clientId from a query param if there is no accept list specified', async () => {
+        const linkString = new CoveoLinkParam(forcedUUID, Date.now());
+        navigateTo('http://my.receivingdomain.com/?cvo_cid=' + linkString.toString());
+        expect(await client.getCurrentVisitorId()).not.toBe(null);
+        expect(await client.getCurrentVisitorId()).toBe(aVisitorId);
+    });
+
+    it('will not extract a clientId from a query param if there is an empty accept list', async () => {
+        client.setAcceptedLinkReferrers([]);
+        const linkString = new CoveoLinkParam(forcedUUID, Date.now());
+        navigateTo('http://my.receivingdomain.com/?cvo_cid=' + linkString.toString());
+        expect(await client.getCurrentVisitorId()).not.toBe(null);
+        expect(await client.getCurrentVisitorId()).toBe(aVisitorId);
+    });
+
+    it('will not extract a clientId from a query param if the referrer list does not match', async () => {
+        client.setAcceptedLinkReferrers(['*.mydomain.com']);
+        const linkString = new CoveoLinkParam(forcedUUID, Date.now());
+        navigateTo('http://my.receivingdomain.com/?cvo_cid=' + linkString.toString());
+        expect(await client.getCurrentVisitorId()).not.toBe(null);
+        expect(await client.getCurrentVisitorId()).toBe(aVisitorId);
+    });
+
+    it('will not extract a clientId from a query param if the referrer list does not match the exact port', async () => {
+        client.setAcceptedLinkReferrers(['*.over:9000']);
+        const linkString = new CoveoLinkParam(forcedUUID, Date.now());
+        navigateTo('http://my.receivingdomain.com/?cvo_cid=' + linkString.toString());
+        expect(await client.getCurrentVisitorId()).not.toBe(null);
+        expect(await client.getCurrentVisitorId()).toBe(aVisitorId);
+    });
+
+    it('will not extract a clientId from a query param if the multi referrer list does not match', async () => {
+        client.setAcceptedLinkReferrers(['*.mydomain.com', 'www.example.com']);
+        const linkString = new CoveoLinkParam(forcedUUID, Date.now());
+        navigateTo('http://my.receivingdomain.com/?cvo_cid=' + linkString.toString());
+        expect(await client.getCurrentVisitorId()).not.toBe(null);
+        expect(await client.getCurrentVisitorId()).toBe(aVisitorId);
+    });
+
+    it('will not extract a clientId from a query param if it is not a UUID', async () => {
+        client.setAcceptedLinkReferrers(['*']);
+        navigateTo('http://my.receivingdomain.com/?cvo_cid=notauuid.' + Math.floor(Date.now() / 1000));
+        expect(await client.getCurrentVisitorId()).not.toBe(null);
+        expect(await client.getCurrentVisitorId()).toBe(aVisitorId);
+    });
+
+    it('will not extract a clientId from a query param if DNT is enabled', async () => {
+        client.setAcceptedLinkReferrers(['*']);
+        jest.spyOn(doNotTrack, 'doNotTrack').mockImplementation(() => true);
+        const linkString = new CoveoLinkParam(forcedUUID, Date.now());
+        navigateTo('http://my.receivingdomain.com/?cvo_cid=' + linkString.toString());
+        expect(await client.getCurrentVisitorId()).not.toBe(null);
+        expect(await client.getCurrentVisitorId()).toBe(aVisitorId);
+    });
+
+    it('will throw when specifying invalid hosts list', async () => {
+        //@ts-ignore
+        expect(() => client.setAcceptedLinkReferrers('*')).toThrow('Parameter should be an array of domain strings');
+        //@ts-ignore
+        expect(() => client.setAcceptedLinkReferrers({})).toThrow('Parameter should be an array of domain strings');
+        //@ts-ignore
+        expect(() => client.setAcceptedLinkReferrers([{}])).toThrow('Parameter should be an array of domain strings');
+    });
+});

--- a/packages/coveo-analytics/src/client/analytics.ts
+++ b/packages/coveo-analytics/src/client/analytics.ts
@@ -1,0 +1,666 @@
+import {
+    AnyEventResponse,
+    ClickEventRequest,
+    ClickEventResponse,
+    CustomEventRequest,
+    CustomEventResponse,
+    EventType,
+    HealthResponse,
+    SearchEventRequest,
+    SearchEventResponse,
+    ViewEventRequest,
+    ViewEventResponse,
+    VisitResponse,
+    IRequestPayload,
+    VariableArgumentsPayload,
+    PreparedClickEventRequest,
+    PreparedCustomEventRequest,
+    PreparedViewEventRequest,
+    PreparedSearchEventRequest,
+} from '../events';
+import {IAnalyticsClientOptions, PreprocessAnalyticsRequest, VisitorIdProvider} from './analyticsRequestClient';
+import {hasWindow, hasDocument} from '../detector';
+import {addDefaultValues} from '../hook/addDefaultValues';
+import {enhanceViewEvent} from '../hook/enhanceViewEvent';
+import {v4 as uuidv4, v5 as uuidv5, validate as uuidValidate} from 'uuid';
+import {libVersion} from '../version';
+import {CoveoLinkParam} from '../plugins/link';
+import {
+    convertKeysToMeasurementProtocol,
+    isMeasurementProtocolKey,
+    convertCustomMeasurementProtocolKeys,
+} from './measurementProtocolMapper';
+import {IRuntimeEnvironment, BrowserRuntime, NodeJSRuntime, NoopRuntime} from './runtimeEnvironment';
+import HistoryStore from '../history';
+import {isApiKey} from './token';
+import {isReactNative, ReactNativeRuntimeWarning} from '../react-native/react-native-utils';
+import {doNotTrack} from '../donottrack';
+import {NullStorage} from '../storage';
+import {isObject} from './utils';
+
+export const Version = 'v15';
+
+export const Endpoints = {
+    default: 'https://analytics.cloud.coveo.com/rest/ua',
+    production: 'https://analytics.cloud.coveo.com/rest/ua',
+    hipaa: 'https://analyticshipaa.cloud.coveo.com/rest/ua',
+};
+
+export interface ClientOptions {
+    token?: string;
+    endpoint: string;
+    isCustomEndpoint?: boolean;
+    version: string;
+    runtimeEnvironment?: IRuntimeEnvironment;
+    beforeSendHooks: AnalyticsClientSendEventHook[];
+    afterSendHooks: AnalyticsClientSendEventHook[];
+    preprocessRequest?: PreprocessAnalyticsRequest;
+}
+
+export type AnalyticsClientSendEventHook = <TResult>(eventType: string, payload: any) => TResult | Promise<TResult>;
+export type EventTypeConfig = {
+    newEventType: EventType;
+    variableLengthArgumentsNames?: string[];
+    addVisitorIdParameter?: boolean;
+    addClientIdParameter?: boolean;
+    usesMeasurementProtocol?: boolean;
+};
+
+export interface PreparedEvent<TPreparedRequest, TCompleteRequest, TResponse extends AnyEventResponse>
+    extends BufferedRequest {
+    log(remainingPayload: Omit<TCompleteRequest, keyof TPreparedRequest>): Promise<TResponse | void>;
+}
+
+export interface AnalyticsClient {
+    getPayload(eventType: string, ...payload: VariableArgumentsPayload): Promise<any>;
+    getParameters(eventType: string, ...payload: VariableArgumentsPayload): Promise<any>;
+    makeEvent<TPreparedRequest, TCompleteRequest, TResponse extends AnyEventResponse>(
+        eventType: string,
+        ...payload: VariableArgumentsPayload
+    ): Promise<PreparedEvent<TPreparedRequest, TCompleteRequest, TResponse>>;
+    sendEvent(eventType: string, ...payload: VariableArgumentsPayload): Promise<AnyEventResponse | void>;
+    makeSearchEvent(
+        request: PreparedSearchEventRequest
+    ): Promise<PreparedEvent<PreparedSearchEventRequest, SearchEventRequest, SearchEventResponse>>;
+    sendSearchEvent(request: SearchEventRequest): Promise<SearchEventResponse | void>;
+    makeClickEvent(
+        request: PreparedClickEventRequest
+    ): Promise<PreparedEvent<PreparedClickEventRequest, ClickEventRequest, ClickEventResponse>>;
+    sendClickEvent(request: ClickEventRequest): Promise<ClickEventResponse | void>;
+    makeCustomEvent(
+        request: PreparedCustomEventRequest
+    ): Promise<PreparedEvent<PreparedCustomEventRequest, CustomEventRequest, CustomEventResponse>>;
+    sendCustomEvent(request: CustomEventRequest): Promise<CustomEventResponse | void>;
+    makeViewEvent(
+        request: PreparedViewEventRequest
+    ): Promise<PreparedEvent<PreparedViewEventRequest, ViewEventRequest, ViewEventResponse>>;
+    sendViewEvent(request: ViewEventRequest): Promise<ViewEventResponse | void>;
+    getVisit(): Promise<VisitResponse>;
+    getHealth(): Promise<HealthResponse>;
+    registerBeforeSendEventHook(hook: AnalyticsClientSendEventHook): void;
+    registerAfterSendEventHook(hook: AnalyticsClientSendEventHook): void;
+    addEventTypeMapping(eventType: string, eventConfig: EventTypeConfig): void;
+    runtime: IRuntimeEnvironment;
+    version: string;
+    /**
+     * @deprecated
+     */
+    readonly currentVisitorId: string;
+    getCurrentVisitorId?(): Promise<string>; // TODO: v3 make required
+    setAcceptedLinkReferrers?(hosts: string[]): void;
+}
+
+export interface BufferedRequest {
+    eventType: EventType;
+    payload: any;
+}
+
+type ProcessPayloadStep = (currentPayload: any) => any;
+type AsyncProcessPayloadStep = (currentPayload: any) => Promise<any>;
+
+export function buildBaseUrl(endpoint = Endpoints.default, apiVersion = Version, isCustomEndpoint = false) {
+    endpoint = endpoint.replace(/\/$/, ''); // Remove trailing slash in endpoint.
+
+    if (isCustomEndpoint) {
+        return `${endpoint}/${apiVersion}`;
+    }
+
+    const hasUARestEndpoint = endpoint.endsWith('/rest') || endpoint.endsWith('/rest/ua');
+
+    return `${endpoint}${hasUARestEndpoint ? '' : '/rest'}/${apiVersion}`;
+}
+
+// Note: Changing this value will destroy the mapping from tracking string to clientId for all customers
+// using the setClientId() api. It will have the same effect as every visitor for those customers clearing
+// their cookie store at the same time, with corresponding downstream effects.
+const COVEO_NAMESPACE = '38824e1f-37f5-42d3-8372-a4b8fa9df946';
+
+export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider {
+    private get defaultOptions(): ClientOptions {
+        return {
+            endpoint: Endpoints.default,
+            isCustomEndpoint: false,
+            token: '',
+            version: Version,
+            beforeSendHooks: [],
+            afterSendHooks: [],
+        };
+    }
+
+    public runtime: IRuntimeEnvironment;
+    public get version(): string {
+        return libVersion;
+    }
+    private visitorId: string;
+    private bufferedRequests: BufferedRequest[];
+    private beforeSendHooks: AnalyticsClientSendEventHook[];
+    private afterSendHooks: AnalyticsClientSendEventHook[];
+    private eventTypeMapping: {[name: string]: EventTypeConfig};
+    private options: ClientOptions;
+    private acceptedLinkReferrers: string[] = [];
+
+    constructor(opts: Partial<ClientOptions>) {
+        if (!opts) {
+            throw new Error('You have to pass options to this constructor');
+        }
+
+        this.options = {
+            ...this.defaultOptions,
+            ...opts,
+        };
+
+        this.visitorId = '';
+        this.bufferedRequests = [];
+        this.beforeSendHooks = [enhanceViewEvent, addDefaultValues].concat(this.options.beforeSendHooks);
+        this.afterSendHooks = this.options.afterSendHooks;
+        this.eventTypeMapping = {};
+
+        const clientsOptions: IAnalyticsClientOptions = {
+            baseUrl: this.baseUrl,
+            token: this.options.token,
+            visitorIdProvider: this,
+            preprocessRequest: this.options.preprocessRequest,
+        };
+
+        if (doNotTrack()) {
+            this.runtime = new NoopRuntime();
+        } else {
+            this.runtime = this.options.runtimeEnvironment || this.initRuntime(clientsOptions);
+        }
+
+        this.addEventTypeMapping(EventType.view, {newEventType: EventType.view, addClientIdParameter: true});
+        this.addEventTypeMapping(EventType.click, {newEventType: EventType.click, addClientIdParameter: true});
+        this.addEventTypeMapping(EventType.custom, {newEventType: EventType.custom, addClientIdParameter: true});
+        this.addEventTypeMapping(EventType.search, {newEventType: EventType.search, addClientIdParameter: true});
+    }
+
+    private initRuntime(clientsOptions: IAnalyticsClientOptions) {
+        if (hasWindow() && hasDocument()) {
+            return new BrowserRuntime(clientsOptions, () => {
+                const copy = [...this.bufferedRequests];
+                this.bufferedRequests = [];
+                return copy;
+            });
+        } else if (isReactNative()) {
+            console.warn(ReactNativeRuntimeWarning);
+        }
+        return new NodeJSRuntime(clientsOptions);
+    }
+
+    private get storage() {
+        return this.runtime.storage;
+    }
+
+    private async determineVisitorId() {
+        try {
+            return (
+                (hasWindow() && this.extractClientIdFromLink(window.location.href)) ||
+                (await this.storage.getItem('visitorId')) ||
+                uuidv4()
+            );
+        } catch (err) {
+            console.log(
+                'Could not get visitor ID from the current runtime environment storage. Using a random ID instead.',
+                err
+            );
+            return uuidv4();
+        }
+    }
+
+    async getCurrentVisitorId() {
+        if (!this.visitorId) {
+            const id = await this.determineVisitorId();
+            await this.setCurrentVisitorId(id);
+        }
+        return this.visitorId;
+    }
+
+    async setCurrentVisitorId(visitorId: string) {
+        this.visitorId = visitorId;
+        await this.storage.setItem('visitorId', visitorId);
+    }
+
+    async setClientId(value: string, namespace?: string) {
+        if (uuidValidate(value)) {
+            this.setCurrentVisitorId(value.toLowerCase());
+        } else {
+            if (!namespace) {
+                throw Error('Cannot generate uuid client id without a specific namespace string.');
+            }
+            this.setCurrentVisitorId(uuidv5(value, uuidv5(namespace, COVEO_NAMESPACE)));
+        }
+    }
+
+    async getParameters(eventType: EventType | string, ...payload: VariableArgumentsPayload) {
+        return await this.resolveParameters(eventType, ...payload);
+    }
+
+    async getPayload(eventType: EventType | string, ...payload: VariableArgumentsPayload) {
+        const parametersToSend = await this.resolveParameters(eventType, ...payload);
+        return await this.resolvePayloadForParameters(eventType, parametersToSend);
+    }
+
+    /**
+     * @deprecated Synchronous method is deprecated, use getCurrentVisitorId instead. This method will NOT work with react-native.
+     */
+    get currentVisitorId() {
+        const visitorId = this.visitorId || this.storage.getItem('visitorId');
+        if (typeof visitorId !== 'string') {
+            this.setCurrentVisitorId(uuidv4());
+        }
+        return this.visitorId;
+    }
+
+    /**
+     * @deprecated Synchronous method is deprecated, use setCurrentVisitorId instead. This method will NOT work with react-native.
+     */
+    set currentVisitorId(visitorId: string) {
+        this.visitorId = visitorId;
+        this.storage.setItem('visitorId', visitorId);
+    }
+
+    private extractClientIdFromLink(urlString: string): string | null {
+        if (doNotTrack()) {
+            return null;
+        }
+        try {
+            const linkParam: string | null = new URL(urlString).searchParams.get(CoveoLinkParam.cvo_cid);
+            if (linkParam == null) {
+                return null;
+            }
+            const linker: CoveoLinkParam | null = CoveoLinkParam.fromString(linkParam);
+            if (!linker || !hasDocument() || !linker.validate(document.referrer, this.acceptedLinkReferrers)) {
+                return null;
+            }
+            return linker.clientId;
+        } catch (error) {
+            // Ignore any parsing errors
+        }
+        return null;
+    }
+
+    async resolveParameters(eventType: EventType | string, ...payload: VariableArgumentsPayload) {
+        const {
+            variableLengthArgumentsNames = [],
+            addVisitorIdParameter = false,
+            usesMeasurementProtocol = false,
+            addClientIdParameter = false,
+        } = this.eventTypeMapping[eventType] || {};
+
+        const processVariableArgumentNamesStep: ProcessPayloadStep = (currentPayload) =>
+            variableLengthArgumentsNames.length > 0
+                ? this.parseVariableArgumentsPayload(variableLengthArgumentsNames, currentPayload)
+                : currentPayload[0];
+        const addVisitorIdStep: AsyncProcessPayloadStep = async (currentPayload) => ({
+            ...currentPayload,
+            visitorId: addVisitorIdParameter ? await this.getCurrentVisitorId() : '',
+        });
+        const addClientIdStep: AsyncProcessPayloadStep = async (currentPayload) => {
+            if (addClientIdParameter) {
+                return {
+                    ...currentPayload,
+                    clientId: await this.getCurrentVisitorId(),
+                };
+            }
+            return currentPayload;
+        };
+        const setAnonymousUserStep: ProcessPayloadStep = (currentPayload) =>
+            usesMeasurementProtocol ? this.ensureAnonymousUserWhenUsingApiKey(currentPayload) : currentPayload;
+        const processBeforeSendHooksStep: AsyncProcessPayloadStep = (currentPayload) =>
+            this.beforeSendHooks.reduce(async (promisePayload, current) => {
+                const payload = await promisePayload;
+                return await current(eventType, payload);
+            }, currentPayload);
+
+        const parametersToSend = await [
+            processVariableArgumentNamesStep,
+            addVisitorIdStep,
+            addClientIdStep,
+            setAnonymousUserStep,
+            processBeforeSendHooksStep,
+        ].reduce(async (payloadPromise, step) => {
+            const payload = await payloadPromise;
+            return await step(payload);
+        }, Promise.resolve(payload));
+
+        return parametersToSend;
+    }
+
+    async resolvePayloadForParameters(eventType: EventType | string, parameters: any) {
+        const {usesMeasurementProtocol = false} = this.eventTypeMapping[eventType] || {};
+
+        const addTrackingIdStep: ProcessPayloadStep = (currentPayload) =>
+            this.setTrackingIdIfTrackingIdNotPresent(currentPayload);
+        const cleanPayloadStep: ProcessPayloadStep = (currentPayload) =>
+            this.removeEmptyPayloadValues(currentPayload, eventType);
+        const validateParams: ProcessPayloadStep = (currentPayload) => this.validateParams(currentPayload, eventType);
+        const processMeasurementProtocolConversionStep: ProcessPayloadStep = (currentPayload) =>
+            usesMeasurementProtocol ? convertKeysToMeasurementProtocol(currentPayload) : currentPayload;
+        const removeUnknownParameters: ProcessPayloadStep = (currentPayload) =>
+            usesMeasurementProtocol ? this.removeUnknownParameters(currentPayload) : currentPayload;
+        const processCustomParameters: ProcessPayloadStep = (currentPayload) =>
+            usesMeasurementProtocol
+                ? this.processCustomParameters(currentPayload)
+                : this.mapCustomParametersToCustomData(currentPayload);
+
+        const payloadToSend = await [
+            addTrackingIdStep,
+            cleanPayloadStep,
+            validateParams,
+            processMeasurementProtocolConversionStep,
+            removeUnknownParameters,
+            processCustomParameters,
+        ].reduce(async (payloadPromise, step) => {
+            const payload = await payloadPromise;
+            return await step(payload);
+        }, Promise.resolve(parameters));
+
+        return payloadToSend;
+    }
+
+    async makeEvent<TPreparedRequest, TCompleteRequest, TResponse extends AnyEventResponse>(
+        eventType: EventType | string,
+        ...payload: VariableArgumentsPayload
+    ): Promise<PreparedEvent<TPreparedRequest, TCompleteRequest, TResponse>> {
+        const {newEventType: eventTypeToSend = eventType as EventType} = this.eventTypeMapping[eventType] || {};
+
+        const parametersToSend = await this.resolveParameters(eventType, ...payload);
+        const payloadToSend = await this.resolvePayloadForParameters(eventType, parametersToSend);
+        return {
+            eventType: eventTypeToSend,
+            payload: payloadToSend,
+            log: async (remainingPayload) => {
+                this.bufferedRequests.push(<BufferedRequest>{
+                    eventType: eventTypeToSend,
+                    payload: {...payloadToSend, ...remainingPayload},
+                });
+                await Promise.all(
+                    this.afterSendHooks.map((hook) => hook(eventType, {...parametersToSend, ...remainingPayload}))
+                );
+                await this.deferExecution();
+                return (await this.sendFromBuffer()) as TResponse | void;
+            },
+        };
+    }
+
+    async sendEvent(eventType: EventType | string, ...payload: VariableArgumentsPayload) {
+        return (await this.makeEvent<any, any, AnyEventResponse>(eventType, ...payload)).log({});
+    }
+
+    private deferExecution(): Promise<void> {
+        return new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    private async sendFromBuffer(): Promise<AnyEventResponse | void> {
+        const popped = this.bufferedRequests.shift();
+        if (popped) {
+            const {eventType, payload} = popped;
+            return this.runtime.getClientDependingOnEventType(eventType).sendEvent(eventType, payload);
+        }
+    }
+
+    public clear() {
+        this.storage.removeItem('visitorId');
+        const store = new HistoryStore();
+        store.clear();
+    }
+
+    public deleteHttpOnlyVisitorId() {
+        this.runtime.client.deleteHttpCookieVisitorId();
+    }
+
+    async makeSearchEvent(request: PreparedSearchEventRequest) {
+        return this.makeEvent<PreparedSearchEventRequest, SearchEventRequest, SearchEventResponse>(
+            EventType.search,
+            request
+        );
+    }
+
+    async sendSearchEvent({searchQueryUid, ...preparedRequest}: SearchEventRequest) {
+        return (await this.makeSearchEvent(preparedRequest)).log({searchQueryUid});
+    }
+
+    async makeClickEvent(request: PreparedClickEventRequest) {
+        return this.makeEvent<PreparedClickEventRequest, ClickEventRequest, ClickEventResponse>(
+            EventType.click,
+            request
+        );
+    }
+
+    async sendClickEvent({searchQueryUid, ...preparedRequest}: ClickEventRequest) {
+        return (await this.makeClickEvent(preparedRequest)).log({searchQueryUid});
+    }
+
+    async makeCustomEvent(request: PreparedCustomEventRequest) {
+        return this.makeEvent<PreparedCustomEventRequest, CustomEventRequest, CustomEventResponse>(
+            EventType.custom,
+            request
+        );
+    }
+
+    async sendCustomEvent({lastSearchQueryUid, ...preparedRequest}: CustomEventRequest) {
+        return (await this.makeCustomEvent(preparedRequest)).log({lastSearchQueryUid});
+    }
+
+    async makeViewEvent(request: PreparedViewEventRequest) {
+        return this.makeEvent<PreparedViewEventRequest, ViewEventRequest, ViewEventResponse>(EventType.view, request);
+    }
+
+    async sendViewEvent(request: ViewEventRequest): Promise<ViewEventResponse | void> {
+        return (await this.makeViewEvent(request)).log({});
+    }
+
+    async getVisit(): Promise<VisitResponse> {
+        // deepcode ignore Ssrf: url is supplied by script owner
+        const response = await fetch(`${this.baseUrl}/analytics/visit`);
+        const visit = (await response.json()) as VisitResponse;
+        this.visitorId = visit.visitorId;
+        return visit;
+    }
+
+    async getHealth(): Promise<HealthResponse> {
+        // deepcode ignore Ssrf: url is supplied by script owner
+        const response = await fetch(`${this.baseUrl}/analytics/monitoring/health`);
+        return (await response.json()) as HealthResponse;
+    }
+
+    registerBeforeSendEventHook(hook: AnalyticsClientSendEventHook): void {
+        this.beforeSendHooks.push(hook);
+    }
+
+    registerAfterSendEventHook(hook: AnalyticsClientSendEventHook): void {
+        this.afterSendHooks.push(hook);
+    }
+
+    addEventTypeMapping(eventType: string, eventConfig: EventTypeConfig): void {
+        this.eventTypeMapping[eventType] = eventConfig;
+    }
+
+    setAcceptedLinkReferrers(hosts: string[]): void {
+        if (Array.isArray(hosts) && hosts.every((host) => typeof host == 'string')) this.acceptedLinkReferrers = hosts;
+        else throw Error('Parameter should be an array of domain strings');
+    }
+
+    private parseVariableArgumentsPayload(fieldsOrder: string[], payload: VariableArgumentsPayload) {
+        const parsedArguments: {[name: string]: any} = {};
+        for (let i = 0, length = payload.length; i < length; i++) {
+            const currentArgument = payload[i];
+            if (typeof currentArgument === 'string') {
+                parsedArguments[fieldsOrder[i]] = currentArgument;
+            } else if (typeof currentArgument === 'object') {
+                // If the argument is an object, it is considered the last argument of the chain. Its values should be returned as-is.
+                return {
+                    ...parsedArguments,
+                    ...currentArgument,
+                };
+            }
+        }
+        return parsedArguments;
+    }
+
+    private isKeyAllowedEmpty(evtType: string, key: string) {
+        const keysThatCanBeEmpty: Record<string, string[]> = {
+            [EventType.search]: ['queryText'],
+        };
+
+        const match = keysThatCanBeEmpty[evtType] || [];
+        return match.indexOf(key) !== -1;
+    }
+
+    private removeEmptyPayloadValues(payload: IRequestPayload, eventType: string): IRequestPayload {
+        const isNotEmptyValue = (value: any) => typeof value !== 'undefined' && value !== null && value !== '';
+        return Object.keys(payload)
+            .filter((key) => this.isKeyAllowedEmpty(eventType, key) || isNotEmptyValue(payload[key]))
+            .reduce(
+                (newPayload, key) => ({
+                    ...newPayload,
+                    [key]: payload[key],
+                }),
+                {}
+            );
+    }
+
+    private removeUnknownParameters(payload: IRequestPayload): IRequestPayload {
+        const newPayload = Object.keys(payload)
+            .filter((key) => {
+                if (isMeasurementProtocolKey(key)) {
+                    return true;
+                } else {
+                    console.log(key, 'is not processed by coveoua');
+                }
+            })
+            .reduce(
+                (newPayload, key) => ({
+                    ...newPayload,
+                    [key]: payload[key],
+                }),
+                {}
+            );
+        return newPayload;
+    }
+
+    private processCustomParameters(payload: IRequestPayload): IRequestPayload {
+        const {custom, ...rest} = payload;
+        let lowercasedCustom = {};
+        if (custom && isObject(custom)) {
+            lowercasedCustom = this.lowercaseKeys(custom);
+        }
+
+        const newPayload = convertCustomMeasurementProtocolKeys(rest);
+
+        return {
+            ...lowercasedCustom,
+            ...newPayload,
+        };
+    }
+
+    private mapCustomParametersToCustomData(payload: IRequestPayload): IRequestPayload {
+        const {custom, ...rest} = payload;
+        if (custom && isObject(custom)) {
+            const lowercasedCustom = this.lowercaseKeys(custom);
+            return {...rest, customData: {...lowercasedCustom, ...payload.customData}};
+        } else {
+            return payload;
+        }
+    }
+
+    private lowercaseKeys(custom: Record<string, unknown>) {
+        const keys = Object.keys(custom);
+        let result: Record<string, unknown> = {};
+        keys.forEach((key) => {
+            result[key.toLowerCase() as string] = custom[key];
+        });
+        return result;
+    }
+
+    private validateParams(payload: IRequestPayload, eventType: EventType | string): IRequestPayload {
+        const {anonymizeIp, ...rest} = payload;
+        if (anonymizeIp !== undefined) {
+            if (['0', 'false', 'undefined', 'null', '{}', '[]', ''].indexOf(`${anonymizeIp}`.toLowerCase()) == -1) {
+                rest.anonymizeIp = 1;
+            }
+        }
+
+        if (
+            eventType == EventType.view ||
+            eventType == EventType.click ||
+            eventType == EventType.search ||
+            eventType == EventType.custom
+        ) {
+            rest.originLevel3 = this.limit(rest.originLevel3, 128);
+        }
+        if (eventType == EventType.view) {
+            rest.location = this.limit(rest.location, 128);
+        }
+        if (eventType == 'pageview' || eventType == 'event') {
+            rest.referrer = this.limit(rest.referrer, 2048);
+            rest.location = this.limit(rest.location, 2048);
+            rest.page = this.limit(rest.page, 2048);
+        }
+        return rest;
+    }
+
+    private ensureAnonymousUserWhenUsingApiKey(payload: IRequestPayload): IRequestPayload {
+        const {userId, ...rest} = payload;
+        if (isApiKey(this.options.token) && !userId) {
+            rest['userId'] = 'anonymous';
+            return rest;
+        } else {
+            return payload;
+        }
+    }
+
+    private setTrackingIdIfTrackingIdNotPresent(payload: IRequestPayload): IRequestPayload {
+        const {trackingId, ...rest} = payload;
+        if (trackingId) {
+            return payload;
+        }
+
+        if (rest.hasOwnProperty('custom') && isObject(rest.custom)) {
+            if (rest.custom.hasOwnProperty('context_website') || rest.custom.hasOwnProperty('siteName')) {
+                rest['trackingId'] = rest.custom.context_website || rest.custom.siteName;
+            }
+        }
+
+        if (rest.hasOwnProperty('customData') && isObject(rest.customData)) {
+            if (rest.customData.hasOwnProperty('context_website') || rest.customData.hasOwnProperty('siteName')) {
+                rest['trackingId'] = rest.customData.context_website || rest.customData.siteName;
+            }
+        }
+
+        return rest;
+    }
+
+    private limit(input: string, length: number): string | undefined | null {
+        if (typeof input !== 'string') {
+            return input;
+        }
+        return input.substring(0, length);
+    }
+
+    private get baseUrl(): string {
+        return buildBaseUrl(this.options.endpoint, this.options.version, this.options.isCustomEndpoint);
+    }
+}
+
+export default CoveoAnalyticsClient;

--- a/packages/coveo-analytics/src/client/analyticsBeaconClient.spec.ts
+++ b/packages/coveo-analytics/src/client/analyticsBeaconClient.spec.ts
@@ -1,0 +1,207 @@
+import {AnalyticsBeaconClient} from './analyticsBeaconClient';
+import {EventType} from '../events';
+import {AnalyticsClientOrigin, IAnalyticsRequestOptions, PreprocessAnalyticsRequest} from './analyticsRequestClient';
+
+describe('AnalyticsBeaconClient', () => {
+    const baseUrl = 'https://bloup.com';
+    const token = '👛';
+    const currentVisitorId = 'hereiam';
+
+    const originalSendBeacon = navigator.sendBeacon;
+    const sendBeaconMock = jest.fn();
+    beforeAll(() => {
+        navigator.sendBeacon = sendBeaconMock;
+    });
+
+    afterAll(() => {
+        navigator.sendBeacon = originalSendBeacon;
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('can send an event', async () => {
+        const eventType: EventType = EventType.custom;
+
+        const client = new AnalyticsBeaconClient({
+            baseUrl,
+            token,
+            visitorIdProvider: {
+                getCurrentVisitorId: () => Promise.resolve(currentVisitorId),
+                setCurrentVisitorId: (visitorId) => {},
+            },
+        });
+
+        await client.sendEvent(eventType, {
+            wow: 'ok',
+        });
+
+        expect(sendBeaconMock).toHaveBeenCalledWith(
+            `${baseUrl}/analytics/custom?access_token=👛&visitorId=${currentVisitorId}&discardVisitInfo=true`,
+            expect.anything()
+        );
+        expect(await getSendBeaconFirstCallBlobArgument()).toBe(`customEvent=${encodeURIComponent('{"wow":"ok"}')}`);
+    });
+
+    it('can send a collect event with the proper payload', async () => {
+        const eventType: EventType = EventType.collect;
+
+        const client = new AnalyticsBeaconClient({
+            baseUrl,
+            token,
+            visitorIdProvider: {
+                getCurrentVisitorId: () => Promise.resolve(currentVisitorId),
+                setCurrentVisitorId: (visitorId) => {},
+            },
+        });
+
+        await client.sendEvent(eventType, {
+            pr1a: 'value',
+            'to encode': 'to encode',
+        });
+
+        expect(sendBeaconMock).toHaveBeenCalledWith(
+            `${baseUrl}/analytics/collect?visitorId=${currentVisitorId}&discardVisitInfo=true`,
+            expect.anything()
+        );
+        expect(await getSendBeaconFirstCallBlobArgument()).toBe(
+            `access_token=${encodeURIComponent('👛')}&collectEvent=${encodeURIComponent(
+                '{"pr1a":"value","to encode":"to encode"}'
+            )}`
+        );
+    });
+
+    it('can send a collect event with a more complex payload', async () => {
+        const eventType: EventType = EventType.collect;
+
+        const client = new AnalyticsBeaconClient({
+            baseUrl,
+            token,
+            visitorIdProvider: {
+                getCurrentVisitorId: () => {
+                    return Promise.resolve(currentVisitorId);
+                },
+                setCurrentVisitorId: (visitorId) => {},
+            },
+        });
+
+        await client.sendEvent(eventType, {
+            value: {
+                subvalue: 'ok',
+            },
+        });
+
+        expect(sendBeaconMock).toHaveBeenCalledWith(
+            `${baseUrl}/analytics/collect?visitorId=${currentVisitorId}&discardVisitInfo=true`,
+            expect.anything()
+        );
+        expect(await getSendBeaconFirstCallBlobArgument()).toBe(
+            `access_token=${encodeURIComponent('👛')}&collectEvent=${encodeURIComponent('{"value":{"subvalue":"ok"}}')}`
+        );
+    });
+
+    describe('allows to preprocessRequest', () => {
+        const setupClient = (preprocessRequest: PreprocessAnalyticsRequest) => {
+            return new AnalyticsBeaconClient({
+                baseUrl,
+                token,
+                visitorIdProvider: {
+                    getCurrentVisitorId: () => {
+                        return Promise.resolve(currentVisitorId);
+                    },
+                    setCurrentVisitorId: () => {},
+                },
+                preprocessRequest,
+            });
+        };
+
+        it('to modify the origin and the body of the request', async () => {
+            let clientOrigin: AnalyticsClientOrigin;
+            const processedRequest: IAnalyticsRequestOptions = {
+                url: 'https://www.myownanalytics.com/endpoint',
+                body: JSON.stringify({
+                    test: 'custom',
+                }),
+            };
+            const client = setupClient((_request, type) => {
+                clientOrigin = type;
+                return processedRequest;
+            });
+
+            await client.sendEvent(EventType.collect, {});
+
+            expect(clientOrigin!).toBe('analyticsBeacon');
+            expect(sendBeaconMock).toHaveBeenCalledWith(processedRequest.url, expect.anything());
+            expect(await getSendBeaconFirstCallBlobArgument()).toContain('%22test%22%3A%22custom%22');
+        });
+
+        it('to modify the request body as a JSON string for a collect event', async () => {
+            const client = setupClient((request) => {
+                const bodyShouldBeAvailableAsJSONString = JSON.parse(request.body as string);
+                expect(bodyShouldBeAvailableAsJSONString).toEqual({foo: 'bar'});
+                bodyShouldBeAvailableAsJSONString.foo = 'baz';
+                request.body = JSON.stringify(bodyShouldBeAvailableAsJSONString);
+                return request;
+            });
+
+            await client.sendEvent(EventType.collect, {foo: 'bar'});
+            expect(await getSendBeaconFirstCallBlobArgument()).toBe(
+                'access_token=%F0%9F%91%9B&collectEvent=%7B%22foo%22%3A%22baz%22%7D'
+            );
+        });
+
+        it('to modify the request body as a JSON string for a click event', async () => {
+            const client = setupClient((request) => {
+                const bodyParsedAsJSON = JSON.parse(request.body as string);
+                expect(bodyParsedAsJSON).toEqual({actionCause: 'foo'});
+                bodyParsedAsJSON.actionCause = 'bar';
+                request.body = JSON.stringify(bodyParsedAsJSON);
+                return request;
+            });
+
+            await client.sendEvent(EventType.click, {actionCause: 'foo'});
+            expect(await getSendBeaconFirstCallBlobArgument()).toContain(
+                `clickEvent=${encodeURIComponent('{"actionCause":"bar"}')}`
+            );
+        });
+
+        it('to augment the request body as a JSON string for a click event', async () => {
+            const client = setupClient((request) => {
+                const bodyParsedAsJSON = JSON.parse(request.body as string);
+                bodyParsedAsJSON.aNewProperty = 'bar';
+                request.body = JSON.stringify(bodyParsedAsJSON);
+                return request;
+            });
+
+            await client.sendEvent(EventType.click, {actionCause: 'foo'});
+            expect(await getSendBeaconFirstCallBlobArgument()).toContain(
+                `clickEvent=${encodeURIComponent('{"actionCause":"foo","aNewProperty":"bar"}')}`
+            );
+        });
+
+        it('should keep original request body if preprocessRequest returns an invalid JSON string', async () => {
+            const client = setupClient((request) => {
+                request.body = 'invalid JSON string';
+                return request;
+            });
+
+            await client.sendEvent(EventType.click, {actionCause: 'bar'});
+            expect(await getSendBeaconFirstCallBlobArgument()).toContain(
+                `clickEvent=${encodeURIComponent(`{"actionCause":"bar"}`)}`
+            );
+        });
+    });
+
+    const getSendBeaconFirstCallBlobArgument = async () => {
+        const blobArgument: Blob = sendBeaconMock.mock.calls[0][1];
+        expect(blobArgument.size).toBeGreaterThan(0);
+        return new Promise((resolve) => {
+            const reader = new FileReader();
+            reader.addEventListener('loadend', () => {
+                resolve(reader.result);
+            });
+            reader.readAsText(blobArgument);
+        });
+    };
+});

--- a/packages/coveo-analytics/src/client/analyticsBeaconClient.ts
+++ b/packages/coveo-analytics/src/client/analyticsBeaconClient.ts
@@ -1,0 +1,98 @@
+import {AnalyticsRequestClient, IAnalyticsClientOptions, PreprocessAnalyticsRequest} from './analyticsRequestClient';
+import {EventType, IRequestPayload} from '../events';
+
+export class AnalyticsBeaconClient implements AnalyticsRequestClient {
+    constructor(private opts: IAnalyticsClientOptions) {}
+
+    public async sendEvent(eventType: EventType, originalPayload: IRequestPayload): Promise<void> {
+        if (!this.isAvailable()) {
+            throw new Error(
+                `navigator.sendBeacon is not supported in this browser. Consider adding a polyfill like "sendbeacon-polyfill".`
+            );
+        }
+
+        const {baseUrl, preprocessRequest} = this.opts;
+
+        const paramsFragments = await this.getQueryParamsForEventType(eventType);
+
+        const {url, payload} = await this.preProcessRequestAsPotentialJSONString(
+            `${baseUrl}/analytics/${eventType}?${paramsFragments}`,
+            originalPayload,
+            preprocessRequest
+        );
+
+        const parsedRequestData = this.encodeForEventType(eventType, payload);
+        const body = new Blob([parsedRequestData], {
+            type: 'application/x-www-form-urlencoded',
+        });
+
+        navigator.sendBeacon(url, body as any); // https://github.com/microsoft/TypeScript/issues/38715
+        return;
+    }
+
+    public isAvailable() {
+        return 'sendBeacon' in navigator;
+    }
+
+    public deleteHttpCookieVisitorId() {
+        return Promise.resolve();
+    }
+
+    private async preProcessRequestAsPotentialJSONString(
+        originalURL: string,
+        originalPayload: IRequestPayload,
+        preprocessRequest?: PreprocessAnalyticsRequest
+    ): Promise<{url: string; payload: IRequestPayload}> {
+        let returnedUrl = originalURL;
+        let returnedPayload = originalPayload;
+
+        if (preprocessRequest) {
+            const processedRequest = await preprocessRequest(
+                {url: originalURL, body: JSON.stringify(originalPayload)},
+                'analyticsBeacon'
+            );
+            const {url: processedURL, body: processedBody} = processedRequest;
+            returnedUrl = processedURL || originalURL;
+            try {
+                returnedPayload = JSON.parse(processedBody as string);
+            } catch (e) {
+                console.error('Unable to process the request body as a JSON string', e);
+            }
+        }
+
+        return {
+            payload: returnedPayload,
+            url: returnedUrl,
+        };
+    }
+
+    private encodeForEventType(eventType: EventType, payload: IRequestPayload): string {
+        return this.isEventTypeLegacy(eventType)
+            ? this.encodeEventToJson(eventType, payload)
+            : this.encodeEventToJson(eventType, payload, this.opts.token);
+    }
+
+    private async getQueryParamsForEventType(eventType: EventType): Promise<string> {
+        const {token, visitorIdProvider} = this.opts;
+        const visitorId = await visitorIdProvider.getCurrentVisitorId();
+        return [
+            token && this.isEventTypeLegacy(eventType) ? `access_token=${token}` : '',
+            visitorId ? `visitorId=${visitorId}` : '',
+            'discardVisitInfo=true',
+        ]
+            .filter((p) => !!p)
+            .join('&');
+    }
+
+    private isEventTypeLegacy(eventType: EventType) {
+        return [EventType.click, EventType.custom, EventType.search, EventType.view].indexOf(eventType) !== -1;
+    }
+
+    private encodeEventToJson(eventType: EventType, payload: IRequestPayload, access_token?: string): string {
+        let encoded = `${eventType}Event=${encodeURIComponent(JSON.stringify(payload))}`;
+        if (access_token) {
+            encoded = `access_token=${encodeURIComponent(access_token)}&${encoded}`;
+        }
+        return encoded;
+    }
+}

--- a/packages/coveo-analytics/src/client/analyticsFetchClient.ts
+++ b/packages/coveo-analytics/src/client/analyticsFetchClient.ts
@@ -1,0 +1,78 @@
+import {AnalyticsRequestClient, IAnalyticsRequestOptions, IAnalyticsClientOptions} from './analyticsRequestClient';
+import {AnyEventResponse, EventType, IRequestPayload} from '../events';
+import {fetch} from 'cross-fetch';
+
+export class AnalyticsFetchClient implements AnalyticsRequestClient {
+    constructor(private opts: IAnalyticsClientOptions) {}
+
+    public async sendEvent(eventType: EventType, payload: IRequestPayload): Promise<AnyEventResponse | void> {
+        const {baseUrl, visitorIdProvider, preprocessRequest} = this.opts;
+
+        const visitorIdParam = this.shouldAppendVisitorId(eventType) ? await this.getVisitorIdParam() : '';
+        const defaultOptions: IAnalyticsRequestOptions = {
+            url: `${baseUrl}/analytics/${eventType}${visitorIdParam}`,
+            credentials: 'include',
+            mode: 'cors',
+            headers: this.getHeaders(),
+            method: 'POST',
+            body: JSON.stringify(payload),
+        };
+        const {url, ...fetchData}: IAnalyticsRequestOptions = {
+            ...defaultOptions,
+            ...(preprocessRequest ? await preprocessRequest(defaultOptions, 'analyticsFetch') : {}),
+        };
+
+        let response: Response;
+
+        try {
+            response = await fetch(url, fetchData);
+        } catch (error) {
+            console.error('An error has occured when sending the event.', error);
+            return;
+        }
+
+        if (response.ok) {
+            const visit = (await response.json()) as AnyEventResponse;
+
+            if (visit.visitorId) {
+                visitorIdProvider.setCurrentVisitorId(visit.visitorId);
+            }
+
+            return visit;
+        } else {
+            try {
+                response.json();
+            } catch {
+                /* If you don't parse the response, it won't appear in the network tab. */
+            }
+            console.error(`An error has occured when sending the "${eventType}" event.`, response, payload);
+            throw new Error(
+                `An error has occurred when sending the "${eventType}" event. Check the console logs for more details.`
+            );
+        }
+    }
+
+    public async deleteHttpCookieVisitorId() {
+        const {baseUrl} = this.opts;
+        const url = `${baseUrl}/analytics/visit`;
+        await fetch(url, {headers: this.getHeaders(), method: 'DELETE'});
+    }
+
+    private shouldAppendVisitorId(eventType: EventType) {
+        return [EventType.click, EventType.custom, EventType.search, EventType.view].indexOf(eventType) !== -1;
+    }
+
+    private async getVisitorIdParam() {
+        const {visitorIdProvider} = this.opts;
+        const visitorId = await visitorIdProvider.getCurrentVisitorId();
+        return visitorId ? `?visitor=${visitorId}` : '';
+    }
+
+    private getHeaders(): Record<string, string> {
+        const {token} = this.opts;
+        return {
+            ...(token ? {Authorization: `Bearer ${token}`} : {}),
+            'Content-Type': `application/json`,
+        };
+    }
+}

--- a/packages/coveo-analytics/src/client/analyticsRequestClient.ts
+++ b/packages/coveo-analytics/src/client/analyticsRequestClient.ts
@@ -1,0 +1,39 @@
+import {AnyEventResponse, EventType, IRequestPayload} from '../events';
+
+export interface VisitorIdProvider {
+    getCurrentVisitorId: () => Promise<string>;
+    setCurrentVisitorId: (visitorId: string) => void;
+}
+
+export interface AnalyticsRequestClient {
+    sendEvent(eventType: string, payload: IRequestPayload): Promise<AnyEventResponse | void>;
+    deleteHttpCookieVisitorId: () => Promise<void>;
+}
+
+export interface IAnalyticsClientOptions {
+    baseUrl: string;
+    token?: string;
+    visitorIdProvider: VisitorIdProvider;
+    preprocessRequest?: PreprocessAnalyticsRequest;
+}
+
+export type AnalyticsClientOrigin = 'analyticsFetch' | 'analyticsBeacon';
+
+export type PreprocessAnalyticsRequest = (
+    request: IAnalyticsRequestOptions,
+    clientOrigin: AnalyticsClientOrigin
+) => IAnalyticsRequestOptions | Promise<IAnalyticsRequestOptions>;
+
+export interface IAnalyticsRequestOptions extends RequestInit {
+    url: string;
+}
+
+export class NoopAnalyticsClient implements AnalyticsRequestClient {
+    public async sendEvent(_: EventType, __: IRequestPayload): Promise<void> {
+        return Promise.resolve();
+    }
+
+    public async deleteHttpCookieVisitorId() {
+        return Promise.resolve();
+    }
+}

--- a/packages/coveo-analytics/src/client/location.ts
+++ b/packages/coveo-analytics/src/client/location.ts
@@ -1,0 +1,4 @@
+export const getFormattedLocation = (location: Location) =>
+    `${location.protocol}//${location.hostname}${
+        location.pathname.indexOf('/') === 0 ? location.pathname : `/${location.pathname}`
+    }${location.search}`;

--- a/packages/coveo-analytics/src/client/measurementProtocolMapper.ts
+++ b/packages/coveo-analytics/src/client/measurementProtocolMapper.ts
@@ -1,0 +1,71 @@
+import {isServiceKey, serviceActionsKeysMapping} from './measurementProtocolMapping/serviceMeasurementProtocolMapper';
+import {
+    commerceActionKeysMappingPerAction,
+    isCommerceKey,
+    isCustomCommerceKey,
+} from './measurementProtocolMapping/commerceMeasurementProtocolMapper';
+import {keysOf} from './utils';
+import {baseMeasurementProtocolKeysMapping} from './measurementProtocolMapping/baseMeasurementProtocolMapper';
+
+const measurementProtocolKeysMapping: {[name: string]: string} = {
+    ...baseMeasurementProtocolKeysMapping,
+    ...serviceActionsKeysMapping,
+};
+
+export const convertKeysToMeasurementProtocol = (params: any) => {
+    const keysMappingForAction = (!!params.action && commerceActionKeysMappingPerAction[params.action]) || {};
+    return keysOf(params).reduce((mappedKeys, key) => {
+        const newKey = keysMappingForAction[key] || measurementProtocolKeysMapping[key] || key;
+        return {
+            ...mappedKeys,
+            [newKey]: params[key],
+        };
+    }, {});
+};
+
+const measurementProtocolKeysMappingValues = keysOf(measurementProtocolKeysMapping).map(
+    (key) => measurementProtocolKeysMapping[key]
+);
+
+const isKnownMeasurementProtocolKey = (key: string) => measurementProtocolKeysMappingValues.indexOf(key) !== -1;
+const isCustomKey = (key: string) => key === 'custom';
+
+export const isMeasurementProtocolKey = (key: string): boolean => {
+    return [...isCommerceKey, ...isServiceKey, isKnownMeasurementProtocolKey, isCustomKey].some((test) => test(key));
+};
+
+export const convertCustomMeasurementProtocolKeys = (data: {[name: string]: string | {[name: string]: string}}) => {
+    return keysOf(data).reduce((all, current) => {
+        const match = getFirstCustomMeasurementProtocolKeyMatch(current);
+        if (match) {
+            return {
+                ...all,
+                ...convertCustomObject(match, data[current] as {[name: string]: string}),
+            };
+        } else {
+            return {
+                ...all,
+                [current]: data[current],
+            };
+        }
+    }, {});
+};
+
+const getFirstCustomMeasurementProtocolKeyMatch = (key: string): string | undefined => {
+    let matchedKey: string | undefined = undefined;
+    [...isCustomCommerceKey].every((regex) => {
+        matchedKey = regex.exec(key)?.[1];
+        return !Boolean(matchedKey);
+    });
+    return matchedKey;
+};
+
+const convertCustomObject = (prefix: string, customData: {[name: string]: string}) => {
+    return keysOf(customData).reduce(
+        (allCustom, currentCustomKey) => ({
+            ...allCustom,
+            [`${prefix}${currentCustomKey}`]: customData[currentCustomKey],
+        }),
+        {}
+    );
+};

--- a/packages/coveo-analytics/src/client/measurementProtocolMapping/baseMeasurementProtocolMapper.ts
+++ b/packages/coveo-analytics/src/client/measurementProtocolMapping/baseMeasurementProtocolMapper.ts
@@ -1,0 +1,61 @@
+import {BasePlugin} from '../../plugins/BasePlugin';
+
+type DefaultContextInformation = ReturnType<typeof BasePlugin.prototype.getDefaultContextInformation> &
+    ReturnType<typeof BasePlugin.prototype.getLocationInformation>;
+
+const globalParamKeysMapping: {[name: string]: string} = {
+    anonymizeIp: 'aip',
+};
+
+const eventKeysMapping: {[name: string]: string} = {
+    eventCategory: 'ec',
+    eventAction: 'ea',
+    eventLabel: 'el',
+    eventValue: 'ev',
+    page: 'dp',
+    visitorId: 'cid',
+    clientId: 'cid',
+    userId: 'uid',
+    currencyCode: 'cu',
+};
+
+const contextInformationMapping: {[key in keyof DefaultContextInformation]: string} = {
+    hitType: 't',
+    pageViewId: 'pid',
+    encoding: 'de',
+    location: 'dl',
+    referrer: 'dr',
+    screenColor: 'sd',
+    screenResolution: 'sr',
+    title: 'dt',
+    userAgent: 'ua',
+    language: 'ul',
+    eventId: 'z',
+    time: 'tm',
+};
+
+/* Those are extension keys that are supported by the Coveo collect protocol (but not Google's protocol). They will be forwarded as-is. */
+const coveoExtensionsKeys = [
+    'contentId',
+    'contentIdKey',
+    'contentType',
+    'searchHub',
+    'tab',
+    'searchUid',
+    'permanentId',
+    'contentLocale',
+    'trackingId',
+];
+
+export const baseMeasurementProtocolKeysMapping: {[name: string]: string} = {
+    ...globalParamKeysMapping,
+    ...eventKeysMapping,
+    ...contextInformationMapping,
+    ...coveoExtensionsKeys.reduce(
+        (all, key) => ({
+            ...all,
+            [key]: key,
+        }),
+        {}
+    ),
+};

--- a/packages/coveo-analytics/src/client/measurementProtocolMapping/commerceMeasurementProtocolMapper.ts
+++ b/packages/coveo-analytics/src/client/measurementProtocolMapping/commerceMeasurementProtocolMapper.ts
@@ -1,0 +1,185 @@
+import {Product, ImpressionList, BaseImpression} from '../../plugins/ec';
+import {keysOf} from '../utils';
+
+// Based off: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#enhanced-ecomm
+const productKeysMapping: {[key in keyof Product]: string} = {
+    id: 'id',
+    name: 'nm',
+    brand: 'br',
+    category: 'ca',
+    variant: 'va',
+    price: 'pr',
+    quantity: 'qt',
+    coupon: 'cc',
+    position: 'ps',
+    // Below are keys that were extended for Coveo
+    group: 'group',
+};
+
+const impressionKeysMapping: {[key in keyof BaseImpression]: string} = {
+    id: 'id',
+    name: 'nm',
+    brand: 'br',
+    category: 'ca',
+    variant: 'va',
+    position: 'ps',
+    price: 'pr',
+    // Below are keys that were extended for Coveo
+    group: 'group',
+};
+
+const productActionsKeysMapping: {[name: string]: string} = {
+    action: 'pa',
+    list: 'pal',
+    listSource: 'pls',
+};
+
+const transactionActionsKeysMapping: {[name: string]: string} = {
+    id: 'ti',
+    revenue: 'tr',
+    tax: 'tt',
+    shipping: 'ts',
+    coupon: 'tcc',
+    affiliation: 'ta',
+    step: 'cos',
+    option: 'col',
+};
+
+// These extension keys do not have direct mappings, we are sending them as-is, thus only requiring an array.
+const coveoCommerceExtensionKeys: string[] = [
+    'loyaltyCardId',
+    'loyaltyTier',
+    'thirdPartyPersona',
+    'companyName',
+    'favoriteStore',
+    'storeName',
+    'userIndustry',
+    'userRole',
+    'userDepartment',
+    'businessUnit',
+];
+
+const quoteActionsKeysMapping: {[name: string]: string} = {
+    id: 'quoteId',
+    affiliation: 'quoteAffiliation',
+};
+
+const reviewActionsKeysMapping: {[name: string]: string} = {
+    id: 'reviewId',
+    rating: 'reviewRating',
+    comment: 'reviewComment',
+};
+
+export const commerceActionKeysMappingPerAction: Record<string, {[name: string]: string}> = {
+    add: productActionsKeysMapping,
+    bookmark_add: productActionsKeysMapping,
+    bookmark_remove: productActionsKeysMapping,
+    click: productActionsKeysMapping,
+    checkout: productActionsKeysMapping,
+    checkout_option: productActionsKeysMapping,
+    detail: productActionsKeysMapping,
+    impression: productActionsKeysMapping,
+    remove: productActionsKeysMapping,
+    refund: {
+        ...productActionsKeysMapping,
+        ...transactionActionsKeysMapping,
+    },
+    purchase: {
+        ...productActionsKeysMapping,
+        ...transactionActionsKeysMapping,
+    },
+    quickview: productActionsKeysMapping,
+    quote: {
+        ...productActionsKeysMapping,
+        ...quoteActionsKeysMapping,
+    },
+    review: {
+        ...productActionsKeysMapping,
+        ...reviewActionsKeysMapping,
+    },
+};
+
+export const convertProductToMeasurementProtocol = (product: Product, index: number) => {
+    return keysOf(product).reduce((mappedProduct, key) => {
+        const newKey = `pr${index + 1}${productKeysMapping[key] || key}`;
+        return {
+            ...mappedProduct,
+            [newKey]: product[key],
+        };
+    }, {});
+};
+
+export const convertImpressionListToMeasurementProtocol = (
+    impressionList: ImpressionList,
+    listIndex: number,
+    prefix: string
+) => {
+    const payload: {[name: string]: any} = impressionList.impressions.reduce(
+        (mappedImpressions, impression, productIndex) => {
+            return {
+                ...mappedImpressions,
+                ...convertImpressionToMeasurementProtocol(impression, listIndex, productIndex, prefix),
+            };
+        },
+        {}
+    );
+
+    if (impressionList.listName) {
+        const listNameKey = `il${listIndex + 1}nm`;
+        payload[listNameKey] = impressionList.listName;
+    }
+    return payload;
+};
+
+const convertImpressionToMeasurementProtocol = (
+    impression: BaseImpression,
+    listIndex: number,
+    productIndex: number,
+    prefix: string
+) => {
+    return keysOf(impression).reduce((mappedImpression, key) => {
+        const newKey = `il${listIndex + 1}${prefix}${productIndex + 1}${impressionKeysMapping[key] || key}`;
+        return {
+            ...mappedImpression,
+            [newKey]: impression[key],
+        };
+    }, {});
+};
+
+const productKeysMappingValues = keysOf(productKeysMapping).map((key) => productKeysMapping[key]);
+const impressionKeysMappingValues = keysOf(impressionKeysMapping).map((key) => impressionKeysMapping[key]);
+const productActionsKeysMappingValues = keysOf(productActionsKeysMapping).map((key) => productActionsKeysMapping[key]);
+const transactionActionsKeysMappingValues = keysOf(transactionActionsKeysMapping).map(
+    (key) => transactionActionsKeysMapping[key]
+);
+const reviewKeysMappingValues = keysOf(reviewActionsKeysMapping).map((key) => reviewActionsKeysMapping[key]);
+const quoteKeysMappingValues = keysOf(quoteActionsKeysMapping).map((key) => quoteActionsKeysMapping[key]);
+
+const productSubKeysMatchGroup = [...productKeysMappingValues, 'custom'].join('|');
+const impressionSubKeysMatchGroup = [...impressionKeysMappingValues, 'custom'].join('|');
+const productPrefixMatchGroup = '(pr[0-9]+)';
+const impressionPrefixMatchGroup = '(il[0-9]+pi[0-9]+)';
+const productKeyRegex = new RegExp(`^${productPrefixMatchGroup}(${productSubKeysMatchGroup})$`);
+const impressionKeyRegex = new RegExp(`^(${impressionPrefixMatchGroup}(${impressionSubKeysMatchGroup}))|(il[0-9]+nm)$`);
+const productActionsKeyRegex = new RegExp(`^(${productActionsKeysMappingValues.join('|')})$`);
+const transactionActionsKeyRegex = new RegExp(`^(${transactionActionsKeysMappingValues.join('|')})$`);
+const customProductKeyRegex = new RegExp(`^${productPrefixMatchGroup}custom$`);
+const customImpressionKeyRegex = new RegExp(`^${impressionPrefixMatchGroup}custom$`);
+const coveoCommerceExtensionKeysRegex = new RegExp(
+    `^(${[...coveoCommerceExtensionKeys, ...reviewKeysMappingValues, ...quoteKeysMappingValues].join('|')})$`
+);
+
+const isProductKey = (key: string) => productKeyRegex.test(key);
+const isImpressionKey = (key: string) => impressionKeyRegex.test(key);
+const isProductActionsKey = (key: string) => productActionsKeyRegex.test(key);
+const isTransactionActionsKeyRegex = (key: string) => transactionActionsKeyRegex.test(key);
+const isCoveoCommerceExtensionKey = (key: string) => coveoCommerceExtensionKeysRegex.test(key);
+
+export const isCommerceKey = [
+    isImpressionKey,
+    isProductKey,
+    isProductActionsKey,
+    isTransactionActionsKeyRegex,
+    isCoveoCommerceExtensionKey,
+];
+export const isCustomCommerceKey = [customProductKeyRegex, customImpressionKeyRegex];

--- a/packages/coveo-analytics/src/client/measurementProtocolMapping/serviceMeasurementProtocolMapper.ts
+++ b/packages/coveo-analytics/src/client/measurementProtocolMapping/serviceMeasurementProtocolMapper.ts
@@ -1,0 +1,35 @@
+import {Ticket} from '../../plugins/svc';
+import {keysOf} from '../utils';
+
+const ticketKeysMapping: {[key in keyof Ticket]: string} = {
+    id: 'svc_ticket_id',
+    subject: 'svc_ticket_subject',
+    description: 'svc_ticket_description',
+    category: 'svc_ticket_category',
+    productId: 'svc_ticket_product_id',
+    custom: 'svc_ticket_custom',
+};
+const ticketKeysMappingValues = keysOf(ticketKeysMapping).map((key) => ticketKeysMapping[key]);
+const ticketSubKeysMatchGroup = [...ticketKeysMappingValues].join('|');
+const ticketKeyRegex = new RegExp(`^(${ticketSubKeysMatchGroup}$)`);
+
+export const serviceActionsKeysMapping: {[name: string]: string} = {
+    svcAction: 'svc_action',
+    svcActionData: 'svc_action_data',
+};
+
+export const convertTicketToMeasurementProtocol = (ticket: Ticket) => {
+    return keysOf(ticket)
+        .filter((key) => ticket[key] !== undefined)
+        .reduce((mappedTicket, key) => {
+            const newKey = ticketKeysMapping[key] || key;
+            return {
+                ...mappedTicket,
+                [newKey]: ticket[key],
+            };
+        }, {});
+};
+
+const isTicketKey = (key: string) => ticketKeyRegex.test(key);
+
+export const isServiceKey = [isTicketKey];

--- a/packages/coveo-analytics/src/client/noopAnalytics.ts
+++ b/packages/coveo-analytics/src/client/noopAnalytics.ts
@@ -1,0 +1,76 @@
+import {AnalyticsClient, PreparedEvent} from './analytics';
+import {
+    AnyEventResponse,
+    SearchEventResponse,
+    ClickEventResponse,
+    CustomEventResponse,
+    VisitResponse,
+    HealthResponse,
+    ViewEventResponse,
+    EventType,
+    PreparedSearchEventRequest,
+    SearchEventRequest,
+    ClickEventRequest,
+    CustomEventRequest,
+    PreparedClickEventRequest,
+    PreparedCustomEventRequest,
+    PreparedViewEventRequest,
+    ViewEventRequest,
+} from '../events';
+import {libVersion} from '../version';
+import {NoopRuntime} from './runtimeEnvironment';
+
+export class NoopAnalytics implements AnalyticsClient {
+    getPayload(): Promise<any> {
+        return Promise.resolve();
+    }
+    getParameters(): Promise<any> {
+        return Promise.resolve();
+    }
+    makeEvent<TPreparedRequest, TCompleteRequest, TResponse extends AnyEventResponse>(
+        eventType: EventType | string
+    ): Promise<PreparedEvent<TPreparedRequest, TCompleteRequest, TResponse>> {
+        return Promise.resolve({eventType: eventType as EventType, payload: null, log: () => Promise.resolve()});
+    }
+    sendEvent(): Promise<AnyEventResponse | void> {
+        return Promise.resolve();
+    }
+    makeSearchEvent() {
+        return this.makeEvent<PreparedSearchEventRequest, SearchEventRequest, SearchEventResponse>(EventType.search);
+    }
+    sendSearchEvent(): Promise<SearchEventResponse | void> {
+        return Promise.resolve();
+    }
+    makeClickEvent() {
+        return this.makeEvent<PreparedClickEventRequest, ClickEventRequest, ClickEventResponse>(EventType.click);
+    }
+    sendClickEvent(): Promise<ClickEventResponse | void> {
+        return Promise.resolve();
+    }
+    makeCustomEvent() {
+        return this.makeEvent<PreparedCustomEventRequest, CustomEventRequest, CustomEventResponse>(EventType.custom);
+    }
+    sendCustomEvent(): Promise<CustomEventResponse | void> {
+        return Promise.resolve();
+    }
+    makeViewEvent() {
+        return this.makeEvent<PreparedViewEventRequest, ViewEventRequest, ViewEventResponse>(EventType.view);
+    }
+    sendViewEvent(): Promise<ViewEventResponse | void> {
+        return Promise.resolve();
+    }
+    getVisit(): Promise<VisitResponse> {
+        return Promise.resolve({id: '', visitorId: ''});
+    }
+    getHealth(): Promise<HealthResponse> {
+        return Promise.resolve({status: ''});
+    }
+    registerBeforeSendEventHook(): void {}
+    registerAfterSendEventHook(): void {}
+    addEventTypeMapping(): void {}
+    runtime = new NoopRuntime();
+    public get version(): string {
+        return libVersion;
+    }
+    currentVisitorId = '';
+}

--- a/packages/coveo-analytics/src/client/runtimeEnvironment.ts
+++ b/packages/coveo-analytics/src/client/runtimeEnvironment.ts
@@ -1,0 +1,65 @@
+import {WebStorage, NullStorage, CookieAndLocalStorage} from '../storage';
+import {AnalyticsBeaconClient} from './analyticsBeaconClient';
+import {hasLocalStorage, hasCookieStorage} from '../detector';
+import {AnalyticsRequestClient, IAnalyticsClientOptions, NoopAnalyticsClient} from './analyticsRequestClient';
+import {AnalyticsFetchClient} from './analyticsFetchClient';
+import {BufferedRequest} from './analytics';
+import {EventType} from '../events';
+
+export interface IRuntimeEnvironment {
+    storage: WebStorage;
+    client: AnalyticsRequestClient;
+    getClientDependingOnEventType(eventType: EventType): AnalyticsRequestClient;
+}
+
+export class BrowserRuntime implements IRuntimeEnvironment {
+    public storage: WebStorage;
+    public client: AnalyticsFetchClient;
+    private beaconClient: AnalyticsBeaconClient;
+
+    constructor(clientOptions: IAnalyticsClientOptions, getUnprocessedRequests: () => Array<BufferedRequest>) {
+        if (hasLocalStorage() && hasCookieStorage()) {
+            this.storage = new CookieAndLocalStorage();
+        } else if (hasLocalStorage()) {
+            this.storage = localStorage;
+        } else {
+            console.warn('BrowserRuntime detected no valid storage available.', this);
+            this.storage = new NullStorage();
+        }
+        this.client = new AnalyticsFetchClient(clientOptions);
+        this.beaconClient = new AnalyticsBeaconClient(clientOptions);
+        window.addEventListener('beforeunload', () => {
+            const requests = getUnprocessedRequests();
+            for (let {eventType, payload} of requests) {
+                this.beaconClient.sendEvent(eventType, payload);
+            }
+        });
+    }
+
+    public getClientDependingOnEventType(eventType: EventType) {
+        return eventType === 'click' && this.beaconClient.isAvailable() ? this.beaconClient : this.client;
+    }
+}
+
+export class NodeJSRuntime implements IRuntimeEnvironment {
+    public storage: WebStorage;
+    public client: AnalyticsFetchClient;
+
+    constructor(clientOptions: IAnalyticsClientOptions, storage?: WebStorage) {
+        this.storage = storage || new NullStorage();
+        this.client = new AnalyticsFetchClient(clientOptions);
+    }
+
+    getClientDependingOnEventType(eventType: EventType): AnalyticsRequestClient {
+        return this.client;
+    }
+}
+
+export class NoopRuntime implements IRuntimeEnvironment {
+    public storage = new NullStorage();
+    public client = new NoopAnalyticsClient();
+
+    getClientDependingOnEventType(eventType: EventType): AnalyticsRequestClient {
+        return this.client;
+    }
+}

--- a/packages/coveo-analytics/src/client/token.ts
+++ b/packages/coveo-analytics/src/client/token.ts
@@ -1,0 +1,3 @@
+const API_KEY_PREFIX = 'xx';
+
+export const isApiKey = (token?: string) => token?.startsWith(API_KEY_PREFIX) || false;

--- a/packages/coveo-analytics/src/client/utils.ts
+++ b/packages/coveo-analytics/src/client/utils.ts
@@ -1,0 +1,17 @@
+// Object.keys returns `string[]` this adds types
+// see https://github.com/microsoft/TypeScript/pull/12253#issuecomment-393954723
+export const keysOf = Object.keys as <T>(o: T) => Extract<keyof T, string>[];
+export function isObject(o: any): boolean {
+    return o !== null && typeof o === 'object' && !Array.isArray(o);
+}
+
+/**
+ * Attempt to coerce strings to number values.
+ * Any non-number characters will fail parsing, in which case the input string is returned.
+ *
+ * @param input The input to possibly coerce to a number, if it is a string and parses to a number.
+ * @returns The input, possibly coerced to a number.
+ */
+export function coerceToNumber(input: any): any {
+    return typeof input === 'string' && input != '' && !Number.isNaN(+input) ? +input : input;
+}

--- a/packages/coveo-analytics/src/cookieutils.ts
+++ b/packages/coveo-analytics/src/cookieutils.ts
@@ -1,0 +1,52 @@
+interface CookieDetails {
+    name: string;
+    value: string;
+    expirationDate?: Date;
+    domain?: string;
+}
+
+// Code originally modified from : https://developers.livechatinc.com/blog/setting-cookies-to-subdomains-in-javascript/
+export class Cookie {
+    static set(name: string, value: string, expire?: number) {
+        var domain: string, expirationDate: Date | undefined, domainParts: string[], host: string;
+        if (expire) {
+            expirationDate = new Date();
+            expirationDate.setTime(expirationDate.getTime() + expire);
+        }
+        host = window.location.hostname;
+        if (host.indexOf('.') === -1) {
+            // no "." in a domain - single domain name, it's localhost or something similar
+            writeCookie(name, value, expirationDate);
+        } else {
+            domainParts = host.split('.');
+            // we always have at least 2 domain parts
+            domain = domainParts[domainParts.length - 2] + '.' + domainParts[domainParts.length - 1];
+            writeCookie(name, value, expirationDate, domain);
+        }
+    }
+
+    static get(name: string) {
+        var cookiePrefix = name + '=';
+        var cookieArray = document.cookie.split(';');
+        for (var i = 0; i < cookieArray.length; i++) {
+            var cookie = cookieArray[i];
+            cookie = cookie.replace(/^\s+/, ''); //strip whitespace from front of cookie only
+            if (cookie.lastIndexOf(cookiePrefix, 0) === 0) {
+                return cookie.substring(cookiePrefix.length, cookie.length);
+            }
+        }
+        return null;
+    }
+
+    static erase(name: string) {
+        Cookie.set(name, '', -1);
+    }
+}
+
+function writeCookie(name: string, value: string, expirationDate?: Date, domain?: string) {
+    document.cookie =
+        `${name}=${value}` +
+        (expirationDate ? `;expires=${expirationDate.toUTCString()}` : '') +
+        (domain ? `;domain=${domain}` : '') +
+        ';path=/;SameSite=Lax';
+}

--- a/packages/coveo-analytics/src/coveoua/browser.ts
+++ b/packages/coveo-analytics/src/coveoua/browser.ts
@@ -1,0 +1,44 @@
+import * as analytics from './library';
+import handleOneAnalyticsEvent from './simpleanalytics';
+
+declare const self: any;
+
+const promise = (window as any)['Promise'];
+if (!(promise instanceof Function) && !global) {
+    console.error(
+        `This script uses window.Promise which is not supported in your browser. Consider adding a polyfill like "es6-promise".`
+    );
+}
+const fetch = (window as any)['fetch'];
+if (!(fetch instanceof Function) && !global) {
+    console.error(
+        `This script uses window.fetch which is not supported in your browser. Consider adding a polyfill like "fetch".`
+    );
+}
+
+// CoveoUAGlobal is the interface for the global function which also has a
+// queue `q` of unexecuted parameters
+export interface CoveoUAGlobal {
+    (action: string, ...params: any[]): void;
+    // CoveoAnalytics.q is the queue of last called actions before lib was included
+    q?: [string, any[]][];
+}
+
+// On load of this script we get the global object `coveoua` (which would be)
+// on `window` in a browser
+const coveoua: CoveoUAGlobal = self.coveoua || handleOneAnalyticsEvent;
+
+// Replace the quick shim with the real thing.
+self.coveoua = handleOneAnalyticsEvent;
+
+self.coveoanalytics = analytics;
+
+// On normal execution this library should be loaded after the snippet execution
+// so we will execute the actions in the `q` array
+if (coveoua.q) {
+    const initEvents = coveoua.q.filter((args: [string, any[]]) => args[0] === 'init');
+    const otherEvents = coveoua.q.filter((args: [string, any[]]) => args[0] !== 'init');
+    [...initEvents, ...otherEvents].forEach((args: [string, any[]]) => handleOneAnalyticsEvent.apply(void 0, args));
+}
+
+export default self.coveoua;

--- a/packages/coveo-analytics/src/coveoua/headless.ts
+++ b/packages/coveo-analytics/src/coveoua/headless.ts
@@ -1,0 +1,6 @@
+export {CoveoSearchPageClient, SearchPageClientProvider} from '../searchPage/searchPageClient';
+export {CaseAssistClient, CaseAssistClientProvider} from '../caseAssist/caseAssistClient';
+export {CoveoInsightClient, InsightClientProvider} from '../insight/insightClient';
+export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
+export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
+export * as history from '../history';

--- a/packages/coveo-analytics/src/coveoua/library.ts
+++ b/packages/coveo-analytics/src/coveoua/library.ts
@@ -1,0 +1,24 @@
+import * as analytics from '../client/analytics';
+import * as donottrack from '../donottrack';
+import * as history from '../history';
+import * as SimpleAnalytics from './simpleanalytics';
+import * as storage from '../storage';
+export {CoveoAnalyticsClient, AnalyticsClientSendEventHook} from '../client/analytics';
+export {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
+export {IRuntimeEnvironment} from '../client/runtimeEnvironment';
+export {CoveoUA, getCurrentClient, handleOneAnalyticsEvent} from './simpleanalytics';
+export {
+    CoveoSearchPageClient,
+    SearchPageClientProvider,
+    EventDescription,
+    EventBuilder,
+} from '../searchPage/searchPageClient';
+export {CaseAssistClient, CaseAssistClientProvider} from '../caseAssist/caseAssistClient';
+export {CoveoInsightClient, InsightClientProvider} from '../insight/insightClient';
+
+export * from '../searchPage/searchPageEvents';
+export * from '../caseAssist/caseAssistActions';
+export * from '../insight/insightEvents';
+export * from '../events';
+
+export {analytics, donottrack, history, SimpleAnalytics, storage};

--- a/packages/coveo-analytics/src/coveoua/plugins.ts
+++ b/packages/coveo-analytics/src/coveoua/plugins.ts
@@ -1,0 +1,47 @@
+import {PluginClass, PluginOptions, BasePlugin, Plugin} from '../plugins/BasePlugin';
+import {EC} from '../plugins/ec';
+import {Link} from '../plugins/link';
+import {SVC} from '../plugins/svc';
+
+export class Plugins {
+    public static readonly DefaultPlugins: string[] = [EC.Id, SVC.Id, Link.Id];
+    private registeredPluginsMap: Record<string, PluginClass> = {
+        [EC.Id]: EC,
+        [SVC.Id]: SVC,
+        [Link.Id]: Link,
+    };
+    private requiredPlugins: Record<string, BasePlugin> = {};
+
+    require(name: string, options: PluginOptions): void {
+        const pluginClass = this.registeredPluginsMap[name];
+        if (!pluginClass) {
+            throw new Error(
+                `No plugin named "${name}" is currently registered. If you use a custom plugin, use 'provide' first.`
+            );
+        }
+        this.requiredPlugins[name] = new (pluginClass as any)(options);
+    }
+
+    provide(name: string, plugin: PluginClass) {
+        this.registeredPluginsMap[name] = plugin;
+    }
+
+    clearRequired(): void {
+        this.requiredPlugins = {};
+    }
+
+    execute(name: string, fn: string, ...args: any[]): any {
+        const plugin = this.requiredPlugins[name] as Plugin;
+        if (!plugin) {
+            throw new Error(`The plugin "${name}" is not required. Check that you required it on initialization.`);
+        }
+        const actionFunction = plugin.getApi(fn);
+        if (!actionFunction) {
+            throw new Error(`The function "${fn}" does not exist on the plugin "${name}".`);
+        }
+        if (typeof actionFunction !== 'function') {
+            throw new Error(`"${fn}" of the plugin "${name}" is not a function.`);
+        }
+        return actionFunction.apply(plugin, args);
+    }
+}

--- a/packages/coveo-analytics/src/coveoua/simpleanalytics.spec.ts
+++ b/packages/coveo-analytics/src/coveoua/simpleanalytics.spec.ts
@@ -1,0 +1,545 @@
+import coveoua from './simpleanalytics';
+import {createAnalyticsClientMock, visitorIdMock} from '../../tests/analyticsClientMock';
+import {TestPlugin} from '../../tests/pluginMock';
+import {v4 as uuidv4} from 'uuid';
+import {PluginOptions} from '../plugins/BasePlugin';
+import {mockFetch, lastCallBody} from '../../tests/fetchMock';
+import {CookieStorage} from '../storage';
+import {libVersion} from '../version';
+
+const uuidv4Mock = jest.fn();
+jest.mock('uuid', () => ({v4: () => uuidv4Mock()}));
+
+const {fetchMock, fetchMockBeforeEach} = mockFetch();
+
+class TestPluginWithSpy extends TestPlugin {
+    public static readonly Id: 'test';
+    public static spy: jest.Mock;
+    constructor({client, uuidGenerator = uuidv4}: PluginOptions) {
+        super({client, uuidGenerator});
+        TestPluginWithSpy.spy = jest.fn();
+    }
+
+    public getApi(name: string): Function | null {
+        switch (name) {
+            case 'testMethod':
+                return this.testMethod;
+            default:
+                return null;
+        }
+    }
+
+    testMethod(...args: any[]) {
+        TestPluginWithSpy.spy(args);
+    }
+}
+
+describe('simpleanalytics', () => {
+    const analyticsClientMock = createAnalyticsClientMock();
+    const analyticsEndpoint = 'https://analytics.cloud.coveo.com/rest/ua/v15/analytics';
+    const someRandomEventName = 'kawabunga';
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        fetchMockBeforeEach();
+
+        new CookieStorage().removeItem('visitorId');
+        localStorage.clear();
+        fetchMock.mock('*', {});
+        uuidv4Mock.mockImplementationOnce(() => visitorIdMock);
+        coveoua('reset');
+    });
+
+    afterEach(() => {
+        fetchMock.reset();
+        fetchMock.resetHistory();
+        fetchMock.resetBehavior();
+    });
+
+    describe('init', () => {
+        it('throws when initializing without a token', () => {
+            expect(() => coveoua('init')).toThrow(`You must pass your token when you call 'init'`);
+        });
+
+        it('throws when initializing with a token that is not a string nor a AnalyticClient', () => {
+            expect(() => coveoua('init', {})).toThrow(
+                `You must pass either your token or a valid object when you call 'init'`
+            );
+        });
+
+        it('can initialize with analyticsClient', () => {
+            expect(() => coveoua('init', analyticsClientMock)).not.toThrow();
+        });
+
+        it('can initialize with a token', () => {
+            expect(() => coveoua('init', 'SOME TOKEN')).not.toThrow();
+        });
+
+        it('default to analytics.cloud.coveo.com when no endpoint is given', async () => {
+            coveoua('init', 'SOME TOKEN');
+
+            await coveoua('send', 'pageview');
+
+            expect(fetchMock.calls().length).toBe(1);
+            const foo = fetchMock.lastUrl();
+            expect(fetchMock.lastUrl()).toMatch(/^https:\/\/analytics\.cloud\.coveo\.com\/rest\/ua/);
+        });
+
+        it('default to analytics.cloud.coveo.com when the endpoint is an empty string', async () => {
+            coveoua('init', 'SOME TOKEN', '');
+
+            await coveoua('send', 'pageview');
+
+            expect(fetchMock.calls().length).toBe(1);
+            const foo = fetchMock.lastUrl();
+            expect(fetchMock.lastUrl()).toMatch(/^https:\/\/analytics\.cloud\.coveo\.com\/rest\/ua/);
+        });
+
+        it('default to analytics.cloud.coveo.com when an options object is given but does not include an endpoint', async () => {
+            coveoua('init', 'SOME TOKEN', {});
+
+            await coveoua('send', 'pageview');
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toMatch(/^https:\/\/analytics\.cloud\.coveo\.com\/rest\/ua/);
+        });
+
+        it('default to analytics.cloud.coveo.com when an options object is given but the endpoint property is falsy', async () => {
+            coveoua('init', 'SOME TOKEN', {endpoint: ''});
+
+            await coveoua('send', 'pageview');
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toMatch(/^https:\/\/analytics\.cloud\.coveo\.com\/rest\/ua/);
+        });
+
+        it('uses the endpoint given if its a non-empty string', async () => {
+            coveoua('init', 'SOME TOKEN', 'https://someendpoint.com');
+
+            await coveoua('send', 'pageview');
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toMatch(/^https:\/\/someendpoint\.com/);
+        });
+
+        it('uses the endpoint given if the options object include a non-empty string', async () => {
+            coveoua('init', 'SOME TOKEN', {endpoint: 'https://someendpoint.com'});
+
+            await coveoua('send', 'pageview');
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toMatch(/^https:\/\/someendpoint\.com/);
+        });
+
+        it('uses EC, SVC and Link plugins by default', () => {
+            coveoua('init', 'SOME TOKEN');
+            expect(() => coveoua('callPlugin', 'ec', 'nosuchfunction')).toThrow(/does not exist/);
+            expect(() => coveoua('callPlugin', 'svc', 'nosuchfunction')).toThrow(/does not exist/);
+            expect(() => coveoua('callPlugin', 'link', 'nosuchfunction')).toThrow(/does not exist/);
+        });
+
+        it('can accept no plugins', () => {
+            coveoua('init', 'SOME TOKEN', {plugins: []});
+            expect(() => coveoua('callPlugin', 'ec', 'nosuchfunction')).toThrow(/is not required/);
+            expect(() => coveoua('callPlugin', 'svc', 'nosuchfunction')).toThrow(/is not required/);
+            expect(() => coveoua('callPlugin', 'link', 'nosuchfunction')).toThrow(/is not required/);
+        });
+
+        it('can accept one plugin', () => {
+            coveoua('init', 'SOME TOKEN', {plugins: ['svc']});
+            expect(() => coveoua('callPlugin', 'ec', 'nosuchfunction')).toThrow(/is not required/);
+            expect(() => coveoua('callPlugin', 'link', 'nosuchfunction')).toThrow(/is not required/);
+            expect(() => coveoua('callPlugin', 'svc', 'nosuchfunction')).toThrow(/does not exist/);
+        });
+
+        it('can send pageview with analyticsClient', () => {
+            coveoua('init', analyticsClientMock);
+            expect(() => coveoua('send', 'pageview')).not.toThrow();
+        });
+    });
+
+    describe('initForProxy', () => {
+        it(`throw if the initForProxy don't receive an endpoint`, () => {
+            expect(() => coveoua('initForProxy')).toThrow(`You must pass your endpoint when you call 'initForProxy'`);
+        });
+
+        it(`throw if the initForProxy receive an endpoint that is not a string`, () => {
+            expect(() => coveoua('initForProxy', {})).toThrow(
+                `You must pass a string as the endpoint parameter when you call 'initForProxy'`
+            );
+        });
+    });
+
+    describe('send', () => {
+        it('throws when not initialized', () => {
+            expect(() => coveoua('send')).toThrow(`You must call init before sending an event`);
+        });
+
+        it('throws when send is called without any other arguments', () => {
+            coveoua('init', 'MYTOKEN');
+            expect(() => coveoua('send')).toThrow(`You must provide an event type when calling "send".`);
+        });
+
+        it('can send pageview', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: []});
+            await coveoua('send', 'pageview');
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/pageview`);
+        });
+
+        it('can send pageview with customdata', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: []});
+            await coveoua('send', 'pageview', {somedata: 'asd'});
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/pageview`);
+            expect(JSON.parse(lastCallBody(fetchMock))).toEqual({somedata: 'asd'});
+        });
+
+        it('can send view event with clientId', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: []});
+            await coveoua('send', 'view');
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/view?visitor=${visitorIdMock}`);
+            expect(JSON.parse(lastCallBody(fetchMock)).clientId).toBe(visitorIdMock);
+        });
+
+        it('can send any event to the endpoint', async () => {
+            coveoua('init', 'MYTOKEN');
+            await coveoua('send', someRandomEventName);
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
+        });
+
+        it('can send an event with a proxy endpoint', async () => {
+            coveoua('initForProxy', 'https://myProxyEndpoint.com');
+            await coveoua('send', someRandomEventName);
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`https://myproxyendpoint.com/rest/v15/analytics/${someRandomEventName}`);
+        });
+
+        describe('will restrict referrers and url lengths', () => {
+            const max: number = 2048;
+            const reallyLongPath1: string = 'http://coveo.com/?q=' + 'a'.repeat(max);
+            const reallyLongPath2: string = 'http://coveo.com/?q=' + 'b'.repeat(max);
+            expect(reallyLongPath1.length).toBeGreaterThan(max);
+            expect(reallyLongPath2.length).toBeGreaterThan(max);
+            it('does this for pageviews', async () => {
+                coveoua('init', 'MYTOKEN');
+                await coveoua('send', 'pageview', reallyLongPath1);
+                await coveoua('send', 'pageview', reallyLongPath2);
+                const body = JSON.parse(lastCallBody(fetchMock));
+                expect(body.dr.length).toBeLessThanOrEqual(max);
+                expect(body.dl.length).toBeLessThanOrEqual(max);
+                expect(body.dp.length).toBeLessThanOrEqual(max);
+            });
+            it('does this for generic events', async () => {
+                coveoua('init', 'MYTOKEN');
+                await coveoua('send', 'pageview', reallyLongPath1);
+                await coveoua('send', 'pageview', reallyLongPath2);
+                await coveoua('send', 'event');
+                const body = JSON.parse(lastCallBody(fetchMock));
+                expect(body.dr.length).toBeLessThanOrEqual(max);
+                expect(body.dl.length).toBeLessThanOrEqual(max);
+            });
+        });
+    });
+
+    describe('set', () => {
+        it('can set a new parameter', async () => {
+            coveoua('init', 'MYTOKEN');
+            coveoua('set', 'userId', 'something');
+            await coveoua('send', someRandomEventName);
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
+            expect(JSON.parse(lastCallBody(fetchMock))).toEqual({userId: 'something'});
+        });
+
+        it('can set parameters using an object', async () => {
+            coveoua('init', 'MYTOKEN');
+            coveoua('set', {
+                userId: 'something',
+            });
+            await coveoua('send', someRandomEventName);
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
+            expect(JSON.parse(lastCallBody(fetchMock))).toEqual({userId: 'something'});
+        });
+
+        it('can set a custom_website parameter on a collect event', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: ['ec']});
+            coveoua('set', 'custom', {context_website: 'MY_WEBSITE'});
+            await coveoua('send', 'pageview');
+
+            expect(fetchMock.calls().length).toBe(1);
+            let result = JSON.parse(lastCallBody(fetchMock));
+            expect(result).toHaveProperty('context_website', 'MY_WEBSITE');
+        });
+
+        it('does not set custom parameters which are strings', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: ['ec']});
+            coveoua('set', 'custom', 'test');
+            await coveoua('send', 'pageview');
+
+            expect(fetchMock.calls().length).toBe(1);
+            let result = JSON.parse(lastCallBody(fetchMock));
+            expect(Object.keys(result).length).toBe(11);
+        });
+
+        it('does not set custom parameters which are arrays', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: ['ec']});
+            coveoua('set', 'custom', ['test']);
+            await coveoua('send', 'pageview');
+
+            expect(fetchMock.calls().length).toBe(1);
+            let result = JSON.parse(lastCallBody(fetchMock));
+            expect(Object.keys(result).length).toBe(11);
+        });
+
+        it('does not set custom parameters which are null', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: ['ec']});
+            coveoua('set', 'custom', null);
+            await coveoua('send', 'pageview');
+
+            expect(fetchMock.calls().length).toBe(1);
+            let result = JSON.parse(lastCallBody(fetchMock));
+            expect(Object.keys(result).length).toBe(11);
+        });
+
+        it('does not set custom parameters which are undefined', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: ['ec']});
+            coveoua('set', 'custom', undefined);
+            await coveoua('send', 'pageview');
+
+            expect(fetchMock.calls().length).toBe(1);
+            let result = JSON.parse(lastCallBody(fetchMock));
+            expect(Object.keys(result).length).toBe(11);
+        });
+
+        it('can set a custom_website parameter on a non-collect event', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: []});
+            coveoua('set', 'custom', {context_website: 'MY_WEBSITE'});
+            await coveoua('send', 'view', {somedata: 'something'});
+
+            expect(fetchMock.calls().length).toBe(1);
+            let result = JSON.parse(lastCallBody(fetchMock));
+            expect(result).toHaveProperty('somedata', 'something');
+            expect(result).toHaveProperty('customData.context_website', 'MY_WEBSITE');
+        });
+
+        it('does not add a customData entry for custom params which are null', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: []});
+            coveoua('set', 'custom', null);
+            await coveoua('send', 'view', {somedata: 'something'});
+
+            expect(fetchMock.calls().length).toBe(1);
+            let result = JSON.parse(lastCallBody(fetchMock));
+            expect(result).toHaveProperty('somedata', 'something');
+            expect(result).not.toHaveProperty('customData');
+        });
+
+        it('does not add a customData entry for custom params which are undefined', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: []});
+            coveoua('set', 'custom', undefined);
+            await coveoua('send', 'view', {somedata: 'something'});
+
+            expect(fetchMock.calls().length).toBe(1);
+            let result = JSON.parse(lastCallBody(fetchMock));
+            expect(result).toHaveProperty('somedata', 'something');
+            expect(result).not.toHaveProperty('customData');
+        });
+
+        it('does not add a customData entry for customData params which are strings', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: []});
+            coveoua('set', 'custom', 'test');
+            await coveoua('send', 'view', {somedata: 'something'});
+
+            expect(fetchMock.calls().length).toBe(1);
+            let result = JSON.parse(lastCallBody(fetchMock));
+            expect(result).toHaveProperty('somedata', 'something');
+            expect(result).not.toHaveProperty('customData');
+        });
+
+        it('does not add a customData entry for customData params which are arrays', async () => {
+            coveoua('init', 'MYTOKEN', [{plugins: []}]);
+            coveoua('set', 'custom', [test]);
+            await coveoua('send', 'view', {somedata: 'something'});
+
+            expect(fetchMock.calls().length).toBe(1);
+            let result = JSON.parse(lastCallBody(fetchMock));
+            expect(result).toHaveProperty('somedata', 'something');
+            expect(result).not.toHaveProperty('customData');
+        });
+
+        it('will not override hardcoded customData parameters', async () => {
+            coveoua('init', 'MYTOKEN', {plugins: []});
+            coveoua('set', 'custom', {context_website: 'MY_WEBSITE'});
+            await coveoua('send', 'view', {somedata: 'something', customData: {context_website: 'MY_OTHER_WEBSITE'}});
+
+            expect(fetchMock.calls().length).toBe(1);
+            let result = JSON.parse(lastCallBody(fetchMock));
+            expect(result).toHaveProperty('somedata', 'something');
+            expect(result).toHaveProperty('customData.context_website', 'MY_OTHER_WEBSITE');
+        });
+
+        it('can set trackingId', async () => {
+            const trackingId = 'yourbestfriend';
+            coveoua('init', 'MYTOKEN');
+            coveoua('set', 'trackingId', trackingId);
+            await coveoua('send', someRandomEventName);
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
+            expect(JSON.parse(lastCallBody(fetchMock))).toHaveProperty('trackingId', trackingId);
+        });
+
+        it('context_website does not overwrite trackingId', async () => {
+            const trackingId = 'yourbestfriend';
+            const contextWebsite = 'yoursite';
+            coveoua('init', 'MYTOKEN');
+            coveoua('set', 'custom', {context_website: contextWebsite});
+            coveoua('set', 'trackingId', trackingId);
+            await coveoua('send', someRandomEventName);
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
+            expect(JSON.parse(lastCallBody(fetchMock))).toHaveProperty('trackingId', trackingId);
+        });
+    });
+
+    describe('onLoad', () => {
+        it('can execute callback with onLoad event', () => {
+            var callback = jest.fn();
+
+            coveoua('onLoad', callback);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
+
+        it('throws when registering an invalid onLoad event', () => {
+            expect(() => coveoua('onLoad', undefined)).toThrow();
+        });
+    });
+
+    describe('provide', () => {
+        it('register properly', () => {
+            coveoua('provide', 'test', TestPlugin);
+
+            coveoua('init', 'MYTOKEN');
+
+            expect(() => coveoua('require', 'test')).not.toThrow();
+        });
+    });
+
+    describe('version', () => {
+        it('returns the current version string', () => {
+            coveoua('init', 'MYTOKEN');
+            expect(coveoua('version')).toBe(libVersion);
+        });
+    });
+
+    describe('callPlugin', () => {
+        it('resolves properly plugin actions', () => {
+            coveoua('provide', 'test', TestPluginWithSpy);
+            coveoua('init', 'MYTOKEN', {plugins: ['test']});
+
+            coveoua('callPlugin', 'test', 'testMethod', 'foo', 'bar');
+
+            expect(TestPluginWithSpy.spy).toHaveBeenCalledTimes(1);
+            expect(TestPluginWithSpy.spy).toHaveBeenCalledWith(['foo', 'bar']);
+        });
+
+        it('throws when a namespaced action is called and that the namespace/plugin is not required', () => {
+            coveoua('init', 'SOME TOKEN', {plugins: ['ec']});
+
+            expect(() => coveoua('callPlugin', 'svc', 'setTicket')).toThrow(/is not required/);
+        });
+
+        it('throws when a namespaced action is called and that this action does not exists on the plugin', () => {
+            coveoua('init', 'SOME TOKEN', {plugins: ['svc']});
+
+            expect(() => coveoua('callPlugin', 'svc', 'fooBarBaz')).toThrow(/does not exist/);
+        });
+    });
+
+    describe('require', () => {
+        it('can require a plugin', () => {
+            coveoua('provide', 'test', TestPlugin);
+            coveoua('init', 'MYTOKEN', {plugins: []});
+
+            expect(() => coveoua('require', 'test')).not.toThrow();
+        });
+
+        it('throws if not initialized', () => {
+            expect(() => coveoua('require', 'test')).toThrow(`You must call init before requiring a plugin`);
+        });
+
+        it('throws if the plugin is not registered first', () => {
+            coveoua('init', 'MYTOKEN', {plugins: []});
+
+            expect(() => coveoua('require', 'test')).toThrow(
+                `No plugin named "test" is currently registered. If you use a custom plugin, use 'provide' first.`
+            );
+        });
+    });
+
+    describe('reset', () => {
+        it('reset the client', () => {
+            coveoua('init', 'MYTOKEN');
+
+            coveoua('reset');
+
+            expect(() => coveoua('send')).toThrow(`You must call init before sending an event`);
+        });
+
+        it('reset the plugins', () => {
+            const fakePlugin = TestPlugin;
+            coveoua('provide', 'test', fakePlugin);
+            coveoua('init', 'MYTOKEN', {plugins: ['test']});
+
+            coveoua('reset');
+
+            expect(() => coveoua('init', 'MYTOKEN', {plugins: ['test']})).toThrow(
+                `No plugin named "test" is currently registered. If you use a custom plugin, use 'provide' first.`
+            );
+        });
+
+        it('reset the params', async () => {
+            coveoua('init', 'MYTOKEN');
+            coveoua('set', 'userId', 'something');
+
+            coveoua('reset');
+
+            coveoua('init', 'MYTOKEN');
+            await coveoua('send', someRandomEventName);
+
+            expect(fetchMock.calls().length).toBe(1);
+            expect(fetchMock.lastUrl()).toBe(`${analyticsEndpoint}/${someRandomEventName}`);
+            expect(JSON.parse(lastCallBody(fetchMock))).toEqual({});
+        });
+    });
+
+    it('throws when called with an unknown action', () => {
+        coveoua('init', 'SOME TOKEN', {plugins: ['svc']});
+
+        expect(() => coveoua('potato')).toThrow(
+            `The action "potato" does not exist. Available actions: init, set, send, onLoad, callPlugin, reset, require, provide, version.`
+        );
+    });
+
+    it('resolves properly plugin actions', () => {
+        coveoua('provide', 'test', TestPluginWithSpy);
+        coveoua('init', 'MYTOKEN', {plugins: ['test']});
+
+        coveoua('test:testMethod', 'foo', 'bar');
+
+        expect(TestPluginWithSpy.spy).toHaveBeenCalledTimes(1);
+        expect(TestPluginWithSpy.spy).toHaveBeenCalledWith(['foo', 'bar']);
+    });
+});

--- a/packages/coveo-analytics/src/coveoua/simpleanalytics.ts
+++ b/packages/coveo-analytics/src/coveoua/simpleanalytics.ts
@@ -1,0 +1,188 @@
+import {AnyEventResponse, EventType, SendEventArguments, VariableArgumentsPayload} from '../events';
+import {AnalyticsClient, CoveoAnalyticsClient, Endpoints} from '../client/analytics';
+import {Plugins} from './plugins';
+import {PluginOptions} from '../plugins/BasePlugin';
+import {PluginClass} from '../plugins/BasePlugin';
+import {libVersion} from '../version';
+
+export type AvailableActions = keyof CoveoUA;
+
+export interface CoveoUAOptions {
+    endpoint?: string;
+    isCustomEndpoint?: boolean;
+    plugins?: string[];
+}
+
+// CoveoUA mimics the GoogleAnalytics API.
+export class CoveoUA {
+    public client?: AnalyticsClient;
+    private plugins: Plugins = new Plugins();
+    private params: {[name: string]: string} = {};
+
+    // init initializes a new SimpleAPI client.
+    // @param token is your coveo access_token / api_key / ...
+    // @param endpoint is the endpoint you want to target defaults to the
+    //        usage analytics production endpoint
+    init(token: string | AnalyticsClient, optionsOrEndpoint: string | CoveoUAOptions): void {
+        if (!token) {
+            throw new Error(`You must pass your token when you call 'init'`);
+        }
+
+        if (typeof token === 'string') {
+            this.client = new CoveoAnalyticsClient({
+                token: token,
+                endpoint: this.getEndpoint(optionsOrEndpoint),
+                isCustomEndpoint: this.getIsCustomEndpoint(optionsOrEndpoint),
+            });
+        } else if (this.isAnalyticsClient(token)) {
+            this.client = token;
+        }
+
+        if (this.client) {
+            const pluginOptions: PluginOptions = {client: this.client};
+            this.plugins.clearRequired();
+            this.getPluginKeys(optionsOrEndpoint).forEach((pluginKey) =>
+                this.plugins.require(pluginKey, pluginOptions)
+            );
+            this.client.registerBeforeSendEventHook((eventType, payload) => ({
+                ...payload,
+                ...this.params,
+            }));
+        } else {
+            throw new Error(`You must pass either your token or a valid object when you call 'init'`);
+        }
+    }
+
+    private isAnalyticsClient(token: AnalyticsClient): token is AnalyticsClient {
+        return typeof token === 'object' && typeof token.sendEvent !== 'undefined';
+    }
+
+    private getPluginKeys(optionsOrEndpoint: string | CoveoUAOptions): string[] {
+        if (typeof optionsOrEndpoint === 'string') {
+            return Plugins.DefaultPlugins;
+        }
+        return Array.isArray(optionsOrEndpoint?.plugins) ? optionsOrEndpoint.plugins : Plugins.DefaultPlugins;
+    }
+
+    private getEndpoint(optionsOrEndpoint: string | CoveoUAOptions) {
+        if (typeof optionsOrEndpoint === 'string') {
+            return optionsOrEndpoint || Endpoints.default;
+        } else if (optionsOrEndpoint?.endpoint) {
+            return optionsOrEndpoint.endpoint;
+        }
+        return Endpoints.default;
+    }
+
+    private getIsCustomEndpoint(optionsOrEndpoint: string | CoveoUAOptions) {
+        if (typeof optionsOrEndpoint === 'string') {
+            return false;
+        } else if (optionsOrEndpoint?.isCustomEndpoint) {
+            return optionsOrEndpoint.isCustomEndpoint;
+        }
+        return false;
+    }
+
+    // init initializes a new client intended to be used with a proxy that injects the access token.
+    // @param endpoint is the endpoint of your proxy.
+    initForProxy(endpoint: string, isCustomEndpoint = false): void {
+        if (!endpoint) {
+            throw new Error(`You must pass your endpoint when you call 'initForProxy'`);
+        }
+
+        if (typeof endpoint !== 'string') {
+            throw new Error(`You must pass a string as the endpoint parameter when you call 'initForProxy'`);
+        }
+
+        this.client = new CoveoAnalyticsClient({
+            endpoint: endpoint,
+            isCustomEndpoint: isCustomEndpoint,
+        });
+    }
+
+    set(keyOrObject: string | any, value: string): void {
+        if (typeof keyOrObject === 'string') {
+            this.params[keyOrObject] = value;
+        } else {
+            Object.keys(keyOrObject).map((key) => {
+                this.params[key] = keyOrObject[key];
+            });
+        }
+    }
+
+    send(...[event, ...payload]: SendEventArguments): Promise<AnyEventResponse | void> {
+        if (typeof this.client == 'undefined') {
+            throw new Error(`You must call init before sending an event`);
+        }
+
+        if (!event) {
+            throw new Error(`You must provide an event type when calling "send".`);
+        }
+
+        return this.client.sendEvent(event.toLowerCase(), ...(payload as VariableArgumentsPayload));
+    }
+
+    onLoad(callback: Function) {
+        if (typeof callback == 'undefined') {
+            throw new Error(`You must pass a function when you call 'onLoad'`);
+        }
+
+        callback();
+    }
+
+    provide(name: string, plugin: PluginClass) {
+        this.plugins.provide(name, plugin);
+    }
+
+    require(name: string, options: Omit<PluginOptions, 'client'>) {
+        if (!this.client) {
+            throw new Error(`You must call init before requiring a plugin`);
+        }
+        this.plugins.require(name, {...options, client: this.client});
+    }
+
+    callPlugin(pluginName: string, fn: string, ...args: any): any {
+        if (!this.client) {
+            throw new Error(`You must call init before calling a plugin function`);
+        }
+        return this.plugins.execute(pluginName, fn, ...args);
+    }
+
+    reset() {
+        this.client = undefined;
+        this.plugins = new Plugins();
+        this.params = {};
+    }
+
+    version(): string {
+        return libVersion;
+    }
+}
+
+export const coveoua = new CoveoUA();
+export const getCurrentClient = () => coveoua.client;
+
+export const handleOneAnalyticsEvent = (command: string, ...params: any[]) => {
+    const [, trackerName, pluginName, fn] = /^(?:(\w+)\.)?(?:(\w+):)?(\w+)$/.exec(command)!;
+
+    const actionFunction = (<any>coveoua)[fn];
+    if (pluginName && fn) {
+        return coveoua.callPlugin(pluginName as string, fn, ...params);
+    } else if (actionFunction) {
+        return actionFunction.apply(coveoua, params);
+    } else {
+        const actions: AvailableActions[] = [
+            'init',
+            'set',
+            'send',
+            'onLoad',
+            'callPlugin',
+            'reset',
+            'require',
+            'provide',
+            'version',
+        ];
+        throw new Error(`The action "${command}" does not exist. Available actions: ${actions.join(', ')}.`);
+    }
+};
+
+export default handleOneAnalyticsEvent;

--- a/packages/coveo-analytics/src/detector.ts
+++ b/packages/coveo-analytics/src/detector.ts
@@ -1,0 +1,43 @@
+export function hasWindow(): boolean {
+    return typeof window !== 'undefined';
+}
+
+export function hasNavigator(): boolean {
+    return typeof navigator !== 'undefined';
+}
+
+export function hasDocument(): boolean {
+    return typeof document !== 'undefined';
+}
+
+export function hasLocalStorage(): boolean {
+    try {
+        return typeof localStorage !== 'undefined';
+    } catch (error) {
+        return false;
+    }
+}
+
+export function hasSessionStorage(): boolean {
+    try {
+        return typeof sessionStorage !== 'undefined';
+    } catch (error) {
+        return false;
+    }
+}
+
+export function hasCookieStorage(): boolean {
+    return hasNavigator() && navigator.cookieEnabled;
+}
+
+export function hasCrypto(): boolean {
+    return typeof crypto !== 'undefined';
+}
+
+export function hasCryptoRandomValues(): boolean {
+    return hasCrypto() && typeof crypto.getRandomValues !== 'undefined';
+}
+
+export function hasLocation(): boolean {
+    return typeof location !== 'undefined';
+}

--- a/packages/coveo-analytics/src/donottrack.spec.ts
+++ b/packages/coveo-analytics/src/donottrack.spec.ts
@@ -1,0 +1,122 @@
+describe('doNotTrack', () => {
+    let doNotTrack: () => boolean;
+    function initModule(
+        hasNav: boolean,
+        options?: {
+            navigatorGlobalPrivacyControl?: any;
+            navigatorDoNotTrack?: any;
+            navigatorMsDoNotTrack?: any;
+            windowDoNotTrack?: any;
+        }
+    ) {
+        jest.resetModules();
+        jest.mock('./detector', () => ({
+            hasNavigator: () => hasNav,
+        }));
+        if (hasNav) {
+            Object.defineProperty(<any>navigator, 'globalPrivacyControl', {
+                get() {
+                    return options!.navigatorGlobalPrivacyControl;
+                },
+                configurable: true,
+            });
+            Object.defineProperty(<any>navigator, 'doNotTrack', {
+                get() {
+                    return options!.navigatorDoNotTrack;
+                },
+                configurable: true,
+            });
+            Object.defineProperty(<any>navigator, 'msDoNotTrack', {
+                get() {
+                    return options!.navigatorMsDoNotTrack;
+                },
+                configurable: true,
+            });
+            Object.defineProperty(<any>window, 'doNotTrack', {
+                get() {
+                    return options!.windowDoNotTrack;
+                },
+                configurable: true,
+            });
+        }
+        doNotTrack = require('./donottrack').doNotTrack;
+    }
+    describe('without a Navigator', () => {
+        it('should be false', () => {
+            initModule(false);
+
+            expect(doNotTrack()).toBeFalsy();
+        });
+    });
+    describe('with a Navigator', () => {
+        it('should respect GPC false', () => {
+            initModule(true, {
+                navigatorGlobalPrivacyControl: false,
+            });
+
+            expect(doNotTrack()).toBeFalsy();
+        });
+        it('should respect GPC true', () => {
+            initModule(true, {
+                navigatorGlobalPrivacyControl: true,
+            });
+
+            expect(doNotTrack()).toBeTruthy();
+        });
+        it('should respect GPC undefined', () => {
+            initModule(true, {
+                navigatorGlobalPrivacyControl: undefined,
+            });
+
+            expect(doNotTrack()).toBeFalsy();
+        });
+
+        [true, 'yes', '1'].forEach((value) => {
+            it('should fallback on `navigator.doNotTrack`: ' + JSON.stringify(value), () => {
+                initModule(true, {
+                    navigatorDoNotTrack: value,
+                });
+
+                expect(doNotTrack()).toBeTruthy();
+            });
+
+            it('should fallback on `navigator.msDoNotTrack`: ' + JSON.stringify(value), () => {
+                initModule(true, {
+                    navigatorMsDoNotTrack: value,
+                });
+                expect(doNotTrack()).toBeTruthy();
+            });
+
+            it('should fallback on `window.doNotTrack`: ' + JSON.stringify(value), () => {
+                initModule(true, {
+                    windowDoNotTrack: value,
+                });
+                expect(doNotTrack()).toBeTruthy();
+            });
+        });
+
+        [false, 'no', '0', 'unspecified'].forEach((value) => {
+            it('should fallback on `navigator.doNotTrack`: ' + JSON.stringify(value), () => {
+                initModule(true, {
+                    navigatorDoNotTrack: value,
+                });
+
+                expect(doNotTrack()).toBeFalsy();
+            });
+
+            it('should fallback on `navigator.msDoNotTrack`: ' + JSON.stringify(value), () => {
+                initModule(true, {
+                    navigatorMsDoNotTrack: value,
+                });
+                expect(doNotTrack()).toBeFalsy();
+            });
+
+            it('should fallback on `window.doNotTrack`: ' + JSON.stringify(value), () => {
+                initModule(true, {
+                    windowDoNotTrack: value,
+                });
+                expect(doNotTrack()).toBeFalsy();
+            });
+        });
+    });
+});

--- a/packages/coveo-analytics/src/donottrack.ts
+++ b/packages/coveo-analytics/src/donottrack.ts
@@ -1,0 +1,23 @@
+// Read the Mozilla Do Not Track Field Guide
+// (https://developer.mozilla.org/en-US/docs/Web/Security/Do_not_track_field_guide),
+// for information on how to use the donottrack
+// gathering data of actions of an user as long as it is not associated to the
+// identity of that user, doNotTrack is not enabled here.
+
+import {hasNavigator} from './detector';
+
+const doNotTrackValues = ['1', 1, 'yes', true];
+
+export function doNotTrack(): boolean {
+    return (
+        hasNavigator() &&
+        [
+            (<any>navigator).globalPrivacyControl,
+            (<any>navigator).doNotTrack,
+            (<any>navigator).msDoNotTrack,
+            (<any>window).doNotTrack,
+        ].some((value) => doNotTrackValues.indexOf(value) !== -1)
+    );
+}
+
+export default doNotTrack;

--- a/packages/coveo-analytics/src/events.ts
+++ b/packages/coveo-analytics/src/events.ts
@@ -1,0 +1,130 @@
+export type IRequestPayload = Record<string, any>;
+
+export enum EventType {
+    search = 'search',
+    click = 'click',
+    custom = 'custom',
+    view = 'view',
+    collect = 'collect',
+}
+
+export interface SearchDocument {
+    documentUri: string;
+    documentUriHash: string;
+}
+
+export type SendEventArguments = [EventType, ...any[]];
+
+export type VariableArgumentsPayload =
+    | []
+    | [any]
+    | [string, any]
+    | [string, string, any]
+    | [string, string, string, any]
+    | [string, string, string, string, any];
+
+export interface EventBaseRequest {
+    language?: string;
+    userAgent?: string;
+    customData?: Record<string, any>;
+    anonymous?: boolean;
+    username?: string;
+    userDisplayName?: any;
+    splitTestRunName?: string;
+    splitTestRunVersion?: string;
+    clientId?: string;
+    originContext?: string;
+    originLevel1?: string;
+    originLevel2?: string;
+    originLevel3?: string;
+}
+
+export interface FacetStateRequest {
+    field: string;
+    id: string;
+    value: string;
+    valuePosition: number;
+    displayValue: string;
+    facetType: 'specific' | 'dateRange' | 'numericalRange' | 'hierarchical';
+    state: 'selected' | 'idle' | 'excluded';
+    facetPosition: number;
+    title: string;
+    start?: string;
+    end?: string;
+    endInclusive?: boolean;
+}
+
+export interface SearchEventRequest extends EventBaseRequest {
+    searchQueryUid: string;
+    queryText: string;
+    actionCause: string;
+    responseTime: number;
+    advancedQuery?: string;
+    numberOfResults?: number;
+    contextual?: boolean;
+    results?: SearchDocument[];
+    queryPipeline?: string;
+    userGroups?: string[];
+    facetState?: FacetStateRequest[];
+}
+
+export interface PreparedSearchEventRequest extends Omit<SearchEventRequest, 'searchQueryUid'> {}
+
+export interface DocumentInformation {
+    documentUri?: string;
+    documentUriHash: string;
+    collectionName?: string;
+    sourceName: string;
+    documentPosition: number;
+    actionCause: string;
+
+    searchQueryUid: string;
+    documentTitle?: string;
+    documentUrl?: string;
+    documentAuthor?: string;
+    queryPipeline?: string;
+    rankingModifier?: string;
+}
+
+export interface ClickEventRequest extends EventBaseRequest, DocumentInformation {}
+
+export interface PreparedClickEventRequest extends Omit<ClickEventRequest, 'searchQueryUid'> {}
+
+export interface CustomEventRequest extends EventBaseRequest {
+    eventType: string;
+    eventValue: string;
+    lastSearchQueryUid?: string;
+}
+
+export interface PreparedCustomEventRequest extends Omit<CustomEventRequest, 'lastSearchQueryUid'> {}
+
+export interface ViewEventRequest extends EventBaseRequest {
+    location?: string;
+    referrer?: string;
+    title?: string;
+    contentIdKey: string;
+    contentIdValue: string;
+    contentType?: string;
+}
+
+export interface PreparedViewEventRequest extends ViewEventRequest {}
+
+export interface DefaultEventResponse {
+    visitId: string;
+    visitorId: string;
+}
+
+export interface SearchEventResponse extends DefaultEventResponse {}
+export interface ClickEventResponse extends DefaultEventResponse {}
+export interface CustomEventResponse extends DefaultEventResponse {}
+export interface ViewEventResponse extends DefaultEventResponse {}
+
+export type AnyEventResponse = SearchEventResponse | ClickEventResponse | CustomEventResponse | ViewEventResponse;
+
+export interface VisitResponse {
+    id: string;
+    visitorId: string;
+}
+export interface HealthResponse {
+    status: string;
+}

--- a/packages/coveo-analytics/src/formatting/format-array-for-coveo-custom-data.spec.ts
+++ b/packages/coveo-analytics/src/formatting/format-array-for-coveo-custom-data.spec.ts
@@ -1,0 +1,18 @@
+import {formatArrayForCoveoCustomData} from './format-array-for-coveo-custom-data';
+
+describe('#formatArrayForCoveoCustomData', () => {
+    it('returns an empty string for an empty array', () => {
+        expect(formatArrayForCoveoCustomData([])).toEqual('');
+    });
+
+    it('returns the correct string for a valid array', () => {
+        expect(formatArrayForCoveoCustomData(['t', 'test'])).toEqual('t;test');
+    });
+
+    it('correctly truncates the data when it contains more than 256 characters', () => {
+        const longString =
+            'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis,';
+        const rawData = ['1', longString];
+        expect(formatArrayForCoveoCustomData(rawData)).toEqual(longString);
+    });
+});

--- a/packages/coveo-analytics/src/formatting/format-array-for-coveo-custom-data.ts
+++ b/packages/coveo-analytics/src/formatting/format-array-for-coveo-custom-data.ts
@@ -1,0 +1,31 @@
+function filterConsecutiveRepeatedValues(rawData: string[]) {
+    let prev = '';
+    return rawData.filter((value) => {
+        const isDifferent = value !== prev;
+        prev = value;
+        return isDifferent;
+    });
+}
+
+function removeSemicolons(rawData: string[]) {
+    return rawData.map((value) => {
+        return value.replace(/;/g, '');
+    });
+}
+
+function getDataString(data: string[]): string {
+    const ANALYTICS_LENGTH_LIMIT = 256;
+
+    const formattedData = data.join(';');
+    if (formattedData.length <= ANALYTICS_LENGTH_LIMIT) {
+        return formattedData;
+    }
+    return getDataString(data.slice(1));
+}
+
+export const formatArrayForCoveoCustomData = (rawData: string[]): string => {
+    const dataWithoutSemicolons = removeSemicolons(rawData);
+    const dataWithoutRepeatedValues = filterConsecutiveRepeatedValues(dataWithoutSemicolons);
+
+    return getDataString(dataWithoutRepeatedValues);
+};

--- a/packages/coveo-analytics/src/formatting/format-omnibox-metadata.ts
+++ b/packages/coveo-analytics/src/formatting/format-omnibox-metadata.ts
@@ -1,0 +1,17 @@
+import {OmniboxSuggestionsMetadata} from '../searchPage/searchPageEvents';
+import {formatArrayForCoveoCustomData} from './format-array-for-coveo-custom-data';
+
+export function formatOmniboxMetadata(meta: OmniboxSuggestionsMetadata): OmniboxSuggestionsMetadata {
+    const partialQueries =
+        typeof meta.partialQueries === 'string'
+            ? meta.partialQueries
+            : formatArrayForCoveoCustomData(meta.partialQueries);
+    const suggestions =
+        typeof meta.suggestions === 'string' ? meta.suggestions : formatArrayForCoveoCustomData(meta.suggestions);
+
+    return {
+        ...meta,
+        partialQueries,
+        suggestions,
+    };
+}

--- a/packages/coveo-analytics/src/history.spec.ts
+++ b/packages/coveo-analytics/src/history.spec.ts
@@ -1,0 +1,201 @@
+import * as history from './history';
+import {MAX_NUMBER_OF_HISTORY_ELEMENTS} from './history';
+import {WebStorage} from './storage';
+
+describe('history', () => {
+    let storageMock: jest.Mocked<WebStorage>;
+    let historyStore: history.HistoryStore;
+    let data: history.HistoryElement;
+
+    beforeEach(() => {
+        let storageData: any;
+        storageMock = {
+            getItem: jest.fn((key) => storageData),
+            setItem: jest.fn((key, data) => {
+                storageData = data;
+            }),
+            removeItem: jest.fn(),
+        };
+        historyStore = new history.HistoryStore(storageMock);
+        data = {
+            name: 'name',
+            value: 'value',
+            time: new Date().toISOString(),
+        };
+    });
+
+    it('should return the same an element after adding it to the history', () => {
+        historyStore.addElement(data);
+
+        expect(storageMock.setItem).toHaveBeenCalledTimes(1);
+        const [setKey, setData] = storageMock.setItem.mock.calls[0];
+
+        expect(setKey).toBe(history.STORE_KEY);
+        expect(setData).toMatch(/"value":"value"/);
+        expect(setData).toMatch(/"time"/);
+        expect(setData).toMatch(/"internalTime"/);
+    });
+
+    it('should return the same an element after adding it to the history', async () => {
+        await historyStore.addElementAsync(data);
+
+        expect(storageMock.setItem).toHaveBeenCalledTimes(1);
+        const [setKey, setData] = storageMock.setItem.mock.calls[0];
+
+        expect(setKey).toBe(history.STORE_KEY);
+        expect(setData).toMatch(/"value":"value"/);
+        expect(setData).toMatch(/"time"/);
+        expect(setData).toMatch(/"internalTime"/);
+    });
+
+    it('should trim query over > 75 char', async () => {
+        data.value = '';
+        let newValue = '';
+        for (let i = 0; i < 100; i++) {
+            newValue += i.toString();
+        }
+        data.name = 'Query';
+        data.value = newValue;
+
+        await historyStore.addElementAsync(data);
+
+        expect(storageMock.setItem).toHaveBeenCalledTimes(1);
+        const [setKey, setData] = storageMock.setItem.mock.calls[0];
+
+        expect(setKey).toBe(history.STORE_KEY);
+        expect(setData).toMatch(/"value":"01234[0-9]{70}"/);
+    });
+
+    it("should not trim elements over 75 char if it's not a query", async () => {
+        data.value = '';
+        let newValue = '';
+        for (let i = 0; i < 100; i++) {
+            newValue += i.toString();
+        }
+        data.name = 'Not A Query';
+        data.value = newValue;
+
+        await historyStore.addElementAsync(data);
+
+        expect(storageMock.setItem).toHaveBeenCalledTimes(1);
+        const [setKey, setData] = storageMock.setItem.mock.calls[0];
+
+        expect(setKey).toBe(history.STORE_KEY);
+        expect(setData).toMatch(/"value":"01234[0-9]{185}"/);
+    });
+
+    it('should not keep more then MAX_ELEMENTS', async () => {
+        for (let i = 0; i < MAX_NUMBER_OF_HISTORY_ELEMENTS + 5; i++) {
+            data.value = i.toString();
+            await historyStore.addElementAsync(data);
+        }
+        const history = await historyStore.getHistoryAsync();
+        expect(history.length).toBe(MAX_NUMBER_OF_HISTORY_ELEMENTS);
+    });
+
+    it('should be able to remove all internalTime', () => {
+        const historyElements: history.HistoryElement[] = [];
+        for (let i = 0; i < 5; i++) {
+            historyElements.push({
+                name: 'name' + i,
+                value: 'value' + i,
+                time: new Date().toISOString(),
+                internalTime: new Date().getTime(),
+            });
+        }
+
+        for (let elem of historyElements) {
+            expect(elem).toHaveProperty('internalTime');
+        }
+
+        const stripedHistoryElements = historyStore['stripInternalTime'](historyElements);
+
+        for (let elem of stripedHistoryElements) {
+            expect(elem).not.toHaveProperty('internalTime');
+        }
+    });
+
+    it('should strip empty query values when calling getHistoryAsync', async () => {
+        data.name = 'Query';
+        data.value = '';
+        const historyElements: history.HistoryElement[] = [data];
+        historyStore.setHistory(historyElements);
+
+        const history = await historyStore.getHistoryAsync();
+        expect(history[0].value).toBeUndefined();
+    });
+
+    it('should strip empty query values when calling getHistory', () => {
+        data.name = 'Query';
+        data.value = '';
+        const historyElements: history.HistoryElement[] = [data];
+        historyStore.setHistory(historyElements);
+
+        const history = historyStore.getHistory();
+        expect(history[0].value).toBeUndefined();
+    });
+
+    it('should strip empty query from new element (addElement)', () => {
+        data.name = 'Query';
+        data.value = '';
+        historyStore.addElement(data);
+
+        const [_, setData] = storageMock.setItem.mock.calls[0];
+        expect(setData).not.toMatch(/"value"/);
+    });
+
+    it('should strip empty query from new element (addElementAsync)', async () => {
+        data.name = 'Query';
+        data.value = '';
+        await historyStore.addElementAsync(data);
+
+        const [_, setData] = storageMock.setItem.mock.calls[0];
+        expect(setData).not.toMatch(/"value"/);
+    });
+
+    it('should remove item when cleared', () => {
+        historyStore.clear();
+
+        expect(storageMock.removeItem).toHaveBeenCalledWith(history.STORE_KEY);
+    });
+
+    it('should be able to set the history', () => {
+        const historyElements: history.HistoryElement[] = [data];
+
+        historyStore.setHistory(historyElements);
+
+        expect(storageMock.setItem).toHaveBeenCalledWith(
+            history.STORE_KEY,
+            expect.stringContaining(JSON.stringify(historyElements))
+        );
+    });
+
+    it('should reject consecutive duplicate values', async () => {
+        await historyStore.addElementAsync(data);
+        await historyStore.addElementAsync(data);
+
+        expect(storageMock.setItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('should accept consecutive values which are not duplicates', async () => {
+        await historyStore.addElementAsync(data);
+        data.value = 'something else';
+        await historyStore.addElementAsync(data);
+
+        expect(storageMock.setItem).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not throw when the content of localStorage is not an array', async () => {
+        storageMock.setItem(history.STORE_KEY, '{"foo":"bar"}');
+        let ex: any;
+        try {
+            const mostRecentElement = await historyStore.getMostRecentElement();
+            expect(mostRecentElement).toBeNull();
+            const localHistory = await historyStore.getHistoryAsync();
+            expect(localHistory).toStrictEqual([]);
+        } catch (err) {
+            ex = err;
+        }
+        expect(ex).toBeUndefined();
+    });
+});

--- a/packages/coveo-analytics/src/history.ts
+++ b/packages/coveo-analytics/src/history.ts
@@ -1,0 +1,169 @@
+import {getAvailableStorage, WebStorage} from './storage';
+
+export const STORE_KEY: string = '__coveo.analytics.history';
+export const MAX_NUMBER_OF_HISTORY_ELEMENTS: number = 20;
+export const MIN_THRESHOLD_FOR_DUPLICATE_VALUE: number = 1000 * 60;
+export const MAX_VALUE_SIZE = 75;
+
+export class HistoryStore {
+    private store: WebStorage;
+    constructor(store?: WebStorage) {
+        this.store = store || getAvailableStorage();
+    }
+
+    /**
+     * @deprecated Synchronous method is deprecated, use addElementAsync instead. This method will NOT work with react-native.
+     */
+    addElement(elem: HistoryElement) {
+        elem.internalTime = new Date().getTime();
+        elem = this.cropQueryElement(this.stripEmptyQuery(elem));
+        let currentHistory = this.getHistoryWithInternalTime();
+        if (currentHistory != null) {
+            if (this.isValidEntry(elem)) {
+                this.setHistory([elem].concat(currentHistory));
+            }
+        } else {
+            this.setHistory([elem]);
+        }
+    }
+
+    async addElementAsync(elem: HistoryElement) {
+        elem.internalTime = new Date().getTime();
+        elem = this.cropQueryElement(this.stripEmptyQuery(elem));
+        let currentHistory = await this.getHistoryWithInternalTimeAsync();
+        if (currentHistory != null) {
+            if (this.isValidEntry(elem)) {
+                this.setHistory([elem].concat(currentHistory));
+            }
+        } else {
+            this.setHistory([elem]);
+        }
+    }
+
+    /**
+     * @deprecated Synchronous method is deprecated, use getHistoryAsync instead. This method will NOT work with react-native.
+     */
+    getHistory(): HistoryElement[] {
+        const history = this.getHistoryWithInternalTime();
+        return this.stripEmptyQueries(this.stripInternalTime(history));
+    }
+
+    async getHistoryAsync(): Promise<HistoryElement[]> {
+        const history = await this.getHistoryWithInternalTimeAsync();
+        return this.stripEmptyQueries(this.stripInternalTime(history));
+    }
+
+    private getHistoryWithInternalTime(): HistoryElement[] {
+        try {
+            const elements = this.store.getItem(STORE_KEY);
+            if (elements && typeof elements === 'string') {
+                return JSON.parse(elements) as HistoryElement[];
+            } else {
+                return [];
+            }
+        } catch (e) {
+            // When using the Storage APIs (localStorage/sessionStorage)
+            // Safari says that those APIs are available but throws when making
+            // a call to them.
+            return [];
+        }
+    }
+
+    private async getHistoryWithInternalTimeAsync(): Promise<HistoryElement[]> {
+        try {
+            const elements = await this.store.getItem(STORE_KEY);
+            if (elements) {
+                return JSON.parse(elements) as HistoryElement[];
+            } else {
+                return [];
+            }
+        } catch (e) {
+            // When using the Storage APIs (localStorage/sessionStorage)
+            // Safari says that those APIs are available but throws when making
+            // a call to them.
+            return [];
+        }
+    }
+
+    setHistory(history: HistoryElement[]) {
+        try {
+            this.store.setItem(STORE_KEY, JSON.stringify(history.slice(0, MAX_NUMBER_OF_HISTORY_ELEMENTS)));
+        } catch (e) {
+            /* refer to this.getHistory() */
+        }
+    }
+
+    clear() {
+        try {
+            this.store.removeItem(STORE_KEY);
+        } catch (e) {
+            /* refer to this.getHistory() */
+        }
+    }
+
+    getMostRecentElement(): HistoryElement | null {
+        let currentHistory = this.getHistoryWithInternalTime();
+        if (Array.isArray(currentHistory)) {
+            const sorted = currentHistory.sort((first: HistoryElement, second: HistoryElement) => {
+                // Internal time might not be set for all history element (on upgrade).
+                // Ensure to return the most recent element for which we have a value for internalTime.
+                return (second.internalTime || 0) - (first.internalTime || 0);
+            });
+            return sorted[0];
+        }
+        return null;
+    }
+
+    private cropQueryElement(part: HistoryElement) {
+        if (part.name && part.value && part.name.toLowerCase() === 'query') {
+            part.value = part.value.slice(0, MAX_VALUE_SIZE);
+        }
+
+        return part;
+    }
+
+    private isValidEntry(elem: HistoryElement): boolean {
+        let lastEntry = this.getMostRecentElement();
+
+        if (lastEntry && lastEntry.value == elem.value) {
+            return (elem.internalTime || 0) - (lastEntry.internalTime || 0) > MIN_THRESHOLD_FOR_DUPLICATE_VALUE;
+        }
+        return true;
+    }
+
+    private stripInternalTime(history: HistoryElement[]): HistoryElement[] {
+        if (Array.isArray(history)) {
+            return history.map((part) => {
+                const {name, time, value} = part;
+                return {name, time, value};
+            });
+        }
+        return [];
+    }
+
+    private stripEmptyQuery(part: HistoryElement) {
+        const {name, time, value} = part;
+        if (name && typeof value === 'string' && name.toLowerCase() === 'query' && value.trim() === '') {
+            return {name, time};
+        }
+
+        return part;
+    }
+
+    private stripEmptyQueries(history: HistoryElement[]): HistoryElement[] {
+        return history.map((part) => this.stripEmptyQuery(part));
+    }
+}
+
+export interface HistoryElement {
+    name: string;
+    value?: string;
+    time: string;
+    internalTime?: number;
+}
+
+export interface HistoryViewElement extends HistoryElement {
+    title?: string;
+}
+
+export default HistoryStore;

--- a/packages/coveo-analytics/src/hook/addDefaultValues.ts
+++ b/packages/coveo-analytics/src/hook/addDefaultValues.ts
@@ -1,0 +1,15 @@
+import {AnalyticsClientSendEventHook} from '../client/analytics';
+import {hasDocument, hasNavigator} from '../detector';
+import {EventType} from '../events';
+
+const eventTypesForDefaultValues: string[] = [EventType.click, EventType.custom, EventType.search, EventType.view];
+
+export const addDefaultValues: AnalyticsClientSendEventHook = (eventType, payload) => {
+    return eventTypesForDefaultValues.indexOf(eventType) !== -1
+        ? {
+              language: hasDocument() ? document.documentElement.lang : 'unknown',
+              userAgent: hasNavigator() ? navigator.userAgent : 'unknown',
+              ...payload,
+          }
+        : payload;
+};

--- a/packages/coveo-analytics/src/hook/enhanceViewEvent.ts
+++ b/packages/coveo-analytics/src/hook/enhanceViewEvent.ts
@@ -1,0 +1,27 @@
+import {AnalyticsClientSendEventHook} from '../client/analytics';
+import {ViewEventRequest, EventType} from '../events';
+import {HistoryStore, STORE_KEY} from '../history';
+
+export const enhanceViewEvent: AnalyticsClientSendEventHook = async (eventType, payload) => {
+    if (eventType === EventType.view) {
+        await addPageViewToHistory(payload.contentIdValue);
+        return {
+            location: window.location.toString(),
+            referrer: document.referrer,
+            title: document.title,
+            ...payload,
+        } as ViewEventRequest;
+    }
+
+    return payload;
+};
+
+const addPageViewToHistory = async (pageViewValue: string) => {
+    const store = new HistoryStore();
+    const historyElement = {
+        name: 'PageView',
+        value: pageViewValue,
+        time: new Date().toISOString(),
+    };
+    await store.addElementAsync(historyElement);
+};

--- a/packages/coveo-analytics/src/insight/insightClient.spec.ts
+++ b/packages/coveo-analytics/src/insight/insightClient.spec.ts
@@ -1,0 +1,1614 @@
+import {lastCallBody, mockFetch} from '../../tests/fetchMock';
+import CoveoAnalyticsClient from '../client/analytics';
+import {NoopAnalytics} from '../client/noopAnalytics';
+import {
+    CustomEventsTypes,
+    GeneratedAnswerFeedbackReason,
+    GeneratedAnswerFeedbackReasonOption,
+    GeneratedAnswerRephraseFormat,
+    PartialDocumentInformation,
+    SearchPageEvents,
+    StaticFilterToggleValueMetadata,
+} from '../searchPage/searchPageEvents';
+import {CoveoInsightClient, InsightClientProvider} from './insightClient';
+import doNotTrack from '../donottrack';
+import {InsightEvents, InsightStaticFilterToggleValueMetadata} from './insightEvents';
+import {Cookie} from '../cookieutils';
+
+const baseCaseMetadata = {
+    caseId: '1234',
+    caseNumber: '5678',
+    caseContext: {Case_Subject: 'test subject', Case_Description: 'test description'},
+};
+
+const expectedBaseCaseMetadata = {
+    CaseId: '1234',
+    CaseNumber: '5678',
+    CaseSubject: 'test subject',
+};
+
+jest.mock('../donottrack', () => {
+    return {
+        default: jest.fn(),
+        doNotTrack: jest.fn(),
+    };
+});
+
+const {fetchMock, fetchMockBeforeEach} = mockFetch();
+describe('InsightClient', () => {
+    const fakeFacetState = [
+        {
+            valuePosition: 0,
+            value: 'foo',
+            state: 'selected' as const,
+            facetPosition: 1,
+            displayValue: 'foobar',
+            facetType: 'specific' as const,
+            field: '@foo',
+            id: 'bar',
+            title: 'title',
+        },
+    ];
+
+    let client: CoveoInsightClient;
+
+    const provider: InsightClientProvider = {
+        getBaseMetadata: () => ({foo: 'bar'}),
+        getSearchEventRequestPayload: () => ({
+            queryText: 'queryText',
+            responseTime: 123,
+        }),
+        getSearchUID: () => 'my-uid',
+        getPipeline: () => 'my-pipeline',
+        getOriginContext: () => 'origin-context',
+        getOriginLevel1: () => 'origin-level-1',
+        getOriginLevel2: () => 'origin-level-2',
+        getOriginLevel3: () => 'origin-level-3',
+        getLanguage: () => 'en',
+        getFacetState: () => fakeFacetState,
+        getIsAnonymous: () => false,
+        getGeneratedAnswerMetadata: () => ({genratedAnswerMetadata: 'foo'}),
+    };
+
+    const initClient = () => {
+        return new CoveoInsightClient({}, provider);
+    };
+
+    const expectOrigins = () => ({
+        originContext: 'origin-context',
+        originLevel1: 'origin-level-1',
+        originLevel2: 'origin-level-2',
+        originLevel3: 'origin-level-3',
+    });
+
+    const expectMatchPayload = (actionCause: SearchPageEvents | InsightEvents, meta = {}) => {
+        const body: string = lastCallBody(fetchMock);
+        const customData = {foo: 'bar', genratedAnswerMetadata: 'foo', ...meta};
+        expect(JSON.parse(body)).toMatchObject({
+            queryText: 'queryText',
+            responseTime: 123,
+            queryPipeline: 'my-pipeline',
+            actionCause,
+            customData,
+            facetState: fakeFacetState,
+            language: 'en',
+            clientId: 'visitor-id',
+            ...expectOrigins(),
+        });
+    };
+
+    const expectMatchCustomEventPayload = (actionCause: SearchPageEvents | InsightEvents, meta = {}) => {
+        const body: string = lastCallBody(fetchMock);
+        const customData = {foo: 'bar', ...meta};
+        expect(JSON.parse(body)).toMatchObject({
+            eventValue: actionCause,
+            eventType: CustomEventsTypes[actionCause],
+            lastSearchQueryUid: 'my-uid',
+            customData,
+            language: 'en',
+            clientId: 'visitor-id',
+            ...expectOrigins(),
+        });
+    };
+
+    const expectMatchDocumentPayload = (actionCause: SearchPageEvents, doc: PartialDocumentInformation, meta = {}) => {
+        const body: string = lastCallBody(fetchMock);
+        const customData = {foo: 'bar', ...meta};
+        expect(JSON.parse(body.toString())).toMatchObject({
+            actionCause,
+            customData,
+            language: 'en',
+            clientId: 'visitor-id',
+            ...doc,
+            ...expectOrigins(),
+        });
+    };
+
+    const fakeDocInfo = {
+        collectionName: 'collection',
+        documentAuthor: 'author',
+        documentPosition: 1,
+        documentTitle: 'title',
+        documentUri: 'uri',
+        documentUriHash: 'hash',
+        documentUrl: 'url',
+        queryPipeline: 'my-pipeline',
+        rankingModifier: 'modifier',
+        sourceName: 'source',
+    };
+
+    const fakeDocID = {
+        contentIDKey: 'permanentID',
+        contentIDValue: 'the-permanent-id',
+    };
+
+    beforeEach(() => {
+        fetchMockBeforeEach();
+
+        client = initClient();
+        client.coveoAnalyticsClient.runtime.storage.setItem('visitorId', 'visitor-id');
+        fetchMock.mock(/.*/, {
+            visitId: 'visit-id',
+        });
+    });
+
+    afterEach(() => {
+        fetchMock.reset();
+    });
+
+    describe('when the case metadata is not included', () => {
+        it('should send proper payload for #interfaceLoad', async () => {
+            await client.logInterfaceLoad();
+            expectMatchPayload(SearchPageEvents.interfaceLoad);
+        });
+
+        it('should send proper payload for #interfaceChange', async () => {
+            await client.logInterfaceChange({
+                interfaceChangeTo: 'bob',
+            });
+            expectMatchPayload(SearchPageEvents.interfaceChange, {interfaceChangeTo: 'bob'});
+        });
+
+        it('should send proper payload for #fetchMoreResults', async () => {
+            await client.logFetchMoreResults();
+            expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
+        });
+
+        it('should send proper payload for #staticFilterDeselect', async () => {
+            const meta: StaticFilterToggleValueMetadata = {
+                staticFilterId: 'filetypes',
+                staticFilterValue: {
+                    caption: 'Youtube',
+                    expression: '@filetype="youtubevideo"',
+                },
+            };
+            await client.logStaticFilterDeselect(meta);
+
+            expectMatchPayload(SearchPageEvents.staticFilterDeselect, meta);
+        });
+
+        it('should send proper payload for #breadcrumbResetAll', async () => {
+            await client.logBreadcrumbResetAll();
+            expectMatchPayload(SearchPageEvents.breadcrumbResetAll);
+        });
+
+        it('should send proper payload for #breadcrumbFacet', async () => {
+            const meta = {
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+            await client.logBreadcrumbFacet(meta);
+            expectMatchPayload(SearchPageEvents.breadcrumbFacet, meta);
+        });
+
+        it('should send proper payload for #logFacetSelect', async () => {
+            const meta = {
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            await client.logFacetSelect(meta);
+            expectMatchPayload(SearchPageEvents.facetSelect, meta);
+        });
+
+        it('should send proper payload for #logFacetExclude', async () => {
+            const meta = {
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            await client.logFacetExclude(meta);
+            expectMatchPayload(SearchPageEvents.facetExclude, meta);
+        });
+
+        it('should send proper payload for #logFacetDeselect', async () => {
+            const meta = {
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            await client.logFacetDeselect(meta);
+            expectMatchPayload(SearchPageEvents.facetDeselect, meta);
+        });
+
+        it('should send proper payload for #logFacetUpdateSort', async () => {
+            const meta = {
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                criteria: 'bazz',
+            };
+            await client.logFacetUpdateSort(meta);
+            expectMatchPayload(SearchPageEvents.facetUpdateSort, meta);
+        });
+
+        it('should send proper payload for #logFacetClearAll', async () => {
+            const meta = {
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+            };
+            await client.logFacetClearAll(meta);
+            expectMatchPayload(SearchPageEvents.facetClearAll, meta);
+        });
+
+        it('should send proper payload for #logFacetShowMore', async () => {
+            const meta = {
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+            };
+            await client.logFacetShowMore(meta);
+            expectMatchCustomEventPayload(SearchPageEvents.facetShowMore, meta);
+        });
+
+        it('should send proper payload for #logFacetShowLess', async () => {
+            const meta = {
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+            };
+            await client.logFacetShowLess(meta);
+            expectMatchCustomEventPayload(SearchPageEvents.facetShowLess, meta);
+        });
+
+        it('should send proper payload for #logQueryError', async () => {
+            const meta = {
+                query: 'q',
+                aq: 'aq',
+                cq: 'cq',
+                dq: 'dq',
+                errorMessage: 'boom',
+                errorType: 'a bad one',
+            };
+            await client.logQueryError(meta);
+            expectMatchCustomEventPayload(SearchPageEvents.queryError, meta);
+        });
+
+        it('should send proper payload for #logPagerNumber', async () => {
+            const meta = {pagerNumber: 123};
+            await client.logPagerNumber(meta);
+            expectMatchCustomEventPayload(SearchPageEvents.pagerNumber, meta);
+        });
+
+        it('should send proper payload for #logPagerNext', async () => {
+            const meta = {pagerNumber: 123};
+            await client.logPagerNext(meta);
+            expectMatchCustomEventPayload(SearchPageEvents.pagerNext, meta);
+        });
+
+        it('should send proper payload for #logPagerPrevious', async () => {
+            const meta = {pagerNumber: 123};
+            await client.logPagerPrevious(meta);
+            expectMatchCustomEventPayload(SearchPageEvents.pagerPrevious, meta);
+        });
+
+        it('should send proper payload for #didyoumeanAutomatic', async () => {
+            await client.logDidYouMeanAutomatic();
+            expectMatchPayload(SearchPageEvents.didyoumeanAutomatic);
+        });
+
+        it('should send proper payload for #didyoumeanClick', async () => {
+            await client.logDidYouMeanClick();
+            expectMatchPayload(SearchPageEvents.didyoumeanClick);
+        });
+
+        it('should send proper payload for #resultsSort', async () => {
+            await client.logResultsSort({resultsSortBy: 'date ascending'});
+            expectMatchPayload(SearchPageEvents.resultsSort, {resultsSortBy: 'date ascending'});
+        });
+
+        it('should send proper payload for #searchboxSubmit', async () => {
+            await client.logSearchboxSubmit();
+            expectMatchPayload(SearchPageEvents.searchboxSubmit);
+        });
+
+        it('should send proper payload for #documentOpen', async () => {
+            await client.logDocumentOpen(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.documentOpen, fakeDocInfo, fakeDocID);
+        });
+
+        it('should send proper payload for #copyToClipboard', async () => {
+            await client.logCopyToClipboard(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.copyToClipboard, fakeDocInfo, fakeDocID);
+        });
+
+        it('should send proper payload for #caseSendEmail', async () => {
+            await client.logCaseSendEmail(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.caseSendEmail, fakeDocInfo, fakeDocID);
+        });
+
+        it('should send proper payload for #feedItemTextPost', async () => {
+            await client.logFeedItemTextPost(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.feedItemTextPost, fakeDocInfo, fakeDocID);
+        });
+
+        it('should send proper payload for #documentQuickview', async () => {
+            const expectedMetadata = {
+                ...fakeDocID,
+                documentTitle: fakeDocInfo.documentTitle,
+                documentURL: fakeDocInfo.documentUrl,
+            };
+            await client.logDocumentQuickview(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.documentQuickview, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #caseAttach', async () => {
+            const expectedMetadata = {
+                ...fakeDocID,
+                documentTitle: fakeDocInfo.documentTitle,
+                documentURL: fakeDocInfo.documentUrl,
+                resultUriHash: fakeDocInfo.documentUriHash,
+            };
+            await client.logCaseAttach(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.caseAttach, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #caseDetach', async () => {
+            const expectedMetadata = {
+                resultUriHash: fakeDocInfo.documentUriHash,
+            };
+            await client.logCaseDetach(fakeDocInfo.documentUriHash);
+            expectMatchCustomEventPayload(SearchPageEvents.caseDetach, expectedMetadata);
+        });
+
+        it('should send proper payload for #likeSmartSnippet', async () => {
+            await client.logLikeSmartSnippet();
+            expectMatchCustomEventPayload(SearchPageEvents.likeSmartSnippet);
+        });
+
+        it('should send proper payload for #dislikeSmartSnippet', async () => {
+            await client.logDislikeSmartSnippet();
+            expectMatchCustomEventPayload(SearchPageEvents.dislikeSmartSnippet);
+        });
+
+        it('should send proper payload for #expandSmartSnippet', async () => {
+            await client.logExpandSmartSnippet();
+            expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippet);
+        });
+
+        it('should send proper payload for #collapseSmartSnippet', async () => {
+            await client.logCollapseSmartSnippet();
+            expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippet);
+        });
+
+        it('should send proper payload for #openSmartSnippetFeedbackModal', async () => {
+            await client.logOpenSmartSnippetFeedbackModal();
+            expectMatchCustomEventPayload(SearchPageEvents.openSmartSnippetFeedbackModal);
+        });
+
+        it('should send proper payload for #closeSmartSnippetFeedbackModal', async () => {
+            await client.logCloseSmartSnippetFeedbackModal();
+            expectMatchCustomEventPayload(SearchPageEvents.closeSmartSnippetFeedbackModal);
+        });
+
+        it('should send proper payload for #sendSmartSnippetReason', async () => {
+            const reason = 'other';
+            const details = 'example details';
+            const expectedMetadata = {
+                reason,
+                details,
+            };
+
+            await client.logSmartSnippetFeedbackReason(reason, details);
+            expectMatchCustomEventPayload(SearchPageEvents.sendSmartSnippetReason, expectedMetadata);
+        });
+
+        it('should send proper payload for #expandSmartSnippetSuggestion', async () => {
+            const exampleSmartSnippetSuggestion = {
+                question: 'Abc',
+                answerSnippet: 'Def',
+                documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+            };
+
+            await client.logExpandSmartSnippetSuggestion(exampleSmartSnippetSuggestion);
+            expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, exampleSmartSnippetSuggestion);
+        });
+
+        it('should send proper payload for #collapseSmartSnippetSuggestion', async () => {
+            const exampleSmartSnippetSuggestion = {
+                question: 'Abc',
+                answerSnippet: 'Def',
+                documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+            };
+
+            await client.logCollapseSmartSnippetSuggestion(exampleSmartSnippetSuggestion);
+            expectMatchCustomEventPayload(
+                SearchPageEvents.collapseSmartSnippetSuggestion,
+                exampleSmartSnippetSuggestion
+            );
+        });
+
+        it('should send proper payload for #openSmartSnippetSource', async () => {
+            await client.logOpenSmartSnippetSource(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSource, fakeDocInfo, fakeDocID);
+        });
+
+        it('should send proper payload for #openSmartSnippetInlineLink', async () => {
+            const meta = {
+                ...fakeDocID,
+                linkText: 'Some text',
+                linkURL: 'https://invalid.com',
+            };
+
+            await client.logOpenSmartSnippetInlineLink(fakeDocInfo, meta);
+            expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetInlineLink, fakeDocInfo, meta);
+        });
+
+        it('should send proper payload for #openSmartSnippetSuggestionSource', async () => {
+            const meta = {
+                question: 'Abc',
+                answerSnippet: 'Def',
+                documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+            };
+
+            const expectedMetadata = {
+                ...meta,
+                contentIDKey: meta.documentId.contentIdKey,
+                contentIDValue: meta.documentId.contentIdValue,
+            };
+
+            await client.logOpenSmartSnippetSuggestionSource(fakeDocInfo, meta);
+            expectMatchDocumentPayload(
+                SearchPageEvents.openSmartSnippetSuggestionSource,
+                fakeDocInfo,
+                expectedMetadata
+            );
+        });
+
+        it('should send proper payload for #openSmartSnippetSuggestionInlineLink', async () => {
+            const meta = {
+                question: 'Abc',
+                answerSnippet: 'Def',
+                documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+                linkText: 'Some text',
+                linkURL: 'https://invalid.com',
+            };
+            const expectedMetadata = {
+                ...meta,
+                contentIDKey: meta.documentId.contentIdKey,
+                contentIDValue: meta.documentId.contentIdValue,
+            };
+
+            await client.logOpenSmartSnippetSuggestionInlineLink(fakeDocInfo, meta);
+            expectMatchDocumentPayload(
+                SearchPageEvents.openSmartSnippetSuggestionInlineLink,
+                fakeDocInfo,
+                expectedMetadata
+            );
+        });
+        it('should send proper payload for #showMoreFoldedResults', async () => {
+            await client.logShowMoreFoldedResults(fakeDocInfo, fakeDocID);
+            expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
+        });
+
+        it('should send proper payload for #showLessFoldedResults', async () => {
+            await client.logShowLessFoldedResults();
+            expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults);
+        });
+
+        it('should send proper payload for #likeGeneratedAnswer', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+
+            await client.logLikeGeneratedAnswer(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.likeGeneratedAnswer, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #dislikeGeneratedAnswer', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+
+            await client.logDislikeGeneratedAnswer(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.dislikeGeneratedAnswer, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #openGeneratedAnswerSource', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                permanentId: 'foo',
+                citationId: 'bar',
+            };
+
+            await client.logOpenGeneratedAnswerSource(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerSourceHover', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                permanentId: 'foo',
+                citationId: 'bar',
+                citationHoverTimeMs: 100,
+            };
+
+            await client.logGeneratedAnswerSourceHover(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerSourceHover, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerCopyToClipboard', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+
+            await client.logGeneratedAnswerCopyToClipboard(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(
+                SearchPageEvents.generatedAnswerCopyToClipboard,
+                exampleGeneratedAnswerMetadata
+            );
+        });
+
+        it('should send proper payload for #generatedAnswerHideAnswers', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+
+            await client.logGeneratedAnswerHideAnswers(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerHideAnswers, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerShowAnswers', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+
+            await client.logGeneratedAnswerShowAnswers(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerShowAnswers, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerExpand', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+
+            await client.logGeneratedAnswerExpand(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerExpand, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerCollapse', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+
+            await client.logGeneratedAnswerCollapse(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCollapse, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerFeedbackSubmit', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                reason: <GeneratedAnswerFeedbackReason>'other',
+                details: 'foo',
+            };
+
+            await client.logGeneratedAnswerFeedbackSubmit(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(
+                SearchPageEvents.generatedAnswerFeedbackSubmit,
+                exampleGeneratedAnswerMetadata
+            );
+        });
+
+        it('should send proper payload for #rephraseGeneratedAnswer', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                rephraseFormat: <GeneratedAnswerRephraseFormat>'step',
+            };
+
+            await client.logRephraseGeneratedAnswer(exampleGeneratedAnswerMetadata);
+            expectMatchPayload(SearchPageEvents.rephraseGeneratedAnswer, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #retryGeneratedAnswer', async () => {
+            await client.logRetryGeneratedAnswer();
+            expectMatchPayload(SearchPageEvents.retryGeneratedAnswer);
+        });
+
+        it('should send proper payload for #generatedAnswerStreamEnd', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                answerGenerated: true,
+                answerTextIsEmpty: false,
+            };
+
+            await client.logGeneratedAnswerStreamEnd(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, exampleGeneratedAnswerMetadata);
+        });
+
+        it('should send proper payload for #createArticle', async () => {
+            const exampleCreateArticleMetadata = {
+                articleType: 'Knowledge__kav',
+                triggeredBy: 'CreateArticleButton',
+            };
+            await client.logCreateArticle(exampleCreateArticleMetadata);
+            expectMatchCustomEventPayload(InsightEvents.createArticle, exampleCreateArticleMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerFeedbackSubmitV2', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                helpful: true,
+                readable: <GeneratedAnswerFeedbackReasonOption>'yes',
+                documented: <GeneratedAnswerFeedbackReasonOption>'no',
+                correctTopic: <GeneratedAnswerFeedbackReasonOption>'unknown',
+                hallucinationFree: <GeneratedAnswerFeedbackReasonOption>'yes',
+                details: 'foo',
+                documentUrl: 'https://document.com',
+            };
+
+            await client.logGeneratedAnswerFeedbackSubmitV2(exampleGeneratedAnswerMetadata);
+            expectMatchCustomEventPayload(
+                SearchPageEvents.generatedAnswerFeedbackSubmitV2,
+                exampleGeneratedAnswerMetadata
+            );
+        });
+    });
+
+    describe('when the case metadata is included', () => {
+        it('should send proper payload for #interfaceLoad', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+            };
+            await client.logInterfaceLoad(metadata);
+            expectMatchPayload(SearchPageEvents.interfaceLoad, expectedMetadata);
+        });
+
+        it('should send proper payload for #interfaceChange', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                interfaceChangeTo: 'bob',
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+                interfaceChangeTo: 'bob',
+            };
+            await client.logInterfaceChange(metadata);
+            expectMatchPayload(SearchPageEvents.interfaceChange, expectedMetadata);
+        });
+
+        it('should send proper payload for #fetchMoreResults', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+                type: 'getMoreResults',
+            };
+            await client.logFetchMoreResults(metadata);
+            expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling, expectedMetadata);
+        });
+
+        it('should send proper payload for #staticFilterDeselect', async () => {
+            const metadata: InsightStaticFilterToggleValueMetadata = {
+                ...baseCaseMetadata,
+                staticFilterId: 'filetypes',
+                staticFilterValue: {
+                    caption: 'Youtube',
+                    expression: '@filetype="youtubevideo"',
+                },
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+                staticFilterId: 'filetypes',
+                staticFilterValue: {
+                    caption: 'Youtube',
+                    expression: '@filetype="youtubevideo"',
+                },
+            };
+            await client.logStaticFilterDeselect(metadata);
+
+            expectMatchPayload(SearchPageEvents.staticFilterDeselect, expectedMetadata);
+        });
+
+        it('should send proper payload for #breadcrumbResetAll', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+            };
+            await client.logBreadcrumbResetAll(metadata);
+            expectMatchPayload(SearchPageEvents.breadcrumbResetAll, expectedMetadata);
+        });
+
+        it('should send proper payload for #breadcrumbFacet', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+            await client.logBreadcrumbFacet(metadata);
+            expectMatchPayload(SearchPageEvents.breadcrumbFacet, expectedMetadata);
+        });
+
+        it('should send proper payload for #logFacetSelect', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            await client.logFacetSelect(metadata);
+            expectMatchPayload(SearchPageEvents.facetSelect, expectedMetadata);
+        });
+
+        it('should send proper payload for #logFacetExclude', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            await client.logFacetExclude(metadata);
+            expectMatchPayload(SearchPageEvents.facetExclude, expectedMetadata);
+        });
+
+        it('should send proper payload for #logFacetDeselect', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                facetValue: 'qwerty',
+            };
+
+            await client.logFacetDeselect(metadata);
+            expectMatchPayload(SearchPageEvents.facetDeselect, expectedMetadata);
+        });
+
+        it('should send proper payload for #logFacetUpdateSort', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                criteria: 'bazz',
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+                criteria: 'bazz',
+            };
+            await client.logFacetUpdateSort(metadata);
+            expectMatchPayload(SearchPageEvents.facetUpdateSort, expectedMetadata);
+        });
+
+        it('should send proper payload for #logFacetClearAll', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+            };
+            await client.logFacetClearAll(metadata);
+            expectMatchPayload(SearchPageEvents.facetClearAll, expectedMetadata);
+        });
+
+        it('should send proper payload for #logFacetShowMore', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+            };
+            await client.logFacetShowMore(metadata);
+            expectMatchCustomEventPayload(SearchPageEvents.facetShowMore, expectedMetadata);
+        });
+
+        it('should send proper payload for #logFacetShowLess', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                facetField: '@foo',
+                facetId: 'bar',
+                facetTitle: 'title',
+            };
+            await client.logFacetShowLess(metadata);
+            expectMatchCustomEventPayload(SearchPageEvents.facetShowLess, expectedMetadata);
+        });
+
+        it('should send proper payload for #logQueryError', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                query: 'q',
+                aq: 'aq',
+                cq: 'cq',
+                dq: 'dq',
+                errorMessage: 'boom',
+                errorType: 'a bad one',
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                query: 'q',
+                aq: 'aq',
+                cq: 'cq',
+                dq: 'dq',
+                errorMessage: 'boom',
+                errorType: 'a bad one',
+            };
+            await client.logQueryError(metadata);
+            expectMatchCustomEventPayload(SearchPageEvents.queryError, expectedMetadata);
+        });
+
+        it('should send proper payload for #logPagerNumber', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                pagerNumber: 123,
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                pagerNumber: 123,
+            };
+            await client.logPagerNumber(metadata);
+            expectMatchCustomEventPayload(SearchPageEvents.pagerNumber, expectedMetadata);
+        });
+
+        it('should send proper payload for #logPagerNext', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                pagerNumber: 123,
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                pagerNumber: 123,
+            };
+            await client.logPagerNext(metadata);
+            expectMatchCustomEventPayload(SearchPageEvents.pagerNext, expectedMetadata);
+        });
+
+        it('should send proper payload for #logPagerPrevious', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                pagerNumber: 123,
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                pagerNumber: 123,
+            };
+            await client.logPagerPrevious(metadata);
+            expectMatchCustomEventPayload(SearchPageEvents.pagerPrevious, expectedMetadata);
+        });
+
+        it('should send proper payload for #didyoumeanAutomatic', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+            };
+            await client.logDidYouMeanAutomatic(metadata);
+            expectMatchPayload(SearchPageEvents.didyoumeanAutomatic, expectedMetadata);
+        });
+
+        it('should send proper payload for #didyoumeanClick', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+            };
+            await client.logDidYouMeanClick(metadata);
+            expectMatchPayload(SearchPageEvents.didyoumeanClick, expectedMetadata);
+        });
+
+        it('should send proper payload for #resultsSort', async () => {
+            const metadata = {
+                ...baseCaseMetadata,
+                resultsSortBy: 'date ascending',
+            };
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+                resultsSortBy: 'date ascending',
+            };
+            await client.logResultsSort(metadata);
+            expectMatchPayload(SearchPageEvents.resultsSort, expectedMetadata);
+        });
+
+        it('should send proper payload for #searchboxSubmit', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                context_Case_Subject: 'test subject',
+                context_Case_Description: 'test description',
+            };
+            await client.logSearchboxSubmit(metadata);
+            expectMatchPayload(SearchPageEvents.searchboxSubmit, expectedMetadata);
+        });
+
+        it('should send proper payload for #documentOpen', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logDocumentOpen(fakeDocInfo, fakeDocID, metadata);
+            expectMatchDocumentPayload(SearchPageEvents.documentOpen, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #copyToClipboard', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logCopyToClipboard(fakeDocInfo, fakeDocID, metadata);
+            expectMatchDocumentPayload(SearchPageEvents.copyToClipboard, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #caseSendEmail', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logCaseSendEmail(fakeDocInfo, fakeDocID, metadata);
+            expectMatchDocumentPayload(SearchPageEvents.caseSendEmail, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #feedItemTextPost', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logFeedItemTextPost(fakeDocInfo, fakeDocID, metadata);
+            expectMatchDocumentPayload(SearchPageEvents.feedItemTextPost, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #documentQuickview', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+                documentTitle: fakeDocInfo.documentTitle,
+                documentURL: fakeDocInfo.documentUrl,
+            };
+            await client.logDocumentQuickview(fakeDocInfo, fakeDocID, metadata);
+            expectMatchDocumentPayload(SearchPageEvents.documentQuickview, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #caseAttach', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+                documentTitle: fakeDocInfo.documentTitle,
+                documentURL: fakeDocInfo.documentUrl,
+                resultUriHash: fakeDocInfo.documentUriHash,
+            };
+            await client.logCaseAttach(fakeDocInfo, fakeDocID, metadata);
+            expectMatchDocumentPayload(SearchPageEvents.caseAttach, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #caseDetach', async () => {
+            const metadata = baseCaseMetadata;
+
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+                resultUriHash: fakeDocInfo.documentUriHash,
+            };
+            await client.logCaseDetach(fakeDocInfo.documentUriHash, metadata);
+            expectMatchCustomEventPayload(SearchPageEvents.caseDetach, expectedMetadata);
+        });
+
+        it('should send proper payload for #likeSmartSnippet', async () => {
+            await client.logLikeSmartSnippet(baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.likeSmartSnippet, expectedBaseCaseMetadata);
+        });
+
+        it('should send proper payload for #dislikeSmartSnippet', async () => {
+            await client.logDislikeSmartSnippet(baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.dislikeSmartSnippet, expectedBaseCaseMetadata);
+        });
+
+        it('should send proper payload for #expandSmartSnippet', async () => {
+            await client.logExpandSmartSnippet(baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippet, expectedBaseCaseMetadata);
+        });
+
+        it('should send proper payload for #collapseSmartSnippet', async () => {
+            await client.logCollapseSmartSnippet(baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippet, expectedBaseCaseMetadata);
+        });
+
+        it('should send proper payload for #openSmartSnippetFeedbackModal', async () => {
+            await client.logOpenSmartSnippetFeedbackModal(baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.openSmartSnippetFeedbackModal, expectedBaseCaseMetadata);
+        });
+
+        it('should send proper payload for #closeSmartSnippetFeedbackModal', async () => {
+            await client.logCloseSmartSnippetFeedbackModal(baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.closeSmartSnippetFeedbackModal, expectedBaseCaseMetadata);
+        });
+
+        it('should send proper payload for #sendSmartSnippetReason', async () => {
+            const reason = 'other';
+            const details = 'example details';
+            const expectedMetadata = {
+                reason,
+                details,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logSmartSnippetFeedbackReason(reason, details, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.sendSmartSnippetReason, expectedMetadata);
+        });
+
+        it('should send proper payload for #expandSmartSnippetSuggestion', async () => {
+            const exampleSmartSnippetSuggestion = {
+                question: 'Abc',
+                answerSnippet: 'Def',
+                documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+            };
+            const expectedMetadata = {
+                ...exampleSmartSnippetSuggestion,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logExpandSmartSnippetSuggestion(exampleSmartSnippetSuggestion, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, expectedMetadata);
+        });
+
+        it('should send proper payload for #collapseSmartSnippetSuggestion', async () => {
+            const exampleSmartSnippetSuggestion = {
+                question: 'Abc',
+                answerSnippet: 'Def',
+                documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+            };
+            const expectedMetadata = {
+                ...exampleSmartSnippetSuggestion,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logCollapseSmartSnippetSuggestion(exampleSmartSnippetSuggestion, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippetSuggestion, expectedMetadata);
+        });
+
+        it('should send proper payload for #openSmartSnippetSource', async () => {
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logOpenSmartSnippetSource(fakeDocInfo, fakeDocID, baseCaseMetadata);
+            expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSource, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #openSmartSnippetInlineLink', async () => {
+            const meta = {
+                ...fakeDocID,
+                linkText: 'Some text',
+                linkURL: 'https://invalid.com',
+            };
+            const expectedMetadata = {
+                ...meta,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logOpenSmartSnippetInlineLink(fakeDocInfo, meta, baseCaseMetadata);
+            expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetInlineLink, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #openSmartSnippetSuggestionSource', async () => {
+            const meta = {
+                question: 'Abc',
+                answerSnippet: 'Def',
+                documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+            };
+
+            const expectedMetadata = {
+                ...meta,
+                ...expectedBaseCaseMetadata,
+                contentIDKey: meta.documentId.contentIdKey,
+                contentIDValue: meta.documentId.contentIdValue,
+            };
+
+            await client.logOpenSmartSnippetSuggestionSource(fakeDocInfo, meta, baseCaseMetadata);
+            expectMatchDocumentPayload(
+                SearchPageEvents.openSmartSnippetSuggestionSource,
+                fakeDocInfo,
+                expectedMetadata
+            );
+        });
+
+        it('should send proper payload for #openSmartSnippetSuggestionInlineLink', async () => {
+            const meta = {
+                question: 'Abc',
+                answerSnippet: 'Def',
+                documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+                linkText: 'Some text',
+                linkURL: 'https://invalid.com',
+            };
+            const expectedMetadata = {
+                ...meta,
+                ...expectedBaseCaseMetadata,
+                contentIDKey: meta.documentId.contentIdKey,
+                contentIDValue: meta.documentId.contentIdValue,
+            };
+
+            await client.logOpenSmartSnippetSuggestionInlineLink(fakeDocInfo, meta, baseCaseMetadata);
+            expectMatchDocumentPayload(
+                SearchPageEvents.openSmartSnippetSuggestionInlineLink,
+                fakeDocInfo,
+                expectedMetadata
+            );
+        });
+
+        it('should send proper payload for #showMoreFoldedResults', async () => {
+            const expectedMetadata = {
+                ...fakeDocID,
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logShowMoreFoldedResults(fakeDocInfo, fakeDocID, baseCaseMetadata);
+            expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, expectedMetadata);
+        });
+
+        it('should send proper payload for #showLessFoldedResults', async () => {
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logShowLessFoldedResults(baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults, expectedMetadata);
+        });
+
+        it('should send proper payload for #likeGeneratedAnswer', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logLikeGeneratedAnswer(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.likeGeneratedAnswer, expectedMetadata);
+        });
+
+        it('should send proper payload for #dislikeGeneratedAnswer', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logDislikeGeneratedAnswer(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.dislikeGeneratedAnswer, expectedMetadata);
+        });
+
+        it('should send proper payload for #openGeneratedAnswerSource', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                permanentId: 'foo',
+                citationId: 'bar',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logOpenGeneratedAnswerSource(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerSourceHover', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                permanentId: 'foo',
+                citationId: 'bar',
+                citationHoverTimeMs: 100,
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerSourceHover(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerSourceHover, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerCopyToClipboard', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerCopyToClipboard(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCopyToClipboard, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerHideAnswers', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerHideAnswers(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerHideAnswers, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerShowAnswers', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerShowAnswers(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerShowAnswers, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerExpand', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerExpand(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerExpand, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerCollapse', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerCollapse(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCollapse, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerFeedbackSubmit', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                reason: <GeneratedAnswerFeedbackReason>'other',
+                details: 'foo',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerFeedbackSubmit(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerFeedbackSubmit, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerFeedbackSubmitV2', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                helpful: true,
+                readable: <GeneratedAnswerFeedbackReasonOption>'yes',
+                documented: <GeneratedAnswerFeedbackReasonOption>'no',
+                correctTopic: <GeneratedAnswerFeedbackReasonOption>'unknown',
+                hallucinationFree: <GeneratedAnswerFeedbackReasonOption>'yes',
+                details: 'foo',
+                documentUrl: 'https://document.com',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerFeedbackSubmitV2(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerFeedbackSubmitV2, expectedMetadata);
+        });
+
+        it('should send proper payload for #rephraseGeneratedAnswer', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                rephraseFormat: <GeneratedAnswerRephraseFormat>'step',
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logRephraseGeneratedAnswer(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchPayload(SearchPageEvents.rephraseGeneratedAnswer, expectedMetadata);
+        });
+
+        it('should send proper payload for #retryGeneratedAnswer', async () => {
+            const expectedMetadata = {
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logRetryGeneratedAnswer(baseCaseMetadata);
+            expectMatchPayload(SearchPageEvents.retryGeneratedAnswer, expectedMetadata);
+        });
+
+        it('should send proper payload for #generatedAnswerStreamEnd', async () => {
+            const exampleGeneratedAnswerMetadata = {
+                generativeQuestionAnsweringId: '123',
+                answerGenerated: true,
+                answerTextIsEmpty: false,
+            };
+            const expectedMetadata = {
+                ...exampleGeneratedAnswerMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+
+            await client.logGeneratedAnswerStreamEnd(exampleGeneratedAnswerMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, expectedMetadata);
+        });
+
+        it('should send proper payload for #createArticle', async () => {
+            const exampleCreateArticleMetadata = {
+                articleType: 'Knowledge__kav',
+            };
+            const expectedMetadata = {
+                ...exampleCreateArticleMetadata,
+                ...expectedBaseCaseMetadata,
+            };
+            await client.logCreateArticle(exampleCreateArticleMetadata, baseCaseMetadata);
+            expectMatchCustomEventPayload(InsightEvents.createArticle, expectedMetadata);
+        });
+    });
+
+    it('should enable analytics tracking by default', () => {
+        const c = new CoveoInsightClient({}, provider);
+        expect(c.coveoAnalyticsClient instanceof CoveoAnalyticsClient).toBe(true);
+    });
+
+    it('should allow disabling analytics on initialization', () => {
+        const c = new CoveoInsightClient({enableAnalytics: false}, provider);
+        expect(c.coveoAnalyticsClient instanceof NoopAnalytics).toBe(true);
+    });
+
+    it('should allow disabling analytics after initialization', () => {
+        const c = new CoveoInsightClient({enableAnalytics: true}, provider);
+        expect(c.coveoAnalyticsClient instanceof CoveoAnalyticsClient).toBe(true);
+        c.disable();
+        expect(c.coveoAnalyticsClient instanceof NoopAnalytics).toBe(true);
+    });
+
+    it('disabling analytics does not delete the visitorId', () => {
+        const visitorId = 'uuid';
+        Cookie.set('coveo_visitorId', visitorId);
+        const c = new CoveoInsightClient({enableAnalytics: true}, provider);
+
+        expect(Cookie.get('coveo_visitorId')).toBe(visitorId);
+        c.disable();
+        expect(Cookie.get('coveo_visitorId')).toBe(visitorId);
+    });
+
+    it('should disable analytics when doNotTrack is enabled', async () => {
+        (doNotTrack as jest.Mock).mockImplementationOnce(() => true);
+
+        const c = new CoveoInsightClient({}, provider);
+        expect(c.coveoAnalyticsClient instanceof NoopAnalytics).toBe(true);
+    });
+
+    it('should allow enabling analytics after initialization', () => {
+        const c = new CoveoInsightClient({enableAnalytics: false}, provider);
+        expect(c.coveoAnalyticsClient instanceof NoopAnalytics).toBe(true);
+        c.enable();
+        expect(c.coveoAnalyticsClient instanceof CoveoAnalyticsClient).toBe(true);
+    });
+
+    it('should send proper payload for #contextChanged', async () => {
+        const meta = {
+            caseId: '1234',
+            caseNumber: '5678',
+            caseContext: {Case_Subject: 'test subject', Case_Description: 'test description'},
+        };
+
+        const expectedMeta = {
+            CaseId: '1234',
+            CaseNumber: '5678',
+            CaseSubject: 'test subject',
+            context_Case_Subject: 'test subject',
+            context_Case_Description: 'test description',
+        };
+
+        await client.logContextChanged(meta);
+        expectMatchPayload(InsightEvents.contextChanged, expectedMeta);
+    });
+
+    it('should send proper payload for #expandToFullUI', async () => {
+        const meta = {
+            caseId: '1234',
+            caseNumber: '5678',
+            caseContext: {Case_Subject: 'test subject', Case_Description: 'test description'},
+            fullSearchComponentName: 'c__FullSearch',
+            triggeredBy: 'openFullSearchButton',
+        };
+
+        const expectedMeta = {
+            CaseId: '1234',
+            CaseNumber: '5678',
+            CaseSubject: 'test subject',
+            fullSearchComponentName: 'c__FullSearch',
+            triggeredBy: 'openFullSearchButton',
+        };
+        await client.logExpandToFullUI(meta);
+        expectMatchCustomEventPayload(InsightEvents.expandToFullUI, expectedMeta);
+    });
+
+    it('should send proper payload for #logOpenUserActions', async () => {
+        await client.logOpenUserActions(baseCaseMetadata);
+        expectMatchCustomEventPayload(InsightEvents.openUserActions, expectedBaseCaseMetadata);
+    });
+
+    it('should send proper payload for #logShowPrecedingSession', async () => {
+        await client.logShowPrecedingSessions(baseCaseMetadata);
+        expectMatchCustomEventPayload(InsightEvents.showPrecedingSessions, expectedBaseCaseMetadata);
+    });
+
+    it('should send proper payload for #logShowFollowingSession', async () => {
+        await client.logShowFollowingSessions(baseCaseMetadata);
+        expectMatchCustomEventPayload(InsightEvents.showFollowingSessions, expectedBaseCaseMetadata);
+    });
+
+    it('should send proper payload for #logViewedDocumentClick', async () => {
+        const document = {
+            title: 'Some Title',
+            uri: 'https://www.some-uri.com',
+            uriHash: 'Acp8NfEWi0DeðeZU',
+            permanentId: '8c88cd894t2767a96fa4f109041bb62bb54ca21ff31c1d760814b60cbcf2',
+        };
+        await client.logViewedDocumentClick(document, baseCaseMetadata);
+        expectMatchCustomEventPayload(InsightEvents.clickViewedDocument, {
+            ...expectedBaseCaseMetadata,
+            document,
+        });
+    });
+
+    it('should send proper payload for #logPageViewClick', async () => {
+        const pageView = {
+            title: 'Some Title',
+            contentIdKey: 'someKey',
+            contentIdValue: 'some-content-id-value',
+        };
+        await client.logPageViewClick(pageView, baseCaseMetadata);
+        expectMatchCustomEventPayload(InsightEvents.clickPageView, {
+            ...expectedBaseCaseMetadata,
+            pageView,
+        });
+    });
+});

--- a/packages/coveo-analytics/src/insight/insightClient.ts
+++ b/packages/coveo-analytics/src/insight/insightClient.ts
@@ -1,0 +1,736 @@
+import CoveoAnalyticsClient, {AnalyticsClient, ClientOptions} from '../client/analytics';
+import {NoopAnalytics} from '../client/noopAnalytics';
+import doNotTrack from '../donottrack';
+import {ClickEventRequest, CustomEventRequest, SearchEventRequest} from '../events';
+import {
+    CustomEventsTypes,
+    DocumentIdentifier,
+    FacetStateMetadata,
+    GeneratedAnswerBaseMeta,
+    GeneratedAnswerCitationMeta,
+    GeneratedAnswerFeedbackMeta,
+    GeneratedAnswerFeedbackMetaV2,
+    GeneratedAnswerRephraseMeta,
+    GeneratedAnswerSourceHoverMeta,
+    GeneratedAnswerStreamEndMeta,
+    PartialDocumentInformation,
+    SearchPageEvents,
+    SmartSnippetDocumentIdentifier,
+    SmartSnippetFeedbackReason,
+    SmartSnippetLinkMeta,
+    SmartSnippetSuggestionMeta,
+} from '../searchPage/searchPageEvents';
+import {
+    ExpandToFullUIMetadata,
+    InsightEvents,
+    InsightFacetMetadata,
+    InsightInterfaceChangeMetadata,
+    InsightStaticFilterToggleValueMetadata,
+    InsightFacetRangeMetadata,
+    InsightCategoryFacetMetadata,
+    CaseMetadata,
+    InsightFacetSortMeta,
+    InsightFacetBaseMeta,
+    InsightQueryErrorMeta,
+    InsightPagerMetadata,
+    InsightResultsSortMetadata,
+    UserActionsDocumentMetadata,
+    UserActionsPageViewMetadata,
+    CreateArticleMetadata,
+} from './insightEvents';
+
+export interface InsightClientProvider {
+    getSearchEventRequestPayload: () => Omit<SearchEventRequest, 'actionCause' | 'searchQueryUid'>;
+    getSearchUID: () => string;
+    getBaseMetadata: () => Record<string, any>;
+    getPipeline: () => string;
+    getOriginContext?: () => string;
+    getOriginLevel1: () => string;
+    getOriginLevel2: () => string;
+    getOriginLevel3: () => string;
+    getLanguage: () => string;
+    getIsAnonymous: () => boolean;
+    getFacetState?: () => FacetStateMetadata[];
+    getGeneratedAnswerMetadata?: () => Record<string, any>;
+}
+
+export interface InsightClientOptions extends ClientOptions {
+    enableAnalytics: boolean;
+}
+
+const extractContextFromMetadata = (meta: {caseContext?: Record<string, string>}) => {
+    const context: Record<string, string> = {};
+    if (meta.caseContext) {
+        Object.keys(meta.caseContext).forEach((contextKey) => {
+            const value = meta.caseContext?.[contextKey];
+            if (value) {
+                const keyToBeSent = `context_${contextKey}`;
+                context[keyToBeSent] = value;
+            }
+        });
+    }
+    return context;
+};
+
+const generateMetadataToSend = (metadata: CaseMetadata, includeContext = true) => {
+    const {caseContext, caseId, caseNumber, ...metadataWithoutContext} = metadata;
+    const context = extractContextFromMetadata(metadata);
+
+    return {
+        CaseId: caseId,
+        CaseNumber: caseNumber,
+        ...metadataWithoutContext,
+        ...(!!context.context_Case_Subject && {CaseSubject: context.context_Case_Subject}),
+        ...(includeContext && context),
+    };
+};
+
+export class CoveoInsightClient {
+    public coveoAnalyticsClient: AnalyticsClient;
+
+    constructor(private opts: Partial<InsightClientOptions>, private provider: InsightClientProvider) {
+        const shouldDisableAnalytics = opts.enableAnalytics === false || doNotTrack();
+        this.coveoAnalyticsClient = shouldDisableAnalytics ? new NoopAnalytics() : new CoveoAnalyticsClient(opts);
+    }
+
+    public disable() {
+        this.coveoAnalyticsClient = new NoopAnalytics();
+    }
+
+    public enable() {
+        this.coveoAnalyticsClient = new CoveoAnalyticsClient(this.opts);
+    }
+
+    public logInterfaceLoad(metadata?: CaseMetadata) {
+        if (metadata) {
+            const metadataToSend = generateMetadataToSend(metadata);
+            return this.logSearchEvent(SearchPageEvents.interfaceLoad, metadataToSend);
+        }
+        return this.logSearchEvent(SearchPageEvents.interfaceLoad);
+    }
+
+    public logInterfaceChange(metadata: InsightInterfaceChangeMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logSearchEvent(SearchPageEvents.interfaceChange, metadataToSend);
+    }
+
+    public logStaticFilterDeselect(metadata: InsightStaticFilterToggleValueMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logSearchEvent(SearchPageEvents.staticFilterDeselect, metadataToSend);
+    }
+
+    public logFetchMoreResults(metadata?: CaseMetadata) {
+        if (metadata) {
+            const metadataToSend = generateMetadataToSend(metadata);
+            return this.logCustomEvent(SearchPageEvents.pagerScrolling, {...metadataToSend, type: 'getMoreResults'});
+        }
+        return this.logCustomEvent(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
+    }
+
+    public logBreadcrumbFacet(
+        metadata: InsightFacetMetadata | InsightFacetRangeMetadata | InsightCategoryFacetMetadata
+    ) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logSearchEvent(SearchPageEvents.breadcrumbFacet, metadataToSend);
+    }
+
+    public logBreadcrumbResetAll(metadata?: CaseMetadata) {
+        if (metadata) {
+            const metadataToSend = generateMetadataToSend(metadata);
+            return this.logSearchEvent(SearchPageEvents.breadcrumbResetAll, metadataToSend);
+        }
+        return this.logSearchEvent(SearchPageEvents.breadcrumbResetAll);
+    }
+
+    public logFacetSelect(metadata: InsightFacetMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logSearchEvent(SearchPageEvents.facetSelect, metadataToSend);
+    }
+
+    public logFacetExclude(metadata: InsightFacetMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logSearchEvent(SearchPageEvents.facetExclude, metadataToSend);
+    }
+
+    public logFacetDeselect(metadata: InsightFacetMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logSearchEvent(SearchPageEvents.facetDeselect, metadataToSend);
+    }
+
+    public logFacetUpdateSort(metadata: InsightFacetSortMeta) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logSearchEvent(SearchPageEvents.facetUpdateSort, metadataToSend);
+    }
+
+    public logFacetClearAll(metadata: InsightFacetBaseMeta) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logSearchEvent(SearchPageEvents.facetClearAll, metadataToSend);
+    }
+
+    public logFacetShowMore(metadata: InsightFacetBaseMeta) {
+        const metadataToSend = generateMetadataToSend(metadata, false);
+        return this.logCustomEvent(SearchPageEvents.facetShowMore, metadataToSend);
+    }
+
+    public logFacetShowLess(metadata: InsightFacetBaseMeta) {
+        const metadataToSend = generateMetadataToSend(metadata, false);
+        return this.logCustomEvent(SearchPageEvents.facetShowLess, metadataToSend);
+    }
+
+    public logQueryError(metadata: InsightQueryErrorMeta) {
+        const metadataToSend = generateMetadataToSend(metadata, false);
+        return this.logCustomEvent(SearchPageEvents.queryError, metadataToSend);
+    }
+
+    public logPagerNumber(metadata: InsightPagerMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata, false);
+        return this.logCustomEvent(SearchPageEvents.pagerNumber, metadataToSend);
+    }
+
+    public logPagerNext(metadata: InsightPagerMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata, false);
+        return this.logCustomEvent(SearchPageEvents.pagerNext, metadataToSend);
+    }
+
+    public logPagerPrevious(metadata: InsightPagerMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata, false);
+        return this.logCustomEvent(SearchPageEvents.pagerPrevious, metadataToSend);
+    }
+
+    public logDidYouMeanAutomatic(metadata?: CaseMetadata) {
+        if (metadata) {
+            const metadataToSend = generateMetadataToSend(metadata);
+            return this.logSearchEvent(SearchPageEvents.didyoumeanAutomatic, metadataToSend);
+        }
+        return this.logSearchEvent(SearchPageEvents.didyoumeanAutomatic);
+    }
+
+    public logDidYouMeanClick(metadata?: CaseMetadata) {
+        if (metadata) {
+            const metadataToSend = generateMetadataToSend(metadata);
+            return this.logSearchEvent(SearchPageEvents.didyoumeanClick, metadataToSend);
+        }
+        return this.logSearchEvent(SearchPageEvents.didyoumeanClick);
+    }
+
+    public logResultsSort(metadata: InsightResultsSortMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logSearchEvent(SearchPageEvents.resultsSort, metadataToSend);
+    }
+
+    public logSearchboxSubmit(metadata?: CaseMetadata) {
+        if (metadata) {
+            const metadataToSend = generateMetadataToSend(metadata);
+            return this.logSearchEvent(SearchPageEvents.searchboxSubmit, metadataToSend);
+        }
+        return this.logSearchEvent(SearchPageEvents.searchboxSubmit);
+    }
+
+    public logContextChanged(metadata: CaseMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logSearchEvent(InsightEvents.contextChanged, metadataToSend);
+    }
+
+    public logExpandToFullUI(metadata: ExpandToFullUIMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata);
+        return this.logCustomEvent(InsightEvents.expandToFullUI, metadataToSend);
+    }
+
+    public logOpenUserActions(metadata: CaseMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata, false);
+        return this.logCustomEvent(InsightEvents.openUserActions, metadataToSend);
+    }
+
+    public logShowPrecedingSessions(metadata: CaseMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata, false);
+        return this.logCustomEvent(InsightEvents.showPrecedingSessions, metadataToSend);
+    }
+
+    public logShowFollowingSessions(metadata: CaseMetadata) {
+        const metadataToSend = generateMetadataToSend(metadata, false);
+        return this.logCustomEvent(InsightEvents.showFollowingSessions, metadataToSend);
+    }
+
+    public logViewedDocumentClick(document: UserActionsDocumentMetadata, metadata: CaseMetadata) {
+        return this.logCustomEvent(InsightEvents.clickViewedDocument, {
+            ...generateMetadataToSend(metadata, false),
+            document,
+        });
+    }
+
+    public logPageViewClick(pageView: UserActionsPageViewMetadata, metadata: CaseMetadata) {
+        return this.logCustomEvent(InsightEvents.clickPageView, {
+            ...generateMetadataToSend(metadata, false),
+            pageView,
+        });
+    }
+
+    public logCreateArticle(createArticleMetadata: CreateArticleMetadata, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            InsightEvents.createArticle,
+            metadata ? {...generateMetadataToSend(metadata, false), ...createArticleMetadata} : createArticleMetadata
+        );
+    }
+
+    public logDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier, metadata?: CaseMetadata) {
+        return this.logClickEvent(
+            SearchPageEvents.documentOpen,
+            info,
+            identifier,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logCopyToClipboard(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: CaseMetadata
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.copyToClipboard,
+            info,
+            identifier,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logCaseSendEmail(info: PartialDocumentInformation, identifier: DocumentIdentifier, metadata?: CaseMetadata) {
+        return this.logClickEvent(
+            SearchPageEvents.caseSendEmail,
+            info,
+            identifier,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logFeedItemTextPost(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: CaseMetadata
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.feedItemTextPost,
+            info,
+            identifier,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logDocumentQuickview(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        caseMetadata?: CaseMetadata
+    ) {
+        const metadata = {
+            documentTitle: info.documentTitle,
+            documentURL: info.documentUrl,
+        };
+        return this.logClickEvent(
+            SearchPageEvents.documentQuickview,
+            info,
+            identifier,
+            caseMetadata ? {...generateMetadataToSend(caseMetadata, false), ...metadata} : metadata
+        );
+    }
+
+    public logCaseAttach(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        caseMetadata?: CaseMetadata
+    ) {
+        const metadata = {
+            documentTitle: info.documentTitle,
+            documentURL: info.documentUrl,
+            resultUriHash: info.documentUriHash,
+        };
+
+        return this.logClickEvent(
+            SearchPageEvents.caseAttach,
+            info,
+            identifier,
+            caseMetadata ? {...generateMetadataToSend(caseMetadata, false), ...metadata} : metadata
+        );
+    }
+
+    public logCaseDetach(resultUriHash: string, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.caseDetach,
+            metadata ? {...generateMetadataToSend(metadata, false), resultUriHash} : {resultUriHash}
+        );
+    }
+
+    public logLikeSmartSnippet(metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.likeSmartSnippet,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logDislikeSmartSnippet(metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.dislikeSmartSnippet,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logExpandSmartSnippet(metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.expandSmartSnippet,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logCollapseSmartSnippet(metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.collapseSmartSnippet,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logOpenSmartSnippetFeedbackModal(metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.openSmartSnippetFeedbackModal,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logCloseSmartSnippetFeedbackModal(metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.closeSmartSnippetFeedbackModal,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logSmartSnippetFeedbackReason(
+        reason: SmartSnippetFeedbackReason,
+        details?: string,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.sendSmartSnippetReason,
+            metadata ? {...generateMetadataToSend(metadata, false), reason, details} : {reason, details}
+        );
+    }
+
+    public logExpandSmartSnippetSuggestion(
+        snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier,
+        metadata?: CaseMetadata
+    ) {
+        const snippetMetadata = 'documentId' in snippet ? snippet : {documentId: snippet};
+        return this.logCustomEvent(
+            SearchPageEvents.expandSmartSnippetSuggestion,
+            metadata ? {...generateMetadataToSend(metadata, false), ...snippetMetadata} : snippetMetadata
+        );
+    }
+
+    public logCollapseSmartSnippetSuggestion(
+        snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier,
+        metadata?: CaseMetadata
+    ) {
+        const snippetMetadata = 'documentId' in snippet ? snippet : {documentId: snippet};
+        return this.logCustomEvent(
+            SearchPageEvents.collapseSmartSnippetSuggestion,
+            metadata ? {...generateMetadataToSend(metadata, false), ...snippetMetadata} : snippetMetadata
+        );
+    }
+
+    public logOpenSmartSnippetSource(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: CaseMetadata
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.openSmartSnippetSource,
+            info,
+            identifier,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public logOpenSmartSnippetSuggestionSource(
+        info: PartialDocumentInformation,
+        snippet: SmartSnippetSuggestionMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.openSmartSnippetSuggestionSource,
+            info,
+            {contentIDKey: snippet.documentId.contentIdKey, contentIDValue: snippet.documentId.contentIdValue},
+            metadata ? {...generateMetadataToSend(metadata, false), ...snippet} : snippet
+        );
+    }
+
+    public logOpenSmartSnippetInlineLink(
+        info: PartialDocumentInformation,
+        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.openSmartSnippetInlineLink,
+            info,
+            {contentIDKey: identifierAndLink.contentIDKey, contentIDValue: identifierAndLink.contentIDValue},
+            metadata ? {...generateMetadataToSend(metadata, false), ...identifierAndLink} : identifierAndLink
+        );
+    }
+
+    public logOpenSmartSnippetSuggestionInlineLink(
+        info: PartialDocumentInformation,
+        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.openSmartSnippetSuggestionInlineLink,
+            info,
+            {
+                contentIDKey: snippetAndLink.documentId.contentIdKey,
+                contentIDValue: snippetAndLink.documentId.contentIdValue,
+            },
+            metadata ? {...generateMetadataToSend(metadata, false), ...snippetAndLink} : snippetAndLink
+        );
+    }
+
+    public logLikeGeneratedAnswer(generatedAnswerMetadata: GeneratedAnswerBaseMeta, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.likeGeneratedAnswer,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerMetadata}
+                : generatedAnswerMetadata
+        );
+    }
+
+    public logDislikeGeneratedAnswer(generatedAnswerMetadata: GeneratedAnswerBaseMeta, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.dislikeGeneratedAnswer,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerMetadata}
+                : generatedAnswerMetadata
+        );
+    }
+
+    public logOpenGeneratedAnswerSource(
+        generatedAnswerSourceMetadata: GeneratedAnswerCitationMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.openGeneratedAnswerSource,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerSourceMetadata}
+                : generatedAnswerSourceMetadata
+        );
+    }
+
+    public logGeneratedAnswerSourceHover(
+        generatedAnswerSourceMetadata: GeneratedAnswerSourceHoverMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerSourceHover,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerSourceMetadata}
+                : generatedAnswerSourceMetadata
+        );
+    }
+
+    public logGeneratedAnswerCopyToClipboard(
+        generatedAnswerMetadata: GeneratedAnswerBaseMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerCopyToClipboard,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerMetadata}
+                : generatedAnswerMetadata
+        );
+    }
+
+    public logGeneratedAnswerHideAnswers(generatedAnswerMetadata: GeneratedAnswerBaseMeta, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerHideAnswers,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerMetadata}
+                : generatedAnswerMetadata
+        );
+    }
+
+    public logGeneratedAnswerShowAnswers(generatedAnswerMetadata: GeneratedAnswerBaseMeta, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerShowAnswers,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerMetadata}
+                : generatedAnswerMetadata
+        );
+    }
+
+    public logGeneratedAnswerExpand(generatedAnswerMetadata: GeneratedAnswerBaseMeta, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerExpand,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerMetadata}
+                : generatedAnswerMetadata
+        );
+    }
+
+    public logGeneratedAnswerCollapse(generatedAnswerMetadata: GeneratedAnswerBaseMeta, metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerCollapse,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerMetadata}
+                : generatedAnswerMetadata
+        );
+    }
+
+    public logGeneratedAnswerFeedbackSubmit(
+        generatedAnswerFeedbackMetadata: GeneratedAnswerFeedbackMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerFeedbackSubmit,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerFeedbackMetadata}
+                : generatedAnswerFeedbackMetadata
+        );
+    }
+
+    public logGeneratedAnswerFeedbackSubmitV2(
+        generatedAnswerFeedbackMetadata: GeneratedAnswerFeedbackMetaV2,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerFeedbackSubmitV2,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerFeedbackMetadata}
+                : generatedAnswerFeedbackMetadata
+        );
+    }
+
+    public logRephraseGeneratedAnswer(
+        generatedAnswerRephraseMetadata: GeneratedAnswerRephraseMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logSearchEvent(
+            SearchPageEvents.rephraseGeneratedAnswer,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerRephraseMetadata}
+                : generatedAnswerRephraseMetadata
+        );
+    }
+
+    public logRetryGeneratedAnswer(metadata?: CaseMetadata) {
+        return this.logSearchEvent(
+            SearchPageEvents.retryGeneratedAnswer,
+            metadata ? {...generateMetadataToSend(metadata, false)} : {}
+        );
+    }
+
+    public logGeneratedAnswerStreamEnd(
+        generatedAnswerStreamEndMetadata: GeneratedAnswerStreamEndMeta,
+        metadata?: CaseMetadata
+    ) {
+        return this.logCustomEvent(
+            SearchPageEvents.generatedAnswerStreamEnd,
+            metadata
+                ? {...generateMetadataToSend(metadata, false), ...generatedAnswerStreamEndMetadata}
+                : generatedAnswerStreamEndMetadata
+        );
+    }
+
+    public async logCustomEvent(event: SearchPageEvents | InsightEvents, metadata?: Record<string, any>) {
+        const customData = {...this.provider.getBaseMetadata(), ...metadata};
+
+        const payload: CustomEventRequest = {
+            ...(await this.getBaseCustomEventRequest(customData)),
+            eventType: CustomEventsTypes[event]!,
+            eventValue: event,
+        };
+
+        return this.coveoAnalyticsClient.sendCustomEvent(payload);
+    }
+
+    public async logSearchEvent(event: SearchPageEvents | InsightEvents, metadata?: Record<string, any>) {
+        return this.coveoAnalyticsClient.sendSearchEvent(await this.getBaseSearchEventRequest(event, metadata));
+    }
+
+    public async logClickEvent(
+        event: SearchPageEvents,
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: Record<string, any>
+    ) {
+        const payload: ClickEventRequest = {
+            ...info,
+            ...(await this.getBaseEventRequest({...identifier, ...metadata})),
+            searchQueryUid: this.provider.getSearchUID(),
+            queryPipeline: this.provider.getPipeline(),
+            actionCause: event,
+        };
+
+        return this.coveoAnalyticsClient.sendClickEvent(payload);
+    }
+
+    public async logShowMoreFoldedResults(
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: CaseMetadata
+    ) {
+        return this.logClickEvent(
+            SearchPageEvents.showMoreFoldedResults,
+            info,
+            identifier,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    public async logShowLessFoldedResults(metadata?: CaseMetadata) {
+        return this.logCustomEvent(
+            SearchPageEvents.showLessFoldedResults,
+            metadata ? generateMetadataToSend(metadata, false) : undefined
+        );
+    }
+
+    private async getBaseCustomEventRequest(metadata?: Record<string, any>) {
+        return {
+            ...(await this.getBaseEventRequest(metadata)),
+            lastSearchQueryUid: this.provider.getSearchUID(),
+        };
+    }
+
+    private async getBaseSearchEventRequest(
+        event: SearchPageEvents | InsightEvents,
+        metadata?: Record<string, any>
+    ): Promise<SearchEventRequest> {
+        return {
+            ...(await this.getBaseEventRequest({...metadata, ...this.provider.getGeneratedAnswerMetadata?.()})),
+            ...this.provider.getSearchEventRequestPayload(),
+            searchQueryUid: this.provider.getSearchUID(),
+            queryPipeline: this.provider.getPipeline(),
+            actionCause: event,
+        };
+    }
+
+    private async getBaseEventRequest(metadata?: Record<string, any>) {
+        const customData = {...this.provider.getBaseMetadata(), ...metadata};
+        return {
+            ...this.getOrigins(),
+            customData,
+            language: this.provider.getLanguage(),
+            facetState: this.provider.getFacetState ? this.provider.getFacetState() : [],
+            anonymous: this.provider.getIsAnonymous(),
+            clientId: await this.getClientId(),
+        };
+    }
+
+    private getOrigins() {
+        return {
+            originContext: this.provider.getOriginContext?.(),
+            originLevel1: this.provider.getOriginLevel1(),
+            originLevel2: this.provider.getOriginLevel2(),
+            originLevel3: this.provider.getOriginLevel3(),
+        };
+    }
+
+    private getClientId() {
+        return this.coveoAnalyticsClient instanceof CoveoAnalyticsClient
+            ? this.coveoAnalyticsClient.getCurrentVisitorId()
+            : undefined;
+    }
+}

--- a/packages/coveo-analytics/src/insight/insightEvents.ts
+++ b/packages/coveo-analytics/src/insight/insightEvents.ts
@@ -1,0 +1,95 @@
+import {
+    CategoryFacetMetadata,
+    FacetBaseMeta,
+    FacetMetadata,
+    FacetRangeMetadata,
+    FacetSortMeta,
+    InterfaceChangeMetadata,
+    PagerMetadata,
+    QueryErrorMeta,
+    ResultsSortMetadata,
+    StaticFilterToggleValueMetadata,
+} from '../searchPage/searchPageEvents';
+
+export enum InsightEvents {
+    /**
+     * Identifies the search event that gets logged when the query context is updated as a result of updating one of the case context fields.
+     */
+    contextChanged = 'contextChanged',
+    /**
+     * Identifies the event that gets logged when the user opens the full search page from the insight panel.
+     */
+    expandToFullUI = 'expandToFullUI',
+    /**
+     * Identifies the event that gets logged when the user opens the user actions section.
+     */
+    openUserActions = 'openUserActions',
+    /**
+     * Identifies the event that gets logged when the user clicks to view user action sessions preceding the ticket creation.
+     */
+    showPrecedingSessions = 'showPrecedingSessions',
+    /**
+     * Identifies the event that gets logged when the user clicks to view user action sessions following the ticket creation.
+     */
+    showFollowingSessions = 'showFollowingSessions',
+    /**
+     * Identifies the event that gets logged when the user clicks a viewed document link on the user actions timeline.
+     */
+    clickViewedDocument = 'clickViewedDocument',
+    /**
+     * Identifies the event that gets logged when the user clicks a viewed page link on the user actions timeline.
+     */
+    clickPageView = 'clickPageView',
+    /**
+     * Identifies the event that gets logged when the user clicks the create article button.
+     */
+    createArticle = 'createArticle',
+}
+
+export interface CaseMetadata {
+    caseId?: string;
+    caseNumber?: string;
+    caseContext?: Record<string, string>;
+}
+
+export interface ExpandToFullUIMetadata extends CaseMetadata {
+    fullSearchComponentName: string;
+    triggeredBy: string;
+}
+
+export interface UserActionsDocumentMetadata {
+    title: string;
+    uri: string;
+    uriHash?: string;
+    permanentId?: string;
+}
+
+export interface UserActionsPageViewMetadata {
+    title: string;
+    contentIdKey: string;
+    contentIdValue: string;
+}
+
+export interface CreateArticleMetadata {
+    articleType: string;
+}
+
+export interface InsightInterfaceChangeMetadata extends InterfaceChangeMetadata, CaseMetadata {}
+
+export interface InsightFacetMetadata extends FacetMetadata, CaseMetadata {}
+
+export interface InsightStaticFilterToggleValueMetadata extends StaticFilterToggleValueMetadata, CaseMetadata {}
+
+export interface InsightFacetRangeMetadata extends FacetRangeMetadata, CaseMetadata {}
+
+export interface InsightCategoryFacetMetadata extends CategoryFacetMetadata, CaseMetadata {}
+
+export interface InsightFacetSortMeta extends FacetSortMeta, CaseMetadata {}
+
+export interface InsightFacetBaseMeta extends FacetBaseMeta, CaseMetadata {}
+
+export interface InsightQueryErrorMeta extends QueryErrorMeta, CaseMetadata {}
+
+export interface InsightPagerMetadata extends PagerMetadata, CaseMetadata {}
+
+export interface InsightResultsSortMetadata extends ResultsSortMetadata, CaseMetadata {}

--- a/packages/coveo-analytics/src/plugins/BasePlugin.ts
+++ b/packages/coveo-analytics/src/plugins/BasePlugin.ts
@@ -1,0 +1,151 @@
+import {AnalyticsClient} from '../client/analytics';
+import {v4 as uuidv4} from 'uuid';
+import {getFormattedLocation} from '../client/location';
+import {hasDocument} from '../detector';
+
+type PluginWithId = {
+    readonly Id: string;
+};
+
+export type PluginClass = typeof Plugin & PluginWithId;
+export const BasePluginEventTypes = {
+    pageview: 'pageview',
+    event: 'event',
+};
+
+export type PluginOptions = {client: AnalyticsClient; uuidGenerator?: typeof uuidv4};
+
+export abstract class Plugin {
+    protected client: AnalyticsClient;
+    protected uuidGenerator: typeof uuidv4;
+    constructor({client, uuidGenerator = uuidv4}: PluginOptions) {
+        this.client = client;
+        this.uuidGenerator = uuidGenerator;
+    }
+    public abstract getApi(name: string): any;
+}
+
+export abstract class BasePlugin extends Plugin {
+    protected action?: string;
+    protected actionData: {[name: string]: string} = {};
+    private pageViewId: string;
+    private nextPageViewId: string;
+    private hasSentFirstPageView?: boolean;
+    private currentLocation: string;
+    private lastReferrer: string;
+
+    constructor({client, uuidGenerator = uuidv4}: PluginOptions) {
+        super({client, uuidGenerator});
+        this.pageViewId = uuidGenerator();
+        this.nextPageViewId = this.pageViewId;
+        this.currentLocation = getFormattedLocation(window.location);
+        this.lastReferrer = hasDocument() ? document.referrer : '';
+
+        this.addHooks();
+    }
+    protected abstract addHooks(): void;
+    protected abstract clearPluginData(): void;
+
+    public getApi(name: string): Function | null {
+        switch (name) {
+            case 'setAction':
+                return this.setAction;
+            default:
+                return null;
+        }
+    }
+
+    public setAction(action: string, options?: any) {
+        this.action = action;
+        this.actionData = options;
+    }
+
+    public clearData() {
+        this.clearPluginData();
+        this.action = undefined;
+        this.actionData = {};
+    }
+
+    public getLocationInformation(eventType: string, payload: any) {
+        return {
+            hitType: eventType,
+            ...this.getNextValues(eventType, payload),
+        };
+    }
+
+    protected updateLocationInformation(eventType: string, payload: any) {
+        this.updateLocationForNextPageView(eventType, payload);
+    }
+
+    public getDefaultContextInformation(eventType: string) {
+        const documentContext = {
+            title: hasDocument() ? document.title : '',
+            encoding: hasDocument() ? document.characterSet : 'UTF-8',
+        };
+        const screenContext = {
+            screenResolution: `${screen.width}x${screen.height}`,
+            screenColor: `${screen.colorDepth}-bit`,
+        };
+        const navigatorContext = {
+            language: navigator.language,
+            userAgent: navigator.userAgent,
+        };
+        const eventContext = {
+            time: Date.now(),
+            eventId: this.uuidGenerator(),
+        };
+        return {
+            ...eventContext,
+            ...screenContext,
+            ...navigatorContext,
+            ...documentContext,
+        };
+    }
+
+    private updateLocationForNextPageView(eventType: string, payload: any) {
+        const {pageViewId, referrer, location} = this.getNextValues(eventType, payload);
+
+        this.lastReferrer = referrer;
+        this.pageViewId = pageViewId;
+        this.currentLocation = location;
+
+        if (eventType === BasePluginEventTypes.pageview) {
+            this.nextPageViewId = this.uuidGenerator();
+            this.hasSentFirstPageView = true;
+        }
+    }
+
+    /*
+        When calling getPayload or getParameters, we need to return what would be sent by the API without updating our internal reference.
+        For instance, if you getPayload("pageview"), we want to return the same payload as if you did coveoua("send", "pageview").
+    */
+    private getNextValues(eventType: string, payload: any) {
+        /*
+            When sending a pageview, we need to generate a new pageview ID.
+            For instance, with the following sequence: 1. pageview, 2. event, 3. pageview, 4. event, 1 and 2 will have the pageviewid, whereas 3 and 4 will have a different pageviewid.
+            We pre-generate the "nextPageViewId" in case you send the following sequence: 1. pageview, 2. event, 3. getPayload, 4. pageview. This ensures that 3 and 4 have the same pageviewid.
+            We applied the same logic to the referrer and the location.
+        */
+        return {
+            pageViewId: eventType === BasePluginEventTypes.pageview ? this.nextPageViewId : this.pageViewId,
+            referrer:
+                eventType === BasePluginEventTypes.pageview && this.hasSentFirstPageView
+                    ? this.currentLocation
+                    : this.lastReferrer,
+            location:
+                eventType === BasePluginEventTypes.pageview
+                    ? this.getCurrentLocationFromPayload(payload)
+                    : this.currentLocation,
+        };
+    }
+
+    private getCurrentLocationFromPayload(payload: any) {
+        if (!!payload.page) {
+            const removeStartingSlash = (page: string) => page.replace(/^\/?(.*)$/, '/$1');
+            const extractHostnamePart = (location: string) => location.split('/').slice(0, 3).join('/');
+            return `${extractHostnamePart(this.currentLocation)}${removeStartingSlash(payload.page)}`;
+        } else {
+            return getFormattedLocation(window.location);
+        }
+    }
+}

--- a/packages/coveo-analytics/src/plugins/ec.spec.ts
+++ b/packages/coveo-analytics/src/plugins/ec.spec.ts
@@ -1,0 +1,608 @@
+import {ECPlugin, ECPluginEventTypes, Product} from './ec';
+import {createAnalyticsClientMock} from '../../tests/analyticsClientMock';
+
+describe('EC plugin', () => {
+    let ec: ECPlugin;
+    let client: ReturnType<typeof createAnalyticsClientMock>;
+
+    const someUUIDGenerator = jest.fn(() => someUUID);
+    const someUUID = '13ccebdb-0138-45e8-bf70-884817ead190';
+    const defaultResult = {
+        pageViewId: someUUID,
+        encoding: document.characterSet,
+        location: 'http://localhost/',
+        referrer: 'http://somewhere.over/thereferrer',
+        title: 'MAH PAGE',
+        screenColor: '24-bit',
+        screenResolution: '0x0',
+        time: expect.any(Number),
+        userAgent: navigator.userAgent,
+        language: 'en-US',
+        hitType: ECPluginEventTypes.event,
+        eventId: someUUID,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        client = createAnalyticsClientMock();
+        ec = new ECPlugin({client, uuidGenerator: someUUIDGenerator as any});
+    });
+
+    it('should register a hook in the client', () => {
+        expect(client.registerBeforeSendEventHook).toHaveBeenCalledTimes(1);
+    });
+
+    it('should register a mapping for each EC type', () => {
+        expect(client.addEventTypeMapping).toHaveBeenCalledTimes(Object.keys(ECPluginEventTypes).length);
+    });
+
+    describe('products', () => {
+        it('should append the product with the specific format when the hook is called', () => {
+            ec.addProduct({id: 'C0V30'});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).toEqual({...defaultResult, pr1id: 'C0V30'});
+        });
+
+        it('should not append the product with the pageview event', () => {
+            ec.addProduct({name: 'Relevance T-Shirt'});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+
+            expect(result).toEqual({...defaultResult, hitType: ECPluginEventTypes.pageview});
+        });
+
+        it('should not append the product with a random event type', () => {
+            ec.addProduct({id: ':sorandom:'});
+
+            const result = executeRegisteredHook('🎲', {});
+
+            expect(result).toEqual({});
+        });
+
+        it('should keep the products until an event type is used', () => {
+            ec.addProduct({id: 'P12345'});
+
+            executeRegisteredHook('🎲', {});
+            executeRegisteredHook('🐟', {});
+            const pageviewResult = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(pageviewResult).toEqual({...defaultResult, hitType: ECPluginEventTypes.pageview});
+            expect(result).toEqual({...defaultResult, pr1id: 'P12345'});
+        });
+
+        it('should convert known product keys into the measurement protocol format', () => {
+            ec.addProduct({name: '🧀', price: 5.99});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).toEqual({...defaultResult, pr1nm: '🧀', pr1pr: 5.99});
+        });
+
+        it('should keep custom metadata in the product', () => {
+            ec.addProduct({name: '🧀', price: 5.99, custom: {verycustom: 'value'}});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).toEqual({...defaultResult, pr1nm: '🧀', pr1pr: 5.99, pr1custom: {verycustom: 'value'}});
+        });
+
+        it('should allow adding multiple products', () => {
+            ec.addProduct({name: '🍟', price: 1.99});
+            ec.addProduct({name: '🍿', price: 3});
+            ec.addProduct({name: '🥤', price: 2});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).toEqual({
+                ...defaultResult,
+                pr1nm: '🍟',
+                pr1pr: 1.99,
+                pr2nm: '🍿',
+                pr2pr: 3,
+                pr3nm: '🥤',
+                pr3pr: 2,
+            });
+        });
+
+        it('should flush the products once they are sent', () => {
+            ec.addProduct({name: '🍟', price: 1.99});
+            ec.addProduct({name: '🍿', price: 3});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).not.toEqual({});
+
+            const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(secondResult).toEqual({...defaultResult});
+        });
+
+        it('should not flush the products when the pageview is sent', () => {
+            ec.addProduct({name: 'boup'});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+
+            expect(result).not.toEqual({});
+
+            const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(secondResult).toEqual({...defaultResult, pr1nm: 'boup'});
+        });
+
+        it('should convert position to number if possible', () => {
+            const validValues = ['13', '5.5'];
+            for (const value of validValues) {
+                // @ts-ignore
+                ec.addProduct({name: 'product', position: value});
+
+                const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+                const expected: Record<string, any> = {...defaultResult, pr1nm: 'product', pr1ps: +value};
+
+                expect(result).toEqual(expected);
+            }
+        });
+
+        it('should keep original value if position is not a number', () => {
+            const invalidValues = ['1-2-3', '.', '-', '123abc'];
+            for (const value of invalidValues) {
+                // @ts-ignore
+                ec.addProduct({name: 'product', position: value});
+
+                const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+                const expected: Record<string, unknown> = {...defaultResult, pr1nm: 'product', pr1ps: value};
+
+                expect(result).toEqual(expected);
+            }
+        });
+
+        it('should convert quantity to number if possible', () => {
+            const validValues = ['13', '0', '.0', '-10', '5.0', '-1.1', '3.124e7'];
+            for (const value of validValues) {
+                // @ts-ignore
+                ec.addProduct({name: 'product', quantity: value});
+
+                const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+                const expected: Record<string, any> = {...defaultResult, pr1nm: 'product', pr1qt: +value};
+
+                expect(result).toEqual(expected);
+            }
+        });
+
+        it('should keep original value if quantity is not a number', () => {
+            const invalidValues = ['1-2-3', '', '.', '5..', '-', '123abc', 'abc123'];
+            for (const value of invalidValues) {
+                // @ts-ignore
+                ec.addProduct({name: 'product', quantity: value});
+
+                const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+                const expected: Record<string, unknown> = {...defaultResult, pr1nm: 'product', pr1qt: value};
+
+                expect(result).toEqual(expected);
+            }
+        });
+
+        describe('when the position is invalid', () => {
+            it('should warn when executing hook on added product', () => {
+                jest.spyOn(console, 'warn').mockImplementation();
+
+                const aProductWithATooSmallPosition = {
+                    name: 'A product with a too small position',
+                    position: 0,
+                };
+
+                ec.addProduct(aProductWithATooSmallPosition);
+
+                expect(console.warn).not.toHaveBeenCalled();
+
+                executeRegisteredHook(ECPluginEventTypes.event, {});
+
+                expect(console.warn).toHaveBeenCalledWith(
+                    `The position for product '${aProductWithATooSmallPosition.name}' must be greater than 0 when provided.`
+                );
+                expect(console.warn).toHaveBeenCalledTimes(1);
+            });
+
+            it('should remove the position when executing hook on added product', () => {
+                jest.spyOn(console, 'warn').mockImplementation();
+
+                ec.addProduct({
+                    name: 'A product with a too small position',
+                    position: 0,
+                });
+
+                const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+                const positionProperty = 'il1pi1ps';
+                expect(result).not.toHaveProperty(positionProperty);
+            });
+
+            it('should warn first using the product name then the id', () => {
+                jest.spyOn(console, 'warn').mockImplementation();
+
+                const aProductWithANameAndId = {
+                    name: 'A product with a name and id',
+                    id: 'A product id',
+                    position: 0,
+                };
+                const aProductWithOnlyAnId = {
+                    id: 'A product id',
+                    position: 0,
+                };
+
+                ec.addProduct(aProductWithANameAndId);
+                ec.addProduct(aProductWithOnlyAnId);
+
+                executeRegisteredHook(ECPluginEventTypes.event, {});
+
+                expect(console.warn).toHaveBeenNthCalledWith(
+                    1,
+                    `The position for product '${aProductWithANameAndId.name}' must be greater than 0 when provided.`
+                );
+                expect(console.warn).toHaveBeenNthCalledWith(
+                    2,
+                    `The position for product '${aProductWithOnlyAnId.id}' must be greater than 0 when provided.`
+                );
+            });
+
+            it('should tolerate an absent or undefined position', () => {
+                jest.spyOn(console, 'warn').mockImplementation();
+
+                ec.addProduct({
+                    name: 'A product with no position',
+                });
+
+                ec.addProduct({
+                    name: 'A product with an undefined position',
+                    position: undefined,
+                });
+
+                const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+                expect(console.warn).not.toHaveBeenCalled();
+                expect(result).not.toHaveProperty('pr1ps');
+                expect(result).toHaveProperty('pr2ps', undefined);
+            });
+        });
+    });
+
+    describe('impressions', () => {
+        it('should append the impression with the specific format when the hook is called', () => {
+            ec.addImpression({id: 'C0V30'});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).toEqual({...defaultResult, il1pi1id: 'C0V30'});
+        });
+
+        it('should not append the impression with the pageview event', () => {
+            ec.addImpression({name: 'Relevance T-Shirt'});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+
+            expect(result).toEqual({
+                ...defaultResult,
+                hitType: ECPluginEventTypes.pageview,
+            });
+        });
+
+        it('should not append the impression with a random event type', () => {
+            ec.addImpression({id: ':sorandom:'});
+
+            const result = executeRegisteredHook('🎲', {});
+
+            expect(result).toEqual({});
+        });
+
+        it('should keep the impressions until an event type is used', () => {
+            ec.addImpression({id: 'P12345'});
+
+            executeRegisteredHook('🎲', {});
+            executeRegisteredHook('🐟', {});
+            const pageviewResult = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(pageviewResult).toEqual({...defaultResult, hitType: ECPluginEventTypes.pageview});
+            expect(result).toEqual({...defaultResult, il1pi1id: 'P12345'});
+        });
+
+        it('should convert known impression keys into the measurement protocol format', () => {
+            ec.addImpression({name: '🧀', price: 5.99});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).toEqual({
+                ...defaultResult,
+                il1pi1nm: '🧀',
+                il1pi1pr: 5.99,
+            });
+        });
+
+        it('should convert known impression keys that are extended for Coveo into the measurement protocol format', () => {
+            ec.addImpression({name: '🧀', group: 'mahgroup'});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).toEqual({
+                ...defaultResult,
+                il1pi1nm: '🧀',
+                il1pi1group: 'mahgroup',
+            });
+        });
+
+        it('should keep custom metadata in the impression', () => {
+            ec.addImpression({name: '🧀', price: 5.99, custom: {verycustom: 'value'}});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).toEqual({
+                ...defaultResult,
+                il1pi1nm: '🧀',
+                il1pi1pr: 5.99,
+                il1pi1custom: {verycustom: 'value'},
+            });
+        });
+
+        it('should allow adding multiple impressions', () => {
+            ec.addImpression({name: '🍟', price: 1.99});
+            ec.addImpression({name: '🍿', price: 3});
+            ec.addImpression({name: '🥤', price: 2});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).toEqual({
+                ...defaultResult,
+                il1pi1nm: '🍟',
+                il1pi1pr: 1.99,
+                il1pi2nm: '🍿',
+                il1pi2pr: 3,
+                il1pi3nm: '🥤',
+                il1pi3pr: 2,
+            });
+        });
+
+        it('should allow adding impressions from multiple lists', () => {
+            ec.addImpression({list: 'food', name: '🍟', price: 1.99});
+            ec.addImpression({list: 'food', name: '🍿', price: 3});
+            ec.addImpression({list: 'drinks', name: '🥤', price: 2});
+            ec.addImpression({list: 'drinks', name: '🧃', price: 0.99});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).toEqual({
+                ...defaultResult,
+                il1nm: 'food',
+                il1pi1nm: '🍟',
+                il1pi1pr: 1.99,
+                il1pi2nm: '🍿',
+                il1pi2pr: 3,
+                il2nm: 'drinks',
+                il2pi1nm: '🥤',
+                il2pi1pr: 2,
+                il2pi2nm: '🧃',
+                il2pi2pr: 0.99,
+            });
+        });
+
+        it('should flush the impressions once they are sent', () => {
+            ec.addImpression({name: '🍟', price: 1.99});
+            ec.addImpression({name: '🍿', price: 3});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(result).not.toEqual({});
+
+            const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(secondResult).toEqual({...defaultResult});
+        });
+
+        it('should not flush the impressions when a pageview is sent', () => {
+            ec.addImpression({name: 'bap'});
+
+            const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+
+            expect(result).not.toEqual({});
+
+            const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+            expect(secondResult).toEqual({...defaultResult, il1pi1nm: 'bap'});
+        });
+
+        describe('when the position is invalid', () => {
+            it('should warn when executing hook on added impression', () => {
+                jest.spyOn(console, 'warn').mockImplementation();
+
+                const anImpression = {
+                    name: 'An impression with a too small position',
+                    position: 0,
+                };
+
+                ec.addImpression(anImpression);
+
+                expect(console.warn).not.toHaveBeenCalled();
+
+                executeRegisteredHook(ECPluginEventTypes.event, {});
+
+                expect(console.warn).toHaveBeenCalledWith(
+                    `The position for impression '${anImpression.name}' must be greater than 0 when provided.`
+                );
+                expect(console.warn).toHaveBeenCalledTimes(1);
+            });
+
+            it('should remove the position when executing hook on added impression', () => {
+                jest.spyOn(console, 'warn').mockImplementation();
+
+                ec.addImpression({
+                    name: 'An impression with a too small position',
+                    position: 0,
+                });
+
+                const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+                const positionProperty = 'il1pi1ps';
+                expect(result).not.toHaveProperty(positionProperty);
+            });
+
+            it('should warn first using the impression name then the id', () => {
+                jest.spyOn(console, 'warn').mockImplementation();
+
+                const anImpressionWithANameAndId = {
+                    name: 'An impression with a name and id',
+                    id: 'An id',
+                    position: 0,
+                };
+                const anImpressionWithOnlyAnId = {
+                    id: 'An id',
+                    position: 0,
+                };
+
+                ec.addImpression(anImpressionWithANameAndId);
+                ec.addImpression(anImpressionWithOnlyAnId);
+
+                executeRegisteredHook(ECPluginEventTypes.event, {});
+
+                expect(console.warn).toHaveBeenNthCalledWith(
+                    1,
+                    `The position for impression '${anImpressionWithANameAndId.name}' must be greater than 0 when provided.`
+                );
+                expect(console.warn).toHaveBeenNthCalledWith(
+                    2,
+                    `The position for impression '${anImpressionWithOnlyAnId.id}' must be greater than 0 when provided.`
+                );
+            });
+
+            it('should tolerate an absent or undefined position', () => {
+                jest.spyOn(console, 'warn').mockImplementation();
+
+                ec.addImpression({
+                    name: 'An impression with no position',
+                });
+
+                ec.addImpression({
+                    name: 'An impression with an undefined position',
+                    position: undefined,
+                });
+
+                const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+                expect(console.warn).not.toHaveBeenCalled();
+                expect(result).not.toHaveProperty('il1pi1ps');
+                expect(result).toHaveProperty('il1pi2ps', undefined);
+            });
+        });
+    });
+
+    it('should be able to set an action', () => {
+        ec.setAction('ok');
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(result).toEqual({
+            ...defaultResult,
+            action: 'ok',
+        });
+    });
+
+    it('should not set an action with a pageview', () => {
+        ec.setAction('ok');
+
+        const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+
+        expect(result).toEqual({
+            ...defaultResult,
+            hitType: ECPluginEventTypes.pageview,
+        });
+    });
+
+    it('should flush the action once it is sent', () => {
+        ec.setAction('ok');
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(result).not.toEqual({});
+
+        const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(secondResult).toEqual({...defaultResult});
+    });
+
+    it('should not flush the action with the pageview', () => {
+        ec.setAction('ok');
+
+        const result = executeRegisteredHook(ECPluginEventTypes.pageview, {});
+
+        expect(result).not.toEqual({});
+
+        const secondResult = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(secondResult).toEqual({...defaultResult, action: 'ok'});
+    });
+
+    it('should be able to clear all the data', () => {
+        ec.addProduct({name: '🍨', price: 2.99});
+        ec.addImpression({id: '🍦', price: 3.49});
+        ec.clearData();
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(result).toEqual({...defaultResult});
+    });
+
+    it('should convert known EC keys to the measurement protocol format in the hook', () => {
+        const payload = {
+            clientId: '1234',
+            encoding: 'en-GB',
+            action: 'bloup',
+        };
+
+        const result = executeRegisteredHook(ECPluginEventTypes.event, payload);
+
+        expect(result).toEqual({
+            ...defaultResult,
+            clientId: payload.clientId,
+            encoding: payload.encoding,
+            action: payload.action,
+        });
+    });
+
+    it('should call the uuidv4 method', async () => {
+        await executeRegisteredHook(ECPluginEventTypes.event, {});
+        await executeRegisteredHook(ECPluginEventTypes.event, {});
+        await executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        // One for generating pageViewId, one for each individual event.
+        expect(someUUIDGenerator).toHaveBeenCalledTimes(1 + 3);
+    });
+
+    it('should update the location when sending a pageview with the page parameter', () => {
+        const payload = {
+            page: '/somepage',
+        };
+
+        const pageview = executeRegisteredHook(ECPluginEventTypes.pageview, payload);
+        const event = executeRegisteredHook(ECPluginEventTypes.event, {});
+
+        expect(pageview).toEqual({
+            ...defaultResult,
+            hitType: ECPluginEventTypes.pageview,
+            page: payload.page,
+            location: `${defaultResult.location}${payload.page.substring(1)}`,
+        });
+        expect(event).toEqual({
+            ...defaultResult,
+            hitType: ECPluginEventTypes.event,
+            location: `${defaultResult.location}${payload.page.substring(1)}`,
+        });
+    });
+
+    const executeRegisteredHook = (eventType: string, payload: any) => {
+        const [beforeHook] = client.registerBeforeSendEventHook.mock.calls[0];
+        const [afterHook] = client.registerAfterSendEventHook.mock.calls[0];
+        const result = beforeHook(eventType, payload);
+        afterHook(eventType, result);
+        return result;
+    };
+});

--- a/packages/coveo-analytics/src/plugins/ec.ts
+++ b/packages/coveo-analytics/src/plugins/ec.ts
@@ -1,0 +1,249 @@
+import {EventType} from '../events';
+import {v4 as uuidv4} from 'uuid';
+import {
+    convertProductToMeasurementProtocol,
+    convertImpressionListToMeasurementProtocol,
+} from '../client/measurementProtocolMapping/commerceMeasurementProtocolMapper';
+import {BasePlugin, BasePluginEventTypes, PluginClass, PluginOptions} from './BasePlugin';
+import {coerceToNumber} from '../client/utils';
+
+export const ECPluginEventTypes = {
+    ...BasePluginEventTypes,
+};
+
+const allECEventTypes = Object.keys(ECPluginEventTypes).map(
+    (key) => ECPluginEventTypes[key as keyof typeof ECPluginEventTypes]
+);
+
+// From https://stackoverflow.com/a/49725198/497731
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
+    {
+        [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
+    }[Keys];
+
+export type CustomValues = {
+    [key: string]: string | number | boolean;
+};
+
+export interface CoveoExtensionProperties {
+    group?: string;
+}
+
+export interface ProductProperties extends CoveoExtensionProperties {
+    id?: string;
+    name?: string;
+    brand?: string;
+    category?: string;
+    variant?: string;
+    price?: number;
+    quantity?: number;
+    coupon?: string;
+    position?: number;
+    custom?: CustomValues;
+}
+
+export type Product = RequireAtLeastOne<ProductProperties, 'id' | 'name'>;
+
+export interface ImpressionProperties extends CoveoExtensionProperties {
+    id?: string;
+    name?: string;
+    list?: string;
+    brand?: string;
+    category?: string;
+    variant?: string;
+    position?: number;
+    price?: number;
+    custom?: CustomValues;
+}
+
+export type Impression = RequireAtLeastOne<ImpressionProperties, 'id' | 'name'>;
+export type BaseImpression = Omit<Impression, 'list'>;
+export interface ImpressionList {
+    listName?: string;
+    impressions: BaseImpression[];
+}
+
+export class ECPlugin extends BasePlugin {
+    public static readonly Id = 'ec';
+    private products: Product[] = [];
+    private impressions: Impression[] = [];
+
+    constructor({client, uuidGenerator = uuidv4}: PluginOptions) {
+        super({client, uuidGenerator});
+    }
+
+    public getApi(name: string): Function | null {
+        const superCall: Function | null = super.getApi(name);
+        if (superCall !== null) return superCall;
+        switch (name) {
+            case 'addProduct':
+                return this.addProduct;
+            case 'addImpression':
+                return this.addImpression;
+            default:
+                return null;
+        }
+    }
+
+    protected addHooks(): void {
+        this.addHooksForPageView();
+        this.addHooksForEvent();
+        this.addHooksForECEvents();
+    }
+
+    addProduct(product: Product) {
+        this.products.push(product);
+    }
+
+    addImpression(impression: Impression) {
+        this.impressions.push(impression);
+    }
+
+    protected clearPluginData() {
+        this.products = [];
+        this.impressions = [];
+    }
+
+    private addHooksForECEvents() {
+        this.client.registerBeforeSendEventHook((eventType, ...[payload]) => {
+            return allECEventTypes.indexOf(eventType) !== -1 ? this.addECDataToPayload(eventType, payload) : payload;
+        });
+        this.client.registerAfterSendEventHook((eventType, ...[payload]) => {
+            if (allECEventTypes.indexOf(eventType) !== -1) {
+                this.updateLocationInformation(eventType, payload);
+            }
+            return payload;
+        });
+    }
+
+    private addHooksForPageView() {
+        this.client.addEventTypeMapping(ECPluginEventTypes.pageview, {
+            newEventType: EventType.collect,
+            variableLengthArgumentsNames: ['page'],
+            addVisitorIdParameter: true,
+            usesMeasurementProtocol: true,
+        });
+    }
+
+    private addHooksForEvent() {
+        this.client.addEventTypeMapping(ECPluginEventTypes.event, {
+            newEventType: EventType.collect,
+            variableLengthArgumentsNames: ['eventCategory', 'eventAction', 'eventLabel', 'eventValue'],
+            addVisitorIdParameter: true,
+            usesMeasurementProtocol: true,
+        });
+    }
+
+    private addECDataToPayload(eventType: string, payload: any) {
+        if (eventType === ECPluginEventTypes.pageview) {
+            return {
+                ...this.getLocationInformation(eventType, payload),
+                ...this.getDefaultContextInformation(eventType),
+                ...payload,
+            };
+        }
+
+        const ecPayload = {
+            ...this.getLocationInformation(eventType, payload),
+            ...this.getDefaultContextInformation(eventType),
+            ...(this.action ? {action: this.action} : {}),
+            ...(this.actionData || {}),
+        };
+
+        const productPayload = this.getProductPayload();
+        const impressionPayload = this.getImpressionPayload();
+
+        this.clearData();
+
+        return {
+            ...impressionPayload,
+            ...productPayload,
+            ...ecPayload,
+            ...payload,
+        };
+    }
+
+    private getProductPayload() {
+        return this.products
+            .map((product) => this.assureProductValidity(product))
+            .reduce((newPayload, product, index) => {
+                return {
+                    ...newPayload,
+                    ...convertProductToMeasurementProtocol(this.convertNumberTypes(product), index),
+                };
+            }, {});
+    }
+
+    private convertNumberTypes(product: Product): Product {
+        let updatedProduct: Product = {...product};
+        if ('quantity' in updatedProduct) {
+            updatedProduct.quantity = coerceToNumber(updatedProduct.quantity);
+        }
+        if ('position' in updatedProduct) {
+            updatedProduct.position = coerceToNumber(updatedProduct.position);
+        }
+        return updatedProduct;
+    }
+
+    private getImpressionPayload() {
+        const impressionsByList = this.getImpressionsByList();
+        return impressionsByList
+            .map(
+                ({impressions, ...rest}) =>
+                    ({
+                        ...rest,
+                        impressions: impressions.map((baseImpression) =>
+                            this.assureBaseImpressionValidity(baseImpression)
+                        ),
+                    } as ImpressionList)
+            )
+            .reduce((newPayload, impressionList, index) => {
+                return {
+                    ...newPayload,
+                    ...convertImpressionListToMeasurementProtocol(impressionList, index, 'pi'),
+                };
+            }, {});
+    }
+
+    private assureProductValidity(product: Product) {
+        const {position, ...productRest} = product;
+        if (position !== undefined && position < 1) {
+            console.warn(
+                `The position for product '${product.name || product.id}' must be greater ` + `than 0 when provided.`
+            );
+
+            return productRest;
+        }
+
+        return product;
+    }
+
+    private assureBaseImpressionValidity(baseImpression: BaseImpression) {
+        const {position, ...baseImpressionRest} = baseImpression;
+        if (position !== undefined && position < 1) {
+            console.warn(
+                `The position for impression '${baseImpression.name || baseImpression.id}'` +
+                    ` must be greater than 0 when provided.`
+            );
+
+            return baseImpressionRest;
+        }
+
+        return baseImpression;
+    }
+
+    private getImpressionsByList() {
+        return this.impressions.reduce((lists, impression) => {
+            const {list: listName, ...baseImpression} = impression;
+            const list = lists.find((list) => list.listName === listName);
+            if (list) {
+                list.impressions.push(baseImpression);
+            } else {
+                lists.push({listName: listName, impressions: [baseImpression]});
+            }
+            return lists;
+        }, [] as ImpressionList[]);
+    }
+}
+
+export const EC: PluginClass = ECPlugin;

--- a/packages/coveo-analytics/src/plugins/link.spec.ts
+++ b/packages/coveo-analytics/src/plugins/link.spec.ts
@@ -1,0 +1,171 @@
+import {CoveoLinkParam, LinkPlugin} from './link';
+import {createAnalyticsClientMock} from '../../tests/analyticsClientMock';
+import {v4 as uuidv4} from 'uuid';
+
+function currentSecsSinceEpoch() {
+    return Math.floor(Date.now() / 1000);
+}
+
+describe('CoveoLinkParam class', () => {
+    it('can create a new link using a uuid', () => {
+        const uuid = uuidv4();
+        const link: CoveoLinkParam = new CoveoLinkParam(uuid, Date.now());
+        expect(link.clientId).toBe(uuid);
+        expect(link.creationDate).toBe(currentSecsSinceEpoch());
+    });
+
+    it('can create a new link using a uuid and timestamp', () => {
+        const uuid = uuidv4();
+        const link: CoveoLinkParam = new CoveoLinkParam(uuid, 1676298678329);
+        expect(link.clientId).toBe(uuid);
+        expect(link.creationDate).toBe(1676298678);
+    });
+
+    it('can not create a new link using a non uuid', () => {
+        const uuid = 'Not_a_uuid';
+        expect(() => new CoveoLinkParam(uuid, Date.now())).toThrow('Not a valid uuid');
+    });
+
+    it('can parse a link from a string', () => {
+        const link = 'c0b48880743e484f8044d7c37910c55b.1676298678';
+        const coveoLinkParam: CoveoLinkParam | null = CoveoLinkParam.fromString(link);
+        expect(coveoLinkParam).not.toBeNull;
+        expect(coveoLinkParam?.clientId).toBe('c0b48880-743e-484f-8044-d7c37910c55b');
+        expect(coveoLinkParam?.creationDate).toBe(1676298678);
+    });
+
+    it('will not parse links without a valid uuid', () => {
+        const link = 'a0c56830743d46537f703.1676298678';
+        const coveoLinkParam: CoveoLinkParam | null = CoveoLinkParam.fromString(link);
+        expect(coveoLinkParam).toBe(null);
+    });
+
+    it('will not parse links with an invalid structure', () => {
+        const link = 'a0c56830743d46537f703.1676298678.353673463';
+        const coveoLinkParam: CoveoLinkParam | null = CoveoLinkParam.fromString(link);
+        expect(coveoLinkParam).toBe(null);
+    });
+
+    it('will not parse links with invalid timestamps', () => {
+        const link = 'a0c56830743d46537f703.invalidtimestamp';
+        const coveoLinkParam: CoveoLinkParam | null = CoveoLinkParam.fromString(link);
+        expect(coveoLinkParam).toBe(null);
+    });
+
+    it('can serialize a link to a string', () => {
+        const coveoLink: CoveoLinkParam = new CoveoLinkParam('074af291-224b-4705-9dc5-a47bd80a8db9', Date.now());
+        const link = coveoLink.toString();
+        const parts = link.split('.');
+        expect(parts[0]).toBe('074af291224b47059dc5a47bd80a8db9');
+        expect(Number.parseInt(parts[1])).toBe(currentSecsSinceEpoch());
+    });
+
+    it('checks for expiration on a link', () => {
+        const coveoLink1: CoveoLinkParam = new CoveoLinkParam('074af291-224b-4705-9dc5-a47bd80a8db9', Date.now());
+        expect(coveoLink1.expired).toBe(false);
+        const coveoLink2: CoveoLinkParam = new CoveoLinkParam(
+            '074af291-224b-4705-9dc5-a47bd80a8db9',
+            Date.now() - 180000
+        );
+        expect(coveoLink2.expired).toBe(true);
+    });
+
+    it('checks for expiration on a link if the timestamp is in the future', () => {
+        const coveoLink1: CoveoLinkParam = new CoveoLinkParam('074af291-224b-4705-9dc5-a47bd80a8db9', Date.now());
+        expect(coveoLink1.expired).toBe(false);
+        const coveoLink2: CoveoLinkParam = new CoveoLinkParam(
+            '074af291-224b-4705-9dc5-a47bd80a8db9',
+            Date.now() + 5000
+        );
+        expect(coveoLink2.expired).toBe(true);
+    });
+
+    it('checks validation on referrers', () => {
+        const coveoLink1: CoveoLinkParam = new CoveoLinkParam('074af291-224b-4705-9dc5-a47bd80a8db9', Date.now());
+        expect(coveoLink1.validate('http://sub.mysite.com', ['*'])).toBe(true);
+        expect(coveoLink1.validate('http://sub.mysite.com', ['*.mysite.com', '*'])).toBe(true);
+        expect(coveoLink1.validate('http://sub.mysite.com', ['*.mysite.com'])).toBe(true);
+        expect(coveoLink1.validate('http://sub.notmysite.com', ['*.mysite.com'])).toBe(false);
+        expect(coveoLink1.validate('http://sub.mysite.com', [])).toBe(false);
+    });
+
+    it('escapes backslash correctly', () => {
+        const coveoLink1: CoveoLinkParam = new CoveoLinkParam('074af291-224b-4705-9dc5-a47bd80a8db9', Date.now());
+        expect(coveoLink1.validate('http://sub.mysite.com', ['\\w'])).toBe(false); // This should not be treated as a \w regexp!
+    });
+});
+
+describe('CoveoLinkPlugin', () => {
+    let link: LinkPlugin;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        const analyticsClient = createAnalyticsClientMock();
+        analyticsClient.getCurrentVisitorId = jest.fn(() => Promise.resolve('85698661-efdf-4c6d-9cad-c4632bf81ce3'));
+        link = new LinkPlugin({client: analyticsClient});
+    });
+
+    it('decorates links with valid urls and no params', async () => {
+        const url: string = 'https://coveo.com';
+        const result: string = await link.decorate(url);
+        expect(result).toBe('https://coveo.com/?cvo_cid=85698661efdf4c6d9cadc4632bf81ce3.' + currentSecsSinceEpoch());
+    });
+
+    it('decorates links with valid urls and no params', async () => {
+        const url: string = 'https://coveo.com/some/path/';
+        const result: string = await link.decorate(url);
+        expect(result).toBe(
+            'https://coveo.com/some/path/?cvo_cid=85698661efdf4c6d9cadc4632bf81ce3.' + currentSecsSinceEpoch()
+        );
+    });
+
+    it('decorates links with valid urls and existing params', async () => {
+        const url: string = 'https://coveo.com/query?q=something&p=param';
+        const result: string = await link.decorate(url);
+        expect(result).toBe(
+            'https://coveo.com/query?q=something&p=param&cvo_cid=85698661efdf4c6d9cadc4632bf81ce3.' +
+                currentSecsSinceEpoch()
+        );
+    });
+
+    it('decorates links with valid urls, existing params and fragments', async () => {
+        const url: string = 'https://coveo.com/?q=something#frag';
+        const result: string = await link.decorate(url);
+        expect(result).toBe(
+            'https://coveo.com/?q=something&cvo_cid=85698661efdf4c6d9cadc4632bf81ce3.' +
+                currentSecsSinceEpoch() +
+                '#frag'
+        );
+    });
+
+    it('updates an existing decoration links with valid urls and no params', async () => {
+        const url: string = 'https://coveo.com/?cvo_cid=c0b48880743e484f8044d7c37910c55b.1676298678';
+        const result: string = await link.decorate(url);
+        expect(result).toBe('https://coveo.com/?cvo_cid=85698661efdf4c6d9cadc4632bf81ce3.' + currentSecsSinceEpoch());
+    });
+
+    it('errors on invalid urls', async () => {
+        const url: string = 'somethingthatisobviouslynotaurl';
+        await expect(link.decorate(url)).rejects.toThrow('Invalid URL provided');
+    });
+
+    it('errors when there is no current clientId', async () => {
+        // initialize with missing clientId method
+        const analyticsClient = createAnalyticsClientMock();
+        analyticsClient.getCurrentVisitorId = undefined;
+        link = new LinkPlugin({client: analyticsClient});
+
+        const url: string = 'https://coveo.com/';
+        await expect(link.decorate(url)).rejects.toThrow('Could not retrieve current clientId');
+    });
+
+    it('can set a list of referrers on the client', () => {
+        const analyticsClient = createAnalyticsClientMock();
+        const mock: jest.Mock = jest.fn();
+        analyticsClient.setAcceptedLinkReferrers = mock;
+        link = new LinkPlugin({client: analyticsClient});
+        link.acceptFrom(['*.somedomain.com', 'www.coveo.com']);
+
+        expect(mock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/coveo-analytics/src/plugins/link.ts
+++ b/packages/coveo-analytics/src/plugins/link.ts
@@ -1,0 +1,109 @@
+import {validate as uuidvalidate, v4 as uuidv4} from 'uuid';
+import {Plugin, PluginOptions, PluginClass} from './BasePlugin';
+
+export class CoveoLinkParam {
+    public static readonly cvo_cid: string = 'cvo_cid'; // name of the url parameter
+    private static readonly expirationTime: number = 120; // expirationTime in secs
+    public readonly clientId: string; //uuid
+    public readonly creationDate: number; //seconds since epoch to save space in serialized param
+
+    constructor(clientId: string, timestamp: number) {
+        if (!uuidvalidate(clientId)) throw Error('Not a valid uuid');
+        this.clientId = clientId;
+        this.creationDate = Math.floor(timestamp / 1000);
+    }
+
+    public toString(): string {
+        // strips the dashes and uses second granularity to save on url length.
+        return this.clientId.replace(/-/g, '') + '.' + this.creationDate.toString();
+    }
+
+    public get expired(): boolean {
+        const age = Math.floor(Date.now() / 1000) - this.creationDate;
+        return age < 0 || age > CoveoLinkParam.expirationTime;
+    }
+
+    public validate(referrerString: string, referrerList: string[]): boolean {
+        return !this.expired && this.matchReferrer(referrerString, referrerList);
+    }
+
+    private matchReferrer(referrerString: string, referrerList: string[]): boolean {
+        try {
+            const url: URL = new URL(referrerString);
+            return referrerList.some((value: string) => {
+                const hostRegExp: RegExp = new RegExp(
+                    value.replace(/\\/g, '\\\\').replace(/\./g, '\\.').replace(/\*/g, '.*') + '$'
+                );
+                return hostRegExp.test(url.host);
+            });
+        } catch (error) {
+            return false;
+        }
+    }
+
+    public static fromString(input: string): CoveoLinkParam | null {
+        const parts = input.split('.');
+        if (parts.length !== 2) {
+            return null;
+        }
+        const [clientIdPart, creationDate] = parts;
+        if (clientIdPart.length !== 32 || isNaN(parseInt(creationDate))) {
+            return null;
+        }
+        const clientId =
+            clientIdPart.substring(0, 8) +
+            '-' +
+            clientIdPart.substring(8, 12) +
+            '-' +
+            clientIdPart.substring(12, 16) +
+            '-' +
+            clientIdPart.substring(16, 20) +
+            '-' +
+            clientIdPart.substring(20, 32);
+        if (uuidvalidate(clientId)) {
+            return new CoveoLinkParam(clientId, Number.parseInt(creationDate) * 1000);
+        } else {
+            return null;
+        }
+    }
+}
+
+export class LinkPlugin extends Plugin {
+    public static readonly Id = 'link';
+
+    constructor({client, uuidGenerator = uuidv4}: PluginOptions) {
+        super({client, uuidGenerator});
+    }
+
+    public getApi(name: string): Function | null {
+        switch (name) {
+            case 'decorate':
+                return this.decorate;
+            case 'acceptFrom':
+                return this.acceptFrom;
+            default:
+                return null;
+        }
+    }
+
+    public async decorate(urlString: string): Promise<string> {
+        // Note: clientId retrieval function is marked as optional
+        if (!this.client.getCurrentVisitorId) {
+            throw new Error('Could not retrieve current clientId');
+        }
+        try {
+            const url = new URL(urlString);
+            const clientId: string = await this.client.getCurrentVisitorId!();
+            url.searchParams.set(CoveoLinkParam.cvo_cid, new CoveoLinkParam(clientId, Date.now()).toString());
+            return url.toString();
+        } catch (error) {
+            throw new Error('Invalid URL provided');
+        }
+    }
+
+    public acceptFrom(acceptedReferrers: string[]) {
+        this.client.setAcceptedLinkReferrers!(acceptedReferrers);
+    }
+}
+
+export const Link: PluginClass = LinkPlugin;

--- a/packages/coveo-analytics/src/plugins/svc.spec.ts
+++ b/packages/coveo-analytics/src/plugins/svc.spec.ts
@@ -1,0 +1,184 @@
+import {SVCPlugin, SVCPluginEventTypes} from './svc';
+import {createAnalyticsClientMock} from '../../tests/analyticsClientMock';
+
+describe('SVC plugin', () => {
+    let svc: SVCPlugin;
+    let client: ReturnType<typeof createAnalyticsClientMock>;
+
+    const someUUIDGenerator = jest.fn(() => someUUID);
+    const someUUID = '13ccebdb-0138-45e8-bf70-884817ead190';
+    const defaultResult = {
+        pageViewId: someUUID,
+        encoding: document.characterSet,
+        location: 'http://localhost/',
+        referrer: 'http://somewhere.over/thereferrer',
+        title: 'MAH PAGE',
+        screenColor: '24-bit',
+        screenResolution: '0x0',
+        time: expect.any(Number),
+        userAgent: navigator.userAgent,
+        language: 'en-US',
+        hitType: SVCPluginEventTypes.event,
+        eventId: someUUID,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        client = createAnalyticsClientMock();
+        svc = new SVCPlugin({client, uuidGenerator: someUUIDGenerator as any});
+    });
+
+    it('should register a hook in the client', () => {
+        expect(client.registerBeforeSendEventHook).toHaveBeenCalledTimes(1);
+    });
+
+    it('should register a mapping for each SVC type', () => {
+        expect(client.addEventTypeMapping).toHaveBeenCalledTimes(Object.keys(SVCPluginEventTypes).length);
+    });
+
+    describe('tickets', () => {
+        it('should set the ticket with the specific format and convert known ticket keys into the measurement protocol format when the hook is called', () => {
+            svc.setTicket({
+                id: 'Some ID',
+                subject: 'Some Subject',
+                description: 'Some Description',
+                category: 'Some Category',
+                productId: 'Some Product ID',
+                custom: {someCustomProp: 'some custom prop value'},
+            });
+
+            const result = executeRegisteredHook(SVCPluginEventTypes.event, {});
+
+            expect(result).toEqual({
+                ...defaultResult,
+                svc_ticket_id: 'Some ID',
+                svc_ticket_subject: 'Some Subject',
+                svc_ticket_description: 'Some Description',
+                svc_ticket_category: 'Some Category',
+                svc_ticket_product_id: 'Some Product ID',
+                svc_ticket_custom: {someCustomProp: 'some custom prop value'},
+            });
+        });
+
+        it('should append the ticket with the pageview event', () => {
+            svc.setTicket({subject: 'Some Subject'});
+
+            const result = executeRegisteredHook(SVCPluginEventTypes.pageview, {});
+
+            expect(result).toEqual({
+                ...defaultResult,
+                hitType: SVCPluginEventTypes.pageview,
+                svc_ticket_subject: 'Some Subject',
+            });
+        });
+
+        it('should not append the product with a random event type', () => {
+            svc.setTicket({subject: 'Some Subject'});
+
+            const result = executeRegisteredHook('🎲', {});
+
+            expect(result).toEqual({});
+        });
+
+        it('should keep the ticket until a valid event type is used', () => {
+            svc.setTicket({subject: 'Some Subject'});
+
+            executeRegisteredHook('🎲', {});
+            executeRegisteredHook('🐟', {});
+            executeRegisteredHook('💀', {});
+            const result = executeRegisteredHook(SVCPluginEventTypes.event, {});
+
+            expect(result).toEqual({...defaultResult, svc_ticket_subject: 'Some Subject'});
+        });
+
+        it('should keep custom metadata in the ticket', () => {
+            svc.setTicket({subject: '🧀', custom: {verycustom: 'value'}});
+
+            const result = executeRegisteredHook(SVCPluginEventTypes.event, {});
+
+            expect(result).toEqual({
+                ...defaultResult,
+                svc_ticket_subject: '🧀',
+                svc_ticket_custom: {verycustom: 'value'},
+            });
+        });
+
+        it('should flush the ticket once they are sent', () => {
+            svc.setTicket({subject: '🍟', description: 'description'});
+
+            const firstResult = executeRegisteredHook(SVCPluginEventTypes.event, {});
+            const secondResult = executeRegisteredHook(SVCPluginEventTypes.event, {});
+
+            expect(firstResult).not.toEqual({});
+            expect(secondResult).toEqual({...defaultResult});
+        });
+    });
+
+    it('should be able to set an action', () => {
+        svc.setAction('ok');
+
+        const result = executeRegisteredHook(SVCPluginEventTypes.event, {});
+
+        expect(result).toEqual({
+            ...defaultResult,
+            svcAction: 'ok',
+        });
+    });
+
+    it('should flush the action once it is sent', () => {
+        svc.setAction('ok');
+
+        const firstResult = executeRegisteredHook(SVCPluginEventTypes.event, {});
+        const secondResult = executeRegisteredHook(SVCPluginEventTypes.event, {});
+
+        expect(firstResult).not.toEqual({});
+        expect(secondResult).toEqual({...defaultResult});
+    });
+
+    it('should be able to clear all the data', () => {
+        svc.setTicket({subject: '🍨', description: 'Some desc'});
+        svc.clearData();
+
+        const result = executeRegisteredHook(SVCPluginEventTypes.event, {});
+
+        expect(result).toEqual({...defaultResult});
+    });
+
+    it('should call the uuidv4 method', async () => {
+        await executeRegisteredHook(SVCPluginEventTypes.event, {});
+        await executeRegisteredHook(SVCPluginEventTypes.event, {});
+        await executeRegisteredHook(SVCPluginEventTypes.event, {});
+
+        // One for generating pageViewId, one for each individual event.
+        expect(someUUIDGenerator).toHaveBeenCalledTimes(1 + 3);
+    });
+
+    it('should update the location when sending a pageview with the page parameter', async () => {
+        const payload = {
+            page: '/somepage',
+        };
+
+        const pageview = await executeRegisteredHook(SVCPluginEventTypes.pageview, payload);
+        const event = await executeRegisteredHook(SVCPluginEventTypes.event, {});
+
+        expect(pageview).toEqual({
+            ...defaultResult,
+            hitType: SVCPluginEventTypes.pageview,
+            page: payload.page,
+            location: `${defaultResult.location}${payload.page.substring(1)}`,
+        });
+        expect(event).toEqual({
+            ...defaultResult,
+            hitType: SVCPluginEventTypes.event,
+            location: `${defaultResult.location}${payload.page.substring(1)}`,
+        });
+    });
+
+    const executeRegisteredHook = (eventType: string, payload: any) => {
+        const [beforeHook] = client.registerBeforeSendEventHook.mock.calls[0];
+        const [afterHook] = client.registerAfterSendEventHook.mock.calls[0];
+        const result = beforeHook(eventType, payload);
+        afterHook(eventType, result);
+        return result;
+    };
+});

--- a/packages/coveo-analytics/src/plugins/svc.ts
+++ b/packages/coveo-analytics/src/plugins/svc.ts
@@ -1,0 +1,115 @@
+import {EventType} from '../events';
+import {v4 as uuidv4} from 'uuid';
+import {convertTicketToMeasurementProtocol} from '../client/measurementProtocolMapping/serviceMeasurementProtocolMapper';
+import {BasePlugin, BasePluginEventTypes, PluginClass, PluginOptions} from './BasePlugin';
+
+export const SVCPluginEventTypes = {
+    ...BasePluginEventTypes,
+};
+
+const allSVCEventTypes = Object.keys(SVCPluginEventTypes).map(
+    (key) => SVCPluginEventTypes[key as keyof typeof SVCPluginEventTypes]
+);
+
+export type CustomValues = {
+    [key: string]: string | number | boolean;
+};
+
+export interface TicketProperties {
+    id?: string;
+    subject?: string;
+    description?: string;
+    category?: string;
+    productId?: string;
+    custom?: CustomValues;
+}
+
+export type Ticket = TicketProperties;
+
+export class SVCPlugin extends BasePlugin {
+    public static readonly Id = 'svc';
+    private ticket: Ticket = {};
+
+    constructor({client, uuidGenerator = uuidv4}: PluginOptions) {
+        super({client, uuidGenerator});
+    }
+
+    public getApi(name: string): Function | null {
+        const superCall: Function | null = super.getApi(name);
+        if (superCall !== null) return superCall;
+        switch (name) {
+            case 'setTicket':
+                return this.setTicket;
+            default:
+                return null;
+        }
+    }
+
+    protected addHooks(): void {
+        this.addHooksForEvent();
+        this.addHooksForPageView();
+        this.addHooksForSVCEvents();
+    }
+
+    setTicket(ticket: Ticket) {
+        this.ticket = ticket;
+    }
+
+    protected clearPluginData() {
+        this.ticket = {};
+    }
+
+    private addHooksForSVCEvents() {
+        this.client.registerBeforeSendEventHook((eventType, ...[payload]) => {
+            return allSVCEventTypes.indexOf(eventType) !== -1 ? this.addSVCDataToPayload(eventType, payload) : payload;
+        });
+        this.client.registerAfterSendEventHook((eventType, ...[payload]) => {
+            if (allSVCEventTypes.indexOf(eventType) !== -1) {
+                this.updateLocationInformation(eventType, payload);
+            }
+            return payload;
+        });
+    }
+
+    private addHooksForPageView() {
+        this.client.addEventTypeMapping(SVCPluginEventTypes.pageview, {
+            newEventType: EventType.collect,
+            variableLengthArgumentsNames: ['page'],
+            addVisitorIdParameter: true,
+            usesMeasurementProtocol: true,
+        });
+    }
+
+    private addHooksForEvent() {
+        this.client.addEventTypeMapping(SVCPluginEventTypes.event, {
+            newEventType: EventType.collect,
+            variableLengthArgumentsNames: ['eventCategory', 'eventAction', 'eventLabel', 'eventValue'],
+            addVisitorIdParameter: true,
+            usesMeasurementProtocol: true,
+        });
+    }
+
+    private addSVCDataToPayload(eventType: string, payload: any) {
+        const svcPayload = {
+            ...this.getLocationInformation(eventType, payload),
+            ...this.getDefaultContextInformation(eventType),
+            ...(this.action ? {svcAction: this.action} : {}),
+            ...(Object.keys(this.actionData ?? {}).length > 0 ? {svcActionData: this.actionData} : {}),
+        };
+
+        const ticketPayload = this.getTicketPayload();
+        this.clearData();
+
+        return {
+            ...ticketPayload,
+            ...svcPayload,
+            ...payload,
+        };
+    }
+
+    private getTicketPayload() {
+        return convertTicketToMeasurementProtocol(this.ticket);
+    }
+}
+
+export const SVC: PluginClass = SVCPlugin;

--- a/packages/coveo-analytics/src/react-native/index.ts
+++ b/packages/coveo-analytics/src/react-native/index.ts
@@ -1,0 +1,3 @@
+export {ReactNativeRuntime, ReactNativeRuntimeOptions, ReactNativeStorage} from './react-native-runtime';
+export * from '../coveoua/headless';
+import 'react-native-get-random-values';

--- a/packages/coveo-analytics/src/react-native/react-native-runtime.ts
+++ b/packages/coveo-analytics/src/react-native/react-native-runtime.ts
@@ -1,0 +1,49 @@
+import {WebStorage} from '../storage';
+import {AnalyticsFetchClient} from '../client/analyticsFetchClient';
+import {IRuntimeEnvironment} from '../client/runtimeEnvironment';
+import {PreprocessAnalyticsRequest} from '../client/analyticsRequestClient';
+import {v4 as uuidv4} from 'uuid';
+import {buildBaseUrl} from '../client/analytics';
+
+export type ReactNativeStorage = WebStorage;
+
+export interface ReactNativeRuntimeOptions {
+    /**
+     * Mandatory Storage implementation.
+     *
+     * We recommend using a storage library. There are a few options presented in the readme: https://github.com/coveo/coveo.analytics.js#using-react-native
+     */
+    storage: ReactNativeStorage;
+    /**
+     * Key for storing the visitor ID value.
+     * @defaut visitorId
+     */
+    visitorIdKey?: string;
+    token?: string;
+    version?: string;
+    endpoint?: string;
+    preprocessRequest?: PreprocessAnalyticsRequest;
+}
+
+export class ReactNativeRuntime implements IRuntimeEnvironment {
+    public client: AnalyticsFetchClient;
+    public storage: ReactNativeStorage;
+
+    constructor(options: ReactNativeRuntimeOptions) {
+        const visitorIdKey = options.visitorIdKey ?? 'visitorId';
+        this.storage = options.storage;
+        this.client = new AnalyticsFetchClient({
+            preprocessRequest: options.preprocessRequest,
+            token: options.token,
+            baseUrl: buildBaseUrl(options.endpoint, options.version),
+            visitorIdProvider: {
+                getCurrentVisitorId: async () => (await this.storage.getItem(visitorIdKey)) || uuidv4(),
+                setCurrentVisitorId: (visitorId: string) => this.storage.setItem(visitorIdKey, visitorId),
+            },
+        });
+    }
+
+    public getClientDependingOnEventType() {
+        return this.client;
+    }
+}

--- a/packages/coveo-analytics/src/react-native/react-native-utils.ts
+++ b/packages/coveo-analytics/src/react-native/react-native-utils.ts
@@ -1,0 +1,9 @@
+export const ReactNativeRuntimeWarning = `
+        We've detected you're using React Native but have not provided the corresponding runtime,
+        for an optimal experience please use the "coveo.analytics/react-native" subpackage.
+        Follow the Readme on how to set it up: https://github.com/coveo/coveo.analytics.js#using-react-native
+    `;
+
+export function isReactNative() {
+    return typeof navigator != 'undefined' && navigator.product == 'ReactNative';
+}

--- a/packages/coveo-analytics/src/react-native/react-native.spec.ts
+++ b/packages/coveo-analytics/src/react-native/react-native.spec.ts
@@ -1,0 +1,30 @@
+import CoveoAnalyticsClient from '../client/analytics';
+import {ReactNativeRuntime} from './react-native-runtime';
+
+describe('ReactNativeRuntime', () => {
+    let runtimeEnvironment: ReactNativeRuntime;
+    let client: CoveoAnalyticsClient;
+
+    beforeEach(() => {
+        runtimeEnvironment = new ReactNativeRuntime({
+            storage: {
+                getItem: jest.fn(),
+                setItem: jest.fn(),
+                removeItem: jest.fn(),
+            },
+        });
+        client = new CoveoAnalyticsClient({runtimeEnvironment});
+    });
+
+    it('should call "storage.getItem" when getting the visitor ID', async () => {
+        jest.spyOn(runtimeEnvironment.storage, 'getItem');
+        await client.getCurrentVisitorId();
+        expect(runtimeEnvironment.storage.getItem).toHaveBeenCalled();
+    });
+
+    it('should call "storage.getItem" when getting the visitor ID', async () => {
+        jest.spyOn(runtimeEnvironment.storage, 'setItem');
+        await client.setCurrentVisitorId('myid');
+        expect(runtimeEnvironment.storage.setItem).toHaveBeenCalled();
+    });
+});

--- a/packages/coveo-analytics/src/searchPage/searchPageClient.spec.ts
+++ b/packages/coveo-analytics/src/searchPage/searchPageClient.spec.ts
@@ -1,0 +1,1661 @@
+import {CoveoSearchPageClient, EventDescription, SearchPageClientProvider} from './searchPageClient';
+import {
+    SearchPageEvents,
+    PartialDocumentInformation,
+    CustomEventsTypes,
+    OmniboxSuggestionsMetadata,
+    StaticFilterToggleValueMetadata,
+    GeneratedAnswerFeedbackReason,
+    GeneratedAnswerRephraseFormat,
+    GeneratedAnswerFeedbackReasonOption,
+} from './searchPageEvents';
+import CoveoAnalyticsClient from '../client/analytics';
+import {NoopAnalytics} from '../client/noopAnalytics';
+import {mockFetch, lastCallBody} from '../../tests/fetchMock';
+import doNotTrack from '../donottrack';
+import {Cookie} from '../cookieutils';
+
+jest.mock('../donottrack', () => {
+    return {
+        default: jest.fn(),
+        doNotTrack: jest.fn(),
+    };
+});
+const {fetchMock, fetchMockBeforeEach} = mockFetch();
+
+describe('SearchPageClient', () => {
+    const fakeDocInfo = {
+        collectionName: 'collection',
+        documentAuthor: 'author',
+        documentPosition: 1,
+        documentTitle: 'title',
+        documentUri: 'uri',
+        documentUriHash: 'hash',
+        documentUrl: 'url',
+        queryPipeline: 'my-pipeline',
+        rankingModifier: 'modifier',
+        sourceName: 'source',
+    };
+
+    const fakeDocID = {
+        contentIDKey: 'permanentID',
+        contentIDValue: 'the-permanent-id',
+    };
+
+    const fakeFacetState = [
+        {
+            valuePosition: 0,
+            value: 'foo',
+            state: 'selected' as const,
+            facetPosition: 1,
+            displayValue: 'foobar',
+            facetType: 'specific' as const,
+            field: '@foo',
+            id: 'bar',
+            title: 'title',
+        },
+    ];
+
+    const fakeStreamId = 'some-stream-id-123';
+
+    let client: CoveoSearchPageClient;
+
+    const provider: SearchPageClientProvider = {
+        getBaseMetadata: () => ({foo: 'bar'}),
+        getGeneratedAnswerMetadata: () => ({genQaMetadata: 'bar'}),
+        getSearchEventRequestPayload: () => ({
+            queryText: 'queryText',
+            responseTime: 123,
+        }),
+        getSearchUID: () => 'my-uid',
+        getPipeline: () => 'my-pipeline',
+        getOriginContext: () => 'origin-context',
+        getOriginLevel1: () => 'origin-level-1',
+        getOriginLevel2: () => 'origin-level-2',
+        getOriginLevel3: () => 'origin-level-3',
+        getLanguage: () => 'en',
+        getFacetState: () => fakeFacetState,
+        getIsAnonymous: () => false,
+        getSplitTestRunName: () => 'split-test-run-something',
+        getSplitTestRunVersion: () => 'split-test-run-something/foo',
+    };
+
+    beforeEach(() => {
+        fetchMockBeforeEach();
+
+        client = initClient();
+        client.coveoAnalyticsClient.runtime.storage.setItem('visitorId', 'visitor-id');
+        fetchMock.mock(/.*/, {
+            visitId: 'visit-id',
+        });
+    });
+
+    afterEach(() => {
+        fetchMock.reset();
+    });
+
+    const customDataFromMiddleware = {helloFromMiddleware: 1234};
+
+    const initClient = () => {
+        return new CoveoSearchPageClient(
+            {
+                beforeSendHooks: [
+                    (_, payload) =>
+                        Promise.resolve({...payload, customData: {...payload.customData, ...customDataFromMiddleware}}),
+                ],
+            },
+            provider
+        );
+    };
+
+    const expectOrigins = () => ({
+        originContext: 'origin-context',
+        originLevel1: 'origin-level-1',
+        originLevel2: 'origin-level-2',
+        originLevel3: 'origin-level-3',
+    });
+
+    const expectSplitTestRun = () => ({
+        splitTestRunName: 'split-test-run-something',
+        splitTestRunVersion: 'split-test-run-something/foo',
+    });
+
+    const expectMatchPayload = (actionCause: SearchPageEvents, meta = {}) => {
+        const body: string = lastCallBody(fetchMock);
+        const customData = {foo: 'bar', genQaMetadata: 'bar', ...customDataFromMiddleware, ...meta};
+        expect(JSON.parse(body)).toEqual({
+            queryText: 'queryText',
+            responseTime: 123,
+            searchQueryUid: provider.getSearchUID(),
+            queryPipeline: 'my-pipeline',
+            actionCause,
+            anonymous: false,
+            customData,
+            facetState: fakeFacetState,
+            language: 'en',
+            clientId: 'visitor-id',
+            userAgent: expect.any(String),
+            ...expectOrigins(),
+            ...expectSplitTestRun(),
+        });
+    };
+
+    const expectMatchDescription = (description: EventDescription, actionCause: SearchPageEvents, meta = {}) => {
+        const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
+        expect(description).toEqual({
+            actionCause,
+            customData,
+        });
+    };
+
+    const expectSearchEventToMatchDescription = (
+        description: EventDescription,
+        actionCause: SearchPageEvents,
+        meta = {}
+    ) => {
+        expectMatchDescription(description, actionCause, {...meta, genQaMetadata: 'bar'});
+    };
+
+    const expectMatchDocumentPayload = (actionCause: SearchPageEvents, doc: PartialDocumentInformation, meta = {}) => {
+        const body: string = lastCallBody(fetchMock);
+        const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
+        expect(JSON.parse(body)).toEqual({
+            anonymous: false,
+            actionCause,
+            customData,
+            language: 'en',
+            clientId: 'visitor-id',
+            facetState: fakeFacetState,
+            searchQueryUid: provider.getSearchUID(),
+            userAgent: expect.any(String),
+            ...doc,
+            ...expectOrigins(),
+            ...expectSplitTestRun(),
+        });
+    };
+
+    const expectMatchCustomEventPayload = (
+        actionCause: SearchPageEvents,
+        meta = {},
+        eventType = CustomEventsTypes[actionCause]
+    ) => {
+        const body: string = lastCallBody(fetchMock);
+        const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
+        expect(JSON.parse(body)).toEqual({
+            anonymous: false,
+            eventValue: actionCause,
+            eventType,
+            lastSearchQueryUid: 'my-uid',
+            customData,
+            language: 'en',
+            clientId: 'visitor-id',
+            facetState: fakeFacetState,
+            userAgent: expect.any(String),
+            ...expectOrigins(),
+            ...expectSplitTestRun(),
+        });
+    };
+
+    const expectMatchCustomEventWithTypePayload = (eventValue: string, eventType: string, meta = {}) => {
+        const body: string = lastCallBody(fetchMock);
+        const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
+        expect(JSON.parse(body)).toEqual({
+            anonymous: false,
+            eventValue,
+            eventType,
+            lastSearchQueryUid: 'my-uid',
+            customData,
+            language: 'en',
+            clientId: 'visitor-id',
+            facetState: fakeFacetState,
+            userAgent: expect.any(String),
+            ...expectOrigins(),
+            ...expectSplitTestRun(),
+        });
+    };
+
+    it('should send proper payload for #interfaceLoad', async () => {
+        await client.logInterfaceLoad();
+        expectMatchPayload(SearchPageEvents.interfaceLoad);
+    });
+
+    it('should send proper payload for #makeInterfaceLoad', async () => {
+        const built = await client.makeInterfaceLoad();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.interfaceLoad);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.interfaceLoad);
+    });
+
+    it('should send proper payload for #interfaceChange', async () => {
+        await client.logInterfaceChange({
+            interfaceChangeTo: 'bob',
+        });
+        expectMatchPayload(SearchPageEvents.interfaceChange, {interfaceChangeTo: 'bob'});
+    });
+
+    it('should send proper payload for #makeInterfaceChange', async () => {
+        const built = await client.makeInterfaceChange({interfaceChangeTo: 'bob'});
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.interfaceChange, {interfaceChangeTo: 'bob'});
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.interfaceChange, {
+            interfaceChangeTo: 'bob',
+        });
+    });
+
+    it('should send proper payload for #didyoumeanAutomatic', async () => {
+        await client.logDidYouMeanAutomatic();
+        expectMatchPayload(SearchPageEvents.didyoumeanAutomatic);
+    });
+
+    it('should send proper payload for #makeDidyoumeanAutomatic', async () => {
+        const built = await client.makeDidYouMeanAutomatic();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.didyoumeanAutomatic);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.didyoumeanAutomatic);
+    });
+
+    it('should send proper payload for #didyoumeanClick', async () => {
+        await client.logDidYouMeanClick();
+        expectMatchPayload(SearchPageEvents.didyoumeanClick);
+    });
+
+    it('should send proper payload for #makeDidyoumeanClick', async () => {
+        const built = await client.makeDidYouMeanClick();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.didyoumeanClick);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.didyoumeanClick);
+    });
+
+    it('should send proper payload for #resultsSort', async () => {
+        await client.logResultsSort({resultsSortBy: 'date ascending'});
+        expectMatchPayload(SearchPageEvents.resultsSort, {resultsSortBy: 'date ascending'});
+    });
+
+    it('should send proper payload for #makeResultsSort', async () => {
+        const built = await client.makeResultsSort({resultsSortBy: 'date ascending'});
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.resultsSort, {resultsSortBy: 'date ascending'});
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.resultsSort, {
+            resultsSortBy: 'date ascending',
+        });
+    });
+
+    it('should send proper payload for #searchboxSubmit', async () => {
+        await client.logSearchboxSubmit();
+        expectMatchPayload(SearchPageEvents.searchboxSubmit);
+    });
+
+    it('should send proper payload for #makeSearchboxSubmit', async () => {
+        const built = await client.makeSearchboxSubmit();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.searchboxSubmit);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.searchboxSubmit);
+    });
+
+    it('should send proper payload for #searchboxClear', async () => {
+        await client.logSearchboxClear();
+        expectMatchPayload(SearchPageEvents.searchboxClear);
+    });
+
+    it('should send proper payload for #makeSearchboxClear', async () => {
+        const built = await client.makeSearchboxClear();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.searchboxClear);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.searchboxClear);
+    });
+
+    it('should send proper payload for #searchboxAsYouType', async () => {
+        await client.logSearchboxAsYouType();
+        expectMatchPayload(SearchPageEvents.searchboxAsYouType);
+    });
+
+    it('should send proper payload for #makeSearchboxAsYouType', async () => {
+        const built = await client.makeSearchboxAsYouType();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.searchboxAsYouType);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.searchboxAsYouType);
+    });
+
+    it('should send proper payload for #documentQuickview', async () => {
+        await client.logDocumentQuickview(fakeDocInfo, fakeDocID);
+        expectMatchDocumentPayload(SearchPageEvents.documentQuickview, fakeDocInfo, fakeDocID);
+    });
+
+    it('should send proper payload for #makeDocumentQuickview', async () => {
+        const built = await client.makeDocumentQuickview(fakeDocInfo, fakeDocID);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchDocumentPayload(SearchPageEvents.documentQuickview, fakeDocInfo, fakeDocID);
+        expectMatchDescription(built.description, SearchPageEvents.documentQuickview, {...fakeDocID});
+    });
+
+    it('should send proper payload for #documentOpen', async () => {
+        await client.logDocumentOpen(fakeDocInfo, fakeDocID);
+        expectMatchDocumentPayload(SearchPageEvents.documentOpen, fakeDocInfo, fakeDocID);
+    });
+
+    it('should send proper payload for #makeDocumentOpen', async () => {
+        const built = await client.makeDocumentOpen(fakeDocInfo, fakeDocID);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchDocumentPayload(SearchPageEvents.documentOpen, fakeDocInfo, fakeDocID);
+        expectMatchDescription(built.description, SearchPageEvents.documentOpen, {...fakeDocID});
+    });
+
+    it('should send proper payload for #showMoreFoldedResults', async () => {
+        await client.logShowMoreFoldedResults(fakeDocInfo, fakeDocID);
+        expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
+    });
+
+    it('should send proper payload for #makeShowMoreFoldedResults', async () => {
+        const built = await client.makeShowMoreFoldedResults(fakeDocInfo, fakeDocID);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchDocumentPayload(SearchPageEvents.showMoreFoldedResults, fakeDocInfo, fakeDocID);
+        expectMatchDescription(built.description, SearchPageEvents.showMoreFoldedResults, fakeDocID);
+    });
+
+    it('should send proper payload for #showLessFoldedResults', async () => {
+        await client.logShowLessFoldedResults();
+        expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults);
+    });
+
+    it('should send proper payload for #makeShowLessFoldedResults', async () => {
+        const built = await client.makeShowLessFoldedResults();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.showLessFoldedResults);
+        expectMatchDescription(built.description, SearchPageEvents.showLessFoldedResults);
+    });
+
+    it('should send proper payload for #omniboxAnalytics', async () => {
+        const meta: OmniboxSuggestionsMetadata = {
+            partialQueries: 'a;b;c',
+            partialQuery: 'abcd',
+            suggestionRanking: 1,
+            suggestions: 'q;w;e;r;t;y',
+            querySuggestResponseId: '1',
+        };
+        await client.logOmniboxAnalytics(meta);
+        expectMatchPayload(SearchPageEvents.omniboxAnalytics, meta);
+    });
+
+    it('should send proper payload for #makeOmniboxAnalytics', async () => {
+        const meta: OmniboxSuggestionsMetadata = {
+            partialQueries: 'a;b;c',
+            partialQuery: 'abcd',
+            suggestionRanking: 1,
+            suggestions: 'q;w;e;r;t;y',
+            querySuggestResponseId: '1',
+        };
+        const built = await client.makeOmniboxAnalytics(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.omniboxAnalytics, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.omniboxAnalytics, meta);
+    });
+
+    it('should send proper payload for #logOmniboxFromLink', async () => {
+        const meta: OmniboxSuggestionsMetadata = {
+            partialQueries: 'a;b;c',
+            partialQuery: 'abcd',
+            suggestionRanking: 1,
+            suggestions: 'q;w;e;r;t;y',
+            querySuggestResponseId: '1',
+        };
+        await client.logOmniboxFromLink(meta);
+        expectMatchPayload(SearchPageEvents.omniboxFromLink, meta);
+    });
+
+    it('should send proper payload for #makeOmniboxFromLink', async () => {
+        const meta: OmniboxSuggestionsMetadata = {
+            partialQueries: 'a;b;c',
+            partialQuery: 'abcd',
+            suggestionRanking: 1,
+            suggestions: 'q;w;e;r;t;y',
+            querySuggestResponseId: '1',
+        };
+        const built = await client.makeOmniboxFromLink(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.omniboxFromLink, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.omniboxFromLink, meta);
+    });
+
+    it('should send proper payload for #logSearchFromLink', async () => {
+        await client.logSearchFromLink();
+        expectMatchPayload(SearchPageEvents.searchFromLink);
+    });
+
+    it('should send proper payload for #makeSearchFromLink', async () => {
+        const built = await client.makeSearchFromLink();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.searchFromLink);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.searchFromLink);
+    });
+
+    it('should send proper payload for #logTriggerNotify', async () => {
+        const meta = {
+            notifications: ['foo', 'bar'],
+        };
+        await client.logTriggerNotify(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.triggerNotify, meta);
+    });
+
+    it('should send proper payload for #makeTriggerNotify', async () => {
+        const meta = {
+            notifications: ['foo', 'bar'],
+        };
+        const built = await client.makeTriggerNotify(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.triggerNotify, meta);
+        expectMatchDescription(built.description, SearchPageEvents.triggerNotify, meta);
+    });
+
+    it('should send proper payload for #logTriggerExecute', async () => {
+        const meta = {
+            executions: [
+                {functionName: 'foo', params: [true, 3, 'hello']},
+                {functionName: 'world', params: []},
+            ],
+        };
+        await client.logTriggerExecute(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.triggerExecute, meta);
+    });
+
+    it('should send proper payload for #makeTriggerExecute', async () => {
+        const meta = {
+            executions: [
+                {functionName: 'foo', params: [true, 3, 'hello']},
+                {functionName: 'world', params: []},
+            ],
+        };
+        const built = await client.makeTriggerExecute(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.triggerExecute, meta);
+        expectMatchDescription(built.description, SearchPageEvents.triggerExecute, meta);
+    });
+
+    it('should send proper payload for #logTriggerQuery', async () => {
+        const meta = {
+            query: 'queryText',
+        };
+        await client.logTriggerQuery();
+        expectMatchCustomEventPayload(SearchPageEvents.triggerQuery, meta, 'queryPipelineTriggers');
+    });
+
+    it('should send proper payload for #makeTriggerQuery', async () => {
+        const meta = {
+            query: 'queryText',
+        };
+        const built = await client.makeTriggerQuery();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.triggerQuery, meta, 'queryPipelineTriggers');
+        expectMatchDescription(built.description, SearchPageEvents.triggerQuery, meta);
+    });
+
+    it('should send proper payload for #logUndoTriggerQuery', async () => {
+        const meta = {
+            undoneQuery: 'foo',
+        };
+        await client.logUndoTriggerQuery(meta);
+        expectMatchPayload(SearchPageEvents.undoTriggerQuery, meta);
+    });
+
+    it('should send proper payload for #makeUndoTriggerQuery', async () => {
+        const meta = {
+            undoneQuery: 'foo',
+        };
+        const built = await client.makeUndoTriggerQuery(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.undoTriggerQuery, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.undoTriggerQuery, meta);
+    });
+
+    it('should send proper payload for #logTriggerRedirect', async () => {
+        const meta = {
+            redirectedTo: 'foo',
+            query: provider.getSearchEventRequestPayload().queryText,
+        };
+        await client.logTriggerRedirect(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.triggerRedirect, meta);
+    });
+
+    it('should send proper payload for #makeTriggerRedirect', async () => {
+        const meta = {
+            redirectedTo: 'foo',
+            query: provider.getSearchEventRequestPayload().queryText,
+        };
+        const built = await client.makeTriggerRedirect(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.triggerRedirect, meta);
+        expectMatchDescription(built.description, SearchPageEvents.triggerRedirect, meta);
+    });
+
+    it('should send proper payload for #logPagerResize', async () => {
+        const meta = {
+            currentResultsPerPage: 123,
+        };
+        await client.logPagerResize(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.pagerResize, meta);
+    });
+
+    it('should send proper payload for #makePagerResize', async () => {
+        const meta = {
+            currentResultsPerPage: 123,
+        };
+        const built = await client.makePagerResize(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.pagerResize, meta);
+        expectMatchDescription(built.description, SearchPageEvents.pagerResize, meta);
+    });
+
+    it('should send proper payload for #logPagerNumber', async () => {
+        const meta = {pagerNumber: 123};
+        await client.logPagerNumber(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.pagerNumber, meta);
+    });
+
+    it('should send proper payload for #makePagerNumber', async () => {
+        const meta = {pagerNumber: 123};
+        const built = await client.makePagerNumber(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.pagerNumber, meta);
+        expectMatchDescription(built.description, SearchPageEvents.pagerNumber, meta);
+    });
+
+    it('should send proper payload for #logPagerNext', async () => {
+        const meta = {pagerNumber: 123};
+        await client.logPagerNext(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.pagerNext, meta);
+    });
+
+    it('should send proper payload for #makePagerNext', async () => {
+        const meta = {pagerNumber: 123};
+        const built = await client.makePagerNext(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.pagerNext, meta);
+        expectMatchDescription(built.description, SearchPageEvents.pagerNext, meta);
+    });
+
+    it('should send proper payload for #logPagerPrevious', async () => {
+        const meta = {pagerNumber: 123};
+        await client.logPagerPrevious(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.pagerPrevious, meta);
+    });
+
+    it('should send proper payload for #makePagerPrevious', async () => {
+        const meta = {pagerNumber: 123};
+        const built = await client.makePagerPrevious(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.pagerPrevious, meta);
+        expectMatchDescription(built.description, SearchPageEvents.pagerPrevious, meta);
+    });
+
+    it('should send proper payload for #logPagerScrolling', async () => {
+        await client.logPagerScrolling();
+        expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling);
+    });
+
+    it('should send proper payload for #makePagerScrolling', async () => {
+        const built = await client.makePagerScrolling();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling);
+        expectMatchDescription(built.description, SearchPageEvents.pagerScrolling);
+    });
+
+    it('should send the proper payload for #logStaticFilterClearAll', async () => {
+        const staticFilterId = 'filetypes';
+        await client.logStaticFilterClearAll({staticFilterId});
+
+        expectMatchPayload(SearchPageEvents.staticFilterClearAll, {staticFilterId});
+    });
+
+    it('should send the proper payload for #makeStaticFilterClearAll', async () => {
+        const staticFilterId = 'filetypes';
+        const built = await client.makeStaticFilterClearAll({staticFilterId});
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.staticFilterClearAll, {staticFilterId});
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.staticFilterClearAll, {staticFilterId});
+    });
+
+    it('should send the proper payload for #logStaticFilterSelect', async () => {
+        const meta: StaticFilterToggleValueMetadata = {
+            staticFilterId: 'filetypes',
+            staticFilterValue: {
+                caption: 'Youtube',
+                expression: '@filetype="youtubevideo"',
+            },
+        };
+        await client.logStaticFilterSelect(meta);
+
+        expectMatchPayload(SearchPageEvents.staticFilterSelect, meta);
+    });
+
+    it('should send the proper payload for #makeStaticFilterSelect', async () => {
+        const meta: StaticFilterToggleValueMetadata = {
+            staticFilterId: 'filetypes',
+            staticFilterValue: {
+                caption: 'Youtube',
+                expression: '@filetype="youtubevideo"',
+            },
+        };
+        const built = await client.makeStaticFilterSelect(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+
+        expectMatchPayload(SearchPageEvents.staticFilterSelect, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.staticFilterSelect, meta);
+    });
+
+    it('should send the proper payload for #logStaticFilterDeselect', async () => {
+        const meta: StaticFilterToggleValueMetadata = {
+            staticFilterId: 'filetypes',
+            staticFilterValue: {
+                caption: 'Youtube',
+                expression: '@filetype="youtubevideo"',
+            },
+        };
+        await client.logStaticFilterDeselect(meta);
+
+        expectMatchPayload(SearchPageEvents.staticFilterDeselect, meta);
+    });
+
+    it('should send the proper payload for #makeStaticFilterDeselect', async () => {
+        const meta: StaticFilterToggleValueMetadata = {
+            staticFilterId: 'filetypes',
+            staticFilterValue: {
+                caption: 'Youtube',
+                expression: '@filetype="youtubevideo"',
+            },
+        };
+        const built = await client.makeStaticFilterDeselect(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.staticFilterDeselect, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.staticFilterDeselect, meta);
+    });
+
+    it('should send proper payload for #logFacetSearch', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+        };
+        await client.logFacetSearch(meta);
+        expectMatchPayload(SearchPageEvents.facetSearch, meta);
+    });
+
+    it('should send proper payload for #makeFacetSearch', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+        };
+        const built = await client.makeFacetSearch(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.facetSearch, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetSearch, meta);
+    });
+
+    it('should send proper payload for #logFacetSelect', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            facetValue: 'qwerty',
+        };
+
+        await client.logFacetSelect(meta);
+        expectMatchPayload(SearchPageEvents.facetSelect, meta);
+    });
+
+    it('should send proper payload for #makeFacetSelect', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            facetValue: 'qwerty',
+        };
+        const built = await client.makeFacetSelect(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.facetSelect, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetSelect, meta);
+    });
+
+    it('should send proper payload for #logFacetDeselect', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            facetValue: 'qwerty',
+        };
+
+        await client.logFacetDeselect(meta);
+        expectMatchPayload(SearchPageEvents.facetDeselect, meta);
+    });
+
+    it('should send proper payload for #makeFacetDeselect', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            facetValue: 'qwerty',
+        };
+
+        const built = await client.makeFacetDeselect(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.facetDeselect, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetDeselect, meta);
+    });
+
+    it('should send proper payload for #logFacetExclude', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            facetValue: 'qwerty',
+        };
+        await client.logFacetExclude(meta);
+        expectMatchPayload(SearchPageEvents.facetExclude, meta);
+    });
+
+    it('should send proper payload for #makeFacetExclude', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            facetValue: 'qwerty',
+        };
+        const built = await client.makeFacetExclude(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.facetExclude, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetExclude, meta);
+    });
+
+    it('should send proper payload for #logFacetUnexclude', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            facetValue: 'qwerty',
+        };
+        await client.logFacetUnexclude(meta);
+        expectMatchPayload(SearchPageEvents.facetUnexclude, meta);
+    });
+
+    it('should send proper payload for #makeFacetUnexclude', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            facetValue: 'qwerty',
+        };
+        const built = await client.makeFacetUnexclude(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.facetUnexclude, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetUnexclude, meta);
+    });
+
+    it('should send proper payload for #logFacetSelectAll', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+        };
+        await client.logFacetSelectAll(meta);
+        expectMatchPayload(SearchPageEvents.facetSelectAll, meta);
+    });
+
+    it('should send proper payload for #makeFacetSelectAll', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+        };
+        const built = await client.makeFacetSelectAll(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.facetSelectAll, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetSelectAll, meta);
+    });
+
+    it('should send proper payload for #logFacetUpdateSort', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            criteria: 'bazz',
+        };
+        await client.logFacetUpdateSort(meta);
+        expectMatchPayload(SearchPageEvents.facetUpdateSort, meta);
+    });
+
+    it('should send proper payload for #makeFacetUpdateSort', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+            criteria: 'bazz',
+        };
+        const built = await client.makeFacetUpdateSort(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.facetUpdateSort, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.facetUpdateSort, meta);
+    });
+
+    it('should send proper payload for #logFacetShowMore', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+        };
+        await client.logFacetShowMore(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.facetShowMore, meta);
+    });
+
+    it('should send proper payload for #makeFacetShowMore', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+        };
+        const built = await client.makeFacetShowMore(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.facetShowMore, meta);
+        expectMatchDescription(built.description, SearchPageEvents.facetShowMore, meta);
+    });
+
+    it('should send proper payload for #logFacetShowLess', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+        };
+        await client.logFacetShowLess(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.facetShowLess, meta);
+    });
+
+    it('should send proper payload for #makeFacetShowLess', async () => {
+        const meta = {
+            facetField: '@foo',
+            facetId: 'bar',
+            facetTitle: 'title',
+        };
+        const built = await client.makeFacetShowLess(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.facetShowLess, meta);
+        expectMatchDescription(built.description, SearchPageEvents.facetShowLess, meta);
+    });
+
+    it('should send proper payload for #logQueryError', async () => {
+        const meta = {
+            query: 'q',
+            aq: 'aq',
+            cq: 'cq',
+            dq: 'dq',
+            errorMessage: 'boom',
+            errorType: 'a bad one',
+        };
+        await client.logQueryError(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.queryError, meta);
+    });
+
+    it('should send proper payload for #makeQueryError', async () => {
+        const meta = {
+            query: 'q',
+            aq: 'aq',
+            cq: 'cq',
+            dq: 'dq',
+            errorMessage: 'boom',
+            errorType: 'a bad one',
+        };
+        const built = await client.makeQueryError(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.queryError, meta);
+        expectMatchDescription(built.description, SearchPageEvents.queryError, meta);
+    });
+
+    it('should send proper payload for #logQueryErrorBack', async () => {
+        await client.logQueryErrorBack();
+        expectMatchPayload(SearchPageEvents.queryErrorBack);
+    });
+
+    it('should send proper payload for #makeQueryErrorBack', async () => {
+        const built = await client.makeQueryErrorBack();
+        await built.log({searchUID: provider.getSearchUID()});
+
+        expectMatchPayload(SearchPageEvents.queryErrorBack);
+        expectMatchDescription(built.description, SearchPageEvents.queryErrorBack);
+    });
+
+    it('should send proper payload for #logQueryErrorRetry', async () => {
+        await client.logQueryErrorRetry();
+        expectMatchPayload(SearchPageEvents.queryErrorRetry);
+    });
+
+    it('should send proper payload for #makeQueryErrorRetry', async () => {
+        const built = await client.makeQueryErrorRetry();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.queryErrorRetry);
+        expectMatchDescription(built.description, SearchPageEvents.queryErrorRetry);
+    });
+
+    it('should send proper payload for #logQueryErrorClear', async () => {
+        await client.logQueryErrorClear();
+        expectMatchPayload(SearchPageEvents.queryErrorClear);
+    });
+
+    it('should send proper payload for #makeQueryErrorClear', async () => {
+        const built = await client.makeQueryErrorClear();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.queryErrorClear);
+        expectMatchDescription(built.description, SearchPageEvents.queryErrorClear);
+    });
+
+    it('should send proper payload for #logRecommendationInterfaceLoad', async () => {
+        await client.logRecommendationInterfaceLoad();
+        expectMatchPayload(SearchPageEvents.recommendationInterfaceLoad);
+    });
+
+    it('should send proper payload for #makeRecommendationInterfaceLoad', async () => {
+        const built = await client.makeRecommendationInterfaceLoad();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.recommendationInterfaceLoad);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.recommendationInterfaceLoad);
+    });
+
+    it('should send proper payload for #logRecommendation', async () => {
+        await client.logRecommendation();
+        expectMatchCustomEventPayload(SearchPageEvents.recommendation);
+    });
+
+    it('should send proper payload for #makeRecommendation', async () => {
+        const built = await client.makeRecommendation();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.recommendation);
+    });
+
+    it('should send proper payload for #recommendationOpen', async () => {
+        await client.logRecommendationOpen(fakeDocInfo, fakeDocID);
+        expectMatchDocumentPayload(SearchPageEvents.recommendationOpen, fakeDocInfo, fakeDocID);
+    });
+
+    it('should send proper payload for #makeRecommendationOpen', async () => {
+        const built = await client.makeRecommendationOpen(fakeDocInfo, fakeDocID);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchDocumentPayload(SearchPageEvents.recommendationOpen, fakeDocInfo, fakeDocID);
+        expectMatchDescription(built.description, SearchPageEvents.recommendationOpen, {...fakeDocID});
+    });
+
+    it('should send proper payload for #fetchMoreResults', async () => {
+        await client.logFetchMoreResults();
+        expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
+    });
+
+    it('should send proper payload for #makeFetchMoreResults', async () => {
+        const built = await client.makeFetchMoreResults();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
+        expectMatchDescription(built.description, SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
+    });
+
+    it('should send proper payload for #logLikeSmartSnippet', async () => {
+        await client.logLikeSmartSnippet();
+        expectMatchCustomEventPayload(SearchPageEvents.likeSmartSnippet);
+    });
+
+    it('should send proper payload for #makeLikeSmartSnippet', async () => {
+        const built = await client.makeLikeSmartSnippet();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.likeSmartSnippet);
+        expectMatchDescription(built.description, SearchPageEvents.likeSmartSnippet);
+    });
+
+    it('should send proper payload for #logDislikeSmartSnippet', async () => {
+        await client.logDislikeSmartSnippet();
+        expectMatchCustomEventPayload(SearchPageEvents.dislikeSmartSnippet);
+    });
+
+    it('should send proper payload for #makeDislikeSmartSnippet', async () => {
+        const built = await client.makeDislikeSmartSnippet();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.dislikeSmartSnippet);
+        expectMatchDescription(built.description, SearchPageEvents.dislikeSmartSnippet);
+    });
+
+    it('should send proper payload for #logExpandSmartSnippet', async () => {
+        await client.logExpandSmartSnippet();
+        expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippet);
+    });
+
+    it('should send proper payload for #makeExpandSmartSnippet', async () => {
+        const built = await client.makeExpandSmartSnippet();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippet);
+        expectMatchDescription(built.description, SearchPageEvents.expandSmartSnippet);
+    });
+
+    it('should send proper payload for #logCollapseSmartSnippet', async () => {
+        await client.logCollapseSmartSnippet();
+        expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippet);
+    });
+
+    it('should send proper payload for #makeCollapseSmartSnippet', async () => {
+        const built = await client.makeCollapseSmartSnippet();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippet);
+        expectMatchDescription(built.description, SearchPageEvents.collapseSmartSnippet);
+    });
+
+    it('should send proper payload for #logOpenSmartSnippetFeedbackModal', async () => {
+        await client.logOpenSmartSnippetFeedbackModal();
+        expectMatchCustomEventPayload(SearchPageEvents.openSmartSnippetFeedbackModal);
+    });
+
+    it('should send proper payload for #makeOpenSmartSnippetFeedbackModal', async () => {
+        const built = await client.makeOpenSmartSnippetFeedbackModal();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.openSmartSnippetFeedbackModal);
+        expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetFeedbackModal);
+    });
+
+    it('should send proper payload for #logCloseSmartSnippetFeedbackModal', async () => {
+        await client.logCloseSmartSnippetFeedbackModal();
+        expectMatchCustomEventPayload(SearchPageEvents.closeSmartSnippetFeedbackModal);
+    });
+
+    it('should send proper payload for #makeCloseSmartSnippetFeedbackModal', async () => {
+        const built = await client.makeCloseSmartSnippetFeedbackModal();
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.closeSmartSnippetFeedbackModal);
+        expectMatchDescription(built.description, SearchPageEvents.closeSmartSnippetFeedbackModal);
+    });
+
+    it('should send proper payload for #logSmartSnippetFeedbackReason', async () => {
+        await client.logSmartSnippetFeedbackReason('does_not_answer', 'this is irrelevant');
+        expectMatchCustomEventPayload(SearchPageEvents.sendSmartSnippetReason, {
+            details: 'this is irrelevant',
+            reason: 'does_not_answer',
+        });
+    });
+
+    it('should send proper payload for #makeSmartSnippetFeedbackReason', async () => {
+        const built = await client.makeSmartSnippetFeedbackReason('does_not_answer', 'this is irrelevant');
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.sendSmartSnippetReason, {
+            details: 'this is irrelevant',
+            reason: 'does_not_answer',
+        });
+        expectMatchDescription(built.description, SearchPageEvents.sendSmartSnippetReason, {
+            details: 'this is irrelevant',
+            reason: 'does_not_answer',
+        });
+    });
+
+    it('should send proper payload for #logExpandSmartSnippetSuggestion', async () => {
+        await client.logExpandSmartSnippetSuggestion({
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
+    it('should send proper payload for #makeExpandSmartSnippetSuggestion', async () => {
+        const built = await client.makeExpandSmartSnippetSuggestion({
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        expectMatchDescription(built.description, SearchPageEvents.expandSmartSnippetSuggestion, {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
+    it('should send proper payload for #logCollapseSmartSnippetSuggestion', async () => {
+        await client.logCollapseSmartSnippetSuggestion({
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippetSuggestion, {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
+    it('should send proper payload for #makeCollapseSmartSnippetSuggestion', async () => {
+        const built = await client.makeCollapseSmartSnippetSuggestion({
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippetSuggestion, {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        expectMatchDescription(built.description, SearchPageEvents.collapseSmartSnippetSuggestion, {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
+    it('should send proper payload for #logExpandSmartSnippetSuggestion when called with only the documentId', async () => {
+        await client.logExpandSmartSnippetSuggestion({contentIdKey: 'permanentid', contentIdValue: 'foo'});
+        expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, {
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
+    it('should send proper payload for #makeExpandSmartSnippetSuggestion when called with only the documentId', async () => {
+        const built = await client.makeExpandSmartSnippetSuggestion({
+            contentIdKey: 'permanentid',
+            contentIdValue: 'foo',
+        });
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.expandSmartSnippetSuggestion, {
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        expectMatchDescription(built.description, SearchPageEvents.expandSmartSnippetSuggestion, {
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
+    it('should send proper payload for #logCollapseSmartSnippetSuggestion when called with only the documentId', async () => {
+        await client.logCollapseSmartSnippetSuggestion({contentIdKey: 'permanentid', contentIdValue: 'foo'});
+        expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippetSuggestion, {
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
+    it('should send proper payload for #makeCollapseSmartSnippetSuggestion when called with only the documentId', async () => {
+        const built = await client.makeCollapseSmartSnippetSuggestion({
+            contentIdKey: 'permanentid',
+            contentIdValue: 'foo',
+        });
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.collapseSmartSnippetSuggestion, {
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        expectMatchDescription(built.description, SearchPageEvents.collapseSmartSnippetSuggestion, {
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
+    it('should send proper payload for #logShowMoreSmartSnippetSuggestion', async () => {
+        await client.logShowMoreSmartSnippetSuggestion({
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        expectMatchCustomEventPayload(SearchPageEvents.showMoreSmartSnippetSuggestion, {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
+    it('should send proper payload for #logShowLessSmartSnippetSuggestion', async () => {
+        await client.logShowLessSmartSnippetSuggestion({
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+        expectMatchCustomEventPayload(SearchPageEvents.showLessSmartSnippetSuggestion, {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        });
+    });
+
+    it('should send proper payload for #logOpenSmartSnippetSource', async () => {
+        await client.logOpenSmartSnippetSource(fakeDocInfo, fakeDocID);
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSource, fakeDocInfo, fakeDocID);
+    });
+
+    it('should send proper payload for #logCopyToClipboard', async () => {
+        await client.logCopyToClipboard(fakeDocInfo, fakeDocID);
+        expectMatchDocumentPayload(SearchPageEvents.copyToClipboard, fakeDocInfo, fakeDocID);
+    });
+
+    it('should send proper payload for #makeOpenSmartSnippetSource', async () => {
+        const built = await client.makeOpenSmartSnippetSource(fakeDocInfo, fakeDocID);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSource, fakeDocInfo, fakeDocID);
+        expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetSource, {...fakeDocID});
+    });
+
+    it('should send proper payload for #logOpenSmartSnippetSuggestionSource', async () => {
+        const meta = {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        };
+        await client.logOpenSmartSnippetSuggestionSource(fakeDocInfo, meta);
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSuggestionSource, fakeDocInfo, {
+            ...meta,
+            contentIDKey: meta.documentId.contentIdKey,
+            contentIDValue: meta.documentId.contentIdValue,
+        });
+    });
+
+    it('should send proper payload for #makeOpenSmartSnippetSuggestionSource', async () => {
+        const meta = {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            contentIDKey: 'permanentid',
+            contentIDValue: 'foo',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+        };
+        const built = await client.makeOpenSmartSnippetSuggestionSource(fakeDocInfo, meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSuggestionSource, fakeDocInfo, meta);
+        expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetSuggestionSource, meta);
+    });
+
+    it('should send proper payload for #logOpenSmartSnippetInlineLink', async () => {
+        const meta = {
+            ...fakeDocID,
+            linkText: 'Some text',
+            linkURL: 'https://invalid.com',
+        };
+        await client.logOpenSmartSnippetInlineLink(fakeDocInfo, meta);
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetInlineLink, fakeDocInfo, meta);
+    });
+
+    it('should send proper payload for #makeOpenSmartSnippetInlineLink', async () => {
+        const meta = {
+            ...fakeDocID,
+            linkText: 'Some text',
+            linkURL: 'https://invalid.com',
+        };
+        const built = await client.makeOpenSmartSnippetInlineLink(fakeDocInfo, meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetInlineLink, fakeDocInfo, meta);
+        expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetInlineLink, meta);
+    });
+
+    it('should send proper payload for #logOpenSmartSnippetSuggestionInlineLink', async () => {
+        const meta = {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+            linkText: 'Some text',
+            linkURL: 'https://invalid.com',
+        };
+        await client.logOpenSmartSnippetSuggestionInlineLink(fakeDocInfo, meta);
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSuggestionInlineLink, fakeDocInfo, {
+            ...meta,
+            contentIDKey: meta.documentId.contentIdKey,
+            contentIDValue: meta.documentId.contentIdValue,
+        });
+    });
+
+    it('should send proper payload for #makeOpenSmartSnippetSuggestionInlineLink', async () => {
+        const meta = {
+            question: 'Abc',
+            answerSnippet: 'Def',
+            contentIDKey: 'permanentid',
+            contentIDValue: 'foo',
+            documentId: {contentIdKey: 'permanentid', contentIdValue: 'foo'},
+            linkText: 'Some text',
+            linkURL: 'https://invalid.com',
+        };
+        const built = await client.makeOpenSmartSnippetSuggestionInlineLink(fakeDocInfo, meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchDocumentPayload(SearchPageEvents.openSmartSnippetSuggestionInlineLink, fakeDocInfo, meta);
+        expectMatchDescription(built.description, SearchPageEvents.openSmartSnippetSuggestionInlineLink, meta);
+    });
+
+    it('should send proper payload for #logRecentQueryClick', async () => {
+        await client.logRecentQueryClick();
+        expectMatchPayload(SearchPageEvents.recentQueryClick);
+    });
+
+    it('should send proper payload for #makeRecentQueryClick', async () => {
+        const built = await client.makeRecentQueryClick();
+        await built.log({searchUID: provider.getSearchUID()});
+
+        expectMatchPayload(SearchPageEvents.recentQueryClick);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.recentQueryClick);
+    });
+
+    it('should send proper payload for #logClearRecentQueries', async () => {
+        await client.logClearRecentQueries();
+        expectMatchCustomEventPayload(SearchPageEvents.clearRecentQueries);
+    });
+
+    it('should send proper payload for #makeClearRecentQueries', async () => {
+        const built = await client.makeClearRecentQueries();
+        await built.log({searchUID: provider.getSearchUID()});
+
+        expectMatchCustomEventPayload(SearchPageEvents.clearRecentQueries);
+        expectMatchDescription(built.description, SearchPageEvents.clearRecentQueries);
+    });
+
+    it('should send proper payload for #logRecentResultClick', async () => {
+        await client.logRecentResultClick(fakeDocInfo, fakeDocID);
+        expectMatchCustomEventPayload(SearchPageEvents.recentResultClick, {
+            info: fakeDocInfo,
+            identifier: fakeDocID,
+        });
+    });
+
+    it('should send proper payload for #makeRecentResultClick', async () => {
+        const built = await client.makeRecentResultClick(fakeDocInfo, fakeDocID);
+        await built.log({searchUID: provider.getSearchUID()});
+
+        expectMatchCustomEventPayload(SearchPageEvents.recentResultClick, {
+            info: fakeDocInfo,
+            identifier: fakeDocID,
+        });
+
+        expectMatchDescription(built.description, SearchPageEvents.recentResultClick, {
+            info: fakeDocInfo,
+            identifier: fakeDocID,
+        });
+    });
+
+    it('should send proper payload for #logNoResultsBack', async () => {
+        await client.logNoResultsBack();
+        expectMatchPayload(SearchPageEvents.noResultsBack);
+    });
+
+    it('should send proper payload for #makeNoResultsBack', async () => {
+        const built = await client.makeNoResultsBack();
+        await built.log({searchUID: provider.getSearchUID()});
+
+        expectMatchPayload(SearchPageEvents.noResultsBack);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.noResultsBack);
+    });
+
+    it('should send proper payload for #logClearRecentResults', async () => {
+        await client.logClearRecentResults();
+        expectMatchCustomEventPayload(SearchPageEvents.clearRecentResults);
+    });
+
+    it('should send proper payload for #makeClearRecentResults', async () => {
+        const built = await client.makeClearRecentResults();
+        await built.log({searchUID: provider.getSearchUID()});
+
+        expectMatchCustomEventPayload(SearchPageEvents.clearRecentResults);
+        expectMatchDescription(built.description, SearchPageEvents.clearRecentResults);
+    });
+
+    it('should send proper payload for #logCustomEventWithType', async () => {
+        await client.logCustomEventWithType('foo', 'bar', {buzz: 'bazz'});
+        expectMatchCustomEventWithTypePayload('foo', 'bar', {buzz: 'bazz'});
+    });
+
+    it('should send proper payload for #makeCustomEventWithType', async () => {
+        const built = await client.makeCustomEventWithType('foo', 'bar', {buzz: 'bazz'});
+        await built.log({searchUID: provider.getSearchUID()});
+
+        expectMatchCustomEventWithTypePayload('foo', 'bar', {buzz: 'bazz'});
+        expectMatchDescription(built.description, 'foo' as SearchPageEvents, {buzz: 'bazz'});
+    });
+
+    it('should enable analytics tracking by default', () => {
+        const c = new CoveoSearchPageClient({}, provider);
+        expect(c.coveoAnalyticsClient instanceof CoveoAnalyticsClient).toBe(true);
+    });
+
+    it('should allow disabling analytics on initialization', () => {
+        const c = new CoveoSearchPageClient({enableAnalytics: false}, provider);
+        expect(c.coveoAnalyticsClient instanceof NoopAnalytics).toBe(true);
+    });
+
+    it('should disable analytics when doNotTrack is enabled', async () => {
+        (doNotTrack as jest.Mock).mockImplementationOnce(() => true);
+
+        const c = new CoveoSearchPageClient({}, provider);
+        expect(c.coveoAnalyticsClient instanceof NoopAnalytics).toBe(true);
+    });
+
+    it('should allow disabling analytics after initialization', () => {
+        const c = new CoveoSearchPageClient({enableAnalytics: true}, provider);
+        expect(c.coveoAnalyticsClient instanceof CoveoAnalyticsClient).toBe(true);
+        c.disable();
+        expect(c.coveoAnalyticsClient instanceof NoopAnalytics).toBe(true);
+    });
+
+    it('disabling analytics does not delete the visitorId', () => {
+        const visitorId = 'uuid';
+        Cookie.set('coveo_visitorId', visitorId);
+        const c = new CoveoSearchPageClient({enableAnalytics: true}, provider);
+
+        expect(Cookie.get('coveo_visitorId')).toBe(visitorId);
+        c.disable();
+        expect(Cookie.get('coveo_visitorId')).toBe(visitorId);
+    });
+
+    it('should allow enabling analytics after initialization', () => {
+        const c = new CoveoSearchPageClient({enableAnalytics: false}, provider);
+        expect(c.coveoAnalyticsClient instanceof NoopAnalytics).toBe(true);
+        c.enable();
+        expect(c.coveoAnalyticsClient instanceof CoveoAnalyticsClient).toBe(true);
+    });
+
+    it('should send proper payload for #logLikeGeneratedAnswer', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logLikeGeneratedAnswer(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.likeGeneratedAnswer, meta);
+    });
+
+    it('should send proper payload for #makeLikeGeneratedAnswer', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        const built = await client.makeLikeGeneratedAnswer(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.likeGeneratedAnswer, meta);
+        expectMatchDescription(built.description, SearchPageEvents.likeGeneratedAnswer, meta);
+    });
+
+    it('should send proper payload for #logDislikeGeneratedAnswer', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logDislikeGeneratedAnswer(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.dislikeGeneratedAnswer, meta);
+    });
+
+    it('should send proper payload for #makeDislikeGeneratedAnswer', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        const built = await client.makeDislikeGeneratedAnswer(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.dislikeGeneratedAnswer, meta);
+        expectMatchDescription(built.description, SearchPageEvents.dislikeGeneratedAnswer, meta);
+    });
+
+    it('should send proper payload for #logOpenGeneratedAnswerSource', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            citationId: 'some-document-id',
+            permanentId: 'perm-id',
+        };
+        await client.logOpenGeneratedAnswerSource(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, meta);
+    });
+
+    it('should send proper payload for #makeOpenGeneratedAnswerSource', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            citationId: 'some-document-id',
+            permanentId: 'perm-id',
+        };
+        const built = await client.makeOpenGeneratedAnswerSource(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.openGeneratedAnswerSource, meta);
+        expectMatchDescription(built.description, SearchPageEvents.openGeneratedAnswerSource, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerStreamEnd', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId, answerGenerated: true, answerTextIsEmpty: false};
+        await client.logGeneratedAnswerStreamEnd(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerStreamEnd', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId, answerGenerated: true, answerTextIsEmpty: false};
+        const built = await client.makeGeneratedAnswerStreamEnd(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerStreamEnd, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerStreamEnd, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerSourceHover', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            citationId: 'some-document-id',
+            permanentId: 'perm-id',
+            citationHoverTimeMs: 100,
+        };
+        await client.logGeneratedAnswerSourceHover(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerSourceHover, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerSourceHover', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            citationId: 'some-document-id',
+            permanentId: 'perm-id',
+            citationHoverTimeMs: 100,
+        };
+        const built = await client.makeGeneratedAnswerSourceHover(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerSourceHover, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerSourceHover, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerCopyToClipboard', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logGeneratedAnswerCopyToClipboard(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCopyToClipboard, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerCopyToClipboard', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        const built = await client.makeGeneratedAnswerCopyToClipboard(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCopyToClipboard, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerCopyToClipboard, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerHideAnswers', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logGeneratedAnswerHideAnswers(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerHideAnswers, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerHideAnswers', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        const built = await client.makeGeneratedAnswerHideAnswers(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerHideAnswers, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerHideAnswers, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerShowAnswers', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logGeneratedAnswerShowAnswers(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerShowAnswers, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerShowAnswers', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        const built = await client.makeGeneratedAnswerShowAnswers(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerShowAnswers, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerShowAnswers, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerExpand', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logGeneratedAnswerExpand(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerExpand, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerExpand', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        const built = await client.makeGeneratedAnswerExpand(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerExpand, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerExpand, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerCollapse', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        await client.logGeneratedAnswerCollapse(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCollapse, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerCollapse', async () => {
+        const meta = {generativeQuestionAnsweringId: fakeStreamId};
+        const built = await client.makeGeneratedAnswerCollapse(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerCollapse, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerCollapse, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerFeedbackSubmitV2', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            helpful: true,
+            readable: <GeneratedAnswerFeedbackReasonOption>'yes',
+            documented: <GeneratedAnswerFeedbackReasonOption>'no',
+            correctTopic: <GeneratedAnswerFeedbackReasonOption>'unknown',
+            hallucinationFree: <GeneratedAnswerFeedbackReasonOption>'yes',
+            details: 'a few additional details',
+            documentUrl: 'https://document.com',
+        };
+        await client.logGeneratedAnswerFeedbackSubmitV2(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerFeedbackSubmitV2, meta);
+    });
+
+    it('should send proper payload for #logGeneratedAnswerFeedbackSubmit', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            reason: <GeneratedAnswerFeedbackReason>'other',
+            details: 'a few additional details',
+        };
+        await client.logGeneratedAnswerFeedbackSubmit(meta);
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerFeedbackSubmit, meta);
+    });
+
+    it('should send proper payload for #makeGeneratedAnswerFeedbackSubmit', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            reason: <GeneratedAnswerFeedbackReason>'other',
+            details: 'a few additional details',
+        };
+        const built = await client.makeGeneratedAnswerFeedbackSubmit(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchCustomEventPayload(SearchPageEvents.generatedAnswerFeedbackSubmit, meta);
+        expectMatchDescription(built.description, SearchPageEvents.generatedAnswerFeedbackSubmit, meta);
+    });
+
+    it('should send proper payload for #logRephraseGeneratedAnswer', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            rephraseFormat: <GeneratedAnswerRephraseFormat>'step',
+        };
+        await client.logRephraseGeneratedAnswer(meta);
+        expectMatchPayload(SearchPageEvents.rephraseGeneratedAnswer, meta);
+    });
+
+    it('should send proper payload for #makeRephraseGeneratedAnswer', async () => {
+        const meta = {
+            generativeQuestionAnsweringId: fakeStreamId,
+            rephraseFormat: <GeneratedAnswerRephraseFormat>'step',
+        };
+        const built = await client.makeRephraseGeneratedAnswer(meta);
+        await built.log({searchUID: provider.getSearchUID()});
+        expectMatchPayload(SearchPageEvents.rephraseGeneratedAnswer, meta);
+        expectSearchEventToMatchDescription(built.description, SearchPageEvents.rephraseGeneratedAnswer, meta);
+    });
+});

--- a/packages/coveo-analytics/src/searchPage/searchPageClient.ts
+++ b/packages/coveo-analytics/src/searchPage/searchPageClient.ts
@@ -1,0 +1,1013 @@
+import CoveoAnalyticsClient, {ClientOptions, AnalyticsClient, PreparedEvent} from '../client/analytics';
+import {
+    SearchEventRequest,
+    CustomEventRequest,
+    SearchEventResponse,
+    AnyEventResponse,
+    ClickEventResponse,
+    CustomEventResponse,
+    PreparedClickEventRequest,
+    PreparedSearchEventRequest,
+} from '../events';
+import {
+    SearchPageEvents,
+    OmniboxSuggestionsMetadata,
+    FacetMetadata,
+    FacetRangeMetadata,
+    CategoryFacetMetadata,
+    DocumentIdentifier,
+    InterfaceChangeMetadata,
+    ResultsSortMetadata,
+    PartialDocumentInformation,
+    CustomEventsTypes,
+    TriggerNotifyMetadata,
+    TriggerExecuteMetadata,
+    TriggerRedirectMetadata,
+    PagerResizeMetadata,
+    PagerMetadata,
+    FacetBaseMeta,
+    FacetSortMeta,
+    QueryErrorMeta,
+    FacetStateMetadata,
+    SmartSnippetFeedbackReason,
+    SmartSnippetSuggestionMeta,
+    SmartSnippetDocumentIdentifier,
+    StaticFilterMetadata,
+    StaticFilterToggleValueMetadata,
+    UndoTriggerRedirectMetadata,
+    SmartSnippetLinkMeta,
+    GeneratedAnswerFeedbackMeta,
+    GeneratedAnswerCitationMeta,
+    GeneratedAnswerStreamEndMeta,
+    GeneratedAnswerSourceHoverMeta,
+    GeneratedAnswerBaseMeta,
+    GeneratedAnswerRephraseMeta,
+    GeneratedAnswerFeedbackMetaV2,
+} from './searchPageEvents';
+import {NoopAnalytics} from '../client/noopAnalytics';
+import {formatOmniboxMetadata} from '../formatting/format-omnibox-metadata';
+import doNotTrack from '../donottrack';
+
+export interface SearchPageClientProvider {
+    getBaseMetadata: () => Record<string, any>;
+    getSearchEventRequestPayload: () => Omit<SearchEventRequest, 'actionCause' | 'searchQueryUid'>;
+    getSearchUID: () => string;
+    getPipeline: () => string;
+    getOriginContext?: () => string;
+    getOriginLevel1: () => string;
+    getOriginLevel2: () => string;
+    getOriginLevel3: () => string;
+    getLanguage: () => string;
+    getIsAnonymous: () => boolean;
+    getFacetState?: () => FacetStateMetadata[];
+    getSplitTestRunName?: () => string | undefined;
+    getSplitTestRunVersion?: () => string | undefined;
+    getGeneratedAnswerMetadata?: () => Record<string, any>;
+}
+
+export interface SearchPageClientOptions extends ClientOptions {
+    enableAnalytics: boolean;
+}
+
+export type EventDescription = Pick<SearchEventRequest, 'actionCause' | 'customData'>;
+
+export interface EventBuilder<T extends AnyEventResponse = AnyEventResponse> {
+    description: EventDescription;
+    log(metadata: {searchUID: string}): Promise<T | void>;
+}
+
+export class CoveoSearchPageClient {
+    public coveoAnalyticsClient: AnalyticsClient;
+
+    constructor(private opts: Partial<SearchPageClientOptions>, private provider: SearchPageClientProvider) {
+        const shouldDisableAnalytics = opts.enableAnalytics === false || doNotTrack();
+        this.coveoAnalyticsClient = shouldDisableAnalytics ? new NoopAnalytics() : new CoveoAnalyticsClient(opts);
+    }
+
+    public disable() {
+        this.coveoAnalyticsClient = new NoopAnalytics();
+    }
+
+    public enable() {
+        this.coveoAnalyticsClient = new CoveoAnalyticsClient(this.opts);
+    }
+
+    public makeInterfaceLoad() {
+        return this.makeSearchEvent(SearchPageEvents.interfaceLoad);
+    }
+
+    public async logInterfaceLoad() {
+        return (await this.makeInterfaceLoad()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeRecommendationInterfaceLoad() {
+        return this.makeSearchEvent(SearchPageEvents.recommendationInterfaceLoad);
+    }
+
+    public async logRecommendationInterfaceLoad() {
+        return (await this.makeRecommendationInterfaceLoad()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeRecommendation() {
+        return this.makeCustomEvent(SearchPageEvents.recommendation);
+    }
+
+    public async logRecommendation() {
+        return (await this.makeRecommendation()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeRecommendationOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeClickEvent(SearchPageEvents.recommendationOpen, info, identifier);
+    }
+
+    public async logRecommendationOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeRecommendationOpen(info, identifier)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeStaticFilterClearAll(meta: StaticFilterMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.staticFilterClearAll, meta);
+    }
+
+    public async logStaticFilterClearAll(meta: StaticFilterMetadata) {
+        return (await this.makeStaticFilterClearAll(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeStaticFilterSelect(meta: StaticFilterToggleValueMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.staticFilterSelect, meta);
+    }
+
+    public async logStaticFilterSelect(meta: StaticFilterToggleValueMetadata) {
+        return (await this.makeStaticFilterSelect(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeStaticFilterDeselect(meta: StaticFilterToggleValueMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.staticFilterDeselect, meta);
+    }
+
+    public async logStaticFilterDeselect(meta: StaticFilterToggleValueMetadata) {
+        return (await this.makeStaticFilterDeselect(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeFetchMoreResults() {
+        return this.makeCustomEvent(SearchPageEvents.pagerScrolling, {type: 'getMoreResults'});
+    }
+
+    public async logFetchMoreResults() {
+        return (await this.makeFetchMoreResults()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeInterfaceChange(metadata: InterfaceChangeMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.interfaceChange, metadata);
+    }
+
+    public async logInterfaceChange(metadata: InterfaceChangeMetadata) {
+        return (await this.makeInterfaceChange(metadata)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeDidYouMeanAutomatic() {
+        return this.makeSearchEvent(SearchPageEvents.didyoumeanAutomatic);
+    }
+
+    public async logDidYouMeanAutomatic() {
+        return (await this.makeDidYouMeanAutomatic()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeDidYouMeanClick() {
+        return this.makeSearchEvent(SearchPageEvents.didyoumeanClick);
+    }
+
+    public async logDidYouMeanClick() {
+        return (await this.makeDidYouMeanClick()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeResultsSort(metadata: ResultsSortMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.resultsSort, metadata);
+    }
+
+    public async logResultsSort(metadata: ResultsSortMetadata) {
+        return (await this.makeResultsSort(metadata)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeSearchboxSubmit() {
+        return this.makeSearchEvent(SearchPageEvents.searchboxSubmit);
+    }
+
+    public async logSearchboxSubmit() {
+        return (await this.makeSearchboxSubmit()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeSearchboxClear() {
+        return this.makeSearchEvent(SearchPageEvents.searchboxClear);
+    }
+
+    public async logSearchboxClear() {
+        return (await this.makeSearchboxClear()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeSearchboxAsYouType() {
+        return this.makeSearchEvent(SearchPageEvents.searchboxAsYouType);
+    }
+
+    public async logSearchboxAsYouType() {
+        return (await this.makeSearchboxAsYouType()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.breadcrumbFacet, metadata);
+    }
+
+    public async logBreadcrumbFacet(metadata: FacetMetadata | FacetRangeMetadata | CategoryFacetMetadata) {
+        return (await this.makeBreadcrumbFacet(metadata)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeBreadcrumbResetAll() {
+        return this.makeSearchEvent(SearchPageEvents.breadcrumbResetAll);
+    }
+
+    public async logBreadcrumbResetAll() {
+        return (await this.makeBreadcrumbResetAll()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeDocumentQuickview(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeClickEvent(SearchPageEvents.documentQuickview, info, identifier);
+    }
+
+    public async logDocumentQuickview(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeDocumentQuickview(info, identifier)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeClickEvent(SearchPageEvents.documentOpen, info, identifier);
+    }
+
+    public async logDocumentOpen(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeDocumentOpen(info, identifier)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeOmniboxAnalytics(meta: OmniboxSuggestionsMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.omniboxAnalytics, formatOmniboxMetadata(meta));
+    }
+
+    public async logOmniboxAnalytics(meta: OmniboxSuggestionsMetadata) {
+        return (await this.makeOmniboxAnalytics(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeOmniboxFromLink(meta: OmniboxSuggestionsMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.omniboxFromLink, formatOmniboxMetadata(meta));
+    }
+
+    public async logOmniboxFromLink(meta: OmniboxSuggestionsMetadata) {
+        return (await this.makeOmniboxFromLink(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeSearchFromLink() {
+        return this.makeSearchEvent(SearchPageEvents.searchFromLink);
+    }
+
+    public async logSearchFromLink() {
+        return (await this.makeSearchFromLink()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeTriggerNotify(meta: TriggerNotifyMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.triggerNotify, meta);
+    }
+
+    public async logTriggerNotify(meta: TriggerNotifyMetadata) {
+        return (await this.makeTriggerNotify(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeTriggerExecute(meta: TriggerExecuteMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.triggerExecute, meta);
+    }
+
+    public async logTriggerExecute(meta: TriggerExecuteMetadata) {
+        return (await this.makeTriggerExecute(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeTriggerQuery() {
+        return this.makeCustomEvent(
+            SearchPageEvents.triggerQuery,
+            {query: this.provider.getSearchEventRequestPayload().queryText},
+            'queryPipelineTriggers'
+        );
+    }
+
+    public async logTriggerQuery() {
+        return (await this.makeTriggerQuery()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeUndoTriggerQuery(meta: UndoTriggerRedirectMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.undoTriggerQuery, meta);
+    }
+
+    public async logUndoTriggerQuery(meta: UndoTriggerRedirectMetadata) {
+        return (await this.makeUndoTriggerQuery(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeTriggerRedirect(meta: TriggerRedirectMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.triggerRedirect, {
+            ...meta,
+            query: this.provider.getSearchEventRequestPayload().queryText,
+        });
+    }
+
+    public async logTriggerRedirect(meta: TriggerRedirectMetadata) {
+        return (await this.makeTriggerRedirect(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makePagerResize(meta: PagerResizeMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.pagerResize, meta);
+    }
+
+    public async logPagerResize(meta: PagerResizeMetadata) {
+        return (await this.makePagerResize(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makePagerNumber(meta: PagerMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.pagerNumber, meta);
+    }
+
+    public async logPagerNumber(meta: PagerMetadata) {
+        return (await this.makePagerNumber(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makePagerNext(meta: PagerMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.pagerNext, meta);
+    }
+
+    public async logPagerNext(meta: PagerMetadata) {
+        return (await this.makePagerNext(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makePagerPrevious(meta: PagerMetadata) {
+        return this.makeCustomEvent(SearchPageEvents.pagerPrevious, meta);
+    }
+
+    public async logPagerPrevious(meta: PagerMetadata) {
+        return (await this.makePagerPrevious(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makePagerScrolling() {
+        return this.makeCustomEvent(SearchPageEvents.pagerScrolling);
+    }
+
+    public async logPagerScrolling() {
+        return (await this.makePagerScrolling()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeFacetClearAll(meta: FacetBaseMeta) {
+        return this.makeSearchEvent(SearchPageEvents.facetClearAll, meta);
+    }
+
+    public async logFacetClearAll(meta: FacetBaseMeta) {
+        return (await this.makeFacetClearAll(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeFacetSearch(meta: FacetBaseMeta) {
+        return this.makeSearchEvent(SearchPageEvents.facetSearch, meta);
+    }
+
+    public async logFacetSearch(meta: FacetBaseMeta) {
+        return (await this.makeFacetSearch(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeFacetSelect(meta: FacetMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.facetSelect, meta);
+    }
+
+    public async logFacetSelect(meta: FacetMetadata) {
+        return (await this.makeFacetSelect(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeFacetDeselect(meta: FacetMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.facetDeselect, meta);
+    }
+
+    public async logFacetDeselect(meta: FacetMetadata) {
+        return (await this.makeFacetDeselect(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeFacetExclude(meta: FacetMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.facetExclude, meta);
+    }
+
+    public async logFacetExclude(meta: FacetMetadata) {
+        return (await this.makeFacetExclude(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeFacetUnexclude(meta: FacetMetadata) {
+        return this.makeSearchEvent(SearchPageEvents.facetUnexclude, meta);
+    }
+
+    public async logFacetUnexclude(meta: FacetMetadata) {
+        return (await this.makeFacetUnexclude(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeFacetSelectAll(meta: FacetBaseMeta) {
+        return this.makeSearchEvent(SearchPageEvents.facetSelectAll, meta);
+    }
+
+    public async logFacetSelectAll(meta: FacetBaseMeta) {
+        return (await this.makeFacetSelectAll(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeFacetUpdateSort(meta: FacetSortMeta) {
+        return this.makeSearchEvent(SearchPageEvents.facetUpdateSort, meta);
+    }
+
+    public async logFacetUpdateSort(meta: FacetSortMeta) {
+        return (await this.makeFacetUpdateSort(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeFacetShowMore(meta: FacetBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.facetShowMore, meta);
+    }
+
+    public async logFacetShowMore(meta: FacetBaseMeta) {
+        return (await this.makeFacetShowMore(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeFacetShowLess(meta: FacetBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.facetShowLess, meta);
+    }
+
+    public async logFacetShowLess(meta: FacetBaseMeta) {
+        return (await this.makeFacetShowLess(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeQueryError(meta: QueryErrorMeta) {
+        return this.makeCustomEvent(SearchPageEvents.queryError, meta);
+    }
+
+    public async logQueryError(meta: QueryErrorMeta) {
+        return (await this.makeQueryError(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public async makeQueryErrorBack(): Promise<EventBuilder<SearchEventResponse>> {
+        const customEventBuilder = await this.makeCustomEvent(SearchPageEvents.queryErrorBack);
+        return {
+            description: customEventBuilder.description,
+            log: async () => {
+                await customEventBuilder.log({searchUID: this.provider.getSearchUID()});
+                return this.logSearchEvent(SearchPageEvents.queryErrorBack);
+            },
+        };
+    }
+
+    public async logQueryErrorBack() {
+        return (await this.makeQueryErrorBack()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public async makeQueryErrorRetry(): Promise<EventBuilder<SearchEventResponse>> {
+        const customEventBuilder = await this.makeCustomEvent(SearchPageEvents.queryErrorRetry);
+        return {
+            description: customEventBuilder.description,
+            log: async () => {
+                await customEventBuilder.log({searchUID: this.provider.getSearchUID()});
+                return this.logSearchEvent(SearchPageEvents.queryErrorRetry);
+            },
+        };
+    }
+
+    public async logQueryErrorRetry() {
+        return (await this.makeQueryErrorRetry()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public async makeQueryErrorClear(): Promise<EventBuilder<SearchEventResponse>> {
+        const customEventBuilder = await this.makeCustomEvent(SearchPageEvents.queryErrorClear);
+        return {
+            description: customEventBuilder.description,
+            log: async () => {
+                await customEventBuilder.log({searchUID: this.provider.getSearchUID()});
+                return this.logSearchEvent(SearchPageEvents.queryErrorClear);
+            },
+        };
+    }
+
+    public async logQueryErrorClear() {
+        return (await this.makeQueryErrorClear()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeLikeSmartSnippet() {
+        return this.makeCustomEvent(SearchPageEvents.likeSmartSnippet);
+    }
+
+    public async logLikeSmartSnippet() {
+        return (await this.makeLikeSmartSnippet()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeDislikeSmartSnippet() {
+        return this.makeCustomEvent(SearchPageEvents.dislikeSmartSnippet);
+    }
+
+    public async logDislikeSmartSnippet() {
+        return (await this.makeDislikeSmartSnippet()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeExpandSmartSnippet() {
+        return this.makeCustomEvent(SearchPageEvents.expandSmartSnippet);
+    }
+
+    public async logExpandSmartSnippet() {
+        return (await this.makeExpandSmartSnippet()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeCollapseSmartSnippet() {
+        return this.makeCustomEvent(SearchPageEvents.collapseSmartSnippet);
+    }
+
+    public async logCollapseSmartSnippet() {
+        return (await this.makeCollapseSmartSnippet()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeOpenSmartSnippetFeedbackModal() {
+        return this.makeCustomEvent(SearchPageEvents.openSmartSnippetFeedbackModal);
+    }
+
+    public async logOpenSmartSnippetFeedbackModal() {
+        return (await this.makeOpenSmartSnippetFeedbackModal()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeCloseSmartSnippetFeedbackModal() {
+        return this.makeCustomEvent(SearchPageEvents.closeSmartSnippetFeedbackModal);
+    }
+
+    public async logCloseSmartSnippetFeedbackModal() {
+        return (await this.makeCloseSmartSnippetFeedbackModal()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeSmartSnippetFeedbackReason(reason: SmartSnippetFeedbackReason, details?: string) {
+        return this.makeCustomEvent(SearchPageEvents.sendSmartSnippetReason, {reason, details});
+    }
+
+    public async logSmartSnippetFeedbackReason(reason: SmartSnippetFeedbackReason, details?: string) {
+        return (await this.makeSmartSnippetFeedbackReason(reason, details)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
+        return this.makeCustomEvent(
+            SearchPageEvents.expandSmartSnippetSuggestion,
+            'documentId' in snippet ? snippet : {documentId: snippet}
+        );
+    }
+
+    public async logExpandSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
+        return (await this.makeExpandSmartSnippetSuggestion(snippet)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeCollapseSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier) {
+        return this.makeCustomEvent(
+            SearchPageEvents.collapseSmartSnippetSuggestion,
+            'documentId' in snippet ? snippet : {documentId: snippet}
+        );
+    }
+
+    public async logCollapseSmartSnippetSuggestion(
+        snippet: SmartSnippetSuggestionMeta | SmartSnippetDocumentIdentifier
+    ) {
+        return (await this.makeCollapseSmartSnippetSuggestion(snippet)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    /**
+     * @deprecated
+     */
+    private makeShowMoreSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
+        return this.makeCustomEvent(SearchPageEvents.showMoreSmartSnippetSuggestion, snippet);
+    }
+
+    /**
+     * @deprecated
+     */
+    public async logShowMoreSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
+        return (await this.makeShowMoreSmartSnippetSuggestion(snippet)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    /**
+     * @deprecated
+     */
+    private makeShowLessSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
+        return this.makeCustomEvent(SearchPageEvents.showLessSmartSnippetSuggestion, snippet);
+    }
+
+    /**
+     * @deprecated
+     */
+    public async logShowLessSmartSnippetSuggestion(snippet: SmartSnippetSuggestionMeta) {
+        return (await this.makeShowLessSmartSnippetSuggestion(snippet)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeOpenSmartSnippetSource(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeClickEvent(SearchPageEvents.openSmartSnippetSource, info, identifier);
+    }
+
+    public async logOpenSmartSnippetSource(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeOpenSmartSnippetSource(info, identifier)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeOpenSmartSnippetSuggestionSource(info: PartialDocumentInformation, snippet: SmartSnippetSuggestionMeta) {
+        return this.makeClickEvent(
+            SearchPageEvents.openSmartSnippetSuggestionSource,
+            info,
+            {contentIDKey: snippet.documentId.contentIdKey, contentIDValue: snippet.documentId.contentIdValue},
+            snippet
+        );
+    }
+
+    public makeCopyToClipboard(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeClickEvent(SearchPageEvents.copyToClipboard, info, identifier);
+    }
+
+    public async logCopyToClipboard(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeCopyToClipboard(info, identifier)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public async logOpenSmartSnippetSuggestionSource(
+        info: PartialDocumentInformation,
+        snippet: SmartSnippetSuggestionMeta
+    ) {
+        return (await this.makeOpenSmartSnippetSuggestionSource(info, snippet)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeOpenSmartSnippetInlineLink(
+        info: PartialDocumentInformation,
+        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta
+    ) {
+        return this.makeClickEvent(
+            SearchPageEvents.openSmartSnippetInlineLink,
+            info,
+            {contentIDKey: identifierAndLink.contentIDKey, contentIDValue: identifierAndLink.contentIDValue},
+            identifierAndLink
+        );
+    }
+
+    public async logOpenSmartSnippetInlineLink(
+        info: PartialDocumentInformation,
+        identifierAndLink: DocumentIdentifier & SmartSnippetLinkMeta
+    ) {
+        return (await this.makeOpenSmartSnippetInlineLink(info, identifierAndLink)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeOpenSmartSnippetSuggestionInlineLink(
+        info: PartialDocumentInformation,
+        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta
+    ) {
+        return this.makeClickEvent(
+            SearchPageEvents.openSmartSnippetSuggestionInlineLink,
+            info,
+            {
+                contentIDKey: snippetAndLink.documentId.contentIdKey,
+                contentIDValue: snippetAndLink.documentId.contentIdValue,
+            },
+            snippetAndLink
+        );
+    }
+
+    public async logOpenSmartSnippetSuggestionInlineLink(
+        info: PartialDocumentInformation,
+        snippetAndLink: SmartSnippetSuggestionMeta & SmartSnippetLinkMeta
+    ) {
+        return (await this.makeOpenSmartSnippetSuggestionInlineLink(info, snippetAndLink)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeRecentQueryClick() {
+        return this.makeSearchEvent(SearchPageEvents.recentQueryClick);
+    }
+
+    public async logRecentQueryClick() {
+        return (await this.makeRecentQueryClick()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeClearRecentQueries() {
+        return this.makeCustomEvent(SearchPageEvents.clearRecentQueries);
+    }
+
+    public async logClearRecentQueries() {
+        return (await this.makeClearRecentQueries()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeRecentResultClick(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeCustomEvent(SearchPageEvents.recentResultClick, {info, identifier});
+    }
+
+    public async logRecentResultClick(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeRecentResultClick(info, identifier)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeClearRecentResults() {
+        return this.makeCustomEvent(SearchPageEvents.clearRecentResults);
+    }
+
+    public async logClearRecentResults() {
+        return (await this.makeClearRecentResults()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeNoResultsBack() {
+        return this.makeSearchEvent(SearchPageEvents.noResultsBack);
+    }
+
+    public async logNoResultsBack() {
+        return (await this.makeNoResultsBack()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return this.makeClickEvent(SearchPageEvents.showMoreFoldedResults, info, identifier);
+    }
+
+    public async logShowMoreFoldedResults(info: PartialDocumentInformation, identifier: DocumentIdentifier) {
+        return (await this.makeShowMoreFoldedResults(info, identifier)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeShowLessFoldedResults() {
+        return this.makeCustomEvent(SearchPageEvents.showLessFoldedResults);
+    }
+
+    public async logShowLessFoldedResults() {
+        return (await this.makeShowLessFoldedResults()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    private makeEventDescription(
+        preparedEvent: PreparedEvent<unknown, unknown, AnyEventResponse>,
+        actionCause: SearchPageEvents
+    ): EventDescription {
+        return {actionCause, customData: preparedEvent.payload?.customData};
+    }
+
+    public async makeCustomEvent(
+        event: SearchPageEvents,
+        metadata?: Record<string, any>,
+        eventType: string = CustomEventsTypes[event]!
+    ): Promise<EventBuilder<CustomEventResponse>> {
+        this.coveoAnalyticsClient.getParameters;
+        const customData = {...this.provider.getBaseMetadata(), ...metadata};
+        const request: CustomEventRequest = {
+            ...(await this.getBaseEventRequest(customData)),
+            eventType,
+            eventValue: event,
+        };
+        const preparedEvent = await this.coveoAnalyticsClient.makeCustomEvent(request);
+        return {
+            description: this.makeEventDescription(preparedEvent, event),
+            log: ({searchUID}) => preparedEvent.log({lastSearchQueryUid: searchUID}),
+        };
+    }
+
+    public async logCustomEvent(
+        event: SearchPageEvents,
+        metadata?: Record<string, any>,
+        eventType: string = CustomEventsTypes[event]!
+    ) {
+        return (await this.makeCustomEvent(event, metadata, eventType)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public async makeCustomEventWithType(
+        eventValue: string,
+        eventType: string,
+        metadata?: Record<string, any>
+    ): Promise<EventBuilder<CustomEventResponse>> {
+        const customData = {...this.provider.getBaseMetadata(), ...metadata};
+        const payload: CustomEventRequest = {
+            ...(await this.getBaseEventRequest(customData)),
+            eventType,
+            eventValue,
+        };
+        const preparedEvent = await this.coveoAnalyticsClient.makeCustomEvent(payload);
+        return {
+            description: this.makeEventDescription(preparedEvent, eventValue as SearchPageEvents),
+            log: ({searchUID}) => preparedEvent.log({lastSearchQueryUid: searchUID}),
+        };
+    }
+
+    public async logCustomEventWithType(eventValue: string, eventType: string, metadata?: Record<string, any>) {
+        return (await this.makeCustomEventWithType(eventValue, eventType, metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public async logSearchEvent(event: SearchPageEvents, metadata?: Record<string, any>) {
+        return (await this.makeSearchEvent(event, metadata)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public async makeSearchEvent(
+        event: SearchPageEvents,
+        metadata?: Record<string, any>
+    ): Promise<EventBuilder<SearchEventResponse>> {
+        const request = await this.getBaseSearchEventRequest(event, metadata);
+        const preparedEvent = await this.coveoAnalyticsClient.makeSearchEvent(request);
+        return {
+            description: this.makeEventDescription(preparedEvent, event),
+            log: ({searchUID}) => preparedEvent.log({searchQueryUid: searchUID}),
+        };
+    }
+
+    public async makeClickEvent(
+        event: SearchPageEvents,
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: Record<string, any>
+    ): Promise<EventBuilder<ClickEventResponse>> {
+        const request: PreparedClickEventRequest = {
+            ...info,
+            ...(await this.getBaseEventRequest({...identifier, ...metadata})),
+            queryPipeline: this.provider.getPipeline(),
+            actionCause: event,
+        };
+        const preparedEvent = await this.coveoAnalyticsClient.makeClickEvent(request);
+        return {
+            description: this.makeEventDescription(preparedEvent, event),
+            log: ({searchUID}) => preparedEvent.log({searchQueryUid: searchUID}),
+        };
+    }
+
+    public async logClickEvent(
+        event: SearchPageEvents,
+        info: PartialDocumentInformation,
+        identifier: DocumentIdentifier,
+        metadata?: Record<string, any>
+    ) {
+        return (await this.makeClickEvent(event, info, identifier, metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    private async getBaseSearchEventRequest(
+        event: SearchPageEvents,
+        metadata?: Record<string, any>
+    ): Promise<PreparedSearchEventRequest> {
+        return {
+            ...(await this.getBaseEventRequest({...metadata, ...this.provider.getGeneratedAnswerMetadata?.()})),
+            ...this.provider.getSearchEventRequestPayload(),
+            queryPipeline: this.provider.getPipeline(),
+            actionCause: event,
+        };
+    }
+
+    private async getBaseEventRequest(metadata?: Record<string, any>) {
+        const customData = {...this.provider.getBaseMetadata(), ...metadata};
+        return {
+            ...this.getOrigins(),
+            ...this.getSplitTestRun(),
+            customData,
+            language: this.provider.getLanguage(),
+            facetState: this.provider.getFacetState ? this.provider.getFacetState() : [],
+            anonymous: this.provider.getIsAnonymous(),
+            clientId: await this.getClientId(),
+        };
+    }
+
+    private getOrigins() {
+        return {
+            originContext: this.provider.getOriginContext?.(),
+            originLevel1: this.provider.getOriginLevel1(),
+            originLevel2: this.provider.getOriginLevel2(),
+            originLevel3: this.provider.getOriginLevel3(),
+        };
+    }
+
+    private getClientId() {
+        return this.coveoAnalyticsClient instanceof CoveoAnalyticsClient
+            ? this.coveoAnalyticsClient.getCurrentVisitorId()
+            : undefined;
+    }
+
+    private getSplitTestRun() {
+        const splitTestRunName = this.provider.getSplitTestRunName ? this.provider.getSplitTestRunName() : '';
+        const splitTestRunVersion = this.provider.getSplitTestRunVersion ? this.provider.getSplitTestRunVersion() : '';
+        return {
+            ...(splitTestRunName && {splitTestRunName}),
+            ...(splitTestRunVersion && {splitTestRunVersion}),
+        };
+    }
+
+    public makeLikeGeneratedAnswer(metadata: GeneratedAnswerBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.likeGeneratedAnswer, metadata);
+    }
+
+    public async logLikeGeneratedAnswer(metadata: GeneratedAnswerBaseMeta) {
+        return (await this.makeLikeGeneratedAnswer(metadata)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeDislikeGeneratedAnswer(metadata: GeneratedAnswerBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.dislikeGeneratedAnswer, metadata);
+    }
+
+    public async logDislikeGeneratedAnswer(metadata: GeneratedAnswerBaseMeta) {
+        return (await this.makeDislikeGeneratedAnswer(metadata)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeOpenGeneratedAnswerSource(metadata: GeneratedAnswerCitationMeta) {
+        return this.makeCustomEvent(SearchPageEvents.openGeneratedAnswerSource, metadata);
+    }
+
+    public async logOpenGeneratedAnswerSource(metadata: GeneratedAnswerCitationMeta) {
+        return (await this.makeOpenGeneratedAnswerSource(metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeGeneratedAnswerSourceHover(metadata: GeneratedAnswerSourceHoverMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerSourceHover, metadata);
+    }
+
+    public async logGeneratedAnswerSourceHover(metadata: GeneratedAnswerSourceHoverMeta) {
+        return (await this.makeGeneratedAnswerSourceHover(metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeGeneratedAnswerCopyToClipboard(metadata: GeneratedAnswerBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerCopyToClipboard, metadata);
+    }
+
+    public async logGeneratedAnswerCopyToClipboard(metadata: GeneratedAnswerBaseMeta) {
+        return (await this.makeGeneratedAnswerCopyToClipboard(metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeGeneratedAnswerHideAnswers(metadata: GeneratedAnswerBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerHideAnswers, metadata);
+    }
+
+    public async logGeneratedAnswerHideAnswers(metadata: GeneratedAnswerBaseMeta) {
+        return (await this.makeGeneratedAnswerHideAnswers(metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeGeneratedAnswerShowAnswers(metadata: GeneratedAnswerBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerShowAnswers, metadata);
+    }
+
+    public async logGeneratedAnswerShowAnswers(metadata: GeneratedAnswerBaseMeta) {
+        return (await this.makeGeneratedAnswerShowAnswers(metadata)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeGeneratedAnswerExpand(metadata: GeneratedAnswerBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerExpand, metadata);
+    }
+
+    public async logGeneratedAnswerExpand(metadata: GeneratedAnswerBaseMeta) {
+        return (await this.makeGeneratedAnswerExpand(metadata)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeGeneratedAnswerCollapse(metadata: GeneratedAnswerBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerCollapse, metadata);
+    }
+
+    public async logGeneratedAnswerCollapse(metadata: GeneratedAnswerBaseMeta) {
+        return (await this.makeGeneratedAnswerCollapse(metadata)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeGeneratedAnswerFeedbackSubmit(meta: GeneratedAnswerFeedbackMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerFeedbackSubmit, meta);
+    }
+
+    public async logGeneratedAnswerFeedbackSubmit(meta: GeneratedAnswerFeedbackMeta) {
+        return (await this.makeGeneratedAnswerFeedbackSubmit(meta)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeGeneratedAnswerFeedbackSubmitV2(metadata: GeneratedAnswerBaseMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerFeedbackSubmitV2, metadata);
+    }
+    public async logGeneratedAnswerFeedbackSubmitV2(meta: GeneratedAnswerFeedbackMetaV2) {
+        return (await this.makeGeneratedAnswerFeedbackSubmitV2(meta)).log({
+            searchUID: this.provider.getSearchUID(),
+        });
+    }
+
+    public makeRephraseGeneratedAnswer(meta: GeneratedAnswerRephraseMeta) {
+        return this.makeSearchEvent(SearchPageEvents.rephraseGeneratedAnswer, meta);
+    }
+
+    public async logRephraseGeneratedAnswer(meta: GeneratedAnswerRephraseMeta) {
+        return (await this.makeRephraseGeneratedAnswer(meta)).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeRetryGeneratedAnswer() {
+        return this.makeSearchEvent(SearchPageEvents.retryGeneratedAnswer);
+    }
+
+    public async logRetryGeneratedAnswer() {
+        return (await this.makeRetryGeneratedAnswer()).log({searchUID: this.provider.getSearchUID()});
+    }
+
+    public makeGeneratedAnswerStreamEnd(metadata: GeneratedAnswerStreamEndMeta) {
+        return this.makeCustomEvent(SearchPageEvents.generatedAnswerStreamEnd, metadata);
+    }
+
+    public async logGeneratedAnswerStreamEnd(metadata: GeneratedAnswerStreamEndMeta) {
+        return (await this.makeGeneratedAnswerStreamEnd(metadata)).log({searchUID: this.provider.getSearchUID()});
+    }
+}

--- a/packages/coveo-analytics/src/searchPage/searchPageEvents.ts
+++ b/packages/coveo-analytics/src/searchPage/searchPageEvents.ts
@@ -1,0 +1,584 @@
+import {DocumentInformation, FacetStateRequest} from '../events';
+import {InsightEvents} from '../insight/insightEvents';
+
+export enum SearchPageEvents {
+    /**
+     * Identifies the search event that gets logged when the initial query is performed as a result of loading a search interface.
+     */
+    interfaceLoad = 'interfaceLoad',
+    /**
+     * Identifies the search event that gets logged when a new tab is selected in the search interface.
+     */
+    interfaceChange = 'interfaceChange',
+    /**
+     * Identifies the search event that gets logged when `enableAutoCorrection: true` and the query is automatically corrected.
+     */
+    didyoumeanAutomatic = 'didyoumeanAutomatic',
+    /**
+     * Identifies the search event that gets logged when the query suggestion with the corrected term is selected and successfully updates the query.
+     */
+    didyoumeanClick = 'didyoumeanClick',
+    /**
+     * Identifies the search event that gets logged when a sorting method is selected.
+     */
+    resultsSort = 'resultsSort',
+    /**
+     * Identifies the search event that gets logged when a submit button is selected on a search box.
+     */
+    searchboxSubmit = 'searchboxSubmit',
+    /**
+     * Identifies the search event that gets logged when a clear button is selected on a search box.
+     */
+    searchboxClear = 'searchboxClear',
+    /**
+     * The search-as-you-type event that gets logged when a query is automatically generated, and results are displayed while a user is entering text in the search box before they voluntarily submit the query.
+     */
+    searchboxAsYouType = 'searchboxAsYouType',
+    /**
+     * The event that gets logged when a breadcrumb facet is selected and the query is updated.
+     */
+    breadcrumbFacet = 'breadcrumbFacet',
+    /**
+     * Identifies the search event that gets logged when the event to clear the current breadcrumbs is triggered.
+     */
+    breadcrumbResetAll = 'breadcrumbResetAll',
+    /**
+     * Identifies the click event that gets logged when the Quick View element is selected and a Quick View modal of the document is displayed.
+     */
+    documentQuickview = 'documentQuickview',
+    /**
+     * Identifies the click event that gets logged when a user clicks on a search result to open an item.
+     */
+    documentOpen = 'documentOpen',
+    /**
+     * Identifies the search event that gets logged when a user clicks a query suggestion based on the usage analytics recorded queries.
+     */
+    omniboxAnalytics = 'omniboxAnalytics',
+    /**
+     * Identifies the search event that gets logged when a suggested search query is selected from a standalone searchbox.
+     */
+    omniboxFromLink = 'omniboxFromLink',
+    /**
+     * Identifies the search event that gets logged when the search page loads with a query, such as when a user clicks a link pointing to a search results page with a query or enters a query in a standalone search box that points to a search page.
+     */
+    searchFromLink = 'searchFromLink',
+    /**
+     * Identifies the custom event that gets logged when a user action triggers a notification set in the effective query pipeline on the search page.
+     */
+    triggerNotify = 'notify',
+    /**
+     * Identifies the custom event that gets logged when a user action executes a JavaScript function set in the effective query pipeline on the search page.
+     */
+    triggerExecute = 'execute',
+    /**
+     * Identifies the custom event that gets logged when a user action triggers a new query set in the effective query pipeline on the search page.
+     */
+    triggerQuery = 'query',
+    /**
+     * Identifies the custom event that gets logged when a user undoes a query set in the effective query pipeline on the search page.
+     */
+    undoTriggerQuery = 'undoQuery',
+    /**
+     * Identifies the custom event that gets logged when a user action redirects them to a URL set in the effective query pipeline on the search page.
+     */
+    triggerRedirect = 'redirect',
+    /**
+     * Identifies the custom event that gets logged when the Results per page component is selected.
+     */
+    pagerResize = 'pagerResize',
+    /**
+     * Identifies the custom event that gets logged when a page number is selected and more items are loaded.
+     */
+    pagerNumber = 'pagerNumber',
+    /**
+     * Identifies the custom event that gets logged when the Next Page link is selected and more items are loaded.
+     */
+    pagerNext = 'pagerNext',
+    /**
+     * Identifies the custom event that gets logged when the Previous Page link is selected and more items are loaded.
+     */
+    pagerPrevious = 'pagerPrevious',
+    /**
+     * Identifies the custom event that gets logged when the user scrolls to the bottom of the item page and more results are loaded.
+     */
+    pagerScrolling = 'pagerScrolling',
+    /**
+     * Identifies the search event that gets logged when the clearing all selected values of a static filter.
+     */
+    staticFilterClearAll = 'staticFilterClearAll',
+    /**
+     * Identifies the search event that gets logged when a static filter check box is selected and the query is updated.
+     */
+    staticFilterSelect = 'staticFilterSelect',
+    /**
+     * Identifies the search event that gets logged when a static filter check box is deselected and the query is updated.
+     */
+    staticFilterDeselect = 'staticFilterDeselect',
+    /**
+     * Identifies the search event that gets logged when the Clear Facet button is selected.
+     */
+    facetClearAll = 'facetClearAll',
+    /**
+     * Identifies the custom event that gets logged when a query is being typed into the facet search box.
+     */
+    facetSearch = 'facetSearch',
+    /**
+     * Identifies the search event that gets logged when a facet check box is selected and the query is updated.
+     */
+    facetSelect = 'facetSelect',
+    /**
+     * Identifies the search event that gets logged when all filters on a facet are selected.
+     */
+    facetSelectAll = 'facetSelectAll',
+    /**
+     * Identifies the search event that gets logged when a facet check box is deselected and the query is updated.
+     */
+    facetDeselect = 'facetDeselect',
+    /**
+     * Identifies the search event that gets logged when a user clicks a facet value to filter out results containing the facet value.
+     */
+    facetExclude = 'facetExclude',
+    /**
+     * Identifies the search event that gets logged when a user clicks a facet value to not filter out results containing the facet value.
+     */
+    facetUnexclude = 'facetUnexclude',
+    /**
+     * Identifies the search event that gets logged when the sort criteria on a facet is updated.
+     */
+    facetUpdateSort = 'facetUpdateSort',
+    /**
+     * The custom event that gets logged when an end-user expands a facet to see additional values.
+     */
+    facetShowMore = 'showMoreFacetResults',
+    /**
+     * The custom event that gets logged when an end-user collapses a facet to see less values.
+     */
+    facetShowLess = 'showLessFacetResults',
+    /**
+     * Identifies the custom event that gets logged when a user query encounters an error during execution.
+     */
+    queryError = 'query',
+    /**
+     * Identifies the search and custom event that gets logged when a user clicks the Go Back link after an error page.
+     */
+    queryErrorBack = 'errorBack',
+    /**
+     * Identifies the search and custom event that gets logged when a user clears the query box after an error page.
+     */
+    queryErrorClear = 'errorClearQuery',
+    /**
+     * Identifies the search and custom event that gets logged when a user clicks the Retry link after an error page.
+     */
+    queryErrorRetry = 'errorRetry',
+    /**
+     * Identifies the custom event that gets logged when a user performs a query that returns recommendations in the Recommendations panel.
+     */
+    recommendation = 'recommendation',
+    /**
+     * Identifies the search event that gets logged when a user action (that is not a query) reloads the Recommendations panel with new recommendations.
+     */
+    recommendationInterfaceLoad = 'recommendationInterfaceLoad',
+    /**
+     * Identifies the click event that gets logged when a user clicks a recommendation in the Recommendations panel.
+     */
+    recommendationOpen = 'recommendationOpen',
+    /**
+     * Identifies the custom event that gets logged when a user identifies a smart snippet answer as relevant.
+     */
+    likeSmartSnippet = 'likeSmartSnippet',
+    /**
+     * Identifies the custom event that gets logged when a user identifies a smart snippet answer as irrelevant.
+     */
+    dislikeSmartSnippet = 'dislikeSmartSnippet',
+    /**
+     * Identifies the custom event that gets logged when a user expand a smart snippet answer.
+     */
+    expandSmartSnippet = 'expandSmartSnippet',
+    /**
+     * Identifies the custom event that gets logged when a user collapse a smart snippet answer.
+     */
+    collapseSmartSnippet = 'collapseSmartSnippet',
+    /**
+     * Identifies the custom event that gets logged when a user open a smart snippet explanation modal for feedback.
+     */
+    openSmartSnippetFeedbackModal = 'openSmartSnippetFeedbackModal',
+    /**
+     * Identifies the custom event that gets logged when a user close a smart snippet explanation modal for feedback.
+     */
+    closeSmartSnippetFeedbackModal = 'closeSmartSnippetFeedbackModal',
+    /**
+     * Identifies the custom event that gets logged when a user sends an explanation for a smart snippet irrelevant answer.
+     */
+    sendSmartSnippetReason = 'sendSmartSnippetReason',
+    /**
+     * Identifies the custom event that gets logged when a snippet suggestion for a related question is expanded.
+     */
+    expandSmartSnippetSuggestion = 'expandSmartSnippetSuggestion',
+    /**
+     * Identifies the custom event that gets logged when a snippet suggestion for a related question is collapsed.
+     */
+    collapseSmartSnippetSuggestion = 'collapseSmartSnippetSuggestion',
+    /**
+     * Identifies the custom event that gets logged when the user presses "show more" on a snippet suggestion for a related question.
+     *
+     * @deprecated
+     */
+    showMoreSmartSnippetSuggestion = 'showMoreSmartSnippetSuggestion',
+    /**
+     * Identifies the custom event that gets logged when the user presses "show less" on a snippet suggestion for a related question.
+     *
+     * @deprecated
+     */
+    showLessSmartSnippetSuggestion = 'showLessSmartSnippetSuggestion',
+    /**
+     * Identifies the custom event that gets logged when a user clicks on the source of an answer in a smart snippet.
+     */
+    openSmartSnippetSource = 'openSmartSnippetSource',
+    /**
+     * Identifies the custom event that gets logged when a user clicks on the source of a snippet suggestion for a related question.
+     */
+    openSmartSnippetSuggestionSource = 'openSmartSnippetSuggestionSource',
+    /**
+     * Identifies the custom event that gets logged when a user clicks on a link in the answer of a smart snippet.
+     */
+    openSmartSnippetInlineLink = 'openSmartSnippetInlineLink',
+    /**
+     * Identifies the custom event that gets logged when a user clicks on a link in the snippet suggestion for a related question.
+     */
+    openSmartSnippetSuggestionInlineLink = 'openSmartSnippetSuggestionInlineLink',
+    /**
+     * Identifies the search event that gets logged when a recent queries list item gets clicked.
+     */
+    recentQueryClick = 'recentQueriesClick',
+    /**
+     * Identifies the custom event that gets logged when a recent queries list gets cleared.
+     */
+    clearRecentQueries = 'clearRecentQueries',
+    /**
+     * Identifies the custom event that gets logged when a recently clicked results list item gets clicked.
+     */
+    recentResultClick = 'recentResultClick',
+    /**
+     * Identifies the custom event that gets logged when a recently clicked results list gets cleared.
+     */
+    clearRecentResults = 'clearRecentResults',
+    /**
+     * Identifies the search event that gets logged when a user clicks the Cancel last action link when no results are returned following their last action.
+     */
+    noResultsBack = 'noResultsBack',
+    /**
+     * Identifies the click event that gets logged when a user clicks the Show More link under a search result that support the folding component.
+     */
+    showMoreFoldedResults = 'showMoreFoldedResults',
+    /**
+     * Identifies the custom event that gets logged when a user clicks the Show Less link under a search result that support the folding component.
+     */
+    showLessFoldedResults = 'showLessFoldedResults',
+    /**
+     * Identifies the click event that gets logged when a user clicks the Copy To Clipboard result action.
+     */
+    copyToClipboard = 'copyToClipboard',
+    /**
+     * Identifies the click event that gets logged when a user clicks the Send As Email result action.
+     */
+    caseSendEmail = 'Case.SendEmail',
+    /**
+     * Identifies the click event that gets logged when a user clicks the Post To Feed result action.
+     */
+    feedItemTextPost = 'FeedItem.TextPost',
+    /**
+     * Identifies the click event that gets logged when a user clicks the Attach To Case result action.
+     */
+    caseAttach = 'caseAttach',
+    /**
+     * Identifies the custom event that gets logged when a user clicks the Detach From Case result action.
+     */
+    caseDetach = 'caseDetach',
+    /**
+     * Identifies the cause of a search request being retried in order to regenerate an answer stream that failed.
+     */
+    retryGeneratedAnswer = 'retryGeneratedAnswer',
+    /**
+     * Identifies the custom event that gets logged when a user identifies a generated answer as relevant.
+     */
+    likeGeneratedAnswer = 'likeGeneratedAnswer',
+    /**
+     * Identifies the custom event that gets logged when a user identifies a generated answer as irrelevant.
+     */
+    dislikeGeneratedAnswer = 'dislikeGeneratedAnswer',
+    /**
+     * Identifies the custom event that gets logged when a user opens a generated answer citation.
+     */
+    openGeneratedAnswerSource = 'openGeneratedAnswerSource',
+    /**
+     * Identified the custom event that gets logged when a generated answer stream is completed.
+     */
+    generatedAnswerStreamEnd = 'generatedAnswerStreamEnd',
+    /**
+     * Identifies the custom event that gets logged when a user hovers over a generated answer citation.
+     */
+    generatedAnswerSourceHover = 'generatedAnswerSourceHover',
+    /**
+     * Identifies the custom event that gets logged when a user clicks the copy to clip board button of a generated answer.
+     */
+    generatedAnswerCopyToClipboard = 'generatedAnswerCopyToClipboard',
+    /**
+     * Identifies the custom event that gets logged when a user deactivates the genQA feature.
+     */
+    generatedAnswerHideAnswers = 'generatedAnswerHideAnswers',
+    /**
+     * Identifies the custom event that gets logged when a user activates the genQA feature.
+     */
+    generatedAnswerShowAnswers = 'generatedAnswerShowAnswers',
+    /**
+     * Identifies the custom event that gets logged when a user expand a generated answer.
+     */
+    generatedAnswerExpand = 'generatedAnswerExpand',
+    /**
+     * Identifies the custom event that gets logged when a user collapse a generated answer.
+     */
+    generatedAnswerCollapse = 'generatedAnswerCollapse',
+    /**
+     * Identifies the custom event that gets logged when a user submits a feedback of a generated answer.
+     */
+    generatedAnswerFeedbackSubmit = 'generatedAnswerFeedbackSubmit',
+    /**
+     * Identifies the search event that gets logged when a user clicks the rephrase button in a generated answer.
+     */
+    rephraseGeneratedAnswer = 'rephraseGeneratedAnswer',
+    /**
+     * Identifies the new version of custom event that gets logged when a user submits a feedback of a generated answer.
+     */
+    generatedAnswerFeedbackSubmitV2 = 'generatedAnswerFeedbackSubmitV2',
+}
+
+export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents, string>> = {
+    [SearchPageEvents.triggerNotify]: 'queryPipelineTriggers',
+    [SearchPageEvents.triggerExecute]: 'queryPipelineTriggers',
+    [SearchPageEvents.triggerQuery]: 'queryPipelineTriggers',
+    [SearchPageEvents.triggerRedirect]: 'queryPipelineTriggers',
+    [SearchPageEvents.queryError]: 'errors',
+    [SearchPageEvents.queryErrorBack]: 'errors',
+    [SearchPageEvents.queryErrorClear]: 'errors',
+    [SearchPageEvents.queryErrorRetry]: 'errors',
+    [SearchPageEvents.pagerNext]: 'getMoreResults',
+    [SearchPageEvents.pagerPrevious]: 'getMoreResults',
+    [SearchPageEvents.pagerNumber]: 'getMoreResults',
+    [SearchPageEvents.pagerResize]: 'getMoreResults',
+    [SearchPageEvents.pagerScrolling]: 'getMoreResults',
+    [SearchPageEvents.facetSearch]: 'facet',
+    [SearchPageEvents.facetShowLess]: 'facet',
+    [SearchPageEvents.facetShowMore]: 'facet',
+    [SearchPageEvents.recommendation]: 'recommendation',
+    [SearchPageEvents.likeSmartSnippet]: 'smartSnippet',
+    [SearchPageEvents.dislikeSmartSnippet]: 'smartSnippet',
+    [SearchPageEvents.expandSmartSnippet]: 'smartSnippet',
+    [SearchPageEvents.collapseSmartSnippet]: 'smartSnippet',
+    [SearchPageEvents.openSmartSnippetFeedbackModal]: 'smartSnippet',
+    [SearchPageEvents.closeSmartSnippetFeedbackModal]: 'smartSnippet',
+    [SearchPageEvents.sendSmartSnippetReason]: 'smartSnippet',
+    [SearchPageEvents.expandSmartSnippetSuggestion]: 'smartSnippetSuggestions',
+    [SearchPageEvents.collapseSmartSnippetSuggestion]: 'smartSnippetSuggestions',
+    [SearchPageEvents.showMoreSmartSnippetSuggestion]: 'smartSnippetSuggestions',
+    [SearchPageEvents.showLessSmartSnippetSuggestion]: 'smartSnippetSuggestions',
+    [SearchPageEvents.clearRecentQueries]: 'recentQueries',
+    [SearchPageEvents.recentResultClick]: 'recentlyClickedDocuments',
+    [SearchPageEvents.clearRecentResults]: 'recentlyClickedDocuments',
+    [SearchPageEvents.showLessFoldedResults]: 'folding',
+    [SearchPageEvents.caseDetach]: 'case',
+    [SearchPageEvents.likeGeneratedAnswer]: 'generatedAnswer',
+    [SearchPageEvents.dislikeGeneratedAnswer]: 'generatedAnswer',
+    [SearchPageEvents.openGeneratedAnswerSource]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerStreamEnd]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerSourceHover]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerCopyToClipboard]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerHideAnswers]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerShowAnswers]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerExpand]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerCollapse]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerFeedbackSubmit]: 'generatedAnswer',
+    [SearchPageEvents.generatedAnswerFeedbackSubmitV2]: 'generatedAnswer',
+    [InsightEvents.expandToFullUI]: 'interface',
+    [InsightEvents.openUserActions]: 'User Actions',
+    [InsightEvents.showPrecedingSessions]: 'User Actions',
+    [InsightEvents.showFollowingSessions]: 'User Actions',
+    [InsightEvents.clickViewedDocument]: 'User Actions',
+    [InsightEvents.clickPageView]: 'User Actions',
+    [InsightEvents.createArticle]: 'createArticle',
+};
+
+export interface StaticFilterMetadata {
+    staticFilterId: string;
+}
+
+export interface StaticFilterToggleValueMetadata extends StaticFilterMetadata {
+    staticFilterValue: StaticFilterValueMetadata;
+}
+
+interface StaticFilterValueMetadata {
+    caption: string;
+    expression: string;
+}
+
+export interface FacetMetadata {
+    facetId: string;
+    facetField: string;
+    facetValue: string;
+    facetTitle: string;
+}
+
+export type FacetStateMetadata = FacetStateRequest;
+export interface FacetRangeMetadata extends Omit<FacetMetadata, 'facetValue'> {
+    facetRangeStart: string;
+    facetRangeEnd: string;
+    facetRangeEndInclusive: boolean;
+}
+
+export interface CategoryFacetMetadata {
+    categoryFacetId: string;
+    categoryFacetField: string;
+    categoryFacetPath: string[];
+    categoryFacetTitle: string;
+}
+
+export interface OmniboxSuggestionsMetadata {
+    suggestionRanking: number;
+    partialQueries: string | string[];
+    suggestions: string | string[];
+    partialQuery: string;
+    querySuggestResponseId: string;
+}
+
+export interface DocumentIdentifier {
+    contentIDKey: string;
+    contentIDValue: string;
+}
+
+export interface InterfaceChangeMetadata {
+    interfaceChangeTo: string;
+}
+
+export interface ResultsSortMetadata {
+    resultsSortBy: string;
+}
+
+export interface TriggerNotifyMetadata {
+    notifications: string[];
+}
+
+export interface TriggerExecution {
+    functionName: string;
+    params: (string | number | boolean)[];
+}
+
+export interface TriggerExecuteMetadata {
+    executions: TriggerExecution[];
+}
+
+export interface UndoTriggerRedirectMetadata {
+    undoneQuery: string;
+}
+
+export interface TriggerRedirectMetadata {
+    redirectedTo: string;
+}
+
+export interface PagerResizeMetadata {
+    currentResultsPerPage: number;
+}
+
+export interface PagerMetadata {
+    pagerNumber: number;
+}
+
+export interface FacetBaseMeta {
+    facetId: string;
+    facetField: string;
+    facetTitle: string;
+}
+
+export interface FacetMetadata extends FacetBaseMeta {
+    facetValue: string;
+}
+
+export interface FacetRangeMetadata extends FacetBaseMeta {
+    facetRangeStart: string;
+    facetRangeEnd: string;
+}
+
+export interface FacetSortMeta extends FacetBaseMeta {
+    criteria: string;
+}
+
+export interface QueryErrorMeta {
+    query: string;
+    aq: string;
+    cq: string;
+    dq: string;
+    errorType: string;
+    errorMessage: string;
+}
+
+export type SmartSnippetFeedbackReason = 'does_not_answer' | 'partially_answers' | 'was_not_a_question' | 'other';
+
+export interface SmartSnippetSuggestionMeta {
+    question: string;
+    answerSnippet: string;
+    documentId: SmartSnippetDocumentIdentifier;
+}
+
+export interface SmartSnippetLinkMeta {
+    linkText: string;
+    linkURL: string;
+}
+
+export interface SmartSnippetDocumentIdentifier {
+    contentIdKey: string;
+    contentIdValue: string;
+}
+
+export type PartialDocumentInformation = Omit<DocumentInformation, 'actionCause' | 'searchQueryUid'>;
+
+export interface GeneratedAnswerBaseMeta {
+    generativeQuestionAnsweringId: string;
+}
+
+export interface GeneratedAnswerStreamEndMeta extends GeneratedAnswerBaseMeta {
+    answerGenerated: boolean;
+    answerTextIsEmpty?: boolean;
+}
+
+export interface GeneratedAnswerCitationMeta {
+    generativeQuestionAnsweringId: string;
+    permanentId: string;
+    citationId: string;
+}
+
+export type GeneratedAnswerFeedbackReason = 'irrelevant' | 'notAccurate' | 'outOfDate' | 'harmful' | 'other';
+
+export type GeneratedAnswerRephraseFormat = 'step' | 'bullet' | 'concise' | 'default';
+
+export interface GeneratedAnswerSourceHoverMeta extends GeneratedAnswerCitationMeta {
+    citationHoverTimeMs: number;
+}
+
+export interface GeneratedAnswerRephraseMeta extends GeneratedAnswerBaseMeta {
+    rephraseFormat: GeneratedAnswerRephraseFormat;
+}
+
+export interface GeneratedAnswerFeedbackMeta extends GeneratedAnswerBaseMeta {
+    reason: GeneratedAnswerFeedbackReason;
+    details?: string;
+}
+
+export type GeneratedAnswerFeedbackReasonOption = 'yes' | 'unknown' | 'no';
+
+export interface GeneratedAnswerFeedbackMetaV2 extends GeneratedAnswerBaseMeta {
+    helpful: boolean;
+    readable: GeneratedAnswerFeedbackReasonOption;
+    documented: GeneratedAnswerFeedbackReasonOption;
+    correctTopic: GeneratedAnswerFeedbackReasonOption;
+    hallucinationFree: GeneratedAnswerFeedbackReasonOption;
+    details?: string;
+    documentUrl?: string;
+}

--- a/packages/coveo-analytics/src/storage.spec.ts
+++ b/packages/coveo-analytics/src/storage.spec.ts
@@ -1,0 +1,70 @@
+import {CookieStorage, CookieAndLocalStorage} from './storage';
+import {Cookie} from './cookieutils';
+
+describe('CookieStorage', () => {
+    const key = 'wow';
+    const someData = 'something';
+
+    it('setItem writes data to a cookie', () => {
+        const storage = new CookieStorage();
+        storage.setItem(key, someData);
+        expect(storage.getItem(key)).toBe(someData);
+    });
+
+    it('removeItem removes the cookie', () => {
+        const storage = new CookieStorage();
+        storage.setItem(key, someData);
+        storage.removeItem(key);
+        expect(storage.getItem(key)).toBe(null);
+    });
+
+    it('honors expiration date', async () => {
+        const storage = new CookieStorage();
+        storage.setItem(key, someData, 1000);
+        await new Promise((res) => setTimeout(res, 1000)); // wait for 1 sec
+        expect(storage.getItem(key)).toBe(null);
+    });
+});
+
+describe('CookieAndLocalStorage', () => {
+    const key = 'hello';
+    const someData = 'world';
+    let storage: CookieAndLocalStorage;
+    let cookie: CookieStorage;
+
+    beforeEach(() => {
+        storage = new CookieAndLocalStorage();
+        cookie = new CookieStorage();
+    });
+
+    it('setItem writes data to a cookie and local storage', () => {
+        storage.setItem(key, someData);
+        expect(cookie.getItem(key)).toBe(someData);
+        expect(localStorage.getItem(key)).toBe(someData);
+    });
+
+    it('removeItem removes the cookie and local storage', () => {
+        storage.setItem(key, someData);
+        storage.removeItem(key);
+
+        expect(storage.getItem(key)).toBe(null);
+        expect(cookie.getItem(key)).toBe(null);
+        expect(localStorage.getItem(key)).toBe(null);
+    });
+
+    it('get item uses local storage first', () => {
+        cookie.setItem(key, 'fail');
+        localStorage.setItem(key, someData);
+
+        storage.getItem(key);
+        expect(storage.getItem(key)).toBe(someData);
+    });
+
+    it('get item fallback on cookie storage if absent from local storage', () => {
+        localStorage.setItem(key, '');
+        cookie.setItem(key, someData);
+
+        storage.getItem(key);
+        expect(storage.getItem(key)).toBe(someData);
+    });
+});

--- a/packages/coveo-analytics/src/storage.ts
+++ b/packages/coveo-analytics/src/storage.ts
@@ -1,0 +1,69 @@
+import * as detector from './detector';
+import {Cookie} from './cookieutils';
+
+export let preferredStorage: WebStorage | null = null;
+
+export interface WebStorage {
+    getItem(key: string): string | null | Promise<string | null>;
+    removeItem(key: string): void;
+    setItem(key: string, data: string): void | Promise<void>;
+}
+
+export function getAvailableStorage(): WebStorage {
+    if (preferredStorage) {
+        return preferredStorage;
+    }
+    if (detector.hasLocalStorage()) {
+        return localStorage;
+    }
+    if (detector.hasCookieStorage()) {
+        return new CookieStorage();
+    }
+    if (detector.hasSessionStorage()) {
+        return sessionStorage;
+    }
+    return new NullStorage();
+}
+
+export class CookieStorage implements WebStorage {
+    static prefix = 'coveo_';
+    getItem(key: string): string | null {
+        return Cookie.get(`${CookieStorage.prefix}${key}`);
+    }
+    removeItem(key: string) {
+        Cookie.erase(`${CookieStorage.prefix}${key}`);
+    }
+    setItem(key: string, data: string, expire?: number): void {
+        Cookie.set(`${CookieStorage.prefix}${key}`, data, expire);
+    }
+}
+
+export class CookieAndLocalStorage implements WebStorage {
+    private cookieStorage = new CookieStorage();
+
+    getItem(key: string): string | null {
+        return localStorage.getItem(key) || this.cookieStorage.getItem(key);
+    }
+
+    removeItem(key: string): void {
+        this.cookieStorage.removeItem(key);
+        localStorage.removeItem(key);
+    }
+
+    setItem(key: string, data: string): void {
+        localStorage.setItem(key, data);
+        this.cookieStorage.setItem(key, data, 31556926000); // 1 year first party cookie
+    }
+}
+
+export class NullStorage implements WebStorage {
+    getItem(key: string): string | null {
+        return null;
+    }
+    removeItem(key: string) {
+        /**/
+    }
+    setItem(key: string, data: string): void {
+        /**/
+    }
+}

--- a/packages/coveo-analytics/src/version.ts
+++ b/packages/coveo-analytics/src/version.ts
@@ -1,0 +1,1 @@
+export const libVersion = process.env.PKG_VERSION || 'local'; // processed by @rollup/plugin-replace

--- a/packages/coveo-analytics/tests/analyticsClientMock.ts
+++ b/packages/coveo-analytics/tests/analyticsClientMock.ts
@@ -1,0 +1,33 @@
+import {AnalyticsClient, PreparedEvent} from '../src/client/analytics';
+import {NoopAnalytics} from '../src/client/noopAnalytics';
+import {NoopRuntime} from '../src/client/runtimeEnvironment';
+import {AnyEventResponse, EventType} from '../src/events';
+
+export const visitorIdMock = 'mockvisitorid';
+
+const makeEvent = (eventType: EventType | string) =>
+    Promise.resolve({eventType: eventType as EventType, payload: null, log: () => Promise.resolve()});
+
+export const createAnalyticsClientMock = (): jest.Mocked<AnalyticsClient> => ({
+    getPayload: jest.fn((eventType, ...payload) => Promise.resolve()) as any,
+    getParameters: jest.fn((eventType, ...payload) => Promise.resolve()) as any,
+    makeEvent: jest.fn(makeEvent) as any,
+    sendEvent: jest.fn((eventType, payload) => Promise.resolve()) as any,
+    makeClickEvent: jest.fn((request) => makeEvent(EventType.click)),
+    sendClickEvent: jest.fn((request) => Promise.resolve()),
+    makeCustomEvent: jest.fn((request) => makeEvent(EventType.custom)),
+    sendCustomEvent: jest.fn((request) => Promise.resolve()),
+    makeSearchEvent: jest.fn((request) => makeEvent(EventType.search)),
+    sendSearchEvent: jest.fn((request) => Promise.resolve()),
+    makeViewEvent: jest.fn((request) => makeEvent(EventType.view)),
+    sendViewEvent: jest.fn((request) => Promise.resolve()),
+    getHealth: jest.fn(() => Promise.resolve({status: 'ok'})),
+    getVisit: jest.fn(() => Promise.resolve({id: 'a', visitorId: 'ok'})),
+    addEventTypeMapping: jest.fn(),
+    registerBeforeSendEventHook: jest.fn(),
+    registerAfterSendEventHook: jest.fn(),
+    runtime: new NoopRuntime(),
+    currentVisitorId: '',
+    getCurrentVisitorId: jest.fn(() => Promise.resolve(visitorIdMock)),
+    version: 'mock',
+});

--- a/packages/coveo-analytics/tests/fetchMock.ts
+++ b/packages/coveo-analytics/tests/fetchMock.ts
@@ -1,0 +1,16 @@
+import * as fm from 'fetch-mock';
+import * as CrossFetch from 'cross-fetch';
+
+export function mockFetch() {
+    const fetchMock = fm.sandbox();
+    return {
+        fetchMock,
+        fetchMockBeforeEach: () => jest.spyOn(CrossFetch, 'fetch').mockImplementation(fetchMock as any),
+    };
+}
+
+export function lastCallBody(fetchMock: fm.FetchMockSandbox): string {
+    const [, res]: any = fetchMock.lastCall();
+    const {body} = res!;
+    return body!.toString();
+}

--- a/packages/coveo-analytics/tests/pluginMock.ts
+++ b/packages/coveo-analytics/tests/pluginMock.ts
@@ -1,0 +1,11 @@
+import {v4 as uuidv4} from 'uuid';
+import {BasePlugin, PluginOptions} from '../src/plugins/BasePlugin';
+
+export class TestPlugin extends BasePlugin {
+    public static readonly Id: 'test';
+    protected addHooks(): void {}
+    protected clearPluginData(): void {}
+    constructor({client, uuidGenerator = uuidv4}: PluginOptions) {
+        super({client, uuidGenerator});
+    }
+}

--- a/packages/coveo-analytics/tests/setup.js
+++ b/packages/coveo-analytics/tests/setup.js
@@ -1,0 +1,7 @@
+const documentMock = {
+    referrer: 'http://somewhere.over/thereferrer',
+    title: 'MAH PAGE',
+    characterSet: 'UTF-8',
+};
+
+Object.keys(documentMock).forEach((key) => Object.defineProperty(document, key, {value: documentMock[key]}));


### PR DESCRIPTION
[KIT-8888](https://coveord.atlassian.net/browse/KIT-8888)

## Problem
The CAJS migration needs a small, independently mergeable source-snapshot PR without activating a new pnpm/Turbo package. Raw legacy source has lint, formatting, spelling, and Knip findings that would otherwise prevent this parent layer from merging.

## Solution
- Copies the reviewed CAJS source snapshot from legacy commit `8c4ef5c` into `packages/coveo-analytics`.
- Includes source, tests, functional tests, browser-fetch helper, license, README, and technical overview only.
- Corrects the two legacy documentation spellings reported by CSpell.
- Temporarily defers the unregistered snapshot in Oxlint, Oxfmt, and Knip. These scoped deferrals avoid a behavioral or broad-formatting rewrite before package activation; #8048 removes the broad Oxlint deferral and aligns source lint rules.
- Excludes every package manifest, workspace registration, lockfile, build/test configuration, generated artifact, deployment configuration, and media asset.

## Validation
- `corepack pnpm install --frozen-lockfile --offline`
- `pnpm exec oxlint --deny-warnings .` (0 warnings, 0 errors)
- `pnpm exec oxfmt --check .`
- `pnpm exec cspell packages/coveo-analytics/README.md packages/coveo-analytics/docs/technical-overview.md --no-progress` (0 issues)
- `pnpm run knip` no longer reports CAJS; local execution remains blocked by unrelated missing generated Atomic outputs and existing `rxjs`/unresolved-import findings.
- `test ! -e packages/coveo-analytics/package.json`
- `pnpm exec turbo build --dry=json --filter='!./samples/**'` (CAJS absent from discovered tasks)
- `git diff --check`
