### PR TITLE
fix(thermidor): hydrate pageSize from snapshot

### DIFF
--- a/packages/thermidor/src/internal/features/pagination/pagination-slice.test.ts
+++ b/packages/thermidor/src/internal/features/pagination/pagination-slice.test.ts
@@ -103,6 +103,108 @@ describe('createPaginationSlice', () => {
     slice.reducer(original, actions.setFirstResult(30));
     expect(original.firstResult).toBe(0);
   });
+
+  describe('hydrateFromSnapshot', () => {
+    function setup(interfaceId = 'hydrate-test') {
+      const engine = createTestEngine();
+      const iface = createTestInterface(engine, interfaceId);
+      const actions = getOrCreatePaginationActions(iface);
+      const hydrateAction = getOrCreateHydrateFromSnapshotAction(iface);
+      const slice = createPaginationSlice(interfaceId, actions, hydrateAction);
+      return {slice, hydrateAction};
+    }
+
+    it('should not modify state when payload is null', () => {
+      const {slice, hydrateAction} = setup('hydrate-null');
+      const state = slice.reducer(initialPaginationState, hydrateAction(null as never));
+      expect(state).toEqual(initialPaginationState);
+    });
+
+    it('should set totalCount from top-level totalCount (search snapshot)', () => {
+      const {slice, hydrateAction} = setup('hydrate-search-tc');
+      const state = slice.reducer(
+        initialPaginationState,
+        hydrateAction({totalCount: 42, results: []})
+      );
+      expect(state.totalCount).toBe(42);
+    });
+
+    it('should infer pageSize from results array length (search snapshot)', () => {
+      const {slice, hydrateAction} = setup('hydrate-search-ps');
+      const results = Array.from({length: 30}, (_, i) => ({id: String(i)}));
+      const state = slice.reducer(
+        initialPaginationState,
+        hydrateAction({totalCount: 100, results})
+      );
+      expect(state.pageSize).toBe(30);
+    });
+
+    it('should infer pageSize from products array length when results is absent', () => {
+      const {slice, hydrateAction} = setup('hydrate-products-ps');
+      const products = Array.from({length: 20}, (_, i) => ({id: String(i)}));
+      const state = slice.reducer(
+        initialPaginationState,
+        hydrateAction({totalCount: 50, products})
+      );
+      expect(state.pageSize).toBe(20);
+    });
+
+    it('should keep default pageSize when results array is empty', () => {
+      const {slice, hydrateAction} = setup('hydrate-empty-results');
+      const state = slice.reducer(
+        initialPaginationState,
+        hydrateAction({totalCount: 0, results: []})
+      );
+      expect(state.pageSize).toBe(10);
+    });
+
+    it('should set totalCount from pagination.totalEntries (commerce snapshot)', () => {
+      const {slice, hydrateAction} = setup('hydrate-commerce-tc');
+      const state = slice.reducer(
+        initialPaginationState,
+        hydrateAction({pagination: {totalEntries: 200, perPage: 25, page: 0}, products: []})
+      );
+      expect(state.totalCount).toBe(200);
+    });
+
+    it('should set pageSize from pagination.perPage (commerce snapshot)', () => {
+      const {slice, hydrateAction} = setup('hydrate-commerce-ps');
+      const state = slice.reducer(
+        initialPaginationState,
+        hydrateAction({pagination: {totalEntries: 200, perPage: 25, page: 0}, products: []})
+      );
+      expect(state.pageSize).toBe(25);
+    });
+
+    it('should set firstResult from pagination.page * pagination.perPage', () => {
+      const {slice, hydrateAction} = setup('hydrate-commerce-fr');
+      const state = slice.reducer(
+        initialPaginationState,
+        hydrateAction({pagination: {totalEntries: 200, perPage: 25, page: 2}, products: []})
+      );
+      expect(state.firstResult).toBe(50);
+    });
+
+    it('should prefer pagination.perPage over product array length inference', () => {
+      const {slice, hydrateAction} = setup('hydrate-prefer-perpage');
+      const products = Array.from({length: 15}, (_, i) => ({id: String(i)}));
+      const state = slice.reducer(
+        initialPaginationState,
+        hydrateAction({pagination: {totalEntries: 100, perPage: 25, page: 0}, products})
+      );
+      expect(state.pageSize).toBe(25);
+    });
+
+    it('should not override pageSize with array length when perPage is set', () => {
+      const {slice, hydrateAction} = setup('hydrate-no-override');
+      const products = Array.from({length: 50}, (_, i) => ({id: String(i)}));
+      const state = slice.reducer(
+        initialPaginationState,
+        hydrateAction({pagination: {totalEntries: 500, perPage: 50, page: 0}, products})
+      );
+      expect(state.pageSize).toBe(50);
+    });
+  });
 });
 
 describe('getOrCreatePaginationSlice', () => {

--- a/packages/thermidor/src/internal/features/pagination/pagination-slice.ts
+++ b/packages/thermidor/src/internal/features/pagination/pagination-slice.ts
@@ -45,10 +45,11 @@ export function createPaginationSlice(
         if (!payload) {
           return;
         }
+
         if (typeof payload.totalCount === 'number') {
           state.totalCount = payload.totalCount;
-          return;
         }
+
         const pagination = payload.pagination as Record<string, unknown> | undefined;
         if (typeof pagination?.totalEntries === 'number') {
           state.totalCount = pagination.totalEntries;
@@ -62,6 +63,15 @@ export function createPaginationSlice(
           pagination.perPage > 0
         ) {
           state.firstResult = pagination.page * pagination.perPage;
+        }
+
+        if (state.pageSize === initialPaginationState.pageSize && !pagination?.perPage) {
+          const products = payload.products as unknown[] | undefined;
+          const results = payload.results as unknown[] | undefined;
+          const itemCount = products?.length ?? results?.length ?? 0;
+          if (itemCount > 0) {
+            state.pageSize = itemCount;
+          }
         }
       });
     },

--- a/samples/thermidor/demo-react/.kiro/specs/search-results-page/design.md
+++ b/samples/thermidor/demo-react/.kiro/specs/search-results-page/design.md
@@ -138,7 +138,7 @@ interface PageSizeSelectorProps {
 
 ### PageSizeSelector Design Notes
 
-The PageSizeSelector receives `PaginationController` directly (same pattern as Pagination). It subscribes to the controller state via `useSyncExternalStore` to read the current `pageSize`, and renders a native `<select>` element with preset options `[10, 25, 50]`. On change, it calls both `controller.setPageSize(newSize)` and `controller.selectPage(0)` to avoid an out-of-bounds page index.
+The PageSizeSelector receives `PaginationController` directly (same pattern as Pagination). It subscribes to the controller state via `useSyncExternalStore` to read the current `pageSize`, and renders a native `<select>` element with default options `[10, 25, 50]`. If the current `pageSize` from the controller state is not among those defaults (e.g., the backend returned 30 results), it is dynamically added to the options list. All options are deduplicated via a `Set` and sorted in ascending numeric order. On change, it calls both `controller.setPageSize(newSize)` and `controller.selectPage(0)` to avoid an out-of-bounds page index.
 
 **Layout integration:** The bottom row of the main content area uses a flex container with `justify-content: space-between`. Pagination is aligned to the left, PageSizeSelector to the right.
 
@@ -245,4 +245,4 @@ function truncate(text: string, maxLen: number): string {
 | `computeVisiblePages` | Returns all pages when totalPages ≤ 5; returns correct window when current page is at start, middle, and end; always includes first and last page; returns at most 5 items for large page counts |
 | `resolveProductImage` | Returns first thumbnail when thumbnails exist; falls back to first image when no thumbnails; returns null when neither thumbnails nor images exist |
 | `formatQuerySummary` / `truncate` | Correct formatting for all state combinations (query+count, query-only, count-only, neither); truncates query at 100 characters with ellipsis; preserves short queries verbatim; formats count with locale separators |
-| PageSizeSelector | Renders select with options 10, 25, 50; reflects current pageSize; calls setPageSize on change; calls selectPage(0) on change; has accessible label "Products per page" |
+| PageSizeSelector | Renders select with options 10, 25, 50; includes current pageSize in options when not a default (e.g., 30); reflects current pageSize; calls setPageSize on change; calls selectPage(0) on change; has accessible label "Products per page" |

--- a/samples/thermidor/demo-react/.kiro/specs/search-results-page/requirements.md
+++ b/samples/thermidor/demo-react/.kiro/specs/search-results-page/requirements.md
@@ -132,7 +132,7 @@ The Search Results Page is the primary view for displaying product search result
 
 #### Acceptance Criteria
 
-1. WHEN the SearchResultsPage renders, THE PageSizeSelector SHALL display a `<select>` element with the options 10, 25, and 50 as available page sizes.
+1. WHEN the SearchResultsPage renders, THE PageSizeSelector SHALL display a `<select>` element with the default options 10, 25, and 50. IF the current `paginationController.state.pageSize` is not already among those defaults, THE PageSizeSelector SHALL include it as an additional option, and all options SHALL be rendered in ascending numeric order.
 2. THE PageSizeSelector SHALL reflect the current `paginationController.state.pageSize` as its selected value.
 3. WHEN the user selects a different page size option, THE PageSizeSelector SHALL call `paginationController.setPageSize(newSize)` with the newly selected numeric value.
 4. WHEN the user selects a different page size option, THE PageSizeSelector SHALL call `paginationController.selectPage(0)` to reset navigation to the first page.

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/PageSizeSelector/PageSizeSelector.test.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/PageSizeSelector/PageSizeSelector.test.tsx
@@ -36,6 +36,25 @@ describe('PageSizeSelector', () => {
     expect(options[2].value).toBe('50');
   });
 
+  it('includes the current pageSize in options even if not a default', () => {
+    const controller = createMockController({
+      page: 0,
+      pageSize: 30,
+      totalCount: 100,
+      totalPages: 4,
+    });
+
+    render(<PageSizeSelector controller={controller} />);
+
+    const select = screen.getByRole('combobox');
+    const options = select.querySelectorAll('option');
+    expect(options).toHaveLength(4);
+    expect(options[0].value).toBe('10');
+    expect(options[1].value).toBe('25');
+    expect(options[2].value).toBe('30');
+    expect(options[3].value).toBe('50');
+  });
+
   it('reflects current pageSize as selected value', () => {
     const controller = createMockController({
       page: 0,

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/PageSizeSelector/PageSizeSelector.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/PageSizeSelector/PageSizeSelector.tsx
@@ -1,8 +1,8 @@
-import {useCallback, useSyncExternalStore} from 'react';
+import {useCallback, useMemo, useSyncExternalStore} from 'react';
 import type {PaginationController} from '@coveo/thermidor';
 import styles from './PageSizeSelector.module.css';
 
-const PAGE_SIZE_OPTIONS = [10, 25, 50];
+const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50];
 
 interface PageSizeSelectorProps {
   controller: PaginationController;
@@ -15,6 +15,11 @@ export function PageSizeSelector({controller}: PageSizeSelectorProps) {
   );
   const getSnapshot = useCallback(() => controller.state, [controller]);
   const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  const options = useMemo(() => {
+    const set = new Set([...DEFAULT_PAGE_SIZE_OPTIONS, state.pageSize]);
+    return [...set].sort((a, b) => a - b);
+  }, [state.pageSize]);
 
   const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const newSize = Number(event.target.value);
@@ -33,7 +38,7 @@ export function PageSizeSelector({controller}: PageSizeSelectorProps) {
         value={state.pageSize}
         onChange={handleChange}
       >
-        {PAGE_SIZE_OPTIONS.map((size) => (
+        {options.map((size) => (
           <option key={size} value={size}>
             {size}
           </option>

--- a/samples/thermidor/generative-angular/src/app/components/pagination.component.ts
+++ b/samples/thermidor/generative-angular/src/app/components/pagination.component.ts
@@ -1,6 +1,6 @@
-import {ChangeDetectionStrategy, Component, input, output} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, input, output} from '@angular/core';
 
-const PAGE_SIZE_OPTIONS = [5, 10, 20, 50];
+const DEFAULT_PAGE_SIZE_OPTIONS = [5, 10, 20, 50];
 
 @Component({
   selector: 'app-pagination',
@@ -29,7 +29,7 @@ const PAGE_SIZE_OPTIONS = [5, 10, 20, 50];
         (change)="onPageSizeChange($event)"
         aria-label="Results per page"
       >
-        @for (size of pageSizeOptions; track size) {
+        @for (size of pageSizeOptions(); track size) {
           <option [value]="size" [selected]="size === pageSize()">{{ size }} per page</option>
         }
       </select>
@@ -99,7 +99,10 @@ export class PaginationComponent {
   readonly next = output<void>();
   readonly pageSizeChange = output<number>();
 
-  protected readonly pageSizeOptions = PAGE_SIZE_OPTIONS;
+  protected readonly pageSizeOptions = computed(() => {
+    const set = new Set([...DEFAULT_PAGE_SIZE_OPTIONS, this.pageSize()]);
+    return [...set].sort((a, b) => a - b);
+  });
 
   protected onPageSizeChange(event: Event): void {
     const value = Number((event.target as HTMLSelectElement).value);

--- a/samples/thermidor/generative-react/src/components/Pagination/Pagination.tsx
+++ b/samples/thermidor/generative-react/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,7 @@
+import {useMemo} from 'react';
 import styles from './Pagination.module.css';
 
-const PAGE_SIZE_OPTIONS = [5, 10, 20, 50];
+const DEFAULT_PAGE_SIZE_OPTIONS = [5, 10, 20, 50];
 
 interface PaginationProps {
   page: number;
@@ -21,6 +22,11 @@ export function Pagination({
 }: PaginationProps) {
   const isPreviousDisabled = page === 0;
   const isNextDisabled = totalPages <= 1 || page === totalPages - 1;
+
+  const pageSizeOptions = useMemo(() => {
+    const set = new Set([...DEFAULT_PAGE_SIZE_OPTIONS, pageSize]);
+    return [...set].sort((a, b) => a - b);
+  }, [pageSize]);
 
   return (
     <div className={styles.container}>
@@ -49,7 +55,7 @@ export function Pagination({
         onChange={(e) => onPageSizeChange(Number(e.target.value))}
         aria-label="Results per page"
       >
-        {PAGE_SIZE_OPTIONS.map((size) => (
+        {pageSizeOptions.map((size) => (
           <option key={size} value={size}>
             {size} per page
           </option>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5946

## Problem

The pagination slice's hydration handler had an early return when it found `totalCount` at the top level of the snapshot payload, so it set `totalCount` and exited without ever updating `pageSize`. Meanwhile, the product list slice independently rendered all products from the snapshot, creating the mismatch.

## Fix

- Removed the early return so both the `totalCount` and pagination branches can execute in a single pass.
- Added a fallback: when no explicit `pagination.perPage` or equivalent is present (e.g., SAPI response snapshot), infer `pageSize` from the length of the products or results array in the snapshot.
- The commerce path (pagination.perPage) still takes precedence when available.

## Adjusted samples

This PR also adjusts the page size selector in generative-react, generative-angular, and demo-react. The options list becomes dynamic: the current `pageSiz` from the controller state is always included alongside the defaults, so whatever the backend returns is selectable.

## Tests

Added tests in Thermidor covering the hydration scenario (search snapshot, commerce snapshot, null payload, precedence rules)

Also adjusted the PageSizeSelector tests in the demo-react app.