### PR TITLE
fix(relay): restore published documentation artifact

### DIFF
--- a/.changeset/restore-relay-docs.md
+++ b/.changeset/restore-relay-docs.md
@@ -1,0 +1,5 @@
+---
+"@coveo/relay": patch
+---
+
+Restore the `relay-docs.json` documentation artifact in published Relay packages.

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -20,7 +20,8 @@
     "directory": "packages/relay"
   },
   "files": [
-    "lib/npm/*"
+    "lib/npm/*",
+    "lib/docs/*"
   ],
   "type": "module",
   "types": "./lib/npm/relay.d.ts",
@@ -34,11 +35,12 @@
     "access": "public"
   },
   "scripts": {
-    "build": "pnpm run clean && rollup --config ./config/rollup.config.mjs",
+    "build": "pnpm run clean && rollup --config ./config/rollup.config.mjs && pnpm run typedoc",
     "clean": "node ../../utils/ci/rm-rf.mjs lib",
     "test": "vitest run",
     "functional-test": "vitest run --config vitest.functional.config.ts",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typedoc": "typedoc"
   },
   "dependencies": {
     "@coveo/explorer-messenger": "0.5.0",
@@ -53,6 +55,7 @@
     "jsdom": "28.1.0",
     "playwright": "catalog:",
     "rollup": "4.62.2",
+    "typedoc": "catalog:",
     "vitest": "catalog:"
   },
   "engines": {

--- a/packages/relay/tsconfig.json
+++ b/packages/relay/tsconfig.json
@@ -20,5 +20,14 @@
     "rootDir": "src",
     "types": ["vitest/globals", "node"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "typedocOptions": {
+    "entryPointStrategy": "expand",
+    "json": "lib/docs/relay-docs.json",
+    "entryPoints": ["src/relay.ts"],
+    "includeVersion": true,
+    "excludePrivate": true,
+    "excludeNotDocumented": true,
+    "treatWarningsAsErrors": true
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1168,6 +1168,9 @@ importers:
       rollup:
         specifier: 4.62.2
         version: 4.62.2
+      typedoc:
+        specifier: 'catalog:'
+        version: 0.28.20(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@26.1.0)(@vitest/browser-playwright@4.1.9)(jsdom@28.1.0)(msw@2.15.0(@types/node@26.1.0)(typescript@6.0.3))(vite@8.1.5(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))


### PR DESCRIPTION
## Problem
The recent @coveo/relay release no longer publishes `lib/docs/relay-docs.json`. The Relay migration removed the TypeDoc build step, its configuration, and the package files allowlist entry.

## Solution
Restore TypeDoc generation and its JSON configuration, include `lib/docs/*` in the published package, and add a patch changeset for @coveo/relay.

## Validation
`git diff --check` and JSON validation passed. The Relay build could not run locally because dependencies are not installed in the isolated worktree; installation is currently blocked by the registry reporting `typedoc@0.28.20` as unavailable.