### PR TITLE
perf(atomic): pre-bundle heavy deps in vitest browser mode

### DIFF
--- a/packages/atomic/vitest.config.js
+++ b/packages/atomic/vitest.config.js
@@ -75,6 +75,22 @@ if (!isVitestVscodeExt) {
 }
 const atomicDefault = defineConfig({
   name: 'atomic-default',
+  optimizeDeps: {
+    include: [
+      '@coveo/headless',
+      '@coveo/headless/commerce',
+      '@coveo/headless/insight',
+      '@coveo/headless/recommendation',
+      '@coveo/bueno',
+      'lit',
+      'lit/decorators.js',
+      'lit/directives/if-defined.js',
+      'lit/directives/unsafe-html.js',
+      'lit/directives/when.js',
+      'lit/directives/ref.js',
+      'i18next',
+    ],
+  },
   server: {
     port: port,
   },


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5950

Add optimizeDeps.include to the atomic-default vitest config to force Vite to pre-bundle workspace-linked packages (@coveo/headless, @coveo/bueno) and other frequently imported libraries (lit, i18next) before serving them to the browser.

Atomic unit tests run in Vitest browser mode (Playwright/Chromium). Each of the 450 test files imports @coveo/headless, which is a workspace-linked package with 1,214 ESM files in its dist output. Because Vite does not pre-bundle symlinked packages by default, every test file triggers the browser to individually resolve and fetch all those modules over HTTP from the Vite dev server.

This results in 452.75s of cumulative import time across workers, making imports — not test execution — the dominant bottleneck in the 4m16s atomic test run.

Explicitly list the heaviest dependencies in optimizeDeps.include:
- @coveo/headless (+ /commerce, /insight, /recommendation subpaths)
- @coveo/bueno
- lit (+ directives and decorators subpaths)
- i18next

Vite will now pre-bundle each into a single optimized chunk at startup. The browser fetches one file instead of 1,214 per import, dramatically reducing per-file module resolution overhead.

Significant reduction in the cumulative import time (452.75s) for the atomic test suite, translating to a meaningful wall-clock improvement on the ~4m16s atomic:test step in CI.

---

Perf gain:
- [Before](https://github.com/coveo/ui-kit/actions/runs/30284615566/job/90040166533): 6m4s
- [After](https://github.com/coveo/ui-kit/actions/runs/30295961031/job/90077986051?pr=8082): 2m50s 

---

> Additional success criteria: when in dev mode (turbo dev --filter=@coveo/atomic), modification of Headless source files are communicated over HMR (i.e. no need for full or slow reload).

Verified:
1. ```sh
   pnpm exec turbo dev --filter=@coveo/atomic
   ```
2. Open storybook
3. Modify headless file
4. Notice update in the storybook terminal:
   ```
   Vite page reload
   /Users/slavoie2/src/github.com/coveo/ui-kit/packages/headless/src/controllers/tab/headless-tab.ts
   ```