### PR TITLE
test(relay): stabilize flaky unit tests

### DIFF
--- a/packages/relay/src/environment/browser/browser.jsdom.test.ts
+++ b/packages/relay/src/environment/browser/browser.jsdom.test.ts
@@ -6,6 +6,10 @@ import {clientIdKey} from '../../constants.js';
 import {createBrowserStorage} from './storage/storage.js';
 
 const sendMessageSpy = vi.fn();
+const successfulFetchResponse = {
+  ok: true,
+  json: async () => ({events: []}),
+} as Response;
 vi.mock('@coveo/explorer-messenger', () => ({
   createExplorerMessenger: () => ({sendMessage: sendMessageSpy}),
 }));
@@ -24,6 +28,11 @@ describe('buildBrowserEnvironment', () => {
   beforeEach(() => {
     sendMessageSpy.mockReset();
     window.location.hostname = '';
+    vi.spyOn(window, 'fetch').mockResolvedValue(successfulFetchResponse);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('environment is browser', () => {
@@ -104,7 +113,7 @@ describe('buildBrowserEnvironment', () => {
   });
 
   it('calls the Fetch API with keepAlive when using send', async () => {
-    const fetchSpy = vi.spyOn(window, 'fetch');
+    const fetchSpy = vi.mocked(window.fetch);
     const event = createMockEvent();
     await buildBrowserEnvironment().send('https://www.coveo.com/', 'token', event);
 

--- a/packages/relay/src/environment/browser/storage/cookie.jsdom.test.ts
+++ b/packages/relay/src/environment/browser/storage/cookie.jsdom.test.ts
@@ -9,6 +9,10 @@ describe('CookieManager', () => {
   const key = 'wow';
   const someData = 'something';
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('setItem writes data to a cookie', () => {
     cookieManager.setItem(key, someData, 1000);
     expect(cookieManager.getItem(key)).toBe(someData);

--- a/packages/relay/src/environment/browser/storage/cookie.jsdom.test.ts
+++ b/packages/relay/src/environment/browser/storage/cookie.jsdom.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment-options {"url": "http://docs.foo.bar.com/tamtam"}
  */
 
+import {vi} from 'vitest';
 import {cookieManager} from './cookie';
 
 describe('CookieManager', () => {
@@ -19,9 +20,13 @@ describe('CookieManager', () => {
     expect(cookieManager.getItem(key)).toBe(null);
   });
 
-  it('honors expiration date', async () => {
+  it('honors expiration date', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2023-08-15T00:00:00.000Z'));
+
     cookieManager.setItem(key, someData, 1000);
-    await new Promise((res) => setTimeout(res, 1000)); // wait for 1 sec
+    vi.advanceTimersByTime(1001);
+
     expect(cookieManager.getItem(key)).toBe(null);
   });
 

--- a/packages/relay/src/event/meta/meta.test.ts
+++ b/packages/relay/src/event/meta/meta.test.ts
@@ -18,6 +18,10 @@ describe('createMeta', () => {
     });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   function getItemViewMeta() {
     return createMeta('itemView', defaultConfig, mockEnv);
   }


### PR DESCRIPTION
[KIT-5947](https://coveord.atlassian.net/browse/KIT-5947)

## Problem
Relay unit tests were intermittently failing in CI because the cookie expiration test waited exactly to the expiration boundary, and a metadata test leaked Vitest fake timers into subsequent tests.

## Solution
Use Vitest fake timers with a fixed system time to verify cookie expiration deterministically, and restore real timers after each metadata test to prevent cross-test state leakage.

[KIT-5947]: https://coveord.atlassian.net/browse/KIT-5947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ