### PR TITLE
chore(agents): Add Jira writer and bucket-routing agent skills

### DIFF
--- a/.agents/skills/jira-create-issue-in-bucket/SKILL.md
+++ b/.agents/skills/jira-create-issue-in-bucket/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: jira-create-issue-in-bucket
+description: >
+  Given a description of work, select the most appropriate KIT Bucket Epic and
+  create a Jira issue as a child of that epic. Use when asked to "create a bucket
+  issue", "file a maintenance ticket", "log a bug in KIT", "create a task in KIT",
+  "add to the maintenance backlog", or when triaging work into the KIT project
+  buckets. Routes to the jira-writer skill for actual issue creation.
+metadata:
+  version: '1.0.0'
+---
+
+# Jira Create Issue in Bucket
+
+Routing layer that classifies work into the correct KIT Bucket Epic and delegates issue creation to the `jira-writer` skill with the parent and project pre-filled.
+
+## Bucket Epics
+
+| Key      | Summary                  | Use for                                                                     |
+| -------- | ------------------------ | --------------------------------------------------------------------------- |
+| KIT-4019 | Maintenance DXUI         | Customer support issues, bug fixes, incidents, ops work                     |
+| KIT-5536 | Continuous Improvement   | Small refactors, process improvements, backlog cleanup, minor optimizations |
+| KIT-5635 | Security Vulnerabilities | Security vulnerability remediation, dependency CVEs                         |
+| KIT-4434 | Failing or flaky tests   | Flaky/failing test triage and fixes                                         |
+
+## Issue type selection
+
+Pick the type based on the nature of the work:
+
+- **Bug** — Defects, broken behavior, customer-reported issues.
+- **Story** — New incremental work that delivers value (small features, enhancements within a bucket).
+- **Spike** — Investigation, research, or time-boxed exploration.
+
+## Process
+
+### 1) Classify the work
+
+Analyze the user's description against the bucket table above. Match on:
+
+- Keywords and domain (security → Snyk, flaky test → Failing tests, refactor → Continuous Improvement).
+- Nature of work (support ticket → Maintenance).
+- Urgency and origin (incident → Maintenance, CVE → Snyk).
+
+If the classification is ambiguous (work could reasonably fit two buckets), ask the user which bucket they prefer and explain the trade-off.
+
+### 2) Check for Feature Epic scope
+
+If the work is clearly bounded delivery for a named Feature (a planned, multi-story initiative with its own epic), stop and tell the user:
+
+> "This looks like Feature-level work rather than bucket work. You should parent it under the appropriate Feature Epic instead. This skill only handles bucket issues."
+
+Do not proceed with issue creation in this case.
+
+### 3) Determine issue type
+
+Apply the issue type rules above. If uncertain between types, ask clarifying questions.
+
+### 4) Delegate to jira-writer
+
+Activate the `jira-writer` skill with the following pre-filled context:
+
+- **Project:** KIT
+- **Parent:** The selected Bucket Epic key (e.g., KIT-4019)
+- **Issue type:** The determined type (Bug, Story, or Spike)
+
+Let jira-writer handle drafting, confirmation, creation, and verification per its own process.
+
+### 5) Confirm result
+
+After jira-writer completes, echo the created issue key and the bucket it was filed under.
+
+## Constraints
+
+- Never create Features or Epics through this skill — only child issue types (Bug, Story, Spike).
+- Always set the parent field to the selected Bucket Epic key.
+- Project is always KIT — do not ask the user for a project.
+- Do not override jira-writer's confirmation gate — the user must still approve the draft before creation.

--- a/.agents/skills/jira-writer/README.md
+++ b/.agents/skills/jira-writer/README.md
@@ -1,0 +1,49 @@
+# Jira Writer Skill
+
+Use this skill to draft and create Jira task artifacts from source notes, tickets, and investigation context.
+
+## What It Does
+
+- Supports issue types: `Epic`, `Spike`, `Story`, `Bug`.
+- Gathers context from source artifacts (Jira links, docs, logs, screenshots, or free-form notes).
+- Produces a complete draft before any Jira write.
+- Requires explicit user confirmation before creating an issue.
+- Uses structured issue templates and ADF formatting rules from the skill.
+
+## When to Use
+
+- You need to turn support or investigation context into a Jira `Bug`.
+- You need an execution-ready `Story` or timeboxed `Spike`.
+- You need a new `Epic` with clear scope, problem, and risks.
+- You want consistent Jira issue quality and creation flow.
+
+## Prerequisites
+
+- Atlassian MCP access is required for direct Jira issue creation.
+- Without Jira write access, the skill can still draft issue content for manual creation.
+
+## How to Use
+
+- Load the skill (for example: `skill({ name: "jira-writer" })` or `$jira-writer`).
+- Provide source inputs and intent:
+  - issue type (`Epic`, `Spike`, `Story`, or `Bug`)
+  - target project key
+  - parent/epic behavior when relevant
+  - optional priority, labels, components, assignee
+- Review the generated draft.
+- Explicitly confirm creation when ready.
+- Capture the returned Jira key, URL, and recap.
+
+## Safety and Quality Gates
+
+- Do not create Jira issues before explicit confirmation.
+- Keep routing metadata in Jira fields, not inside rendered description text.
+- Verify post-create description structure per ADF contract.
+
+## Files in This Skill
+
+- `SKILL.md`
+- `references/BUG_REPORT_TEMPLATE.md`
+- `references/EPIC_TEMPLATE.md`
+- `references/SPIKE_TEMPLATE.md`
+- `references/USER_STORY_TEMPLATE.md`

--- a/.agents/skills/jira-writer/SKILL.md
+++ b/.agents/skills/jira-writer/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: jira-writer
+description: Drafts and creates Jira task artifacts (epics, spikes, user stories, bugs) from notes or source artifacts, with strict routing and confirmation gates.
+metadata:
+  version: "1.0.0"
+  last-evaluated: "2026-07-06"
+  maturity: 4/5      # Production
+---
+
+# Jira Writer
+
+Use this skill when the user asks to write or create Jira task artifacts.
+
+## Core rules
+
+- Supported issue types: `Epic`, `Spike`, `Story`, `Bug`.
+- Always show a complete draft before creating the Jira issue.
+- Never create the Jira issue until the user explicitly confirms the draft.
+- If the user asks for a task artifact in Confluence by mistake, ask a targeted routing question and recommend Jira.
+- Use the project requested by the user; if none is provided, ask or apply a team default project policy when known.
+- For `Bug`/`Spike`/`Story`, apply a team default parent epic only when a project-specific policy is known; otherwise ask.
+- `Epic` has no default parent/epic linkage.
+- If no project-specific parent policy is known, ask for parent behavior (or proceed without parent if the user prefers).
+
+## Routing and ambiguity rules
+
+- Jira artifacts: epics, spikes, bugs, execution-ready stories.
+- User stories are phase-based:
+  - Planning/review -> Confluence (`user-story` skill)
+  - Accepted/execution-ready -> Jira (`jira-writer` skill)
+- If platform intent is unclear, ask exactly one targeted question before creating anything.
+- If clear intent was already stated earlier in the same conversation, follow that intent.
+
+## Process
+
+1. Identify issue type and source.
+2. Gather context from source artifacts and user notes.
+3. Ask focused follow-up questions for missing critical data.
+4. Produce a draft using the issue-type template.
+5. Request explicit confirmation.
+6. Create Jira issue.
+7. Return created issue key + URL + short recap.
+
+## 1) Identify type and input source
+
+Determine the target issue type first:
+
+- `Bug`: production defect or incorrect behavior.
+- `Spike`: timeboxed investigation/prototype/research task.
+- `Story`: execution-ready unit of customer or internal value.
+- `Epic`: larger outcome that groups related stories/spikes/bugs.
+
+Then capture source input.
+
+Accept any of the following:
+
+- Jira support ticket URL or key (for example `CMS-256`)
+- Other artifact links (Slack thread, Confluence page, logs, screenshots)
+- Free-form user prompt with no source link
+
+If a Jira issue is provided, fetch and extract at least:
+
+- Summary
+- Description
+- Priority
+- Labels/components when useful
+- Relevant comments/investigation notes when available
+
+## 2) Gather context
+
+Collect and normalize the issue into clear facts:
+
+- Problem statement
+- Expected vs actual behavior
+- Impact and urgency
+- Reproduction details
+- Technical clues (payloads, stack traces, code references)
+- Proposed behavior when ambiguous (for example OR vs AND aggregation)
+
+When there are contradictions between source and user, prefer the latest user clarification and mention the discrepancy in Open Questions.
+
+## 3) Ask focused follow-ups
+
+Ask only for missing, decision-critical information. Prefer concise questions.
+
+Typical follow-ups:
+
+- Target project key
+- Parent epic for `Bug`/`Spike`/`Story` (apply team default only when known; otherwise ask)
+- Parent behavior for `Epic` only if the user explicitly requests hierarchy linkage
+- Severity/priority if unclear
+- Any missing acceptance criteria
+- Assignee/labels/components if the user cares
+
+## 4) Draft using issue-type templates
+
+Use one of:
+
+- `references/BUG_REPORT_TEMPLATE.md`
+- `references/SPIKE_TEMPLATE.md`
+- `references/USER_STORY_TEMPLATE.md`
+- `references/EPIC_TEMPLATE.md`
+
+Draft quality bar:
+
+- Clear title focused on outcome and scope.
+- Concrete behavior statements and boundaries; avoid vague language.
+- Acceptance criteria must be testable and unambiguous.
+- Include source ticket/artifact links.
+- Use strict standardized headings from the templates. Do not rename or reorder sections.
+- Omit empty optional sections rather than including them with placeholder text.
+
+## 5) Confirmation gate (mandatory)
+
+After drafting, ask for explicit confirmation in plain terms, adapting the wording based on whether a parent/epic is set:
+
+- For `Epic` with no parent/epic: "Ready to create this as a Jira Epic in <PROJECT> with no parent/epic?"
+- For non-`Epic` when there is a parent/epic: "Ready to create this as a Jira <ISSUE TYPE> in <PROJECT> under <PARENT>?"
+- For non-`Epic` when there is no parent/epic: "Ready to create this as a Jira <ISSUE TYPE> in <PROJECT> with no parent/epic?"
+
+Do not create anything before this confirmation.
+
+## 6) Create Jira issue
+
+On confirmation:
+
+- Create issue type `Epic`, `Spike`, `Story`, or `Bug` in chosen project.
+- Build the description payload as ADF per the Description Formatting Contract.
+- Set parent/epic linkage when applicable to issue type and requested/defaulted.
+- Apply priority/labels/components/assignee if provided.
+- After creation, run the Post-Create Verification step.
+
+`Epic` does not use default parent/epic linkage and Jira hierarchy rules may reject Epic-under-Epic links. If parent/epic linkage cannot be set with the current API flow, create the issue and clearly tell the user what to set manually.
+
+## 7) Final response
+
+Return:
+
+- Created issue key and URL
+- Target project and parent/epic used (if applicable)
+- One-line recap of what was captured
+- Any manual follow-up still needed
+
+## Description Formatting Contract (Mandatory)
+
+All Jira issue descriptions must use Atlassian Document Format (ADF). Never send the full description as a single `paragraph` node.
+
+### ADF node mapping rules
+
+- Section headings -> `heading` (level 2)
+- Story statements, problem descriptions -> `paragraph`
+- Acceptance criteria, reproduction steps -> `orderedList`
+- Scope, details, investigation, references, risks, deliverables -> `bulletList`
+- JSON or code examples -> `codeBlock` with `language: "json"` (or appropriate language)
+
+### Strict heading names per issue type
+
+**Story:**
+
+1. `User Story` (paragraph)
+2. `Acceptance Criteria` (orderedList)
+3. `Additional Details` (bulletList)
+
+**Bug:**
+
+1. `Problem` (paragraph)
+2. `Expected Behavior` (paragraph)
+3. `Reproduction Steps` (orderedList)
+4. `Investigation` (bulletList)
+
+**Spike:**
+
+1. `Problem` (paragraph)
+2. `Scope` (bulletList)
+3. `Questions to Answer` (bulletList)
+4. `Deliverables` (bulletList)
+5. `Timebox` (paragraph or bulletList)
+
+**Epic:**
+
+1. `Objective` (paragraph)
+2. `Problem` (paragraph)
+3. `Scope` (bulletList)
+4. `Risks` (bulletList)
+
+### Additional rules
+
+- Use exactly the heading names listed above. Do not rename or reorder sections.
+- Omit empty optional sections rather than including them with placeholder text.
+- Routing metadata (project, parent epic, priority) must never appear in the rendered Jira description. Use Jira fields for these.
+- If a section contains code examples, place the `codeBlock` node immediately after the related `paragraph` or `listItem` node.
+
+## Post-Create Verification (Mandatory)
+
+After creating the issue:
+
+1. `GET` the issue from the Jira API and inspect `fields.description.content` top-level node types.
+2. Assert the expected node sequence for the issue type. For example, a Story should have: `heading`, `paragraph`, `heading`, `orderedList`, `heading`, `bulletList`.
+3. If the node sequence is wrong (for example, the entire description is a single `paragraph` node), immediately `PUT` a corrected ADF description.
+4. Report "Description verified" or "Description auto-corrected" in the final response to the user.
+
+## Output conventions
+
+- Keep wording concise and operational.
+- Prefer bullets and short sections.
+- Preserve raw technical evidence exactly when quoting payloads/logs.

--- a/.agents/skills/jira-writer/references/BUG_REPORT_TEMPLATE.md
+++ b/.agents/skills/jira-writer/references/BUG_REPORT_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Problem
+
+<What's broken, where, and when. Include current behavior and source links.>
+
+## Expected Behavior
+
+<What should happen instead.>
+
+## Reproduction Steps
+
+1. <Step 1>
+2. <Step 2>
+
+## Investigation
+
+- <Root cause, evidence, code references — whatever is known>

--- a/.agents/skills/jira-writer/references/EPIC_TEMPLATE.md
+++ b/.agents/skills/jira-writer/references/EPIC_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Objective
+
+<What outcome this epic delivers.>
+
+## Problem
+
+<Current pain, constraint, or opportunity.>
+
+## Scope
+
+- In scope: <area>
+- Out of scope: <area>
+
+## Risks
+
+- <Risk and its mitigation, on one line>

--- a/.agents/skills/jira-writer/references/SPIKE_TEMPLATE.md
+++ b/.agents/skills/jira-writer/references/SPIKE_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Problem
+
+<What uncertainty are we reducing and why now?>
+
+## Scope
+
+- <Required item 1>
+- <Required item 2>
+- <Stretch item (optional)>
+
+## Questions to Answer
+
+- <Question 1>
+- <Question 2>
+
+## Deliverables
+
+- <Expected output>
+
+## Timebox
+
+- <N dev-days or target date>

--- a/.agents/skills/jira-writer/references/USER_STORY_TEMPLATE.md
+++ b/.agents/skills/jira-writer/references/USER_STORY_TEMPLATE.md
@@ -1,0 +1,12 @@
+## User Story
+
+As a <persona>, I want <goal>, so that <outcome>.
+
+## Acceptance Criteria
+
+1. <Criterion 1, testable>
+2. <Criterion 2, testable>
+
+## Additional Details
+
+- <Technical notes, constraints, dependencies, references>

--- a/.agents/skills/user-story/README.md
+++ b/.agents/skills/user-story/README.md
@@ -1,0 +1,3 @@
+# user-story
+
+Create and review Coveo user stories with clear acceptance criteria and story breakdowns.

--- a/.agents/skills/user-story/SKILL.md
+++ b/.agents/skills/user-story/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: user-story
+description: Creates or reviews user stories for Coveo features using a strict format with acceptance criteria. Use when a user wants to draft new user stories, review existing stories, or needs acceptance criteria and story breakdowns.
+metadata:
+  version: "1.0.0"
+  last-evaluated: "2026-07-06"
+  maturity: 3/5      # Robust
+---
+
+# User Story Companion
+
+Support two modes: Creation and Review. Use the command markers below to switch modes.
+
+Commands:
+
+- /create: Switch to Creation mode
+- /review: Switch to Review mode
+
+## Creation mode
+
+### Gathering
+
+- Ask clarifying questions until the feature and user value are understood.
+- State assumptions and validate them.
+- Drill on business value and user impact.
+
+### Challenging (optional)
+
+This phase is optional when time is constrained.
+
+- Probe for gaps, ambiguities, or unstated assumptions.
+- Ask "what could go wrong?" and "what's missing?"
+- Note unresolved concerns as open questions in the story.
+
+### Writing
+
+- Draft stories using the exact format below.
+- Keep stories clear, concise, and individually valuable.
+- Break large work into smaller stories.
+- Make acceptance criteria testable and unambiguous.
+- Clearly label open questions.
+- Use the template reference when drafting: references/USER_STORY_TEMPLATE.md
+
+Format:
+
+"As a [type of user], I want [an action] so that [a benefit/a value]."
+Acceptance criteria:
+
+- [Criterion]
+Additional details:
+- [Detail]
+
+### Scoring
+
+Ask for a 1-5 rating for clarity and completeness. If below 4, ask for more detail and rewrite.
+
+## Review mode
+
+- Ask the user to paste the stories to review.
+- Critique clarity and completeness.
+- Identify ambiguities and missing details.
+- Flag stories that are too large and propose splits.
+- Summarize main gaps and suggested improvements.
+
+## Related documents
+
+- Supports Feature delivery. See OVERVIEW.md for document relationships.

--- a/.agents/skills/user-story/references/USER_STORY_TEMPLATE.md
+++ b/.agents/skills/user-story/references/USER_STORY_TEMPLATE.md
@@ -1,0 +1,11 @@
+# User story format
+
+"As a [type of user], I want [an action] so that [a benefit/a value]."
+
+Acceptance criteria:
+
+- [Criterion]
+
+Additional details:
+
+- [Detail]

--- a/.cspell.json
+++ b/.cspell.json
@@ -58,6 +58,7 @@
     "debouncers",
     "dupl",
     "dynamicscrmitem",
+    "dxui",
     "Ecommerce",
     "electronicscoveodemocomo",
     "ellipsed",

--- a/.kiro-sync.yaml
+++ b/.kiro-sync.yaml
@@ -1,0 +1,7 @@
+repo: coveo/ai-tools
+ref: main
+skills:
+  - jira-writer
+  - user-story
+steering: []
+agents: []

--- a/.kiro/.kiro-sync-manifest.json
+++ b/.kiro/.kiro-sync-manifest.json
@@ -1,0 +1,27 @@
+{
+  "skills": {
+    "jira-writer": {
+      "repo": "coveo/ai-tools",
+      "ref": "main",
+      "files": [
+        "README.md",
+        "SKILL.md",
+        "references/BUG_REPORT_TEMPLATE.md",
+        "references/EPIC_TEMPLATE.md",
+        "references/SPIKE_TEMPLATE.md",
+        "references/USER_STORY_TEMPLATE.md"
+      ]
+    },
+    "user-story": {
+      "repo": "coveo/ai-tools",
+      "ref": "main",
+      "files": [
+        "README.md",
+        "SKILL.md",
+        "references/USER_STORY_TEMPLATE.md"
+      ]
+    }
+  },
+  "steering": {},
+  "agents": {}
+}

--- a/.kiro/skills
+++ b/.kiro/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,6 +6,7 @@
   "bracketSpacing": false,
   "ignorePatterns": [
     "**/.kiro/**/*",
+    "**/.agents/**/*",
     "AGENTS.md",
     "**/packages/quantic/**/*",
     "!**/packages/quantic/catalog-info.yaml",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -14,6 +14,7 @@
   },
   "ignorePatterns": [
     "**/.kiro/**",
+    "**/.agents/skills/**",
     "**/node_modules/**",
     "**/dist/**",
     "**/packages/quantic/**",

--- a/knip.js
+++ b/knip.js
@@ -4,6 +4,8 @@ export default {
   ignoreWorkspaces: ['packages/quantic', 'packages/create-atomic-component-project/template'],
   ignoreDependencies: ['semver'],
   ignore: [
+    '.kiro/**',
+    '.agents/skills/**',
     'packages/quantic/**',
     // Temporary until CAJS package activation supplies package metadata and entry points.
     'packages/coveo-analytics/**',
@@ -19,7 +21,7 @@ export default {
   },
   workspaces: {
     '.': {
-      entry: ['.agents/skills/**/scripts/*.mjs', 'scripts/**/*.{js,mjs}'],
+      entry: ['scripts/**/*.{js,mjs}'],
       ignoreBinaries: ['ts-node'],
       ignoreDependencies: ['@playwright/mcp', 'handlebars'],
     },

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -4,6 +4,9 @@ module.exports = {
       // Exclude .vscode directory
       if (file.includes('/.vscode/')) return false;
 
+      // Exclude synced agent skills
+      if (file.includes('/.agents/skills/')) return false;
+
       // Exclude quantic and create-atomic-template packages
       if (file.includes('/packages/quantic/')) return false;
       if (file.includes('/packages/create-atomic-template/')) return false;
@@ -31,6 +34,8 @@ module.exports = {
   },
   '**/*.{json,css,html}': (files) => {
     const filteredFiles = files.filter((file) => {
+      if (file.includes('/.kiro/')) return false;
+      if (file.includes('/.agents/skills/')) return false;
       if (file.includes('/.vscode/')) return false;
       if (file.includes('/packages/quantic/')) return false;
       if (file.includes('/.deployment.config/')) return false;


### PR DESCRIPTION
### Summary

⚠️ This PR uses `kiro-sync` and skills from `coveo/ai-tools`, both internal tools. The PR knowingly makes some of that public with the understanding that an external contributor cannot access the references.

This PR introduces two new agent skills to the repository and the infrastructure to sync them from an internal source.

The **jira-writer** skill provides a structured workflow for drafting and creating Jira issues (Epics, Spikes, Stories, Bugs) with ADF-formatted descriptions, confirmation gates, and post-create verification. It includes reference templates for each issue type.

The **jira-create-issue-in-bucket** skill is a routing layer that classifies incoming work into the correct KIT maintenance bucket epic (Maintenance DXUI, Continuous Improvement, Security Vulnerabilities, Failing/Flaky Tests) and delegates actual issue creation to jira-writer with the project and parent pre-filled.

Supporting changes:
- A `.kiro-sync.yaml` config and `.kiro/.kiro-sync-manifest.json` manifest track which skills are synced from the upstream `coveo/ai-tools` repo.
- A `.kiro/skills` symlink points to `.agents/skills` so Kiro can discover the skills.
- `lint-staged.config.js` excludes `.kiro/` directory files from formatting checks (they're managed externally).
- `.cspell.json` adds "dxui" to the dictionary to avoid spell-check noise from the bucket epic name.

### What was tested

These are configuration and documentation files with no runtime code. 

I verified manually in Kiro IDE that the agent skills are loaded.