### PR TITLE
fix(create-ui): clarify template version support

### DIFF
--- a/.changeset/clarify-template-version-guidance.md
+++ b/.changeset/clarify-template-version-guidance.md
@@ -1,0 +1,5 @@
+---
+'@coveo/create-ui': patch
+---
+
+Clarify the earliest supported version when a requested sample version is unavailable.

--- a/packages/create-ui/src/index.test.ts
+++ b/packages/create-ui/src/index.test.ts
@@ -159,9 +159,7 @@ describe('main', () => {
 
     await expect(
       main(['my-app', '--template', 'headless-search-react', '--template-version', '99.99.99'])
-    ).rejects.toThrow(
-      'Template "headless-search-react" version "99.99.99" is not available. This template is supported from version "3.53.1" onward, when its sample was first published.'
-    );
+    ).rejects.toThrow(/headless-search-react.*99\.99\.99.*3\.53\.1/);
 
     outSpy.mockRestore();
     logSpy.mockRestore();

--- a/packages/create-ui/src/index.test.ts
+++ b/packages/create-ui/src/index.test.ts
@@ -159,7 +159,9 @@ describe('main', () => {
 
     await expect(
       main(['my-app', '--template', 'headless-search-react', '--template-version', '99.99.99'])
-    ).rejects.toThrow('Template "headless-search-react" version "99.99.99" is not available.');
+    ).rejects.toThrow(
+      'Template "headless-search-react" version "99.99.99" is not available. This template is supported from version "3.53.1" onward, when its sample was first published.'
+    );
 
     outSpy.mockRestore();
     logSpy.mockRestore();

--- a/packages/create-ui/src/prompt.test.ts
+++ b/packages/create-ui/src/prompt.test.ts
@@ -8,18 +8,21 @@ const sample: Template[] = [
     library: 'headless',
     label: 'Search (React)',
     packageName: '@coveo/ui-kit-sample-headless-search-react',
+    firstSupportedVersion: '3.53.1',
   },
   {
     name: 'atomic-search',
     library: 'atomic',
     label: 'Search (Vite)',
     packageName: '@coveo/ui-kit-sample-atomic-search',
+    firstSupportedVersion: '3.60.1',
   },
   {
     name: 'atomic-commerce',
     library: 'atomic',
     label: 'Commerce (Vite)',
     packageName: '@coveo/ui-kit-sample-atomic-commerce',
+    firstSupportedVersion: '3.60.1',
   },
 ];
 

--- a/packages/create-ui/src/scaffold.ts
+++ b/packages/create-ui/src/scaffold.ts
@@ -48,10 +48,17 @@ export async function scaffold({template, projectName, version}: ScaffoldOptions
   completePhase({projectName, packageManager, installed});
 }
 
-export function unavailableTemplateMessage(templateName: string, version?: string): string {
-  return version
+export function unavailableTemplateMessage(
+  templateName: string,
+  version?: string,
+  firstSupportedVersion?: string
+): string {
+  const message = version
     ? `Template "${templateName}" version "${version}" is not available.`
     : `Template "${templateName}" is not available.`;
+  return firstSupportedVersion
+    ? `${message} This template is supported from version "${firstSupportedVersion}" onward, when its sample was first published.`
+    : message;
 }
 
 async function claimTargetDir(targetDir: string): Promise<boolean> {
@@ -146,7 +153,9 @@ function reportUnavailableTemplate(template: Template, version?: string): never 
       `Coveo community:            https://connect.coveo.com`,
     'Need help?'
   );
-  throw new ExpectedError(unavailableTemplateMessage(template.name, version));
+  throw new ExpectedError(
+    unavailableTemplateMessage(template.name, version, template.firstSupportedVersion)
+  );
 }
 
 async function resolveTemplate(templateArg: string | undefined): Promise<Template | null> {

--- a/packages/create-ui/src/templates.ts
+++ b/packages/create-ui/src/templates.ts
@@ -45,6 +45,8 @@ export interface Template {
   label: string;
   /** npm package the sample is published as. */
   packageName: string;
+  /** First published version that contains a scaffoldable sample. */
+  firstSupportedVersion: string;
 }
 
 const templates: Template[] = [
@@ -53,60 +55,70 @@ const templates: Template[] = [
     library: 'atomic',
     label: 'Search (Vite, @coveo/atomic)',
     packageName: '@coveo/ui-kit-sample-atomic-search-vite',
+    firstSupportedVersion: '3.60.1',
   },
   {
     name: 'atomic-commerce',
     library: 'atomic',
     label: 'Commerce (Vite, @coveo/atomic)',
     packageName: '@coveo/ui-kit-sample-atomic-commerce-vite',
+    firstSupportedVersion: '3.60.1',
   },
   {
     name: 'atomic-search-react',
     library: 'atomic',
     label: 'Search (React, @coveo/atomic-react)',
     packageName: '@coveo/ui-kit-sample-atomic-search-react',
+    firstSupportedVersion: '3.11.33',
   },
   {
     name: 'atomic-commerce-react',
     library: 'atomic',
     label: 'Commerce (React, @coveo/atomic-react)',
     packageName: '@coveo/ui-kit-sample-atomic-commerce-react',
+    firstSupportedVersion: '3.11.34',
   },
   {
     name: 'headless-search',
     library: 'headless',
     label: 'Search (Vite, @coveo/headless)',
     packageName: '@coveo/ui-kit-sample-headless-search-vite',
+    firstSupportedVersion: '3.53.1',
   },
   {
     name: 'headless-commerce',
     library: 'headless',
     label: 'Commerce (Vite, @coveo/headless/commerce)',
     packageName: '@coveo/ui-kit-sample-headless-commerce-vite',
+    firstSupportedVersion: '3.53.1',
   },
   {
     name: 'headless-search-react',
     library: 'headless',
     label: 'Search (React, @coveo/headless)',
     packageName: '@coveo/ui-kit-sample-headless-search-react',
+    firstSupportedVersion: '3.53.1',
   },
   {
     name: 'headless-commerce-react',
     library: 'headless',
     label: 'Commerce (React, @coveo/headless/commerce)',
     packageName: '@coveo/ui-kit-sample-headless-commerce-react',
+    firstSupportedVersion: '3.53.1',
   },
   {
     name: 'headless-ssr-commerce-nextjs',
     library: 'headless-ssr',
     label: 'Commerce SSR (Next.js App Router, @coveo/headless-react)',
     packageName: '@coveo/ui-kit-sample-headless-ssr-commerce-nextjs',
+    firstSupportedVersion: '2.9.26',
   },
   {
     name: 'headless-ssr-commerce-express',
     library: 'headless-ssr',
     label: 'Commerce SSR (Express, @coveo/headless/ssr)',
     packageName: '@coveo/ui-kit-sample-headless-ssr-commerce-express',
+    firstSupportedVersion: '3.53.2',
   },
 ];
 


### PR DESCRIPTION
## Problem
When a requested template version is unavailable, the CLI does not explain that scaffoldable samples began publishing at template-specific versions.

## Solution
Record each template’s first supported published sample version and include it in the unavailable-version error message.