### PR TITLE
chore(agents): add commit-changes skill and PR templates

### DIFF
--- a/.agents/skills/commit-changes/SKILL.md
+++ b/.agents/skills/commit-changes/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: commit-changes
+description: Guides composing commits and PR descriptions following Conventional Commits 1.0.0. Use when committing changes, writing PR titles, or composing PR descriptions.
+license: Apache-2.0
+metadata:
+  author: coveo
+  version: '1.0'
+---
+
+## Commit message
+
+### Commit subject (title)
+
+This repository follows Conventional Commits 1.0.0.
+
+Use the package directory name under `packages/` as the scope. 
+For infrastructure changes use `ci`, `deps`, `agents`, or `changesets`. 
+Comma-separate when multiple scopes apply.
+
+### Commit body (description)
+
+1. Select the template that matches your change type:
+
+    | Type                                                         | Jira work item | Use when                                           |
+    | ------------------------------------------------------------ | -------------- | -------------------------------------------------- |
+    | [`feat`](../../../.github/PULL_REQUEST_TEMPLATE/feature.md)  | Story / Task   | Adding new functionality or enhancements           |
+    | [`fix`](../../../.github/PULL_REQUEST_TEMPLATE/bugfix.md)    | Bug            | Fixing a defect                                    |
+    | [`chore`](../../../.github/PULL_REQUEST_TEMPLATE/chore.md)   | Task           | Maintenance, dependency updates, tooling, refactor |
+    | [`style`](../../../.github/PULL_REQUEST_TEMPLATE/style.md)   | Task           | Formatting/whitespace with no logic change         |
+    | [`docs`](../../../.github/PULL_REQUEST_TEMPLATE/docs.md)     | Task           | Documentation-only changes                         |
+    | [`test`](../../../.github/PULL_REQUEST_TEMPLATE/test.md)     | Task           | Adding or updating tests only                      |
+    | [`revert`](../../../.github/PULL_REQUEST_TEMPLATE/revert.md) | —              | Reverting a previous commit                        |
+
+2. Read the selected template file.
+3. Fill in its sections using GitHub Markdown.
+4. Remove sections that are empty or do not apply.
+
+## Jira work item
+
+Ask the user to either:
+1. Provide a Jira to replace the placeholder link (`https://coveord.atlassian.net/browse/TICKET-ID`) in the description template.
+2. Automatically create a Jira in a bucket using the [`jira-create-issue-in-bucket`](../jira-create-issue-in-bucket/SKILL.md) skill.
+3. Skip adding a Jira and remove the Jira section from the description.
+
+## Changeset
+
+This repository uses [changeset](https://changesets.dev/guide/getting-started).
+
+Required whenever you modify source code of a public package.
+
+However, do not create changesets for trivial or internal changes. See the PR templates for each corresponding change type for guidance.
+
+If you determine that a changeset is required, run `pnpm changeset` and follow the instructions as prompted.
+
+## Commit changes
+
+If the user is only asking for a commit message or PR description, output that in GitHub Markdown format and STOP.
+
+If the user is asking to commit changes or open a PR:
+
+1. Make sure you are on a branch other than `main` that is relevant to the current changes.
+    1. If not on a branch, offer to create it for the user.
+    2. If unclear or uncertain, pause and ask for clarification.
+2. Identify which changes should be part of this commit. If unclear or uncertain, pause and ask for clarification. 
+3. `.kiro/specs` files do not always go in commits. If present, ask the user if they want to include them in the commit.
+4. Stage the relevant parts using `git add`.
+5. Commit using `git commit -m "<type>(<scope>): <summary>" -m "<Description>"`
+
+## Open a draft Pull Request
+
+If changes were successfully committed, offer to the user to open a PR.
+
+If they agree:
+
+1. Push the branch to GitHub
+2. Open a draft pull request, using the title and description from before
+3. Print the link to the PR.
+   

--- a/.agents/skills/commit-changes/SKILL.md
+++ b/.agents/skills/commit-changes/SKILL.md
@@ -13,8 +13,8 @@ metadata:
 
 This repository follows Conventional Commits 1.0.0.
 
-Use the package directory name under `packages/` as the scope. 
-For infrastructure changes use `ci`, `deps`, `agents`, or `changesets`. 
+Use the package directory name under `packages/` as the scope.
+For infrastructure changes use `ci`, `deps`, `agents`, or `changesets`.
 Comma-separate when multiple scopes apply.
 
 ### Commit body (description)

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,0 +1,24 @@
+## Jira
+
+https://coveord.atlassian.net/browse/TICKET-ID
+
+## Motivation
+
+<!-- Describe the bug that was observed. What was the incorrect behavior? -->
+
+## Root Cause
+
+<!-- Explain the underlying cause of the bug. -->
+
+## Changes
+
+<!-- Summarize the approach taken to fix the bug and any key decisions. -->
+
+## Validation
+
+<!-- List the steps taken to verify the fix (manual testing, automated tests, etc.). -->
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`fix(<scope>): <description>`)
+- [ ] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code

--- a/.github/PULL_REQUEST_TEMPLATE/chore.md
+++ b/.github/PULL_REQUEST_TEMPLATE/chore.md
@@ -1,0 +1,25 @@
+## Jira
+
+https://coveord.atlassian.net/browse/TICKET-ID
+
+## Motivation
+
+<!-- Explain why this chore is needed (1-3 sentences). -->
+
+## Changes
+
+<!-- Summarize what was changed and any key decisions. -->
+
+## Validation
+
+<!-- List manual or automated steps taken to verify the change. -->
+<!-- How did you verify external behavior is unchanged? -->
+
+- [ ] All existing tests pass without modification
+- [ ] No new features or bug fixes are included in this PR
+- [ ] Public API surface is unchanged
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`chore(<scope>): <description>`)
+- [ ] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -1,0 +1,22 @@
+## Jira
+
+https://coveord.atlassian.net/browse/TICKET-ID
+
+## Motivation
+
+<!-- Explain why this documentation change is needed. -->
+
+## Changes
+
+<!-- Describe what documentation was added or changed. -->
+
+## Validation
+
+<!-- How did you verify the documentation is accurate and renders correctly? -->
+
+- [ ] Links are valid and pages render correctly
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`docs(<scope>): <description>`)
+- [ ] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if the public API surface is affected (e.g., TSDoc changes that appear in generated docs).

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,24 @@
+## Jira
+
+https://coveord.atlassian.net/browse/TICKET-ID
+
+## Motivation
+
+<!-- Describe the problem or need this feature addresses (1-3 sentences). -->
+
+## Changes
+
+<!-- Summarize the approach taken and key decisions. -->
+
+## Validation
+
+<!-- List manual or automated steps taken to verify the change. -->
+
+## Screenshots
+
+<!-- Add screenshots if applicable. Remove this entire section if no UI changes. -->
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`feat(<scope>): <description>`)
+- [ ] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code

--- a/.github/PULL_REQUEST_TEMPLATE/revert.md
+++ b/.github/PULL_REQUEST_TEMPLATE/revert.md
@@ -1,0 +1,23 @@
+## Jira
+
+https://coveord.atlassian.net/browse/TICKET-ID
+
+## Motivation
+
+<!-- Explain why this commit is being reverted. -->
+
+## Changes
+
+<!-- Identify the commit(s) being reverted (SHA or PR number) and summarize what they introduced. -->
+
+## Validation
+
+<!-- How did you verify the revert restores correct behavior? -->
+
+- [ ] All existing tests pass after the revert
+- [ ] No unrelated changes are included in this PR
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`revert(<scope>): <description>`)
+- [ ] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if needed (ask if unsure whether the reverted change was released)

--- a/.github/PULL_REQUEST_TEMPLATE/style.md
+++ b/.github/PULL_REQUEST_TEMPLATE/style.md
@@ -21,4 +21,4 @@ https://coveord.atlassian.net/browse/TICKET-ID
 ## Checklist
 
 - [ ] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`style(<scope>): <description>`)
-- [ ] No changeset is included in this PR since it should not affect the public API surface.
+- [ ] No changeset is included in this PR (unless you modified source code of a public package under `packages/`; if so, add one with `pnpm changeset`).

--- a/.github/PULL_REQUEST_TEMPLATE/style.md
+++ b/.github/PULL_REQUEST_TEMPLATE/style.md
@@ -1,0 +1,24 @@
+## Jira
+
+https://coveord.atlassian.net/browse/TICKET-ID
+
+## Motivation
+
+<!-- Explain why this formatting change is needed. -->
+
+## Changes
+
+<!-- Describe what formatting or whitespace changes were applied. -->
+
+## Validation
+
+<!-- How did you verify no logic was changed? -->
+
+- [ ] All existing tests pass without modification
+- [ ] Diff contains only whitespace, formatting, or punctuation changes (no logic changes)
+- [ ] No functional behavior is altered
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`style(<scope>): <description>`)
+- [ ] No changeset is included in this PR since it should not affect the public API surface.

--- a/.github/PULL_REQUEST_TEMPLATE/test.md
+++ b/.github/PULL_REQUEST_TEMPLATE/test.md
@@ -1,0 +1,24 @@
+## Jira
+
+https://coveord.atlassian.net/browse/TICKET-ID
+
+## Motivation
+
+<!-- Explain why these tests are needed (coverage gap, regression prevention, etc.). -->
+
+## Changes
+
+<!-- Describe what tests were added or updated and which functionality they cover. -->
+
+## Validation
+
+<!-- How did you verify the tests are correct? -->
+
+- [ ] All new and existing tests pass
+- [ ] No production code was modified (test files only)
+- [ ] Tests cover the intended scenarios
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`test(<scope>): <description>`)
+- [ ] No changeset is included in this PR since it should not affect the public API surface.

--- a/.github/PULL_REQUEST_TEMPLATE/test.md
+++ b/.github/PULL_REQUEST_TEMPLATE/test.md
@@ -21,4 +21,4 @@ https://coveord.atlassian.net/browse/TICKET-ID
 ## Checklist
 
 - [ ] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`test(<scope>): <description>`)
-- [ ] No changeset is included in this PR since it should not affect the public API surface.
+- [ ] No changeset is included in this PR (unless you modified source code of a public package under `packages/`; if so, add one with `pnpm changeset`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@
 **You must ALWAYS**:
 
 - Discover available Agent Skills under `.agents/skills` when beginning a new session
+- Add a changeset file when modifying source code of any public package
 - Run `pnpm run lint:fix` before committing work
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,7 @@
 **You must ALWAYS**:
 
 - Discover available Agent Skills under `.agents/skills` when beginning a new session
-- Add a changeset file when modifying source code of any public package
 - Run `pnpm run lint:fix` before committing work
-- Use the Conventional Commits 1.0.0 specification when composing a commit message
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,32 +1,24 @@
 # Contributing to ui-kit
 
-Thank you for contributing to coveo/ui-kit. This guide covers the conventions and workflow for submitting changes to this monorepo.
+Thank you for contributing to coveo/ui-kit. This guide describes the conventions we use in this monorepo. The goal is a clean, consistent commit history — you're welcome to achieve that however works for you, as long as the end result meets the quality bar described below.
 
-## Commit message
+## PR title
 
-### Commit subject (title)
+We follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). Because we use **squash merge**, the PR title becomes the final commit message in `main`.
 
-This repository follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
-
-Because we use **squash merge**, the PR title becomes the final commit message.
-
-Your PR title must follow this pattern:
+Your PR title **should** follow this pattern:
 
 ```
 <type>(<scope>): <short lowercase imperative summary>
 ```
 
-Use the imperative mood, start with a lowercase letter, and omit trailing punctuation.
+Imperative mood, lowercase start, no trailing period. Append `!` after the scope for breaking changes.
 
 ### Scope Selection
 
 Use the package directory name under `packages/` as the scope.
 For infrastructure changes use `ci`, `deps`, `agents`, or `changesets`.
 Comma-separate when multiple scopes apply.
-
-### Breaking changes
-
-Append `!` after the scope to signal a breaking change (e.g., `feat(headless)!: remove deprecated controller`).
 
 ### Examples
 
@@ -37,13 +29,9 @@ chore(deps): bump vitest to v3
 feat(relay)!: change event payload structure
 ```
 
-### Commit body (description)
+## PR description
 
-Read the selected template file and fill in its sections using [GitHub Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
-
-All templates include a Jira link placeholder (`https://coveord.atlassian.net/browse/TICKET-ID`). If the change is not associated with a Jira, remove the Jira section from the description.
-
-When you prepare a commit message, select the template that matches your change type from [`.github/PULL_REQUEST_TEMPLATE/`](.github/PULL_REQUEST_TEMPLATE/).
+Your PR description **should** follow one of the templates in [`.github/PULL_REQUEST_TEMPLATE/`](.github/PULL_REQUEST_TEMPLATE/). Pick the one that matches your change type:
 
 | Type                                                | Jira work item | Use when                                           |
 | --------------------------------------------------- | -------------- | -------------------------------------------------- |
@@ -55,7 +43,11 @@ When you prepare a commit message, select the template that matches your change 
 | [`test`](.github/PULL_REQUEST_TEMPLATE/test.md)     | Task           | Adding or updating tests only                      |
 | [`revert`](.github/PULL_REQUEST_TEMPLATE/revert.md) | —              | Reverting a previous commit                        |
 
-Each template pre-fills the relevant sections and includes a shared checklist.
+If a template doesn't fit your situation, feel free to structure the description differently — the point is giving reviewers enough context to understand the what, why, and how.
+
+## Commit messages
+
+Individual commit messages within a PR are **optional** to format — they get squashed away. That said, you **could** follow the same Conventional Commits pattern for your commits so that the PR title and description pre-fill automatically when you open the PR.
 
 ## Changeset
 
@@ -68,12 +60,12 @@ If you determine that a changeset is required, run `pnpm changeset` and follow t
 
 ## Contribution Workflow
 
-1. **Create a branch** — no specific naming convention is enforced.
+1. **Create a branch** — no naming convention enforced.
 2. **Make your changes** in the relevant package(s).
-3. **Add a changeset** (when applicable) — run `pnpm changeset` and select the affected packages. Required whenever you modify source code of a public package; CI will fail if one is missing.
-4. **Commit** using the [Conventional Commits format](#commit-subject-title). A [Husky](https://typicode.github.io/husky/) pre-commit hook automatically runs `pnpm run pre-commit` to catch lint and formatting issues.
-5. **Open a pull request** — select the appropriate [PR template](#commit-body-description) and ensure the PR title follows Conventional Commits format.
-6. **Address review feedback** — push additional commits as needed; they will be squashed on merge.
+3. **Add a changeset** when applicable (see [above](#changeset)).
+4. **Commit** A [Husky](https://typicode.github.io/husky/) pre-commit hook runs `pnpm run pre-commit` to catch lint and formatting issues.
+5. **Open a pull request** — pick a [PR template](#pr-description) and write a title that follows [Conventional Commits](#pr-title).
+6. **Address review feedback** — push additional commits; they'll be squashed on merge.
 
 ## Additional References
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to ui-kit
+
+Thank you for contributing to coveo/ui-kit. This guide covers the conventions and workflow for submitting changes to this monorepo.
+
+## Commit message
+
+### Commit subject (title)
+
+This repository follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+
+Because we use **squash merge**, the PR title becomes the final commit message.
+
+Your PR title must follow this pattern:
+
+```
+<type>(<scope>): <short lowercase imperative summary>
+```
+
+Use the imperative mood, start with a lowercase letter, and omit trailing punctuation.
+
+### Scope Selection
+
+Use the package directory name under `packages/` as the scope.
+For infrastructure changes use `ci`, `deps`, `agents`, or `changesets`.
+Comma-separate when multiple scopes apply.
+
+### Breaking changes
+
+Append `!` after the scope to signal a breaking change (e.g., `feat(headless)!: remove deprecated controller`).
+
+### Examples
+
+```
+feat(atomic): add new facet breadcrumb component
+fix(headless, quantic): correct subscription cleanup on unmount
+chore(deps): bump vitest to v3
+feat(relay)!: change event payload structure
+```
+
+### Commit body (description)
+
+Read the selected template file and fill in its sections using [GitHub Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax).
+
+All templates include a Jira link placeholder (`https://coveord.atlassian.net/browse/TICKET-ID`). If the change is not associated with a Jira, remove the Jira section from the description.
+
+When you prepare a commit message, select the template that matches your change type from [`.github/PULL_REQUEST_TEMPLATE/`](.github/PULL_REQUEST_TEMPLATE/).
+
+| Type                                                | Jira work item | Use when                                           |
+| --------------------------------------------------- | -------------- | -------------------------------------------------- |
+| [`feat`](.github/PULL_REQUEST_TEMPLATE/feature.md)  | Story / Task   | Adding new functionality or enhancements           |
+| [`fix`](.github/PULL_REQUEST_TEMPLATE/bugfix.md)    | Bug            | Fixing a defect                                    |
+| [`chore`](.github/PULL_REQUEST_TEMPLATE/chore.md)   | Task           | Maintenance, dependency updates, tooling, refactor |
+| [`style`](.github/PULL_REQUEST_TEMPLATE/style.md)   | Task           | Formatting/whitespace with no logic change         |
+| [`docs`](.github/PULL_REQUEST_TEMPLATE/docs.md)     | Task           | Documentation-only changes                         |
+| [`test`](.github/PULL_REQUEST_TEMPLATE/test.md)     | Task           | Adding or updating tests only                      |
+| [`revert`](.github/PULL_REQUEST_TEMPLATE/revert.md) | —              | Reverting a previous commit                        |
+
+Each template pre-fills the relevant sections and includes a shared checklist.
+
+## Changeset
+
+This repository uses [changeset](https://changesets.dev/guide/getting-started).
+
+Required whenever you modify source code of the public API surface.
+
+However, do not create changesets for trivial or internal changes. See the PR templates for each corresponding change type for guidance.
+
+If you determine that a changeset is required, run `pnpm changeset` and follow the instructions as prompted.
+
+## Contribution Workflow
+
+1. **Create a branch** — no specific naming convention is enforced.
+2. **Make your changes** in the relevant package(s).
+3. **Add a changeset** (when applicable) — run `pnpm changeset` and select the affected packages. Required whenever you modify source code of a public package; CI will fail if one is missing.
+4. **Commit** using the [Conventional Commits format](#commit-subject-title). A [Husky](https://typicode.github.io/husky/) pre-commit hook automatically runs `pnpm run pre-commit` to catch lint and formatting issues.
+5. **Open a pull request** — select the appropriate [PR template](#commit-body-description) and ensure the PR title follows Conventional Commits format.
+6. **Address review feedback** — push additional commits as needed; they will be squashed on merge.
+
+## Additional References
+
+- [AGENTS.md](./AGENTS.md) — Instructions for AI agents.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,10 +59,9 @@ Each template pre-fills the relevant sections and includes a shared checklist.
 
 ## Changeset
 
-This repository uses [changeset](https://changesets.dev/guide/getting-started).
+This repository uses [Changesets](https://changesets.dev/guide/getting-started).
 
-Required whenever you modify source code of the public API surface.
-
+Required whenever you modify source code of a public package under `packages/`.
 However, do not create changesets for trivial or internal changes. See the PR templates for each corresponding change type for guidance.
 
 If you determine that a changeset is required, run `pnpm changeset` and follow the instructions as prompted.


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-5955

## Motivation

Standardize commit message guidelines and PR description templates so that both human contributors and AI agents follow a consistent format.

## Changes

- Add `commit-changes` agent skill with Conventional Commits instructions and Jira/changeset workflow guidance.
- Add PR description templates for each change type (feat, fix, chore, style, docs, test, revert) under `.github/PULL_REQUEST_TEMPLATE/`.
- Add `CONTRIBUTING.md` documenting commit format, changeset workflow, and contribution process.
- Remove redundant inline commit/changeset rules from `AGENTS.md` (now covered by the skill).

## Design decision – Why separate CONTRIBUTING.md and SKILL.md?

Agents already know Conventional Commits and git — repeating that wastes context window. 

What they *don't* know is repo-specific policy (valid scopes, type→template mapping, changeset rules, staging guardrails). The SKILL focuses exclusively on that.

CONTRIBUTING keeps the examples, spec links, and workflow narrative that humans need to make judgment calls.

Both share the scope rules and type→template table (repo-specific, can't be inferred). The PR templates are the single shared contract that keeps output consistent regardless of author.

| Content | CONTRIBUTING | SKILL |
|---------|:---:|:---:|
| Format pattern + examples | ✅ | ❌ |
| Breaking change `!` syntax | ✅ | ❌ |
| Contribution workflow (branch → PR → review) | ✅ | ❌ |
| Scope rules + type→template table | ✅ | ✅ |
| Changeset guidance | ✅ | ✅ |
| Procedural guardrails (branch check, staging, .kiro/specs) | ❌ | ✅ |
| "Output and STOP" vs "execute" decision tree | ❌ | ✅ |

## Validation

- All existing tests pass without modification
- No new features or bug fixes are included in this PR
- Public API surface is unchanged

The commit and the PR for this was generated by the skill, except the "Design decision" above, which was done separately.

Abridged AI conversation:
    

> Let me first understand the changes better so I can create an appropriate Jira ticket, then we'll create the branch and commit.
> 
> ...
> 
> Now I have a good picture of the changes. Let me create the Jira ticket using the bucket skill.
> 
> 
> Loaded skill: jira-create-issue-in-bucket
> 
> jira-create-issue-in-bucket
> 
> This change adds a commit-changes agent skill, PR description templates, a CONTRIBUTING.md, and updates AGENTS.md. This is a process improvement / tooling enhancement — it fits the Continuous Improvement bucket (KIT-5536), and it's a Story (delivering incremental value).
> 
> Loaded skill: jira-writer
> Loaded steering: mcp-tools
> 
> Ready to create this as a Jira Story in KIT under KIT-5536?
> 
> Yes
> 
> ...
> 
> Created: KIT-5955 — Story under KIT-5536 (Continuous Improvement).
> 
> Now let me create the branch and commit the changes. I'll read the chore template since this is a tooling/process change.
> 
> ...
> 
> Now let me create the branch and commit:
> 
> ...
> 
> Good. Staged exactly the right files, excluding .kiro/specs/. Now let me run lint:fix first as required, then commit.
> 
> ```
> pnpm run lint:fix -- --filter=. 2>&1 | tail -20
> ```
> 
> Lint ran successfully (that exit code issue is from the turbo output, not an actual failure). Let me now commit:
> 
> 
> ```
> git commit -m "chore(agents): add commit-changes skill and PR templates" -m "## Jira ..."
> ```
> 
> Push and open a draft PR
> 
> ```
> git push -u origin chore/commit-changes-skill
> ```
> 
> Pushed. Now let me create the draft PR:
> 
> ```
> gh pr create --draft --title "chore(agents): add commit-changes skill and PR templates" --body "## Jira..."
> ```
> 
> Creating draft pull request for chore/commit-changes-skill into main in coveo/ui-kit
> 
> Done. Draft PR is live: https://github.com/coveo/ui-kit/pull/8093

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`chore(<scope>): <description>`)
- [x] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code — N/A, no public package source modified