### PR TITLE
fix(coveo.analytics): align source with lint rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -25,8 +25,7 @@
     "**/packages/atomic/**/*.d.ts",
     "**/packages/atomic/stencil-proxy/**",
     "**/packages/documentation/**/assets/**",
-    "**/packages/headless/**/coveo.analytics/**",
-    "**/packages/coveo-analytics/**"
+    "**/packages/headless/**/coveo.analytics/**"
   ],
   "overrides": [
     {
@@ -52,6 +51,15 @@
       ],
       "rules": {
         "no-restricted-imports": "off"
+      }
+    },
+    {
+      "files": [
+        "**/packages/coveo-analytics/src/caseAssist/caseAssistActions.ts",
+        "**/packages/coveo-analytics/src/searchPage/searchPageEvents.ts"
+      ],
+      "rules": {
+        "typescript/no-duplicate-enum-values": "off"
       }
     }
   ]

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -52,15 +52,6 @@
       "rules": {
         "no-restricted-imports": "off"
       }
-    },
-    {
-      "files": [
-        "**/packages/coveo-analytics/src/caseAssist/caseAssistActions.ts",
-        "**/packages/coveo-analytics/src/searchPage/searchPageEvents.ts"
-      ],
-      "rules": {
-        "typescript/no-duplicate-enum-values": "off"
-      }
     }
   ]
 }

--- a/packages/coveo-analytics/src/caseAssist/caseAssistActions.ts
+++ b/packages/coveo-analytics/src/caseAssist/caseAssistActions.ts
@@ -5,6 +5,7 @@ export enum CaseAssistEvents {
     flowStart = 'flowStart',
 }
 
+// oxlint-disable typescript/no-duplicate-enum-values -- Preserves legacy emitted event values
 export enum CaseAssistActions {
     enterInterface = 'ticket_create_start',
     fieldUpdate = 'ticket_field_update',
@@ -16,6 +17,7 @@ export enum CaseAssistActions {
     caseSolved = 'ticket_cancel',
     caseCreated = 'ticket_create',
 }
+// oxlint-enable typescript/no-duplicate-enum-values
 
 export enum CaseCancelledReasons {
     quit = 'Quit',

--- a/packages/coveo-analytics/src/caseAssist/caseAssistClient.spec.ts
+++ b/packages/coveo-analytics/src/caseAssist/caseAssistClient.spec.ts
@@ -90,7 +90,7 @@ describe('CaseAssistClient', () => {
         };
     };
 
-    const expectMatchPayload = (actionName: CaseAssistActions, actionData: Object, ticket: TicketProperties) => {
+    const expectMatchPayload = (actionName: CaseAssistActions, actionData: object, ticket: TicketProperties) => {
         const body: string = lastCallBody(fetchMock);
         const content = JSON.parse(body);
 
@@ -102,7 +102,7 @@ describe('CaseAssistClient', () => {
     const expectMatchActionPayload = (
         content: Record<string, unknown>,
         actionName: CaseAssistActions,
-        actionData: Object
+        actionData: object
     ) => {
         expectMatchProperty(content, 'ec', 'svc');
         expectMatchProperty(content, 'svc_action', actionName);

--- a/packages/coveo-analytics/src/client/measurementProtocolMapper.ts
+++ b/packages/coveo-analytics/src/client/measurementProtocolMapper.ts
@@ -55,7 +55,7 @@ const getFirstCustomMeasurementProtocolKeyMatch = (key: string): string | undefi
     let matchedKey: string | undefined = undefined;
     [...isCustomCommerceKey].every((regex) => {
         matchedKey = regex.exec(key)?.[1];
-        return !Boolean(matchedKey);
+        return !matchedKey;
     });
     return matchedKey;
 };

--- a/packages/coveo-analytics/src/plugins/BasePlugin.ts
+++ b/packages/coveo-analytics/src/plugins/BasePlugin.ts
@@ -140,7 +140,7 @@ export abstract class BasePlugin extends Plugin {
     }
 
     private getCurrentLocationFromPayload(payload: any) {
-        if (!!payload.page) {
+        if (payload.page) {
             const removeStartingSlash = (page: string) => page.replace(/^\/?(.*)$/, '/$1');
             const extractHostnamePart = (location: string) => location.split('/').slice(0, 3).join('/');
             return `${extractHostnamePart(this.currentLocation)}${removeStartingSlash(payload.page)}`;

--- a/packages/coveo-analytics/src/searchPage/searchPageEvents.ts
+++ b/packages/coveo-analytics/src/searchPage/searchPageEvents.ts
@@ -1,6 +1,7 @@
 import {DocumentInformation, FacetStateRequest} from '../events';
 import {InsightEvents} from '../insight/insightEvents';
 
+// oxlint-disable typescript/no-duplicate-enum-values -- Preserves legacy emitted event values
 export enum SearchPageEvents {
     /**
      * Identifies the search event that gets logged when the initial query is performed as a result of loading a search interface.
@@ -351,6 +352,7 @@ export enum SearchPageEvents {
      */
     generatedAnswerFeedbackSubmitV2 = 'generatedAnswerFeedbackSubmitV2',
 }
+// oxlint-enable typescript/no-duplicate-enum-values
 
 export const CustomEventsTypes: Partial<Record<SearchPageEvents | InsightEvents, string>> = {
     [SearchPageEvents.triggerNotify]: 'queryPipelineTriggers',


### PR DESCRIPTION
[KIT-8888](https://coveord.atlassian.net/browse/KIT-8888)

## Problem
The CAJS source snapshot landed through #8046 with a temporary broad Oxlint deferral so it could merge without package activation. This follow-up exposes the source to lint rules while preserving its legacy analytics wire behavior.

## Solution
- Removes the broad CAJS Oxlint exclusion introduced with the source snapshot.
- Fixes the three non-semantic source findings: redundant boolean coercions and boxed `Object` test-helper types.
- Preserves the two legacy duplicate enum values through enum-scoped inline Oxlint suppressions rather than changing emitted analytics event values.
- Retains the temporary Oxfmt and Knip deferrals already on `main`; formatting and Knip package analysis remain deferred until package activation.
- Adds no `package.json`, workspace registration, Turbo configuration, consumer import, or generated artifact.

## Validation
- `pnpm exec oxlint --deny-warnings packages/coveo-analytics` (0 warnings, 0 errors)
- `pnpm exec cspell packages/coveo-analytics/README.md packages/coveo-analytics/docs/technical-overview.md --no-progress` (0 issues)
- `test ! -e packages/coveo-analytics/package.json`
- `pnpm exec turbo build --dry=json --filter='!./samples/**'` (CAJS absent from discovered tasks)
- `git diff --check`
