### PR TITLE
feat(samples): restore field-suggestions example in headless search-react sample

### DIFF
--- a/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
+++ b/packages/headless/src/controllers/field-suggestions/facet/headless-field-suggestions.ts
@@ -84,6 +84,7 @@ export interface FieldSuggestionsState {
  *
  * This controller is a wrapper around the basic facet controller search functionality, and thus exposes similar options and properties.
  *
+ * Example: [field-suggestions.tsx](https://github.com/coveo/ui-kit/blob/main/samples/headless/search-react/src/components/field-suggestions.tsx)
  *
  * @group Controllers
  * @category FieldSuggestions

--- a/samples/headless/search-react/src/App.tsx
+++ b/samples/headless/search-react/src/App.tsx
@@ -3,6 +3,7 @@ import {
   buildCategoryFacet,
   buildDateSortCriterion,
   buildFacet,
+  buildFieldSuggestions,
   buildInstantResults,
   buildPager,
   buildQuerySummary,
@@ -54,8 +55,15 @@ function App({engine: providedEngine}: AppProps) {
         articleType: buildFacet(engine, {options: {field: 'article_type'}}),
         robotSeries: buildFacet(engine, {options: {field: 'robot_series'}}),
         difficulty: buildFacet(engine, {options: {field: 'difficulty_level'}}),
-        author: buildFacet(engine, {options: {field: 'author'}}),
+        author: buildFacet(engine, {options: {facetId: 'author', field: 'author'}}),
       },
+      // Drives the "Authors" column of the search box dropdown. It shares its `facetId`
+      // with the author facet above, so selecting a suggestion selects the matching
+      // facet value. Both must declare the same facet options, because only the first
+      // controller built for a `facetId` applies them.
+      authorSuggestions: buildFieldSuggestions(engine, {
+        options: {facet: {facetId: 'author', field: 'author'}},
+      }),
     };
   }, [engine]);
 
@@ -89,6 +97,7 @@ function App({engine: providedEngine}: AppProps) {
           engine={engine}
           controller={controllers.searchBox}
           instantResults={controllers.instantResults}
+          fieldSuggestions={controllers.authorSuggestions}
         />
 
         <div className="results-toolbar">

--- a/samples/headless/search-react/src/components/field-suggestions.tsx
+++ b/samples/headless/search-react/src/components/field-suggestions.tsx
@@ -1,0 +1,50 @@
+import type {
+  FieldSuggestions as FieldSuggestionsController,
+  FieldSuggestionsValue,
+} from '@coveo/headless';
+import {useController} from '../use-controller';
+
+interface FieldSuggestionsProps {
+  controller: FieldSuggestionsController;
+  title: string;
+  onSelect?: () => void;
+}
+
+/**
+ * Renders field suggestions as a column of the search box dropdown, next to the
+ * query suggestions and instant results. The query comes from the search box
+ * input: see `search-box.tsx`, which forwards each keystroke to this
+ * controller's `updateText`.
+ */
+export function FieldSuggestions({controller, title, onSelect}: FieldSuggestionsProps) {
+  const {values} = useController(controller);
+
+  if (values.length === 0) {
+    return null;
+  }
+
+  const select = (value: FieldSuggestionsValue) => {
+    controller.select(value);
+    onSelect?.();
+  };
+
+  return (
+    <div className="search-box__column">
+      <p className="search-box__column-title">{title}</p>
+      <ul>
+        {values.map((value) => (
+          <li key={value.rawValue}>
+            <button
+              type="button"
+              className="search-box__suggestion field-suggestion"
+              onClick={() => select(value)}
+            >
+              <span>{value.displayValue}</span>
+              <span className="field-suggestion__count">{value.count}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/samples/headless/search-react/src/components/search-box.tsx
+++ b/samples/headless/search-react/src/components/search-box.tsx
@@ -1,5 +1,6 @@
 import {
   buildInteractiveInstantResult,
+  type FieldSuggestions as FieldSuggestionsController,
   type InstantResults,
   type Result,
   type SearchBox as SearchBoxController,
@@ -7,16 +8,19 @@ import {
 } from '@coveo/headless';
 import {type KeyboardEvent, useState} from 'react';
 import {useController} from '../use-controller';
+import {FieldSuggestions} from './field-suggestions';
 
 interface SearchBoxProps {
   engine: SearchEngine;
   controller: SearchBoxController;
   instantResults: InstantResults;
+  fieldSuggestions: FieldSuggestionsController;
 }
 
-export function SearchBox({engine, controller, instantResults}: SearchBoxProps) {
+export function SearchBox({engine, controller, instantResults, fieldSuggestions}: SearchBoxProps) {
   const {value, suggestions} = useController(controller);
   const {results} = useController(instantResults);
+  const {values: fieldSuggestionValues} = useController(fieldSuggestions);
   const [focused, setFocused] = useState(false);
   const [active, setActive] = useState(-1);
 
@@ -24,6 +28,11 @@ export function SearchBox({engine, controller, instantResults}: SearchBoxProps) 
     setActive(-1);
     controller.updateText(text);
     instantResults.updateQuery(text);
+    if (text === '') {
+      fieldSuggestions.clear();
+    } else {
+      fieldSuggestions.updateText(text);
+    }
   };
 
   const selectSuggestion = (rawValue: string) => {
@@ -68,7 +77,10 @@ export function SearchBox({engine, controller, instantResults}: SearchBoxProps) 
     }
   };
 
-  const showDropdown = focused && value !== '' && (suggestions.length > 0 || results.length > 0);
+  const showDropdown =
+    focused &&
+    value !== '' &&
+    (suggestions.length > 0 || results.length > 0 || fieldSuggestionValues.length > 0);
 
   return (
     <div className="search-box">
@@ -106,6 +118,11 @@ export function SearchBox({engine, controller, instantResults}: SearchBoxProps) 
               </ul>
             </div>
           )}
+          <FieldSuggestions
+            controller={fieldSuggestions}
+            title="Authors"
+            onSelect={() => setFocused(false)}
+          />
           {results.length > 0 && (
             <div className="search-box__column">
               <p className="search-box__column-title">Instant results</p>

--- a/samples/headless/search-react/src/index.css
+++ b/samples/headless/search-react/src/index.css
@@ -267,6 +267,27 @@ select:focus-visible {
   color: var(--accent-hover);
 }
 
+/* Field suggestions (a column of the search box dropdown) */
+.field-suggestion {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.field-suggestion span:first-of-type {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.field-suggestion__count {
+  flex: none;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
 /* Category facet drill-down */
 .facet__breadcrumb {
   list-style: none;


### PR DESCRIPTION
## Problem

The `FieldSuggestions` TypeDoc pointed at a sample that no longer existed:

```
Example: [field-suggestions.fn.tsx](.../samples/headless/search-react/src/components/field-suggestions/specific-field/field-suggestions.fn.tsx)
```

That file was deleted in #7897 (the BarcaKnowledge rewrite of the `headless-search-react` sample), and #8071 then removed the resulting dead link. So the controller was left with no example at all, and the sample lost its only demonstration of `FieldSuggestions`.

## Solution

Restore the example where it originally lived — the CSR `headless/search-react` sample — and re-point the TypeDoc link at it.

`FieldSuggestions` is a typeahead, so it's presented as a third column of the search box dropdown, alongside the query suggestions and instant results, rather than as a separate sidebar widget with its own input.

- `components/field-suggestions.tsx`: new component rendering the suggestion column (value + result count). Follows the sample's conventions: flat `components/` file, state read through the `useController` hook. Renders nothing when there are no values.
- `components/search-box.tsx`: forwards each keystroke to the controller's `updateText` (and `clear` on an empty input), and renders the new column. Selecting a suggestion closes the dropdown.
- `App.tsx`: builds the controller and passes it to the search box. It shares `facetId: 'author'` with the existing author facet, so selecting a suggestion checks the matching facet value. Both declare the same facet options, because only the first controller built for a given `facetId` applies them.
- `index.css`: styles for the suggestion rows, reusing the existing dropdown and facet variables.
- `headless-field-suggestions.ts`: restore the `Example:` link, now pointing at the new file.

## Tested

- `vite build` and the existing Playwright smoke test pass.
- Verified in the browser that typing surfaces an "Authors" column in the dropdown, and that picking a value closes the dropdown and checks the corresponding Author facet value.