### PR TITLE
chore(coveo.analytics): enable publint scan

### DIFF
--- a/scripts/ci/package-compatibility.mjs
+++ b/scripts/ci/package-compatibility.mjs
@@ -8,7 +8,7 @@ import {publint} from 'publint';
 const runCommand = promisify(execFile);
 
 const WORKSPACE_ROOTS = ['packages', 'samples', 'utils'];
-const EXCLUDED_PACKAGES = new Set(['@coveo/quantic', 'coveo.analytics']);
+const EXCLUDED_PACKAGES = new Set(['@coveo/quantic']);
 const IGNORED_DIRECTORIES = new Set([
   '.git',
   '.next',


### PR DESCRIPTION
> Stacked on #8099. Base is `enable-knip-coveo-analytics`, so review that one first. This PR's own diff is a single line.

## Problem
`coveo.analytics` was listed in `EXCLUDED_PACKAGES` in `scripts/ci/package-compatibility.mjs`, so the publint scan skipped it while every other public package was checked.

## Solution
Remove the exclusion. No other change: the scan passes as-is.

```diff
-const EXCLUDED_PACKAGES = new Set(['@coveo/quantic', 'coveo.analytics']);
+const EXCLUDED_PACKAGES = new Set(['@coveo/quantic']);
```

The check only fails on publint **errors** (`exitCode = 1` is set solely when `errors.length > 0`); warnings and suggestions are printed for visibility. `coveo.analytics` reports zero errors.

### What publint reports for the package, and why it is left alone

Two warnings, both `FILE_INVALID_FORMAT`:

- `/dist/library.es.js` and `/dist/react-native.es.js` are ESM but interpreted as CJS, so publint suggests `.mjs`.

These are real smells, but both file names are part of the published surface and appear in the `coveo.analytics@2.30.56` tarball. Renaming them is a breaking change, so it belongs to a deliberate major, not to enabling a scan.

Five suggestions: `USE_TYPE`, `INVALID_REPOSITORY_VALUE`, `USE_SIDE_EFFECTS`, `HAS_MODULE_BUT_NO_EXPORTS`, `USE_ENGINES_NODE`. publint itself flags the exports-map, `engines.node`, and `type` ones as potentially breaking. `HAS_MODULE_BUT_NO_EXPORTS` in particular must **not** be acted on: the migration plan explicitly rules out a root `exports` map, because a restricted map would block the supported `dist/**` and `modules` deep imports.

For context, the repo already emits 32 publint messages across packages, including warnings on `@coveo/atomic`, so `coveo.analytics` is not an outlier here.

## Validation
- `pnpm run package-compatibility` exits 0 with `packages/coveo-analytics` present in the scanned list, after a full `pnpm run build` as CI does.
- Zero `Errors` sections repo-wide, so no other package regressed.
- `pnpm run lint:check` passes.
- `pnpm run knip` still passes on this branch, confirming the stack is consistent.

No changeset: CI configuration only, with no effect on the published package.

## Note for reviewers
The script requires every public package to be built first, so running `pnpm run package-compatibility` without a preceding `pnpm run build` fails with `Unable to find the package artifact for @coveo/atomic-angular`. That is pre-existing behavior, not introduced here.