### PR TITLE
fix(atomic): resolve workspace packages to source in Storybook dev mode

### DIFF
--- a/packages/atomic/.storybook/main.ts
+++ b/packages/atomic/.storybook/main.ts
@@ -86,6 +86,7 @@ const virtualOpenApiModules = (): Plugin => {
 const externalizeDependencies = (configType: ConfigType): Plugin => {
   const packageMappings: Record<string, {cdn?: string; local: string}> =
     generateExternalPackageMappings();
+
   return {
     name: 'externalize-dependencies',
     enforce: 'pre',
@@ -98,9 +99,9 @@ const externalizeDependencies = (configType: ConfigType): Plugin => {
         return false;
       }
 
-      const packageMapping = packageMappings[source];
+      const {cdn, local} = packageMappings[source] ?? {};
 
-      if (!packageMapping) {
+      if (!local) {
         // If the package isn't in our mapping, we assume it's a local dependency and leave it as-is
         return null;
       }
@@ -113,17 +114,17 @@ const externalizeDependencies = (configType: ConfigType): Plugin => {
       // For local Storybook development, we want to use local packages source to allow for easier debugging and HMR.
       if (configType === 'DEVELOPMENT') {
         return {
-          id: packageMapping.local,
+          id: local,
         };
       }
 
-      if (!packageMapping.cdn) {
+      if (!cdn) {
         return null;
       }
 
       // For production Storybook builds, we want to use Domain-relative URL to use the CDN versions of the packages.
       return {
-        id: packageMapping.cdn,
+        id: cdn,
         external: 'absolute',
       };
     },

--- a/packages/atomic/.storybook/main.ts
+++ b/packages/atomic/.storybook/main.ts
@@ -8,6 +8,8 @@ import type {Plugin} from 'vite';
 import {mergeConfig} from 'vite';
 import {generateExternalPackageMappings} from '../scripts/externalPackageMappings.mjs';
 
+type ConfigType = 'DEVELOPMENT' | 'PRODUCTION' | undefined;
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const isVitest = process.env.VITEST !== undefined;
@@ -81,7 +83,7 @@ const virtualOpenApiModules = (): Plugin => {
   };
 };
 
-const externalizeDependencies = (configType: 'DEVELOPMENT' | 'PRODUCTION' | undefined): Plugin => {
+const externalizeDependencies = (configType: ConfigType): Plugin => {
   const packageMappings: Record<string, {cdn?: string; local: string}> =
     generateExternalPackageMappings();
   return {
@@ -344,9 +346,7 @@ const virtualAssetsList = (): Plugin => {
 };
 
 export default config;
-function markComponentImportsAsSideEffectful(
-  configType: 'DEVELOPMENT' | 'PRODUCTION' | undefined
-): Plugin {
+function markComponentImportsAsSideEffectful(configType: ConfigType): Plugin {
   const absolutePathToRoot = resolve(__dirname, '..');
   return {
     name: 'mark-components-as-side-effectful',

--- a/packages/atomic/.storybook/main.ts
+++ b/packages/atomic/.storybook/main.ts
@@ -118,14 +118,17 @@ const externalizeDependencies = (configType: ConfigType): Plugin => {
         };
       }
 
-      if (!cdn) {
-        return null;
+      // For production Storybook builds, we want to use Domain-relative URL to use the CDN versions of the packages.
+      if (cdn) {
+        return {
+          id: cdn,
+          external: 'absolute',
+        };
       }
 
-      // For production Storybook builds, we want to use Domain-relative URL to use the CDN versions of the packages.
+      // Some packages, like platform-mock-api, do not have a CDN path and are only available through the local files.
       return {
-        id: cdn,
-        external: 'absolute',
+        id: local,
       };
     },
   };

--- a/packages/atomic/.storybook/main.ts
+++ b/packages/atomic/.storybook/main.ts
@@ -91,11 +91,11 @@ const externalizeDependencies = (configType: ConfigType): Plugin => {
     name: 'externalize-dependencies',
     enforce: 'pre',
     resolveId(source, _importer, _options) {
-      if (/^\/(headless|bueno)/.test(source)) {
+      if (/^\/(headless|bueno|relay)/.test(source)) {
         return false;
       }
 
-      if (/(.*)(\/|\\)+(bueno|headless)\/v\d+\.\d+\.\d+(-nightly)?(\/|\\).*/.test(source)) {
+      if (/(.*)(\/|\\)+(bueno|headless|relay)\/v\d+\.\d+\.\d+(-nightly)?(\/|\\).*/.test(source)) {
         return false;
       }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5948

## Summary

Adapts the Storybook `externalizeDependencies` plugin to resolve workspace packages — including `@coveo/relay` and `@coveo/platform-mock-api` — to their TypeScript source files during local development. This eliminates the need to pre-build those packages before running `pnpm run dev:storybook`.

## Stack

Depends on #8101, which defines explicit domain entrypoints for `@coveo/platform-mock-api` and generates all Storybook mappings from the package manifest's `source` conditions. See [ADR-0001](packages/platform-mock-api/docs/adr/0001-explicit-domain-entrypoints.md) for the architecture rationale.

## Changes

- **`packages/atomic/.storybook/main.ts`**:
  - Extract a `ConfigType` type alias to reduce repetition across plugin signatures.
  - Extend the CDN path-skip regexes to also match `relay` paths.
  - Handle packages without a CDN path (platform-mock-api).

## What was broken

Running `pnpm run dev:storybook` without a prior `pnpm run build` produced Vite pre-transform errors:
- `Failed to resolve import "@coveo/platform-mock-api/insight"`
- `Failed to resolve import "@coveo/relay"`

## Testing

- Delete `packages/atomic/dist`
- `pnpm run build:assets` (still required for static asset serving)
- `pnpm run storybook:dev`
- Verify pages load without resolution errors