### PR TITLE
docs(thermidor): add button to go back to conversation from search results in UX-aligned demo

### DIFF
--- a/samples/thermidor/demo-react/src/a2ui/SurfaceRenderer/SurfaceRenderer.tsx
+++ b/samples/thermidor/demo-react/src/a2ui/SurfaceRenderer/SurfaceRenderer.tsx
@@ -102,7 +102,7 @@ export function SurfaceRenderer({surfaces, onAction, isStreaming = true}: Surfac
     }
 
     return items;
-  }, [allParsed]);
+  }, [allParsed, isStreaming]);
 
   if (renderItems.length === 0) {
     return null;

--- a/samples/thermidor/demo-react/src/components/AppShell.bidirectional.test.tsx
+++ b/samples/thermidor/demo-react/src/components/AppShell.bidirectional.test.tsx
@@ -1,0 +1,675 @@
+import {render, screen, act} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import type {ConverseControllerState, Turn} from '@coveo/thermidor';
+import {AppShell} from './AppShell.js';
+
+const mockSubmit = vi.fn();
+const mockClear = vi.fn();
+
+let mockConverseState: ConverseControllerState;
+
+vi.mock('../context/generative-interface.js', () => ({
+  useGenerativeInterface: () => ({}),
+}));
+
+vi.mock('../hooks/use-build-controller.js', () => ({
+  useBuildController: () => [
+    {submit: mockSubmit, clear: mockClear, subscribe: vi.fn(), state: {}},
+    mockConverseState,
+  ],
+}));
+
+vi.mock('./LandingPage/LandingPage.js', () => ({
+  LandingPage: (props: any) => (
+    <div data-testid="landing-page">
+      <button data-testid="submit-btn" onClick={() => props.onSubmit('surfboards')} />
+    </div>
+  ),
+}));
+
+vi.mock('./SearchResultsPage/SearchResultsPage.js', () => ({
+  SearchResultsPage: (props: any) => (
+    <div data-testid="search-results-page">
+      <span data-testid="routed-interface-id">{props.routedInterface?.id}</span>
+      <span data-testid="search-query">{props.query}</span>
+      <button
+        data-testid="search-submit-conversational"
+        onClick={() => props.onSubmit('tell me about wetsuits')}
+      />
+      <button data-testid="search-submit-new-search" onClick={() => props.onSubmit('kayaks')} />
+      <button data-testid="back-to-conversation-btn" onClick={props.onBackToConversation} />
+    </div>
+  ),
+}));
+
+vi.mock('./ConversationPage/index.js', () => ({
+  ConversationPage: (props: any) => (
+    <div data-testid="conversation-page">
+      <span data-testid="turn-count">{props.turns.length}</span>
+      <span data-testid="turn-ids">{props.turns.map((t: Turn) => t.id).join(',')}</span>
+      <span data-testid="can-go-back">{String(props.canGoBackToSearch)}</span>
+      <button data-testid="back-btn" onClick={props.onBackToSearch} />
+      <button data-testid="reset-btn" onClick={props.onResetToLanding} />
+      <button
+        data-testid="conversation-submit"
+        onClick={() => props.onSubmit('follow up question')}
+      />
+    </div>
+  ),
+}));
+
+function makeTurn(overrides: Partial<Turn> & {id: string}): Turn {
+  return {
+    prompt: 'test prompt',
+    status: 'complete',
+    ...overrides,
+  } as Turn;
+}
+
+describe('AppShell — bidirectional navigation flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConverseState = {
+      turns: [],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+  });
+
+  it('full cycle: landing → search → conversation → back to search (state preserved) → new search → conversation', () => {
+    const mockDispose1 = vi.fn();
+    const routedInterface1 = {
+      id: 'ri-1',
+      useCase: 'search' as const,
+      interface: {dispose: mockDispose1},
+    };
+
+    // Step 1: Start at landing
+    const {rerender} = render(<AppShell />);
+    expect(screen.getByTestId('landing-page')).toBeDefined();
+
+    // Step 2: Submit a search query from landing
+    act(() => {
+      screen.getByTestId('submit-btn').click();
+    });
+    expect(mockSubmit).toHaveBeenCalledWith({prompt: 'surfboards'});
+
+    // Step 3: Turn completes with a routedInterface → navigate to search
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'surfboards', routedInterface: routedInterface1 as any}),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+
+    expect(screen.getByTestId('search-results-page')).toBeDefined();
+    expect(screen.getByTestId('routed-interface-id').textContent).toBe('ri-1');
+    expect(screen.getByTestId('search-query').textContent).toBe('surfboards');
+
+    // Step 4: From search, submit a conversational query
+    act(() => {
+      screen.getByTestId('search-submit-conversational').click();
+    });
+    expect(mockSubmit).toHaveBeenCalledWith({prompt: 'tell me about wetsuits'});
+
+    // Step 5: Turn completes with agentResponse → navigate to conversation
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'surfboards', routedInterface: routedInterface1 as any}),
+        makeTurn({
+          id: 'turn-2',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'Wetsuits are great!', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'Looking up wetsuits'}],
+          } as any,
+        }),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+
+    expect(screen.getByTestId('conversation-page')).toBeDefined();
+    expect(screen.getByTestId('can-go-back').textContent).toBe('true');
+    expect(screen.getByTestId('turn-count').textContent).toBe('2');
+    expect(screen.getByTestId('turn-ids').textContent).toBe('turn-1,turn-2');
+
+    // Step 6: Navigate back to search results
+    act(() => {
+      screen.getByTestId('back-btn').click();
+    });
+
+    // Search page should render with the SAME persisted interface (not disposed)
+    expect(screen.getByTestId('search-results-page')).toBeDefined();
+    expect(screen.getByTestId('routed-interface-id').textContent).toBe('ri-1');
+    expect(mockDispose1).not.toHaveBeenCalled();
+    // Query should be cleared when navigating back via "Back to search results"
+    expect(screen.getByTestId('search-query').textContent).toBe('');
+
+    // Step 7: From search, submit a new search query
+    act(() => {
+      screen.getByTestId('search-submit-new-search').click();
+    });
+    expect(mockSubmit).toHaveBeenCalledWith({prompt: 'kayaks'});
+
+    // Step 8: New turn completes with a new routedInterface → stays on search, old interface disposed
+    const mockDispose2 = vi.fn();
+    const routedInterface2 = {
+      id: 'ri-2',
+      useCase: 'search' as const,
+      interface: {dispose: mockDispose2},
+    };
+
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'surfboards', routedInterface: routedInterface1 as any}),
+        makeTurn({
+          id: 'turn-2',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'Wetsuits are great!', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'Looking up wetsuits'}],
+          } as any,
+        }),
+        makeTurn({id: 'turn-3', prompt: 'kayaks', routedInterface: routedInterface2 as any}),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+
+    expect(screen.getByTestId('search-results-page')).toBeDefined();
+    expect(screen.getByTestId('routed-interface-id').textContent).toBe('ri-2');
+    expect(mockDispose1).toHaveBeenCalledTimes(1);
+    expect(mockDispose2).not.toHaveBeenCalled();
+
+    // Step 9: From the new search, submit a conversational query again
+    act(() => {
+      screen.getByTestId('search-submit-conversational').click();
+    });
+
+    // Step 10: Turn completes with agentResponse → navigate to conversation with full history
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'surfboards', routedInterface: routedInterface1 as any}),
+        makeTurn({
+          id: 'turn-2',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'Wetsuits are great!', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'Looking up wetsuits'}],
+          } as any,
+        }),
+        makeTurn({id: 'turn-3', prompt: 'kayaks', routedInterface: routedInterface2 as any}),
+        makeTurn({
+          id: 'turn-4',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'More info on wetsuits', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'Explaining wetsuits in depth'}],
+          } as any,
+        }),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+
+    expect(screen.getByTestId('conversation-page')).toBeDefined();
+    expect(screen.getByTestId('turn-count').textContent).toBe('4');
+    expect(screen.getByTestId('turn-ids').textContent).toBe('turn-1,turn-2,turn-3,turn-4');
+    expect(screen.getByTestId('can-go-back').textContent).toBe('true');
+  });
+
+  it('conversation history is preserved when navigating back from search to conversation via new conversational submission', () => {
+    const mockDispose = vi.fn();
+    const routedInterface = {
+      id: 'ri-1',
+      useCase: 'search' as const,
+      interface: {dispose: mockDispose},
+    };
+
+    // Start in search mode
+    mockConverseState = {
+      turns: [makeTurn({id: 'turn-1', prompt: 'shoes', routedInterface: routedInterface as any})],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+
+    const {rerender} = render(<AppShell />);
+    expect(screen.getByTestId('search-results-page')).toBeDefined();
+
+    // Submit conversational query
+    act(() => {
+      screen.getByTestId('search-submit-conversational').click();
+    });
+
+    // Turn completes → conversation mode
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'shoes', routedInterface: routedInterface as any}),
+        makeTurn({
+          id: 'turn-2',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'Info', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'x'}],
+          } as any,
+        }),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+    expect(screen.getByTestId('conversation-page')).toBeDefined();
+
+    // Submit a follow-up in conversation
+    act(() => {
+      screen.getByTestId('conversation-submit').click();
+    });
+
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'shoes', routedInterface: routedInterface as any}),
+        makeTurn({
+          id: 'turn-2',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'Info', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'x'}],
+          } as any,
+        }),
+        makeTurn({
+          id: 'turn-3',
+          prompt: 'follow up question',
+          agentResponse: {
+            messages: [{content: 'Follow up answer', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'y'}],
+          } as any,
+        }),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+
+    // All 3 turns present
+    expect(screen.getByTestId('turn-count').textContent).toBe('3');
+
+    // Go back to search
+    act(() => {
+      screen.getByTestId('back-btn').click();
+    });
+    expect(screen.getByTestId('search-results-page')).toBeDefined();
+    expect(screen.getByTestId('routed-interface-id').textContent).toBe('ri-1');
+    expect(mockDispose).not.toHaveBeenCalled();
+
+    // Submit another conversational query from search → conversation should have all turns
+    act(() => {
+      screen.getByTestId('search-submit-conversational').click();
+    });
+
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'shoes', routedInterface: routedInterface as any}),
+        makeTurn({
+          id: 'turn-2',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'Info', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'x'}],
+          } as any,
+        }),
+        makeTurn({
+          id: 'turn-3',
+          prompt: 'follow up question',
+          agentResponse: {
+            messages: [{content: 'Follow up answer', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'y'}],
+          } as any,
+        }),
+        makeTurn({
+          id: 'turn-4',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'Even more info', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'z'}],
+          } as any,
+        }),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+
+    // Full history preserved — all 4 turns visible
+    expect(screen.getByTestId('conversation-page')).toBeDefined();
+    expect(screen.getByTestId('turn-count').textContent).toBe('4');
+    expect(screen.getByTestId('turn-ids').textContent).toBe('turn-1,turn-2,turn-3,turn-4');
+  });
+
+  it('controller session continuity: same controller instance used across all transitions', () => {
+    const mockDispose = vi.fn();
+    const routedInterface = {
+      id: 'ri-1',
+      useCase: 'search' as const,
+      interface: {dispose: mockDispose},
+    };
+
+    // Landing → submit
+    const {rerender} = render(<AppShell />);
+    act(() => {
+      screen.getByTestId('submit-btn').click();
+    });
+    expect(mockSubmit).toHaveBeenCalledTimes(1);
+
+    // Arrive at search
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'surfboards', routedInterface: routedInterface as any}),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+
+    // Search → submit conversational
+    act(() => {
+      screen.getByTestId('search-submit-conversational').click();
+    });
+    expect(mockSubmit).toHaveBeenCalledTimes(2);
+
+    // Arrive at conversation
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'surfboards', routedInterface: routedInterface as any}),
+        makeTurn({
+          id: 'turn-2',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'x', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'r'}],
+          } as any,
+        }),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+
+    // Conversation → follow up
+    act(() => {
+      screen.getByTestId('conversation-submit').click();
+    });
+    expect(mockSubmit).toHaveBeenCalledTimes(3);
+
+    // All calls to the same mockSubmit instance confirms same controller
+    expect(mockSubmit).toHaveBeenNthCalledWith(1, {prompt: 'surfboards'});
+    expect(mockSubmit).toHaveBeenNthCalledWith(2, {prompt: 'tell me about wetsuits'});
+    expect(mockSubmit).toHaveBeenNthCalledWith(3, {prompt: 'follow up question'});
+  });
+
+  it('search interface disposed only on explicit reset, not on view transitions', () => {
+    const mockDispose = vi.fn();
+    const routedInterface = {
+      id: 'ri-1',
+      useCase: 'search' as const,
+      interface: {dispose: mockDispose},
+    };
+
+    // Start in search
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'surfboards', routedInterface: routedInterface as any}),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+
+    const {rerender} = render(<AppShell />);
+    expect(screen.getByTestId('search-results-page')).toBeDefined();
+
+    // Go to conversation
+    act(() => {
+      screen.getByTestId('search-submit-conversational').click();
+    });
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'surfboards', routedInterface: routedInterface as any}),
+        makeTurn({
+          id: 'turn-2',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'x', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'r'}],
+          } as any,
+        }),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+    expect(screen.getByTestId('conversation-page')).toBeDefined();
+    expect(mockDispose).not.toHaveBeenCalled();
+
+    // Back to search
+    act(() => {
+      screen.getByTestId('back-btn').click();
+    });
+    expect(screen.getByTestId('search-results-page')).toBeDefined();
+    expect(mockDispose).not.toHaveBeenCalled();
+
+    // Back to conversation
+    act(() => {
+      screen.getByTestId('search-submit-conversational').click();
+    });
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'surfboards', routedInterface: routedInterface as any}),
+        makeTurn({
+          id: 'turn-2',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'x', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'r'}],
+          } as any,
+        }),
+        makeTurn({
+          id: 'turn-3',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'y', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 's'}],
+          } as any,
+        }),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+    expect(screen.getByTestId('conversation-page')).toBeDefined();
+    expect(mockDispose).not.toHaveBeenCalled();
+
+    // Only dispose on explicit reset
+    act(() => {
+      screen.getByTestId('reset-btn').click();
+    });
+    expect(mockDispose).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('landing-page')).toBeDefined();
+  });
+
+  it('"Back to conversation" button navigates from search to conversation without submitting', () => {
+    const mockDispose = vi.fn();
+    const routedInterface = {
+      id: 'ri-1',
+      useCase: 'search' as const,
+      interface: {dispose: mockDispose},
+    };
+
+    // Step 1: Start at landing, get a search result
+    mockConverseState = {
+      turns: [],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+
+    const {rerender} = render(<AppShell />);
+    expect(screen.getByTestId('landing-page')).toBeDefined();
+
+    // Submit from landing
+    act(() => {
+      screen.getByTestId('submit-btn').click();
+    });
+
+    // Search turn completes
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'surfboards', routedInterface: routedInterface as any}),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+    expect(screen.getByTestId('search-results-page')).toBeDefined();
+
+    // Submit conversational query from search
+    act(() => {
+      screen.getByTestId('search-submit-conversational').click();
+    });
+
+    // Conversation turn completes
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'surfboards', routedInterface: routedInterface as any}),
+        makeTurn({
+          id: 'turn-2',
+          prompt: 'tell me about wetsuits',
+          agentResponse: {
+            messages: [{content: 'Wetsuits info', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'r'}],
+          } as any,
+        }),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+    expect(screen.getByTestId('conversation-page')).toBeDefined();
+
+    // Go back to search
+    act(() => {
+      screen.getByTestId('back-btn').click();
+    });
+    expect(screen.getByTestId('search-results-page')).toBeDefined();
+
+    // "Back to conversation" button should be visible
+    expect(screen.getByTestId('back-to-conversation-btn')).toBeDefined();
+
+    // Click it — should navigate to conversation without any new submission
+    const submitCallCount = mockSubmit.mock.calls.length;
+    act(() => {
+      screen.getByTestId('back-to-conversation-btn').click();
+    });
+
+    expect(screen.getByTestId('conversation-page')).toBeDefined();
+    expect(screen.getByTestId('turn-count').textContent).toBe('2');
+    // No new submit call was made
+    expect(mockSubmit.mock.calls.length).toBe(submitCallCount);
+  });
+
+  it('"Back to conversation" navigates to conversation showing routed turn when no agent-response turn exists', () => {
+    const routedInterface = {
+      id: 'ri-1',
+      useCase: 'search' as const,
+      interface: {dispose: vi.fn()},
+    };
+
+    // First turn routes to search — no agent response exists yet
+    mockConverseState = {
+      turns: [
+        makeTurn({id: 'turn-1', prompt: 'surfboards', routedInterface: routedInterface as any}),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+
+    render(<AppShell />);
+    expect(screen.getByTestId('search-results-page')).toBeDefined();
+
+    // The button is always visible
+    expect(screen.getByTestId('back-to-conversation-btn')).toBeDefined();
+
+    // Click "Back to conversation" — navigates to conversation with the single routed turn
+    act(() => {
+      screen.getByTestId('back-to-conversation-btn').click();
+    });
+
+    expect(screen.getByTestId('conversation-page')).toBeDefined();
+    expect(screen.getByTestId('turn-count').textContent).toBe('1');
+    expect(screen.getByTestId('turn-ids').textContent).toBe('turn-1');
+  });
+
+  it('navigates to search when a turn has both routedInterface and agentResponse.reasoningSteps (ordering invariant)', () => {
+    mockConverseState = {
+      turns: [],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+
+    const {rerender} = render(<AppShell />);
+    expect(screen.getByTestId('landing-page')).toBeDefined();
+
+    // Submit a prompt from landing
+    act(() => {
+      screen.getByTestId('submit-btn').click();
+    });
+
+    // Turn arrives with BOTH routedInterface and agentResponse.reasoningSteps
+    const mockDispose = vi.fn();
+    const routedInterface = {
+      id: 'ri-dual',
+      useCase: 'search' as const,
+      interface: {dispose: mockDispose},
+    };
+
+    mockConverseState = {
+      turns: [
+        makeTurn({
+          id: 'turn-dual',
+          prompt: 'surfboards',
+          routedInterface: routedInterface as any,
+          agentResponse: {
+            messages: [{content: 'Here are surfboards', role: 'assistant'}],
+            surfaces: [],
+            reasoningSteps: [{type: 'reasoning', content: 'Looking up surfboards'}],
+          } as any,
+        }),
+      ],
+      activeTurn: undefined,
+      isStreaming: false,
+    };
+    rerender(<AppShell />);
+
+    // Per the ordering invariant: routedInterface takes precedence → search view
+    expect(screen.getByTestId('search-results-page')).toBeDefined();
+    expect(screen.getByTestId('routed-interface-id').textContent).toBe('ri-dual');
+  });
+});

--- a/samples/thermidor/demo-react/src/components/AppShell.tsx
+++ b/samples/thermidor/demo-react/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
-import {useEffect, useRef, useState} from 'react';
-import {buildConverseController, type RoutedInterface} from '@coveo/thermidor';
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {buildConverseController, type RoutedInterface, type Turn} from '@coveo/thermidor';
 import {useGenerativeInterface} from '../context/generative-interface.js';
 import {useBuildController} from '../hooks/use-build-controller.js';
 import {useAppState, deriveTransitionAction} from '../hooks/use-app-state.js';
@@ -19,8 +19,23 @@ export function AppShell() {
   const persistedInterfaceTurnIdRef = useRef<string | null>(null);
   const persistedQueryRef = useRef<string>('');
   const lastObservedTurnIdRef = useRef<string | null>(null);
-  const pendingLandingNavigationRef = useRef(false);
+  const pendingNavigationRef = useRef(false);
   const [canGoBackToSearch, setCanGoBackToSearch] = useState(false);
+
+  const persistAndNavigateToSearch = useCallback(
+    (turn: Turn) => {
+      if (persistedInterfaceRef.current) {
+        persistedInterfaceRef.current.interface.dispose();
+      }
+      persistedInterfaceRef.current = turn.routedInterface!;
+      persistedInterfaceTurnIdRef.current = turn.id;
+      persistedQueryRef.current = turn.prompt;
+      lastObservedTurnIdRef.current = turn.id;
+      setCanGoBackToSearch(true);
+      dispatch({type: 'NAVIGATE_SEARCH'});
+    },
+    [dispatch]
+  );
 
   useEffect(() => {
     return () => {
@@ -31,30 +46,22 @@ export function AppShell() {
   useEffect(() => {
     const turns = converseState.turns;
 
-    // NAVIGATION ORDERING INVARIANT: When pendingLandingNavigationRef is true,
+    // NAVIGATION ORDERING INVARIANT: When pendingNavigationRef is true,
     // we check routedInterface BEFORE agentResponse.reasoningSteps.
     // This ensures that if a turn produces a routed interface, we navigate to
     // search regardless of whether reasoning steps also appeared. The routedInterface
     // check uses an early return to guarantee mutual exclusivity.
-    if (pendingLandingNavigationRef.current && turns.length > 0) {
+    if (pendingNavigationRef.current && turns.length > 0) {
       const latestTurn = turns[turns.length - 1];
 
       if (latestTurn.routedInterface) {
-        pendingLandingNavigationRef.current = false;
-        if (persistedInterfaceRef.current) {
-          persistedInterfaceRef.current.interface.dispose();
-        }
-        persistedInterfaceRef.current = latestTurn.routedInterface;
-        persistedInterfaceTurnIdRef.current = latestTurn.id;
-        persistedQueryRef.current = latestTurn.prompt;
-        lastObservedTurnIdRef.current = latestTurn.id;
-        setCanGoBackToSearch(true);
-        dispatch({type: 'NAVIGATE_SEARCH'});
+        pendingNavigationRef.current = false;
+        persistAndNavigateToSearch(latestTurn);
         return;
       }
 
       if (latestTurn.agentResponse && latestTurn.agentResponse.reasoningSteps?.length > 0) {
-        pendingLandingNavigationRef.current = false;
+        pendingNavigationRef.current = false;
         dispatch({type: 'NAVIGATE_CONVERSATION'});
       }
     }
@@ -75,27 +82,20 @@ export function AppShell() {
     const action = deriveTransitionAction(latestCompletedTurn);
 
     if (action?.type === 'NAVIGATE_SEARCH' && latestCompletedTurn.routedInterface) {
-      if (persistedInterfaceRef.current) {
-        persistedInterfaceRef.current.interface.dispose();
-      }
-      persistedInterfaceRef.current = latestCompletedTurn.routedInterface;
-      persistedInterfaceTurnIdRef.current = latestCompletedTurn.id;
-      persistedQueryRef.current = latestCompletedTurn.prompt;
-      setCanGoBackToSearch(true);
-      dispatch(action);
+      persistAndNavigateToSearch(latestCompletedTurn);
     } else if (action?.type === 'NAVIGATE_CONVERSATION') {
-      if (pendingLandingNavigationRef.current) {
-        pendingLandingNavigationRef.current = false;
+      if (pendingNavigationRef.current) {
+        pendingNavigationRef.current = false;
         dispatch(action);
       }
     }
-  }, [converseState.turns, dispatch]);
+  }, [converseState.turns, dispatch, persistAndNavigateToSearch]);
 
   const handleSubmit = (prompt: string) => {
     if (!prompt.trim() || converseState.isStreaming) return;
     controller.submit({prompt});
     if (view === 'landing' || view === 'search') {
-      pendingLandingNavigationRef.current = true;
+      pendingNavigationRef.current = true;
     }
   };
 
@@ -104,6 +104,10 @@ export function AppShell() {
       persistedQueryRef.current = '';
       dispatch({type: 'NAVIGATE_SEARCH'});
     }
+  };
+
+  const handleBackToConversation = () => {
+    dispatch({type: 'NAVIGATE_CONVERSATION'});
   };
 
   const handleResetToLanding = () => {
@@ -117,37 +121,36 @@ export function AppShell() {
     dispatch({type: 'NAVIGATE_LANDING'});
   };
 
-  const viewContent = (() => {
-    switch (view) {
-      case 'search':
-        return (
+  return (
+    <div className="view-shell">
+      {persistedInterfaceRef.current && (
+        <div className={`view-panel ${view === 'search' ? 'view-panel--active' : ''}`}>
           <SearchResultsPage
             key={persistedInterfaceTurnIdRef.current!}
             onSubmit={handleSubmit}
             isStreaming={converseState.isStreaming}
-            routedInterface={persistedInterfaceRef.current!}
+            routedInterface={persistedInterfaceRef.current}
             query={persistedQueryRef.current}
+            onBackToConversation={handleBackToConversation}
           />
-        );
-      case 'conversation':
-        return (
-          <ConversationPage
-            onSubmit={handleSubmit}
-            isStreaming={converseState.isStreaming}
-            turns={converseState.turns}
-            onBackToSearch={handleBackToSearch}
-            canGoBackToSearch={canGoBackToSearch}
-            onResetToLanding={handleResetToLanding}
-          />
-        );
-      default:
-        return <LandingPage onSubmit={handleSubmit} isStreaming={converseState.isStreaming} />;
-    }
-  })();
-
-  return (
-    <div key={view} className="view-transition">
-      {viewContent}
+        </div>
+      )}
+      {view !== 'search' && (
+        <div className="view-panel view-panel--active">
+          {view === 'conversation' ? (
+            <ConversationPage
+              onSubmit={handleSubmit}
+              isStreaming={converseState.isStreaming}
+              turns={converseState.turns}
+              onBackToSearch={handleBackToSearch}
+              canGoBackToSearch={canGoBackToSearch}
+              onResetToLanding={handleResetToLanding}
+            />
+          ) : (
+            <LandingPage onSubmit={handleSubmit} isStreaming={converseState.isStreaming} />
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.module.css
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.module.css
@@ -8,7 +8,8 @@
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  padding: var(--space-3) var(--space-4);
+  padding: 16px 24px;
+  min-height: var(--header-height);
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
 }

--- a/samples/thermidor/demo-react/src/components/PromptInput/PromptInput.test.tsx
+++ b/samples/thermidor/demo-react/src/components/PromptInput/PromptInput.test.tsx
@@ -341,4 +341,25 @@ describe('disabled + focus interaction', () => {
 
     expect(screen.queryByRole('listbox')).toBeNull();
   });
+
+  it('updates textarea value when initialValue prop changes', () => {
+    const {rerender} = render(<PromptInput onSubmit={vi.fn()} initialValue="surfboards" />);
+
+    const textarea = screen.getByLabelText('Prompt') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('surfboards');
+
+    rerender(<PromptInput onSubmit={vi.fn()} initialValue="" />);
+    expect(textarea.value).toBe('');
+  });
+
+  it('does not reset user-typed value when initialValue stays the same across rerenders', () => {
+    const {rerender} = render(<PromptInput onSubmit={vi.fn()} initialValue="surfboards" />);
+
+    const textarea = screen.getByLabelText('Prompt') as HTMLTextAreaElement;
+    fireEvent.change(textarea, {target: {value: 'wetsuits'}});
+    expect(textarea.value).toBe('wetsuits');
+
+    rerender(<PromptInput onSubmit={vi.fn()} initialValue="surfboards" />);
+    expect(textarea.value).toBe('wetsuits');
+  });
 });

--- a/samples/thermidor/demo-react/src/components/PromptInput/PromptInput.tsx
+++ b/samples/thermidor/demo-react/src/components/PromptInput/PromptInput.tsx
@@ -46,6 +46,14 @@ export function PromptInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const suppressNextFocusRef = useRef(false);
+  const prevInitialValueRef = useRef(initialValue);
+
+  useEffect(() => {
+    if (initialValue !== prevInitialValueRef.current) {
+      prevInitialValueRef.current = initialValue;
+      setValue(initialValue);
+    }
+  }, [initialValue]);
 
   const totalItems = useMemo(
     () => (suggestions ? suggestions.flatMap((s) => s.items) : []),

--- a/samples/thermidor/demo-react/src/components/PromptInput/PromptInput.tsx
+++ b/samples/thermidor/demo-react/src/components/PromptInput/PromptInput.tsx
@@ -207,7 +207,7 @@ export function PromptInput({
           onKeyDown={handleKeyDown}
           onFocus={handleFocus}
           onBlur={handleBlur}
-          placeholder={disabled && !value ? '' : placeholder}
+          placeholder={placeholder}
           disabled={disabled}
           autoFocus={autoFocus}
           rows={1}

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/FacetSidebar.test.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/FacetSidebar.test.tsx
@@ -33,6 +33,7 @@ describe('Facet sidebar placeholder', () => {
     onSubmit: vi.fn(),
     isStreaming: false,
     routedInterface: {useCase: 'search', interface: {id: 'mock'}} as any,
+    onBackToConversation: vi.fn(),
   };
 
   it('renders text "Facets (coming soon)"', () => {

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
@@ -9,13 +9,42 @@
 .header {
   grid-column: 1 / -1;
   padding: 16px 24px;
+  min-height: var(--header-height);
   border-bottom: 1px solid var(--color-border, #e5e7eb);
   display: flex;
-  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  position: relative;
 }
 
-.header > * {
+.header > *:not(.backToConversation) {
   width: 33.333%;
+  margin: 0 auto;
+}
+
+.backToConversation {
+  position: absolute;
+  left: 24px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--color-bg-primary, #fff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  color: var(--color-text-primary, #333);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.backToConversation:hover {
+  background: var(--color-surface-hover, #f3f4f6);
+}
+
+.backToConversation:focus-visible {
+  outline: 2px solid var(--color-focus, #2563eb);
+  outline-offset: 2px;
 }
 
 .sidebar {

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
@@ -17,7 +17,7 @@
   position: relative;
 }
 
-.header > *:not(.backToConversation) {
+.header > * {
   width: 33.333%;
   margin: 0 auto;
 }
@@ -27,6 +27,8 @@
   left: 24px;
   top: 50%;
   transform: translateY(-50%);
+  width: auto;
+  margin: 0;
   background: var(--color-bg-primary, #fff);
   border: 1px solid var(--color-border, #e5e7eb);
   color: var(--color-text-primary, #333);
@@ -36,15 +38,15 @@
   border-radius: 999px;
   white-space: nowrap;
   flex-shrink: 0;
-}
 
-.backToConversation:hover {
-  background: var(--color-surface-hover, #f3f4f6);
-}
+  &:hover {
+    background: var(--color-surface-hover, #f3f4f6);
+  }
 
-.backToConversation:focus-visible {
-  outline: 2px solid var(--color-focus, #2563eb);
-  outline-offset: 2px;
+  &:focus-visible {
+    outline: 2px solid var(--color-focus, #2563eb);
+    outline-offset: 2px;
+  }
 }
 
 .sidebar {

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.test.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.test.tsx
@@ -179,3 +179,32 @@ describe('SearchResultsPage PageSizeSelector integration', () => {
     expect(options[2].textContent).toBe('50');
   });
 });
+
+describe('SearchResultsPage "Back to conversation" button', () => {
+  const defaultProps = {
+    onSubmit: vi.fn(),
+    isStreaming: false,
+    routedInterface: {useCase: 'search', interface: {id: 'mock'}} as any,
+    onBackToConversation: vi.fn(),
+  };
+
+  function renderPage(overrides = {}) {
+    const props = {...defaultProps, onSubmit: vi.fn(), onBackToConversation: vi.fn(), ...overrides};
+    const result = render(<SearchResultsPage {...props} />);
+    return {...result, props};
+  }
+
+  it('always shows "Back to conversation" button', () => {
+    renderPage();
+
+    expect(screen.getByRole('button', {name: /Back to conversation/})).toBeDefined();
+  });
+
+  it('calls onBackToConversation when the button is clicked', () => {
+    const onBackToConversation = vi.fn();
+    renderPage({onBackToConversation});
+
+    fireEvent.click(screen.getByRole('button', {name: /Back to conversation/}));
+    expect(onBackToConversation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.tsx
@@ -21,6 +21,7 @@ interface SearchResultsPageProps {
   isStreaming: boolean;
   routedInterface: RoutedInterface;
   query?: string;
+  onBackToConversation: () => void;
 }
 
 export function SearchResultsPage(props: SearchResultsPageProps) {
@@ -36,6 +37,7 @@ function SearchResultsPageInner({
   isStreaming,
   routedInterface,
   query,
+  onBackToConversation,
 }: SearchResultsPageProps) {
   const [productListController, productListState] = useBuildController(() =>
     buildProductListController({interface: routedInterface.interface})
@@ -81,6 +83,9 @@ function SearchResultsPageInner({
   return (
     <div className={styles.page} data-testid="search-results-page">
       <header className={styles.header}>
+        <button type="button" className={styles.backToConversation} onClick={onBackToConversation}>
+          &larr; Back to conversation
+        </button>
         <PromptInput
           onSubmit={onSubmit}
           disabled={isStreaming}

--- a/samples/thermidor/demo-react/src/components/views.test.tsx
+++ b/samples/thermidor/demo-react/src/components/views.test.tsx
@@ -84,6 +84,7 @@ describe('SearchResultsPage', () => {
         onSubmit={vi.fn()}
         isStreaming={false}
         routedInterface={mockRoutedInterface}
+        onBackToConversation={vi.fn()}
       />
     );
     expect(screen.getByTestId('search-results-page')).toBeDefined();
@@ -95,6 +96,7 @@ describe('SearchResultsPage', () => {
         onSubmit={vi.fn()}
         isStreaming={false}
         routedInterface={mockRoutedInterface}
+        onBackToConversation={vi.fn()}
       />
     );
     expect(screen.getByText('Facets (coming soon)')).toBeDefined();
@@ -107,6 +109,7 @@ describe('SearchResultsPage', () => {
         onSubmit={onSubmit}
         isStreaming={false}
         routedInterface={mockRoutedInterface}
+        onBackToConversation={vi.fn()}
       />
     );
 
@@ -123,6 +126,7 @@ describe('SearchResultsPage', () => {
         onSubmit={vi.fn()}
         isStreaming={true}
         routedInterface={mockRoutedInterface}
+        onBackToConversation={vi.fn()}
       />
     );
     expect((screen.getByLabelText('Prompt') as HTMLInputElement).disabled).toBe(true);

--- a/samples/thermidor/demo-react/src/index.css
+++ b/samples/thermidor/demo-react/src/index.css
@@ -50,6 +50,9 @@
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 12px;
+
+  /* Layout */
+  --header-height: 84px;
 }
 
 *,
@@ -74,8 +77,17 @@ body {
   background: var(--color-bg-secondary);
 }
 
-.view-transition {
+.view-shell {
   height: 100%;
+}
+
+.view-panel {
+  display: none;
+  height: 100%;
+}
+
+.view-panel--active {
+  display: block;
   animation: viewFadeIn 250ms ease-out;
 }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5923

While this is not in the UX mockup, it will be quite convenient.

Might go in the end, but good addition for now.

<img width="1017" height="442" alt="back-to-conversation" src="https://github.com/user-attachments/assets/990b8024-c428-4d30-8bbd-922644d66554" />

This PR also fixes a few small bugs I found while testing.
