### PR TITLE
style(coveo.analytics): fix lint issues

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -25,8 +25,7 @@
     "**/packages/atomic/**/*.d.ts",
     "**/packages/atomic/stencil-proxy/**",
     "**/packages/documentation/**/assets/**",
-    "**/packages/headless/**/coveo.analytics/**",
-    "**/packages/coveo-analytics/**"
+    "**/packages/headless/**/coveo.analytics/**"
   ],
   "overrides": [
     {

--- a/packages/coveo-analytics/src/caseAssist/caseAssistActions.ts
+++ b/packages/coveo-analytics/src/caseAssist/caseAssistActions.ts
@@ -13,6 +13,7 @@ export enum CaseAssistActions {
     documentSuggestionQuickview = 'documentSuggestionQuickview',
     suggestionRate = 'suggestion_rate',
     nextCaseStep = 'ticket_next_stage',
+    // oxlint-disable-next-line typescript/no-duplicate-enum-values
     caseCancelled = 'ticket_cancel',
     caseSolved = 'ticket_cancel',
     caseCreated = 'ticket_create',

--- a/packages/coveo-analytics/src/caseAssist/caseAssistClient.spec.ts
+++ b/packages/coveo-analytics/src/caseAssist/caseAssistClient.spec.ts
@@ -105,7 +105,7 @@ describe('CaseAssistClient', () => {
         },
     };
 
-    const expectMatchPayload = (actionName: CaseAssistActions, actionData: Object, ticket: TicketProperties) => {
+    const expectMatchPayload = (actionName: CaseAssistActions, actionData: object, ticket: TicketProperties) => {
         const body: string = lastCallBody(fetchMock);
         const content = JSON.parse(body);
 
@@ -133,7 +133,7 @@ describe('CaseAssistClient', () => {
     const expectMatchActionPayload = (
         content: Record<string, unknown>,
         actionName: CaseAssistActions,
-        actionData: Object,
+        actionData: object,
     ) => {
         expectMatchProperty(content, 'ec', 'svc');
         expectMatchProperty(content, 'svc_action', actionName);

--- a/packages/coveo-analytics/src/client/measurementProtocolMapper.ts
+++ b/packages/coveo-analytics/src/client/measurementProtocolMapper.ts
@@ -55,7 +55,7 @@ const getFirstCustomMeasurementProtocolKeyMatch = (key: string): string | undefi
     let matchedKey: string | undefined = undefined;
     [...isCustomCommerceKey].every((regex) => {
         matchedKey = regex.exec(key)?.[1];
-        return !Boolean(matchedKey);
+        return !matchedKey;
     });
     return matchedKey;
 };

--- a/packages/coveo-analytics/src/plugins/BasePlugin.ts
+++ b/packages/coveo-analytics/src/plugins/BasePlugin.ts
@@ -140,7 +140,7 @@ export abstract class BasePlugin extends Plugin {
     }
 
     private getCurrentLocationFromPayload(payload: any) {
-        if (!!payload.page) {
+        if (payload.page) {
             const removeStartingSlash = (page: string) => page.replace(/^\/?(.*)$/, '/$1');
             const extractHostnamePart = (location: string) => location.split('/').slice(0, 3).join('/');
             return `${extractHostnamePart(this.currentLocation)}${removeStartingSlash(payload.page)}`;

--- a/packages/coveo-analytics/src/searchPage/searchPageEvents.ts
+++ b/packages/coveo-analytics/src/searchPage/searchPageEvents.ts
@@ -73,6 +73,7 @@ export enum SearchPageEvents {
     /**
      * Identifies the custom event that gets logged when a user action triggers a new query set in the effective query pipeline on the search page.
      */
+    // oxlint-disable-next-line typescript/no-duplicate-enum-values
     triggerQuery = 'query',
     /**
      * Identifies the custom event that gets logged when a user undoes a query set in the effective query pipeline on the search page.


### PR DESCRIPTION
## Summary

This PR applies only current ui-kit oxlint fixes to `packages/coveo-analytics/**` and removes the package-specific oxlint ignore so CI validates CAJS. Intentional duplicate public enum values retain their existing behavior through narrow rule suppressions.

Formatting, workspace integration, dependency alignment, release/CDN configuration, and package compatibility remain deferred to later phases.

## Validation

- Targeted `pnpm exec oxlint --deny-warnings packages/coveo-analytics`
- `git diff --check`
- No changeset added (mechanical linting; package is not workspace-registered)