### PR TITLE
docs(atomic): add setRenderFunction usage section to result list components

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.usage.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.usage.mdx
@@ -87,3 +87,28 @@ For example,
 </script>
 
 ```
+
+### Using `setRenderFunction` for custom rendering
+
+The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render product items. Instead of defining an `atomic-product-template`, you provide a callback that receives each product and renders it into a given root element.
+
+```html
+<script type="module">
+  await customElements.whenDefined('atomic-commerce-product-list');
+  const productList = document.querySelector('atomic-commerce-product-list');
+
+  await productList.setRenderFunction((product, root, linkContainer) => {
+    root.innerHTML = `
+      <atomic-product-section-name>
+        <atomic-product-link>${product.ec_name}</atomic-product-link>
+      </atomic-product-section-name>
+      <atomic-product-section-metadata>
+        <atomic-product-price></atomic-product-price>
+      </atomic-product-section-metadata>
+    `;
+    return root.innerHTML;
+  });
+</script>
+```
+
+> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. In React, `@coveo/atomic-react` exports `AtomicCommerceProductList` (backed by `CommerceProductListWrapper`) as the canonical pattern — it calls `setRenderFunction` internally. For plain HTML deployments, use `atomic-product-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.usage.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.usage.mdx
@@ -99,14 +99,21 @@ For example,
   const productList = document.querySelector('atomic-commerce-product-list');
 
   await productList.setRenderFunction((product, root, linkContainer) => {
+    const link = `<atomic-product-link>${product.ec_name}</atomic-product-link>`;
+
     root.innerHTML = `
       <atomic-product-section-name>
-        <atomic-product-link>${product.ec_name}</atomic-product-link>
+        ${link}
       </atomic-product-section-name>
       <atomic-product-section-metadata>
         <atomic-product-price></atomic-product-price>
       </atomic-product-section-metadata>
     `;
+
+    if (linkContainer) {
+      linkContainer.innerHTML = link;
+    }
+
     return root.innerHTML;
   });
 </script>

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.usage.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.usage.mdx
@@ -1,3 +1,4 @@
+import SetRenderFunctionNote from '@/storybook-utils/documentation/set-render-function-note.mdx';
 
 This component is typically placed within the `products` section of the layout.
 
@@ -90,7 +91,7 @@ For example,
 
 ### Using `setRenderFunction` for custom rendering
 
-The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render product items. Instead of defining an `atomic-product-template`, you provide a callback that receives each product and renders it into a given root element.
+<SetRenderFunctionNote />
 
 ```html
 <script type="module">
@@ -110,5 +111,3 @@ The `setRenderFunction` method bypasses the HTML template mechanism and allows y
   });
 </script>
 ```
-
-> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. In React, `@coveo/atomic-react` exports `AtomicCommerceProductList` (backed by `CommerceProductListWrapper`) as the canonical pattern — it calls `setRenderFunction` internally. For plain HTML deployments, use `atomic-product-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.usage.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.usage.mdx
@@ -27,14 +27,21 @@ You can include multiple recommendation lists within a single interface:
   const recList = document.querySelector('atomic-commerce-recommendation-list');
 
   await recList.setRenderFunction((product, root, linkContainer) => {
+    const link = `<atomic-product-link>${product.ec_name}</atomic-product-link>`;
+
     root.innerHTML = `
       <atomic-product-section-name>
-        <atomic-product-link>${product.ec_name}</atomic-product-link>
+        ${link}
       </atomic-product-section-name>
       <atomic-product-section-metadata>
         <atomic-product-price></atomic-product-price>
       </atomic-product-section-metadata>
     `;
+
+    if (linkContainer) {
+      linkContainer.innerHTML = link;
+    }
+
     return root.innerHTML;
   });
 </script>

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.usage.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.usage.mdx
@@ -1,3 +1,4 @@
+import SetRenderFunctionNote from '@/storybook-utils/documentation/set-render-function-note.mdx';
 
 The `atomic-commerce-recommendation-list` component must be placed inside an `atomic-commerce-recommendation-interface` to work properly.
 
@@ -18,7 +19,7 @@ You can include multiple recommendation lists within a single interface:
 
 ### Using `setRenderFunction` for custom rendering
 
-The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render product recommendations. Instead of defining an `atomic-product-template`, you provide a callback that receives each product and renders it into a given root element.
+<SetRenderFunctionNote />
 
 ```html
 <script type="module">
@@ -38,5 +39,3 @@ The `setRenderFunction` method bypasses the HTML template mechanism and allows y
   });
 </script>
 ```
-
-> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. In React, `@coveo/atomic-react` exports `AtomicCommerceRecommendationList` (backed by `ListWrapper`) as the canonical pattern — it calls `setRenderFunction` internally. For plain HTML deployments, use `atomic-product-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.usage.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.usage.mdx
@@ -15,3 +15,28 @@ You can include multiple recommendation lists within a single interface:
   <atomic-commerce-recommendation-list></atomic-commerce-recommendation-list>
 </atomic-commerce-recommendation-interface>
 ```
+
+### Using `setRenderFunction` for custom rendering
+
+The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render product recommendations. Instead of defining an `atomic-product-template`, you provide a callback that receives each product and renders it into a given root element.
+
+```html
+<script type="module">
+  await customElements.whenDefined('atomic-commerce-recommendation-list');
+  const recList = document.querySelector('atomic-commerce-recommendation-list');
+
+  await recList.setRenderFunction((product, root, linkContainer) => {
+    root.innerHTML = `
+      <atomic-product-section-name>
+        <atomic-product-link>${product.ec_name}</atomic-product-link>
+      </atomic-product-section-name>
+      <atomic-product-section-metadata>
+        <atomic-product-price></atomic-product-price>
+      </atomic-product-section-metadata>
+    `;
+    return root.innerHTML;
+  });
+</script>
+```
+
+> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. In React, `@coveo/atomic-react` exports `AtomicCommerceRecommendationList` (backed by `ListWrapper`) as the canonical pattern — it calls `setRenderFunction` internally. For plain HTML deployments, use `atomic-product-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.usage.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.usage.mdx
@@ -21,7 +21,7 @@ This component needs the `atomic-commerce-search-box-query-suggestions` componen
   await customElements.whenDefined('atomic-commerce-search-box-instant-products');
   const instantProducts = document.querySelector('atomic-commerce-search-box-instant-products');
 
-  await instantProducts.setRenderFunction((product, root, linkContainer) => {
+  await instantProducts.setRenderFunction((product, root) => {
     root.innerHTML = `
       <atomic-product-section-name>
         <atomic-product-link>${product.ec_name}</atomic-product-link>

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.usage.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.usage.mdx
@@ -10,3 +10,28 @@ This component needs the `atomic-commerce-search-box-query-suggestions` componen
   <atomic-commerce-search-box-instant-products></atomic-commerce-search-box-instant-products>
 </atomic-commerce-search-box>
 ```
+
+### Using `setRenderFunction` for custom rendering
+
+The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render instant product items. Instead of defining an `atomic-product-template`, you provide a callback that receives each product and renders it into a given root element.
+
+```html
+<script type="module">
+  await customElements.whenDefined('atomic-commerce-search-box-instant-products');
+  const instantProducts = document.querySelector('atomic-commerce-search-box-instant-products');
+
+  await instantProducts.setRenderFunction((product, root, linkContainer) => {
+    root.innerHTML = `
+      <atomic-product-section-name>
+        <atomic-product-link>${product.ec_name}</atomic-product-link>
+      </atomic-product-section-name>
+      <atomic-product-section-metadata>
+        <atomic-product-price></atomic-product-price>
+      </atomic-product-section-metadata>
+    `;
+    return root.innerHTML;
+  });
+</script>
+```
+
+> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. There is no dedicated React wrapper for this component in `@coveo/atomic-react`. For plain HTML deployments, use `atomic-product-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.usage.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-search-box-instant-products/atomic-commerce-search-box-instant-products.usage.mdx
@@ -1,3 +1,4 @@
+import SetRenderFunctionNote from '@/storybook-utils/documentation/set-render-function-note.mdx';
 
 This component is placed inside the [atomic-commerce-search-box](/docs/atomic-commerce-search-box--docs) to display instant products as the user types.
 
@@ -13,7 +14,7 @@ This component needs the `atomic-commerce-search-box-query-suggestions` componen
 
 ### Using `setRenderFunction` for custom rendering
 
-The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render instant product items. Instead of defining an `atomic-product-template`, you provide a callback that receives each product and renders it into a given root element.
+<SetRenderFunctionNote />
 
 ```html
 <script type="module">
@@ -33,5 +34,3 @@ The `setRenderFunction` method bypasses the HTML template mechanism and allows y
   });
 </script>
 ```
-
-> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. There is no dedicated React wrapper for this component in `@coveo/atomic-react`. For plain HTML deployments, use `atomic-product-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/insight/atomic-insight-folded-result-list/atomic-insight-folded-result-list.usage.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-folded-result-list/atomic-insight-folded-result-list.usage.mdx
@@ -85,3 +85,28 @@ To display child results (e.g., replies in an email thread), use the `atomic-ins
 ```
 
 For more information on Result Folding, see [Result Folding](https://docs.coveo.com/en/1884).
+
+### Using `setRenderFunction` for custom rendering
+
+The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render folded result items. Instead of defining an `atomic-insight-result-template`, you provide a callback that receives each result and renders it into a given root element.
+
+```html
+<script type="module">
+  await customElements.whenDefined('atomic-insight-folded-result-list');
+  const foldedResultList = document.querySelector('atomic-insight-folded-result-list');
+
+  await foldedResultList.setRenderFunction((result, root, linkContainer) => {
+    root.innerHTML = `
+      <atomic-result-section-title>
+        <atomic-result-link></atomic-result-link>
+      </atomic-result-section-title>
+      <atomic-result-section-excerpt>
+        <atomic-result-text field="excerpt"></atomic-result-text>
+      </atomic-result-section-excerpt>
+    `;
+    return root.innerHTML;
+  });
+</script>
+```
+
+> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. There is no dedicated React wrapper for this component in `@coveo/atomic-react`. For plain HTML deployments, use `atomic-insight-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/insight/atomic-insight-folded-result-list/atomic-insight-folded-result-list.usage.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-folded-result-list/atomic-insight-folded-result-list.usage.mdx
@@ -1,3 +1,5 @@
+import SetRenderFunctionNote from '@/storybook-utils/documentation/set-render-function-note.mdx';
+
 The `atomic-insight-folded-result-list` component is responsible for displaying folded insight query results by applying one or more result templates. Folded results group related documents together, such as email threads or document versions.
 
 This component should be placed within an `atomic-insight-interface` component, typically inside an `atomic-insight-layout` with a results section.
@@ -88,7 +90,7 @@ For more information on Result Folding, see [Result Folding](https://docs.coveo.
 
 ### Using `setRenderFunction` for custom rendering
 
-The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render folded result items. Instead of defining an `atomic-insight-result-template`, you provide a callback that receives each result and renders it into a given root element.
+<SetRenderFunctionNote />
 
 ```html
 <script type="module">
@@ -108,5 +110,3 @@ The `setRenderFunction` method bypasses the HTML template mechanism and allows y
   });
 </script>
 ```
-
-> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. There is no dedicated React wrapper for this component in `@coveo/atomic-react`. For plain HTML deployments, use `atomic-insight-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/insight/atomic-insight-folded-result-list/atomic-insight-folded-result-list.usage.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-folded-result-list/atomic-insight-folded-result-list.usage.mdx
@@ -97,7 +97,7 @@ For more information on Result Folding, see [Result Folding](https://docs.coveo.
   await customElements.whenDefined('atomic-insight-folded-result-list');
   const foldedResultList = document.querySelector('atomic-insight-folded-result-list');
 
-  await foldedResultList.setRenderFunction((result, root, linkContainer) => {
+  await foldedResultList.setRenderFunction((result, root) => {
     root.innerHTML = `
       <atomic-result-section-title>
         <atomic-result-link></atomic-result-link>

--- a/packages/atomic/src/components/insight/atomic-insight-result-list/atomic-insight-result-list.usage.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-list/atomic-insight-result-list.usage.mdx
@@ -53,3 +53,28 @@ The component requires at least one `atomic-insight-result-template` child to de
   </atomic-insight-result-template>
 </atomic-insight-result-list>
 ```
+
+### Using `setRenderFunction` for custom rendering
+
+The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render result items. Instead of defining an `atomic-insight-result-template`, you provide a callback that receives each result and renders it into a given root element.
+
+```html
+<script type="module">
+  await customElements.whenDefined('atomic-insight-result-list');
+  const resultList = document.querySelector('atomic-insight-result-list');
+
+  await resultList.setRenderFunction((result, root, linkContainer) => {
+    root.innerHTML = `
+      <atomic-result-section-title>
+        <atomic-result-link></atomic-result-link>
+      </atomic-result-section-title>
+      <atomic-result-section-excerpt>
+        <atomic-result-text field="excerpt"></atomic-result-text>
+      </atomic-result-section-excerpt>
+    `;
+    return root.innerHTML;
+  });
+</script>
+```
+
+> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. There is no dedicated React wrapper for this component in `@coveo/atomic-react`. For plain HTML deployments, use `atomic-insight-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/insight/atomic-insight-result-list/atomic-insight-result-list.usage.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-list/atomic-insight-result-list.usage.mdx
@@ -1,3 +1,5 @@
+import SetRenderFunctionNote from '@/storybook-utils/documentation/set-render-function-note.mdx';
+
 The `atomic-insight-result-list` component is responsible for displaying insight query results by applying one or more result templates.
 
 This component should be placed within an `atomic-insight-interface` component, typically inside an `atomic-insight-layout` with a results section.
@@ -56,7 +58,7 @@ The component requires at least one `atomic-insight-result-template` child to de
 
 ### Using `setRenderFunction` for custom rendering
 
-The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render result items. Instead of defining an `atomic-insight-result-template`, you provide a callback that receives each result and renders it into a given root element.
+<SetRenderFunctionNote />
 
 ```html
 <script type="module">
@@ -76,5 +78,3 @@ The `setRenderFunction` method bypasses the HTML template mechanism and allows y
   });
 </script>
 ```
-
-> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. There is no dedicated React wrapper for this component in `@coveo/atomic-react`. For plain HTML deployments, use `atomic-insight-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/insight/atomic-insight-result-list/atomic-insight-result-list.usage.mdx
+++ b/packages/atomic/src/components/insight/atomic-insight-result-list/atomic-insight-result-list.usage.mdx
@@ -65,7 +65,7 @@ The component requires at least one `atomic-insight-result-template` child to de
   await customElements.whenDefined('atomic-insight-result-list');
   const resultList = document.querySelector('atomic-insight-result-list');
 
-  await resultList.setRenderFunction((result, root, linkContainer) => {
+  await resultList.setRenderFunction((result, root) => {
     root.innerHTML = `
       <atomic-result-section-title>
         <atomic-result-link></atomic-result-link>

--- a/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-ipx-recs-list.usage.mdx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-ipx-recs-list.usage.mdx
@@ -1,3 +1,5 @@
+import SetRenderFunctionNote from '@/storybook-utils/documentation/set-render-function-note.mdx';
+
 The `atomic-ipx-recs-list` component displays recommendations for the In-Product Experience (IPX) use case by applying one or more result templates.
 It supports carousel pagination, customizable display layouts, and integrates with the IPX actions history for tracking user interactions.
 
@@ -52,7 +54,7 @@ Customize the number of columns using the `--atomic-recs-number-of-columns` CSS 
 
 ### Using `setRenderFunction` for custom rendering
 
-The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render recommendation items. Instead of defining an `atomic-recs-result-template`, you provide a callback that receives each result and renders it into a given root element.
+<SetRenderFunctionNote />
 
 ```html
 <script type="module">
@@ -72,5 +74,3 @@ The `setRenderFunction` method bypasses the HTML template mechanism and allows y
   });
 </script>
 ```
-
-> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. There is no dedicated React wrapper for this component in `@coveo/atomic-react`. For plain HTML deployments, use `atomic-recs-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-ipx-recs-list.usage.mdx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-ipx-recs-list.usage.mdx
@@ -62,14 +62,21 @@ Customize the number of columns using the `--atomic-recs-number-of-columns` CSS 
   const ipxRecsList = document.querySelector('atomic-ipx-recs-list');
 
   await ipxRecsList.setRenderFunction((result, root, linkContainer) => {
+    const link = `<atomic-result-link></atomic-result-link>`;
+
     root.innerHTML = `
       <atomic-result-section-title>
-        <atomic-result-link></atomic-result-link>
+        ${link}
       </atomic-result-section-title>
       <atomic-result-section-excerpt>
         <atomic-result-text field="excerpt"></atomic-result-text>
       </atomic-result-section-excerpt>
     `;
+
+    if (linkContainer) {
+      linkContainer.innerHTML = link;
+    }
+
     return root.innerHTML;
   });
 </script>

--- a/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-ipx-recs-list.usage.mdx
+++ b/packages/atomic/src/components/ipx/atomic-ipx-recs-list/atomic-ipx-recs-list.usage.mdx
@@ -49,3 +49,28 @@ Customize the number of columns using the `--atomic-recs-number-of-columns` CSS 
   }
 </style>
 ```
+
+### Using `setRenderFunction` for custom rendering
+
+The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render recommendation items. Instead of defining an `atomic-recs-result-template`, you provide a callback that receives each result and renders it into a given root element.
+
+```html
+<script type="module">
+  await customElements.whenDefined('atomic-ipx-recs-list');
+  const ipxRecsList = document.querySelector('atomic-ipx-recs-list');
+
+  await ipxRecsList.setRenderFunction((result, root, linkContainer) => {
+    root.innerHTML = `
+      <atomic-result-section-title>
+        <atomic-result-link></atomic-result-link>
+      </atomic-result-section-title>
+      <atomic-result-section-excerpt>
+        <atomic-result-text field="excerpt"></atomic-result-text>
+      </atomic-result-section-excerpt>
+    `;
+    return root.innerHTML;
+  });
+</script>
+```
+
+> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. There is no dedicated React wrapper for this component in `@coveo/atomic-react`. For plain HTML deployments, use `atomic-recs-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.usage.mdx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.usage.mdx
@@ -30,3 +30,28 @@ Setting `number-of-recommendations-per-page` to a value greater than 0 and less 
   ...
 </atomic-recs-list>
 ```
+
+### Using `setRenderFunction` for custom rendering
+
+The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render recommendation items. Instead of defining an `atomic-recs-result-template`, you provide a callback that receives each result and renders it into a given root element.
+
+```html
+<script type="module">
+  await customElements.whenDefined('atomic-recs-list');
+  const recsList = document.querySelector('atomic-recs-list');
+
+  await recsList.setRenderFunction((result, root, linkContainer) => {
+    root.innerHTML = `
+      <atomic-result-section-title>
+        <atomic-result-link></atomic-result-link>
+      </atomic-result-section-title>
+      <atomic-result-section-excerpt>
+        <atomic-result-text field="excerpt"></atomic-result-text>
+      </atomic-result-section-excerpt>
+    `;
+    return root.innerHTML;
+  });
+</script>
+```
+
+> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. In React, `@coveo/atomic-react` exports `AtomicRecsList` (backed by `RecsListWrapper`) as the canonical pattern — it calls `setRenderFunction` internally. For plain HTML deployments, use `atomic-recs-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.usage.mdx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.usage.mdx
@@ -43,14 +43,21 @@ Setting `number-of-recommendations-per-page` to a value greater than 0 and less 
   const recsList = document.querySelector('atomic-recs-list');
 
   await recsList.setRenderFunction((result, root, linkContainer) => {
+    const link = `<atomic-result-link></atomic-result-link>`;
+
     root.innerHTML = `
       <atomic-result-section-title>
-        <atomic-result-link></atomic-result-link>
+        ${link}
       </atomic-result-section-title>
       <atomic-result-section-excerpt>
         <atomic-result-text field="excerpt"></atomic-result-text>
       </atomic-result-section-excerpt>
     `;
+
+    if (linkContainer) {
+      linkContainer.innerHTML = link;
+    }
+
     return root.innerHTML;
   });
 </script>

--- a/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.usage.mdx
+++ b/packages/atomic/src/components/recommendations/atomic-recs-list/atomic-recs-list.usage.mdx
@@ -1,3 +1,5 @@
+import SetRenderFunctionNote from '@/storybook-utils/documentation/set-render-function-note.mdx';
+
 The `atomic-recs-list` component displays recommendations by applying one or more result templates.
 
 ```html
@@ -33,7 +35,7 @@ Setting `number-of-recommendations-per-page` to a value greater than 0 and less 
 
 ### Using `setRenderFunction` for custom rendering
 
-The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render recommendation items. Instead of defining an `atomic-recs-result-template`, you provide a callback that receives each result and renders it into a given root element.
+<SetRenderFunctionNote />
 
 ```html
 <script type="module">
@@ -53,5 +55,3 @@ The `setRenderFunction` method bypasses the HTML template mechanism and allows y
   });
 </script>
 ```
-
-> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. In React, `@coveo/atomic-react` exports `AtomicRecsList` (backed by `RecsListWrapper`) as the canonical pattern — it calls `setRenderFunction` internally. For plain HTML deployments, use `atomic-recs-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/search/atomic-folded-result-list/atomic-folded-result-list.usage.mdx
+++ b/packages/atomic/src/components/search/atomic-folded-result-list/atomic-folded-result-list.usage.mdx
@@ -47,3 +47,28 @@ You can [define custom templates](https://docs.coveo.com/en/atomic/latest/usage/
 ```
 
 For more information on Result Folding, see [Result Folding](https://docs.coveo.com/en/1884).
+
+### Using `setRenderFunction` for custom rendering
+
+The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render folded result items. Instead of defining an `atomic-result-template`, you provide a callback that receives each folded result and renders it into a given root element.
+
+```html
+<script type="module">
+  await customElements.whenDefined('atomic-folded-result-list');
+  const foldedResultList = document.querySelector('atomic-folded-result-list');
+
+  await foldedResultList.setRenderFunction((foldedResult, root) => {
+    root.innerHTML = `
+      <atomic-result-section-title>
+        <atomic-result-link></atomic-result-link>
+      </atomic-result-section-title>
+      <atomic-result-section-excerpt>
+        <atomic-result-text field="excerpt"></atomic-result-text>
+      </atomic-result-section-excerpt>
+    `;
+    return root.innerHTML;
+  });
+</script>
+```
+
+> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. In React, `@coveo/atomic-react` exports `AtomicFoldedResultList` (backed by `FoldedResultListWrapper`) as the canonical pattern — it calls `setRenderFunction` internally. For plain HTML deployments, use `atomic-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/search/atomic-folded-result-list/atomic-folded-result-list.usage.mdx
+++ b/packages/atomic/src/components/search/atomic-folded-result-list/atomic-folded-result-list.usage.mdx
@@ -1,3 +1,4 @@
+import SetRenderFunctionNote from '@/storybook-utils/documentation/set-render-function-note.mdx';
 
 This component is typically placed within the `results` section of the layout to display folded query results. Folded results group related documents together, such as email threads or document versions.
 
@@ -50,7 +51,7 @@ For more information on Result Folding, see [Result Folding](https://docs.coveo.
 
 ### Using `setRenderFunction` for custom rendering
 
-The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render folded result items. Instead of defining an `atomic-result-template`, you provide a callback that receives each folded result and renders it into a given root element.
+<SetRenderFunctionNote />
 
 ```html
 <script type="module">
@@ -70,5 +71,3 @@ The `setRenderFunction` method bypasses the HTML template mechanism and allows y
   });
 </script>
 ```
-
-> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. In React, `@coveo/atomic-react` exports `AtomicFoldedResultList` (backed by `FoldedResultListWrapper`) as the canonical pattern — it calls `setRenderFunction` internally. For plain HTML deployments, use `atomic-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.usage.mdx
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.usage.mdx
@@ -81,14 +81,21 @@ The following table outlines the key differences and best use cases for grids, l
   const resultList = document.querySelector('atomic-result-list');
 
   await resultList.setRenderFunction((result, root, linkContainer) => {
+    const link = `<atomic-result-link></atomic-result-link>`;
+
     root.innerHTML = `
       <atomic-result-section-title>
-        <atomic-result-link></atomic-result-link>
+        ${link}
       </atomic-result-section-title>
       <atomic-result-section-excerpt>
         <atomic-result-text field="excerpt"></atomic-result-text>
       </atomic-result-section-excerpt>
     `;
+
+    if (linkContainer) {
+      linkContainer.innerHTML = link;
+    }
+
     return root.innerHTML;
   });
 </script>

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.usage.mdx
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.usage.mdx
@@ -1,3 +1,4 @@
+import SetRenderFunctionNote from '@/storybook-utils/documentation/set-render-function-note.mdx';
 
 This component is typically placed within the `results` section of the layout.
 
@@ -72,7 +73,7 @@ The following table outlines the key differences and best use cases for grids, l
 
 ### Using `setRenderFunction` for custom rendering
 
-The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render result items. Instead of defining an `atomic-result-template`, you provide a callback that receives each result and renders it into a given root element.
+<SetRenderFunctionNote />
 
 ```html
 <script type="module">
@@ -92,5 +93,3 @@ The `setRenderFunction` method bypasses the HTML template mechanism and allows y
   });
 </script>
 ```
-
-> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. In React, `@coveo/atomic-react` exports `AtomicResultList` (backed by `ResultListWrapper`) as the canonical pattern — it calls `setRenderFunction` internally. For plain HTML deployments, use `atomic-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.usage.mdx
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.usage.mdx
@@ -69,3 +69,28 @@ The following table outlines the key differences and best use cases for grids, l
 
 ## Reference
 [UI cheat sheet: list vs grid](https://uxdesign.cc/ui-cheat-sheet-list-vs-grids-48151a7262a7)
+
+### Using `setRenderFunction` for custom rendering
+
+The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render result items. Instead of defining an `atomic-result-template`, you provide a callback that receives each result and renders it into a given root element.
+
+```html
+<script type="module">
+  await customElements.whenDefined('atomic-result-list');
+  const resultList = document.querySelector('atomic-result-list');
+
+  await resultList.setRenderFunction((result, root, linkContainer) => {
+    root.innerHTML = `
+      <atomic-result-section-title>
+        <atomic-result-link></atomic-result-link>
+      </atomic-result-section-title>
+      <atomic-result-section-excerpt>
+        <atomic-result-text field="excerpt"></atomic-result-text>
+      </atomic-result-section-excerpt>
+    `;
+    return root.innerHTML;
+  });
+</script>
+```
+
+> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. In React, `@coveo/atomic-react` exports `AtomicResultList` (backed by `ResultListWrapper`) as the canonical pattern — it calls `setRenderFunction` internally. For plain HTML deployments, use `atomic-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/search/atomic-search-box-instant-results/atomic-search-box-instant-results.usage.mdx
+++ b/packages/atomic/src/components/search/atomic-search-box-instant-results/atomic-search-box-instant-results.usage.mdx
@@ -1,3 +1,4 @@
+import SetRenderFunctionNote from '@/storybook-utils/documentation/set-render-function-note.mdx';
 
 This component is placed inside the [atomic-search-box](/docs/atomic-search-box--docs) to display instant results as the user types.
 
@@ -13,7 +14,7 @@ This component needs the `atomic-search-box-query-suggestions` component to be p
 
 ### Using `setRenderFunction` for custom rendering
 
-The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render instant result items. Instead of defining an `atomic-result-template`, you provide a callback that receives each result and renders it into a given root element.
+<SetRenderFunctionNote />
 
 ```html
 <script type="module">
@@ -33,5 +34,3 @@ The `setRenderFunction` method bypasses the HTML template mechanism and allows y
   });
 </script>
 ```
-
-> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. In React, `@coveo/atomic-react` exports `AtomicSearchBoxInstantResults` (backed by `SearchBoxInstantResultsWrapper`) as the canonical pattern — it calls `setRenderFunction` internally. For plain HTML deployments, use `atomic-result-template` with `<template>` elements instead.

--- a/packages/atomic/src/components/search/atomic-search-box-instant-results/atomic-search-box-instant-results.usage.mdx
+++ b/packages/atomic/src/components/search/atomic-search-box-instant-results/atomic-search-box-instant-results.usage.mdx
@@ -10,3 +10,28 @@ This component needs the `atomic-search-box-query-suggestions` component to be p
   <atomic-search-box-instant-results></atomic-search-box-instant-results>
 </atomic-search-box>
 ```
+
+### Using `setRenderFunction` for custom rendering
+
+The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render instant result items. Instead of defining an `atomic-result-template`, you provide a callback that receives each result and renders it into a given root element.
+
+```html
+<script type="module">
+  await customElements.whenDefined('atomic-search-box-instant-results');
+  const instantResults = document.querySelector('atomic-search-box-instant-results');
+
+  await instantResults.setRenderFunction((result, root) => {
+    root.innerHTML = `
+      <atomic-result-section-title>
+        <atomic-result-link></atomic-result-link>
+      </atomic-result-section-title>
+      <atomic-result-section-excerpt>
+        <atomic-result-text field="excerpt"></atomic-result-text>
+      </atomic-result-section-excerpt>
+    `;
+    return root.innerHTML;
+  });
+</script>
+```
+
+> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. In React, `@coveo/atomic-react` exports `AtomicSearchBoxInstantResults` (backed by `SearchBoxInstantResultsWrapper`) as the canonical pattern — it calls `setRenderFunction` internally. For plain HTML deployments, use `atomic-result-template` with `<template>` elements instead.

--- a/packages/atomic/storybook-utils/documentation/set-render-function-note.mdx
+++ b/packages/atomic/storybook-utils/documentation/set-render-function-note.mdx
@@ -1,0 +1,3 @@
+The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render items. Instead of defining a template element, you provide a callback that receives each item and renders it into a given root element.
+
+> **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. For plain HTML deployments, use the appropriate template element with `<template>` instead.

--- a/packages/atomic/storybook-utils/documentation/set-render-function-note.mdx
+++ b/packages/atomic/storybook-utils/documentation/set-render-function-note.mdx
@@ -1,3 +1,7 @@
-The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render items. Instead of defining a template element, you provide a callback that receives each item and renders it into a given root element.
+The `setRenderFunction` method bypasses the HTML template mechanism and allows you to programmatically render items. Instead of defining a template element, you provide a callback that receives each item and renders it into a root element. Components that support custom-rendered grid or recommendation cards can also provide a `linkContainer` element.
+
+For components with grid or recommendation card layouts, render the visible link in `root` and, when `linkContainer` is provided, render the same link there as well. The `linkContainer` is hidden, but the card-click handler uses its direct-child link to navigate when the user clicks elsewhere on a card. This pattern works across the component's supported display modes: the visible link handles list or table layouts, while the hidden link handles grid or recommendation card clicks.
+
+Components with fixed list layouts or without grid card-click handling, such as instant results, folded results, and Insight results, only need the link in `root` and do not need the third callback argument.
 
 > **Note:** `setRenderFunction` is intended for framework integrations (React, Angular, Vue) where rendering is managed programmatically. For plain HTML deployments, use the appropriate template element with `<template>` instead.


### PR DESCRIPTION
[KIT-4357](https://coveord.atlassian.net/browse/KIT-4357)

## Problem
The initial setRenderFunction usage examples did not explain how the hidden linkContainer participates in grid and recommendation card clicks. They also exposed the third callback argument in fixed list or Insight components where it is not needed.

## Solution
Added shared documentation explaining the root versus linkContainer responsibilities. Result, product, and recommendation components now show a display-safe pattern: the visible link is rendered in root and the same link is rendered in linkContainer when available, supporting grid, list, and table layouts. Instant, folded, and Insight components keep the link in root and use the two-argument callback because they do not use grid card-click handling.

The documentation was validated with oxlint, oxfmt, Quantic lint-fix, and targeted CSpell checks.

[KIT-4357]: https://coveord.atlassian.net/browse/KIT-4357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ