### PR TITLE
docs(thermidor): product targetting feature + polishing

### DIFF
--- a/samples/thermidor/demo-react/.kiro/specs/product-context-attachment/design.md
+++ b/samples/thermidor/demo-react/.kiro/specs/product-context-attachment/design.md
@@ -1,0 +1,280 @@
+# Design Document: Product Context Attachment
+
+## Overview
+
+The Product Context Attachment feature enables users to attach products as context to their prompts via an interactive "targeting mode." The architecture prioritizes self-containment: the `ProductTargeting` component owns all targeting logic, state management, and submit-with-context behavior. Pages only need to provide a content area wrapped in `TargetingProvider` and pass through persistence props.
+
+## Architecture
+
+```mermaid
+graph TD
+    AppShell -->|"products, onProductsChange, isStreaming, onSubmit"| SearchResultsPage
+    AppShell -->|"products, onProductsChange, isStreaming, onSubmit"| ConversationPage
+    
+    subgraph "Page (Search or Conversation)"
+        ProductTargeting -->|wraps| PromptInput
+        ProductTargeting -->|provides| TargetingProvider
+        TargetingProvider -->|context| ContentArea["Product Surfaces"]
+    end
+    
+    ContentArea --> ProductCard
+    ContentArea --> A2UIProductCard
+    ContentArea --> ComparisonTable
+    ContentArea --> BundleDisplay
+```
+
+### Key Architectural Principle
+
+`ProductTargeting` is a **self-contained orchestrator**. It:
+- Owns the targeting boolean state (via internal `useTargetingMode` hook)
+- Owns the submit-with-context logic (appends `[ADDITIONAL CONTEXT: ...]` before calling parent `onSubmit`)
+- Provides `TargetingContext` to its content area children
+- Renders the toolbar UI (attach button, pills, clear, hints)
+- Manages the toggle/deduplication logic for adding/removing products
+- Auto-exits targeting on submit or when streaming starts
+
+Pages do NOT contain any targeting logic — they just render ProductTargeting and pass it the content area as a render prop or context consumer.
+
+## Components and Interfaces
+
+### File Structure
+
+```
+src/
+├── hooks/
+│   └── use-targeting-mode.ts              # Internal: boolean toggle + Escape listener
+├── context/
+│   └── targeting.tsx                      # TargetingContext type + Provider + useTargeting hook
+├── components/
+│   └── ProductTargeting/
+│       ├── ProductTargeting.tsx           # Self-contained orchestrator component
+│       └── ProductTargeting.module.css    # All targeting-related styles
+```
+
+### Component Interfaces
+
+```typescript
+// ProductTargeting.tsx — the only public API surface
+interface TargetedProduct {
+  id: string;
+  name: string;
+  thumbnail?: string;
+}
+
+interface ProductTargetingProps {
+  /** Current list of attached products (lifted state for persistence) */
+  products: TargetedProduct[];
+  /** Callback when the product list changes (add/remove/clear) */
+  onProductsChange: (products: TargetedProduct[]) => void;
+  /** Parent's submit handler — ProductTargeting wraps it to append context */
+  onSubmit: (prompt: string) => void;
+  /** Whether the backend is currently streaming (disables targeting) */
+  isStreaming: boolean;
+  /** Whether the PromptInput is disabled (passed through) */
+  disabled?: boolean;
+  /** PromptInput props forwarded through */
+  promptProps?: {
+    initialValue?: string;
+    clearOnSubmit?: boolean;
+    placeholder?: string;
+    suggestions?: SuggestionSection[];
+    onSuggestionSelect?: (item: SuggestionItem, sectionId: string) => void;
+  };
+  /** Content area that contains targetable product surfaces */
+  children: React.ReactNode;
+}
+```
+
+```typescript
+// targeting.tsx — React Context consumed by product surfaces
+interface TargetingContext {
+  isTargeting: boolean;
+  onProductTargeted: (productId: string, productName: string, productThumbnail?: string) => void;
+  selectedProductIds: Set<string>;
+}
+```
+
+```typescript
+// use-targeting-mode.ts — internal hook (not exported publicly)
+interface UseTargetingModeReturn {
+  isTargeting: boolean;
+  startTargeting: () => void;
+  stopTargeting: () => void;
+  toggleTargeting: () => void;
+}
+```
+
+### Design Decisions
+
+1. **Single propagation mechanism: React Context everywhere.** Both search and conversation views use `TargetingProvider` to propagate targeting state to product surfaces. This eliminates the need for `onProductTargeted`/`selectedProductIds` props on `ProductGrid` and `ProductCard`. All product components consume `useTargeting()` from context.
+
+2. **ProductTargeting owns submit-with-context logic.** The context-appending (`[ADDITIONAL CONTEXT: ...]`) happens inside `ProductTargeting` before calling the parent's `onSubmit`. Pages never see or construct the context format — they just pass their `onSubmit` to `ProductTargeting`.
+
+3. **ProductTargeting owns targeting state internally.** The `useTargetingMode` hook is used internally by `ProductTargeting` — not by the pages. The hook is not exported. Pages don't need to know whether targeting is active; they just render the component.
+
+4. **ProductTargeting auto-manages streaming interactions.** It receives `isStreaming` and internally handles: disabling the attach button, preventing pill removal, auto-exiting targeting mode. No `useEffect` needed in the pages.
+
+5. **Products state is lifted for persistence, not for logic.** AppShell holds `targetedProducts` state and passes it as `products`/`onProductsChange`. But all mutation logic (add, remove, toggle, clear) lives inside `ProductTargeting`. The parent only sees the final list.
+
+6. **No modifications to PromptInput.** ProductTargeting renders its own PromptInput internally (not as `children`). It controls focus detection via a ref on the compound container and handles dropdown positioning purely through CSS (`position: relative` on the container). No `externalPositioning` or `onFocusChange` props needed on PromptInput.
+
+7. **Deduplication uses `id` field uniformly.** The caller passes the product `id` (which may be `permanentid` from search or `ec_name` from A2UI). `ProductTargeting` deduplicates based on the `id` field of `TargetedProduct` — it doesn't care what the value represents.
+
+8. **Muting via CSS overlay pattern.** Instead of manually applying `.muted` to individual elements, the ProductTargeting container applies a `cursor: crosshair` class to a parent wrapper. Individual page elements that should be muted during targeting receive a shared `.muted` class — but this is applied by the page layout, not by ProductTargeting itself. ProductTargeting only controls its own UI and the targeting context. Muted elements include sidebar, pagination, and sort controls.
+
+9. **PromptInput rendered internally, not as children.** ProductTargeting renders the PromptInput as part of its own template, forwarding relevant props via `promptProps`. This gives it full control over the compound box layout (textarea + toolbar) without requiring PromptInput to know about external positioning. The `children` prop is used for the targetable content area that gets wrapped in `TargetingProvider`.
+
+10. **Navigation between views uses floating action buttons.** Instead of inline navigation buttons taking up layout space, each page renders a `position: fixed` circular icon button. In search mode it floats bottom-right (chat bubble icon → conversation). In conversation mode it floats top-right (list icon → search results). Both use semi-transparency with hover-to-opaque transitions.
+
+11. **No top navigation bar in conversation mode.** The conversation page uses the full height for the thread and prompt. Navigation back to search is handled by the floating button.
+
+12. **Reset feature removed.** There is no "Reset to landing" action. Users stay in the search/conversation flow.
+
+## Component Rendering Structure
+
+```tsx
+// SearchResultsPage:
+<div className={styles.searchLayout}>
+  <ProductTargeting
+    products={targetedProducts}
+    onProductsChange={onTargetedProductsChange}
+    onSubmit={onSubmit}
+    isStreaming={isStreaming}
+    promptProps={{ initialValue: query, suggestions, onSuggestionSelect }}
+  >
+    <SearchResultsPageContent ... />
+  </ProductTargeting>
+  <button className={styles.floatingBackButton} title="Back to conversation" ...>
+    {/* chat bubble SVG */}
+  </button>
+</div>
+
+// ConversationPage:
+<section className={styles.page}>
+  <div className={styles.promptAtBottom}>
+    <ProductTargeting
+      products={targetedProducts}
+      onProductsChange={onTargetedProductsChange}
+      onSubmit={onSubmit}
+      isStreaming={isStreaming}
+      promptProps={{ suggestions, onSuggestionSelect }}
+    >
+      <div className={styles.scrollContainer}>...</div>
+    </ProductTargeting>
+  </div>
+  {canGoBackToSearch && (
+    <button className={styles.floatingBackButton} title="Back to search results" ...>
+      {/* list SVG */}
+    </button>
+  )}
+</section>
+```
+
+```tsx
+// Internal rendering of ProductTargeting:
+<div className={styles.container}>
+  <div className={styles.promptArea}>
+    <PromptInput {...promptProps} onSubmit={handleSubmitWithContext} />
+    <div className={styles.toolbar}>
+      <button className={styles.attachButton} />
+      <span className={styles.separator} />
+      <span className={styles.pillsArea}>{/* pills, hint, done, clear */}</span>
+    </div>
+  </div>
+  <TargetingProvider value={targetingContextValue}>
+    <div className={isTargeting ? styles.targetingActive : ''}>
+      {children}
+    </div>
+  </TargetingProvider>
+</div>
+```
+
+When targeting is active, a "Done" button replaces the "Clear" button (right-aligned in the pills area) to provide an explicit exit action. If no products are selected yet, the Done button appears alongside the hint text.
+
+## Data Flow
+
+### Attaching a product
+
+```
+User activates targeting (clicks paperclip)
+  → ProductTargeting.toggleTargeting() → isTargeting = true
+  → TargetingContext updates → all product surfaces re-render as targetable
+
+User clicks product (any surface)
+  → Product component reads useTargeting()
+  → Calls targeting.onProductTargeted(id, name, thumbnail)
+  → ProductTargeting.handleProductTargeted()
+  → Checks if id already in products list
+    → If yes: removes it (toggle off)
+    → If no: adds it
+  → Calls onProductsChange(newList)
+  → AppShell state updates → ProductTargeting re-renders with new products
+  → Pill appears in toolbar, product highlighted in surface
+```
+
+### Submitting with context
+
+```
+User presses Enter in PromptInput
+  → PromptInput calls onSubmit(trimmedText)
+  → ProductTargeting.handleSubmitWithContext(prompt)
+  → if products.length > 0:
+      finalPrompt = `${prompt} [ADDITIONAL CONTEXT: ${names.join(', ')}]`
+    else:
+      finalPrompt = prompt
+  → Calls parent onSubmit(finalPrompt)
+  → Exits targeting mode
+  → Products remain (NOT cleared)
+```
+
+### Rendering in conversation history
+
+```
+Turn completes → UserPromptBubble receives turn.prompt
+  → parsePrompt(prompt) extracts text + product names via regex
+  → Renders: text + <hr> + "Products:" + <ul> of names
+```
+
+## Styling Strategy
+
+- **Compound box:** ProductTargeting's `.promptArea` div has `position: relative`. Textarea has no bottom radius; toolbar has no top border. Shared side borders create a unified container.
+- **Focus ring:** Detected via `:focus-within` on the `.promptArea` container — no JavaScript needed. Applies `box-shadow` to the container when any child (textarea, buttons) has focus.
+- **Targeting highlight on products:** `box-shadow: 0 0 0 2px var(--color-border-active)` on hover, persistent for selected. Uses `inset` for table cells.
+- **Carousel overflow fix:** Track gets `padding: 4px; margin: -4px` so box-shadows aren't clipped.
+- **Dropdown positioning:** Since `.promptArea` has `position: relative`, the `SuggestionsDropdown` (rendered inside PromptInput with `position: absolute; top: 100%`) naturally positions below the textarea. The toolbar sits between, but the dropdown's `z-index` places it above.
+- **Floating nav buttons:** `position: fixed`, circular (44px), `opacity: 0.7` default, `opacity: 1` on hover. Box-shadow for elevation. `z-index: 100`.
+- **Conversation layout:** Uses `column-reverse` on ProductTargeting container to place prompt at the bottom. A `border-bottom` on the scroll area section creates the visual separator.
+- **Prompt area sizing:** Container has `max-width: 560px`, `margin: 0 auto`. Textarea has `min-height: 44px`, `padding: 10px` (reduced from original 52px/14px). Icons vertically centered with `top: 50%; transform: translateY(-50%)`.
+- **Disabled state:** `.promptArea:has(textarea:disabled)` applies `opacity: 0.6` and secondary background to the entire compound box.
+- **Pill badge:** Gray circle (`var(--color-text-secondary)`), not red. Uses flexbox centering.
+- **Hint text:** Italic, uses `var(--color-text-muted)` for a paler appearance.
+- **Done button:** Right-aligned in toolbar during targeting. Light blue background with primary text color, transitions to filled primary on hover. Same positioning as Clear button.
+- **Tab order:** PromptInput clear/submit buttons get `tabIndex={-1}` when textarea is empty; Tab key immediately closes suggestions dropdown.
+
+Wait — this means the dropdown would appear between textarea and toolbar. To fix: the dropdown should position relative to the `.promptArea` container, not the textarea. This requires PromptInput to NOT have `position: relative` on its own wrapper. Since ProductTargeting renders PromptInput internally, it can control this via a CSS override:
+
+```css
+.promptArea :global(.promptWrapper) { position: static; }
+```
+
+Or simpler: ProductTargeting passes a `className` to PromptInput that overrides the wrapper positioning. This is an internal implementation detail — PromptInput's public API doesn't change.
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Product has no thumbnail | Grey placeholder square rendered in pill |
+| Product already in context (duplicate click) | Removed from context (toggle behavior) |
+| Streaming starts while targeting | Targeting auto-exits, attach button disabled |
+| No products attached on submit | Prompt submitted as-is, no suffix added |
+| User presses Escape outside targeting mode | No effect (listener only active when targeting) |
+| Product name contains comma | Still works — the regex captures everything between `[ADDITIONAL CONTEXT:` and `]`, then splits by `,`. Product names with commas would be incorrectly split. This is a known limitation of the string format. |
+
+## Testing Strategy
+
+| Component / Utility | Key assertions |
+|---------------------|----------------|
+| ProductTargeting | Renders toolbar with attach button; toggling shows hint text; clicking products adds pills; clear removes all; submit appends context; auto-exits on streaming |
+| useTargeting() in product surfaces | Returns null outside provider; returns context values inside provider; clicking calls onProductTargeted |
+| UserPromptBubble | Parses context suffix correctly; renders product list; handles no-context prompts; handles empty product list |
+| useTargetingMode (internal) | Toggle works; Escape exits; does not exit when not active |

--- a/samples/thermidor/demo-react/.kiro/specs/product-context-attachment/requirements.md
+++ b/samples/thermidor/demo-react/.kiro/specs/product-context-attachment/requirements.md
@@ -1,0 +1,124 @@
+# Requirements Document
+
+## Introduction
+
+The Product Context Attachment feature allows users to attach products as contextual information to their prompts in the `demo-react` application. This enables the conversational backend to consider specific products when generating responses. The feature is available in both the Search Results and Conversation views (but NOT on the Landing Page), and uses a "targeting mode" interaction pattern where users click products in the UI to attach them to their next prompt. The Landing Page PromptInput renders without the ProductTargeting wrapper and has no attachment capability.
+
+## Glossary
+
+- **Product Context Attachment**: The mechanism by which a user selects one or more products from the UI and attaches them to their prompt as additional context for the backend.
+- **Targeting Mode**: An interactive state where the page cursor changes to a crosshair and product elements become clickable for selection. Activated by clicking the attach button.
+- **Attach Button**: A paperclip icon button in the toolbar below the prompt input that toggles targeting mode on/off.
+- **Context Pill**: A small product thumbnail displayed in the toolbar area representing an attached product. Clickable to remove.
+- **Toolbar**: The always-visible area below the prompt textarea that contains the attach button, context pills, hint text, and clear button.
+- **ProductTargeting Component**: The compound component that wraps the PromptInput and provides the toolbar, targeting controls, and context pill management.
+- **TargetingContext**: A React context that propagates targeting state to all nested A2UI product surfaces (carousels, comparison tables, bundle displays).
+- **Floating Navigation Button**: A circular icon button with `position: fixed` used to navigate between search results and conversation views without occupying persistent layout space.
+
+## Requirements
+
+### Requirement 1: Toolbar and Attach Button
+
+**User Story:** As a user, I want a persistent toolbar below the prompt input with an attach button, so that I can discover and activate product attachment at any time.
+
+#### Acceptance Criteria
+
+1. THE toolbar SHALL always be rendered below the prompt textarea, forming a visually connected compound box (shared side borders, no bottom radius on textarea, no top border on toolbar).
+2. THE toolbar SHALL contain a paperclip icon button on the left side that toggles targeting mode.
+3. WHEN targeting mode is inactive and no products are attached, THE toolbar SHALL display the text "Attach product context" in italic, muted color (paler than secondary text) next to the attach button as a discoverable hint.
+4. WHEN targeting mode is active and no products are attached yet, THE toolbar SHALL display the text "Select products to attach" in italic, muted color (paler than secondary text) next to the attach button.
+5. THE attach button SHALL be visually highlighted (blue background/border) when targeting mode is active, using the same paperclip icon with a slightly bolder stroke weight.
+6. THE attach button SHALL be disabled (greyed out, non-interactive) while the ConverseController is streaming.
+7. THE toolbar SHALL have a consistent minimum height (42px) to prevent layout shift when content changes between hint text, pills, or empty state.
+8. A thin vertical separator line SHALL visually separate the attach button from the hint text / context pills area.
+9. THE attach button SHALL be the next tabbable element after the textarea WHEN the textarea is empty (clear and submit buttons are removed from tab order when empty).
+
+### Requirement 2: Product Selection via Targeting Mode
+
+**User Story:** As a user, I want to click products in the page to attach them as context, so that I can reference specific products in my prompt.
+
+#### Acceptance Criteria
+
+1. WHEN targeting mode is active, THE page cursor SHALL change to a crosshair cursor across the entire page content area.
+2. WHEN targeting mode is active, ALL product elements (ProductCards in search grid, A2UIProductCards in carousels, product header cells in comparison tables, item rows in bundle displays) SHALL become clickable with a blue box-shadow highlight on hover.
+3. WHEN the user clicks a product in targeting mode, THE product SHALL be added to the attached context (appearing as a thumbnail pill in the toolbar) and remain highlighted in the product list with a persistent blue ring and reduced opacity.
+4. WHEN the user clicks an already-selected product in targeting mode, THE product SHALL be removed from the attached context (toggle behavior).
+5. Targeting mode SHALL remain active after selecting a product, allowing multiple products to be selected without re-activating the mode.
+6. THE user SHALL be able to exit targeting mode by: clicking the attach button again, pressing the Escape key, clicking the "Done" button in the toolbar, or when a prompt is submitted.
+7. WHILE targeting mode is active, ALL non-product interactive elements (sidebar, pagination, sort controls) SHALL be visually muted (reduced opacity) and non-interactive (pointer-events disabled).
+8. Targeting mode SHALL be automatically exited when streaming begins.
+9. WHEN targeting mode is active, A "Done" button SHALL appear right-aligned in the toolbar to provide an explicit way to complete product selection.
+
+### Requirement 3: Context Pills Display
+
+**User Story:** As a user, I want to see which products I've attached as thumbnails below the input, so that I can review and manage my context before submitting.
+
+#### Acceptance Criteria
+
+1. WHEN products are attached, THE toolbar SHALL display small thumbnail images (28x28px) for each attached product, positioned to the right of the vertical separator.
+2. IF a product has no thumbnail image available, THE pill SHALL render a grey placeholder square of the same dimensions.
+3. WHEN the user hovers over a context pill, THE thumbnail SHALL fade slightly and a small x badge SHALL appear at the top-right corner of the pill as a gray circle (not red).
+4. WHEN the user clicks a context pill (outside of streaming), THE corresponding product SHALL be removed from the attached context.
+5. Context pills SHALL be keyboard-accessible: focusable via Tab, removable via Enter or Space key.
+6. EACH pill SHALL have a title tooltip showing the product name and "click to remove" instruction.
+7. WHILE streaming is active, context pills SHALL NOT be removable (pointer-events disabled, not focusable).
+8. THE toolbar SHALL have `overflow: visible` to allow pill badges to overflow without clipping.
+
+### Requirement 4: Clear All Action
+
+**User Story:** As a user, I want to clear all attached products at once, so that I can start fresh without removing them one by one.
+
+#### Acceptance Criteria
+
+1. WHEN products are attached AND targeting mode is NOT active, A "Clear" button SHALL appear right-aligned in the toolbar area.
+2. THE "Clear" button SHALL be hidden while targeting mode is active (to avoid confusion during selection).
+3. WHEN the user clicks "Clear", ALL attached products SHALL be removed from the context.
+4. THE "Clear" button SHALL highlight blue on hover (matching the attach button style).
+5. THE "Clear" button SHALL be disabled while streaming.
+
+### Requirement 5: Prompt Submission with Context
+
+**User Story:** As a user, I want my attached products to be included when I submit a prompt, so that the backend can use them for a better response.
+
+#### Acceptance Criteria
+
+1. WHEN the user submits a prompt with attached products, THE submitted prompt text SHALL be: `<user text> [ADDITIONAL CONTEXT: <product_name_1>, <product_name_2>, ...]` where product names are the `ec_name` field values joined by commas.
+2. WHEN the user submits a prompt without attached products, THE prompt SHALL be submitted as-is without any suffix.
+3. AFTER submission, targeting mode SHALL be exited.
+4. AFTER submission, THE attached products SHALL remain visible in the toolbar (not cleared), allowing the user to reuse the same context for follow-up prompts.
+5. THE `[ADDITIONAL CONTEXT: ...]` annotation SHALL NOT be visible in the textarea — it is only appended at submit time.
+6. A product that is already present in the attached list SHALL NOT be added again when clicked in targeting mode (duplicate prevention).
+
+### Requirement 6: Context Persistence Across Views
+
+**User Story:** As a user, I want my attached products to persist when switching between search and conversation views, so that I don't lose my context selections.
+
+#### Acceptance Criteria
+
+1. THE attached products state SHALL be managed at the AppShell level and passed to both SearchResultsPage and ConversationPage.
+2. WHEN navigating from search to conversation (or vice versa), THE attached products SHALL be preserved.
+3. WHEN navigating between search and conversation views via the floating navigation buttons, THE prompt text SHALL be cleared but attached products SHALL remain.
+
+### Requirement 7: Context Display in Conversation History
+
+**User Story:** As a user, I want to see which products were attached to my previous prompts in the conversation thread, so that I can understand the context of past turns.
+
+#### Acceptance Criteria
+
+1. WHEN a user prompt bubble in the conversation thread contains the `[ADDITIONAL CONTEXT: ...]` suffix, THE bubble SHALL render the user's text without the suffix, followed by a horizontal separator and a "Products:" section listing the product names as a bulleted list.
+2. THE raw `[ADDITIONAL CONTEXT: ...]` text SHALL NOT be displayed to the user in the conversation thread.
+3. THE product list in the bubble SHALL use a smaller font size and secondary text color to visually distinguish it from the prompt text.
+
+### Requirement 8: View Navigation
+
+**User Story:** As a user, I want to quickly navigate between search results and conversation views without the navigation taking up persistent layout space.
+
+#### Acceptance Criteria
+
+1. IN search results mode, A floating circular icon button with a speech bubble icon SHALL be fixed at the bottom-right of the viewport (24px margins) to navigate back to conversation.
+2. IN conversation mode, A floating circular icon button with a list icon SHALL be fixed at the top-right of the viewport (24px margins) to navigate back to search results.
+3. THE floating buttons SHALL be semi-transparent (opacity ~0.7) by default and become fully opaque on hover.
+4. THE floating buttons SHALL have a subtle box-shadow for visibility against content.
+5. THE floating buttons SHALL have `title` tooltips ("Back to conversation" / "Back to search results").
+6. IN conversation mode, THE floating back-to-search button SHALL only be visible when there are search results to return to (`canGoBackToSearch` is true).
+7. THE conversation page SHALL NOT have a top navigation bar — the full viewport height is used for the conversation thread and prompt.

--- a/samples/thermidor/demo-react/.kiro/specs/search-results-page/design.md
+++ b/samples/thermidor/demo-react/.kiro/specs/search-results-page/design.md
@@ -2,25 +2,26 @@
 
 ## Overview
 
-The Search Results Page is the primary product-browsing view in the `demo-react` Thermidor sample application. It uses a 12-column proportional CSS Grid layout (1fr 2fr 8fr 1fr with 24px gap) — empty gutters on left/right, a facet sidebar, and a main content area — built on top of Thermidor's `ProductListController`, `PaginationController`, and `SearchBoxController`. The header spans the full width with a centered PromptInput at 1/3 width. The page receives a persisted `RoutedInterface` from the `AppShell` parent, builds controllers once per mount via the existing `useBuildController` hook, and remounts cleanly when the interface identity changes (via React key strategy).
+The Search Results Page is the primary product-browsing view in the `demo-react` Thermidor sample application. It uses a 12-column proportional CSS Grid layout (1fr 2fr 8fr 1fr with 24px gap) — empty gutters on left/right, a facet sidebar, and a main content area — built on top of Thermidor's `ProductListController` and `PaginationController`. The header spans the full width with a centered PromptInput (max-width: 560px). The page receives a persisted `RoutedInterface` and the associated `query` from the `AppShell` parent, builds controllers once per mount via the existing `useBuildController` hook, and remounts cleanly when the interface identity changes (via React key strategy).
 
 Key design goals:
 - Reuse existing infrastructure (`PromptInput`, `useSuggestions`, `useBuildController`, toast mechanism)
 - Keep presentational components pure and testable in isolation
 - Extract the pagination windowing algorithm as a pure utility for easy unit testing
 - Use CSS Modules with the project's design tokens for consistent styling
+- Responsive layout aligned with `@coveo/atomic` breakpoints (sm: 640px, md: 768px, lg: 1024px, xl: 1280px)
 
 ## Architecture
 
 ```mermaid
 graph TD
-    AppShell -->|"routedInterface, key={id}"| SearchResultsPage
+    AppShell -->|"routedInterface, query, key={id}"| SearchResultsPage
     SearchResultsPage -->|useBuildController| ProductListController
     SearchResultsPage -->|useBuildController| PaginationController
-    SearchResultsPage -->|useBuildController| SearchBoxController
     SearchResultsPage --> Header[Header Region]
     SearchResultsPage --> Sidebar[Sidebar Region]
     SearchResultsPage --> MainContent[Main Content Region]
+    Header --> BackToConversation[Back to conversation button]
     Header --> PromptInput
     Sidebar --> FacetPlaceholder["Facets (coming soon)"]
     MainContent --> TopRow[Top Row]
@@ -28,14 +29,16 @@ graph TD
     MainContent --> Pagination
     MainContent --> PageSizeSelector
     TopRow --> QuerySummaryPlaceholder
-    TopRow --> SortPlaceholder
+    TopRow --> SortPlaceholder["SortPlaceholder (desktop)"]
+    TopRow --> SortFiltersButton["Sort & Filters button (mobile)"]
+    SearchResultsPage --> SortFiltersModal["SortFiltersModal (dialog)"]
     ProductGrid --> ProductCard
 ```
 
 ### Mounting & Lifecycle
 
 1. `AppShell` renders `<SearchResultsPage key={routedInterface.interface.id} ... />` so that when the routed interface identity changes, React unmounts and remounts the entire page, discarding stale controller subscriptions.
-2. Inside `SearchResultsPage`, three `useBuildController` calls (one per controller) run their factory exactly once per mount (guarded by `useRef` inside the hook).
+2. Inside `SearchResultsPage`, two `useBuildController` calls (one for `ProductListController`, one for `PaginationController`) run their factory exactly once per mount (guarded by `useRef` inside the hook). The current search query is provided via the `query` prop from `AppShell` (sourced from `turn.prompt`).
 3. On unmount, `SearchResultsPage` does **not** dispose the interface — `AppShell` retains ownership for navigation-back scenarios.
 
 > **Tradeoff note:** The full unmount/remount strategy (via React key) is suboptimal — ideally only components whose data changed would re-render. However, this is currently unavoidable because `useBuildController` binds a controller to a specific interface instance via `useRef`, and Thermidor produces a new interface object on each routed turn rather than mutating the existing one. A future optimization would be for Thermidor to support re-binding a controller to a new interface (or providing a stable mutable handle), which would allow in-place updates without remounting. In practice, the remount cost is low since the new interface arrives pre-hydrated with data from the snapshot.
@@ -71,6 +74,9 @@ src/components/
 │   │   ├── SortPlaceholder.tsx
 │   │   ├── SortPlaceholder.module.css
 │   │   └── SortPlaceholder.test.tsx
+│   ├── SortFiltersModal/
+│   │   ├── SortFiltersModal.tsx
+│   │   └── SortFiltersModal.module.css
 │   └── PageSizeSelector/
 │       ├── PageSizeSelector.tsx
 │       ├── PageSizeSelector.module.css
@@ -85,11 +91,13 @@ interface SearchResultsPageProps {
   onSubmit: (prompt: string) => void;
   isStreaming: boolean;
   routedInterface: RoutedInterface;
+  query?: string;
+  onBackToConversation: () => void;
 }
 
 // ProductCard.tsx
 interface ProductCardProps {
-  product: Product;
+  product: Product; // imported from @coveo/thermidor
 }
 
 // ProductGrid.tsx
@@ -116,6 +124,13 @@ interface SortPlaceholderProps {
   onToast: () => void;
 }
 
+// SortFiltersModal.tsx
+interface SortFiltersModalProps {
+  open: boolean;
+  onClose: () => void;
+  onToast: () => void;
+}
+
 // PageSizeSelector.tsx
 interface PageSizeSelectorProps {
   controller: PaginationController;
@@ -124,17 +139,23 @@ interface PageSizeSelectorProps {
 
 ### Design Decisions
 
-1. **Components tightly coupled to a single controller receive the controller directly.** `ProductGrid` receives `ProductListController` and `Pagination` receives `PaginationController`. This reduces prop-threading and colocates the subscription logic with the component that renders it. Components that combine data from multiple controllers (`QuerySummaryPlaceholder` — SearchBox query + Pagination totalCount) or are leaf presentational nodes rendered in a list (`ProductCard`) still receive plain props.
+1. **Components tightly coupled to a single controller receive the controller directly.** `ProductGrid` receives `ProductListController` and `Pagination` receives `PaginationController`. This reduces prop-threading and colocates the subscription logic with the component that renders it. Components that combine data from multiple sources (`QuerySummaryPlaceholder` — query prop + Pagination totalCount) or are leaf presentational nodes rendered in a list (`ProductCard`) still receive plain props.
 
-2. **Controller-passing is the intended pattern for all future components.** When Thermidor adds controllers for facets, sort, and query summary, the current placeholders (FacetPlaceholder, SortPlaceholder, QuerySummaryPlaceholder) will be replaced with real components that receive their respective controller directly — the same pattern used by `ProductGrid` and `Pagination`. The placeholder components are temporary stand-ins designed to be swapped with minimal refactoring.
+2. **The query is provided via props, not a SearchBoxController.** The current search query is available from `turn.prompt` on the parent `AppShell`. There is no need to build a `SearchBoxController` on the routed interface just to read the query string. This simplifies the component and removes an unnecessary controller dependency.
 
-3. **Pagination receives the `PaginationController` directly** and calls `controller.selectPage(page)` internally. This colocates the navigation logic and avoids prop-threading through the parent. The `pagination-utils.ts` module remains a pure function for testability of the windowing algorithm.
+3. **Controller-passing is the intended pattern for all future components.** When Thermidor adds controllers for facets, sort, and query summary, the current placeholders (FacetPlaceholder, SortPlaceholder, QuerySummaryPlaceholder) will be replaced with real components that receive their respective controller directly — the same pattern used by `ProductGrid` and `Pagination`. The placeholder components are temporary stand-ins designed to be swapped with minimal refactoring.
 
-4. **`pagination-utils.ts` exports a pure `computeVisiblePages` function** that takes `(currentPage, totalPages)` and returns an array of page numbers or ellipsis sentinels. This enables straightforward unit testing of the windowing algorithm without DOM rendering.
+4. **Pagination receives the `PaginationController` directly** and calls `controller.selectPage(page)` internally. This colocates the navigation logic and avoids prop-threading through the parent. The `pagination-utils.ts` module remains a pure function for testability of the windowing algorithm.
 
-5. **Toast mechanism is lifted to `SearchResultsPage`** and shared between `SortPlaceholder` and suggestion actions, reusing the existing `useState`/`useRef` timer pattern already in the current codebase.
+5. **`pagination-utils.ts` exports a pure `computeVisiblePages` function** that takes `(currentPage, totalPages)` and returns an array of page numbers or ellipsis sentinels. This enables straightforward unit testing of the windowing algorithm without DOM rendering.
 
-6. **RoutedInterface null guard:** If `routedInterface` is unexpectedly null/undefined, the component returns `null` early without building controllers. In practice, `AppShell` only renders `SearchResultsPage` when the ref is non-null, but the guard provides defense-in-depth.
+6. **Toast mechanism is lifted to `SearchResultsPage`** and shared between `SortPlaceholder`, `SortFiltersModal`, and suggestion actions, reusing the existing `useState`/`useRef` timer pattern.
+
+7. **RoutedInterface null guard:** If `routedInterface` is unexpectedly null/undefined, the component returns `null` early without building controllers.
+
+8. **Responsive layout uses `@coveo/atomic` breakpoints.** The desktop/mobile split occurs at lg (1024px). Below this breakpoint: sidebar is hidden, layout collapses to single column, inline SortPlaceholder is replaced by a "Sort & Filters" pill button that opens a `<dialog>`-based modal, pagination and page-size controls are centered, and the "Back to conversation" button wraps below the search box.
+
+9. **SortFiltersModal uses native `<dialog>`** for accessibility (built-in focus trap, Escape key, backdrop). The modal has a fixed footer with "View results" that's always visible, and a scrollable content area with Sort and Filters sections.
 
 ### PageSizeSelector Design Notes
 
@@ -236,7 +257,7 @@ function truncate(text: string, maxLen: number): string {
 
 | Component / Utility | Key assertions |
 |---------------------|----------------|
-| SearchResultsPage | Renders header with PromptInput, sidebar, main content; builds all 3 controllers via mock interface; returns null when routedInterface is null |
+| SearchResultsPage | Renders header with PromptInput, sidebar, main content; builds controllers via mock interface; returns null when routedInterface is null |
 | ProductCard | Renders name, brand, price; shows placeholder when no image; shows promo price correctly; displays title attribute with full product name |
 | ProductGrid | Renders correct number of cards; shows empty state message |
 | Pagination | Renders nothing when totalPages <= 1; calls onSelectPage with correct args; disables previous-page on first page; disables next-page on last page; enables both when in middle; uses chevron icons for navigation |

--- a/samples/thermidor/demo-react/.kiro/specs/search-results-page/requirements.md
+++ b/samples/thermidor/demo-react/.kiro/specs/search-results-page/requirements.md
@@ -10,12 +10,12 @@ The Search Results Page is the primary view for displaying product search result
 - **RoutedInterface**: A union type (`{ useCase: 'commerceSearch'; interface: CommerceInterface } | { useCase: 'search'; interface: SearchInterface }`) representing the interface created by the backend in response to a routed search query.
 - **ProductListController**: A Thermidor controller built with `buildProductListController({interface})` that exposes a `products: Product[]` array from the search response.
 - **PaginationController**: A Thermidor controller built with `buildPaginationController({interface})` that exposes page state (`page`, `pageSize`, `totalCount`, `totalPages`) and methods (`selectPage`, `setPageSize`).
+- **SearchBoxController**: A Thermidor controller built with `buildSearchBoxController({interface})` that exposes the current `query` and provides `setQuery`/`submit` methods.
 - **ProductCard**: A presentational component that renders a single product's image, name, brand, and price.
 - **ProductGrid**: A layout component that arranges ProductCard instances in a responsive CSS grid.
 - **Pagination**: A navigation component that renders page controls (previous, next, page numbers) based on PaginationController state.
 - **QuerySummaryPlaceholder**: A temporary component displaying the current query and result count, implemented without a dedicated controller since no QuerySummaryController exists in Thermidor yet.
 - **SortPlaceholder**: A non-functional dropdown element displaying a sort option label (e.g., "Sort by: Relevance"), positioned at the top-right of the product list area. It serves as a visual placeholder until a sort controller is available in Thermidor.
-- **SortFiltersModal**: A full-screen `<dialog>`-based modal shown on mobile (below lg breakpoint) that combines the Sort and Filters sections with a fixed "View results" button. Replaces the inline SortPlaceholder on narrow viewports.
 - **AppShell**: The parent component that manages the persisted RoutedInterface ref and passes it to SearchResultsPage.
 - **useBuildController**: A React hook that instantiates a Thermidor controller once (via `useRef`) and subscribes to its state via `useSyncExternalStore`.
 - **PageSizeSelector**: A dropdown control positioned adjacent to the Pagination component that allows users to change the number of products displayed per page by calling `paginationController.setPageSize(size)`.
@@ -28,7 +28,7 @@ The Search Results Page is the primary view for displaying product search result
 
 #### Acceptance Criteria
 
-1. WHEN the SearchResultsPage renders, THE SearchResultsPage SHALL display a header bar containing a "Back to conversation" navigation button and a PromptInput component (the same component used on the landing page) configured without suggestion pills and with a single-row text area. The PromptInput SHALL have a maximum width of 560px and be horizontally centered within the header. On viewports below the xl breakpoint (1280px), the back button SHALL wrap above the PromptInput. On xl+ viewports, the back button SHALL be absolutely positioned to the left of the centered input. The header SHALL NOT contain a logo element.
+1. WHEN the SearchResultsPage renders, THE SearchResultsPage SHALL display a header bar containing only a PromptInput component (the same component used on the landing page) configured without suggestion pills and with a single-row text area. The PromptInput SHALL occupy one third of the total available width and be horizontally centered within the header. The header SHALL NOT contain a logo element.
 2. WHEN the SearchResultsPage renders, THE SearchResultsPage SHALL display a sidebar region positioned to the left of the main content area, containing the visible text "Facets (coming soon)".
 3. WHEN the SearchResultsPage renders, THE SearchResultsPage SHALL display a main content area with the following top-to-bottom layout: a top row containing the QuerySummaryPlaceholder positioned at the left and the SortPlaceholder positioned at the right, followed by the ProductGrid component, followed by a bottom row with the Pagination aligned to the left and the PageSizeSelector aligned to the right.
 4. THE SearchResultsPage SHALL use a 12-column proportional grid layout with a 24px column gap: 1/12 empty left gutter, 2/12 facet sidebar, 8/12 main content, 1/12 empty right gutter. The header spans the full width above all columns.
@@ -45,9 +45,9 @@ The Search Results Page is the primary view for displaying product search result
 3. THE ProductCard SHALL display the product image sourced from `ec_thumbnails[0]` (falling back to `ec_images[0]` if `ec_thumbnails` is empty or undefined), `ec_name`, `ec_brand`, and `ec_price` formatted as a currency value.
 4. IF a product has neither `ec_thumbnails[0]` nor `ec_images[0]` available, THEN THE ProductCard SHALL render a placeholder image element of the same dimensions as a product image.
 5. WHEN a product has an `ec_promo_price` that is both defined and numerically less than `ec_price`, THE ProductCard SHALL display the original `ec_price` with a visible strikethrough style and the `ec_promo_price` as the current price.
-6. THE ProductGrid SHALL arrange ProductCard instances in a responsive CSS grid layout: 1 column by default, 2 columns at the sm breakpoint (640px), 3 columns at the md breakpoint (768px), and 4 columns at the xl breakpoint (1280px).
+6. THE ProductGrid SHALL arrange ProductCard instances in a responsive CSS grid layout that displays a minimum of 1 column on viewports narrower than 600px and a maximum of 4 columns on viewports 1200px or wider.
 7. IF `ec_name` text exceeds 2 lines within the ProductCard layout, THEN THE ProductCard SHALL truncate the text with an ellipsis and expose the full name via a `title` attribute.
-8. THE ProductCard SHALL display a subtle elevation effect (box-shadow and border color change) on hover to indicate visual feedback, but SHALL NOT display a pointer cursor since the card is not currently interactive (no click handler or link).
+8. THE ProductCard SHALL display a pointer cursor on hover to indicate interactivity.
 
 ### Requirement 3: Pagination Controls
 
@@ -73,7 +73,7 @@ The Search Results Page is the primary view for displaying product search result
 
 1. WHEN the SearchResultsPage mounts with a RoutedInterface, THE SearchResultsPage SHALL call `buildProductListController({interface: routedInterface.interface})` via the `useBuildController` hook and render product data from the resulting controller state.
 2. WHEN the SearchResultsPage mounts with a RoutedInterface, THE SearchResultsPage SHALL call `buildPaginationController({interface: routedInterface.interface})` via the `useBuildController` hook and render pagination controls from the resulting controller state.
-3. WHEN the SearchResultsPage mounts, THE SearchResultsPage SHALL pre-fill the header PromptInput with the `query` prop provided by AppShell (sourced from `turn.prompt`). No `SearchBoxController` is built — the query is passed directly as a prop.
+3. WHEN the SearchResultsPage mounts with a RoutedInterface, THE SearchResultsPage SHALL call `buildSearchBoxController({interface: routedInterface.interface})` via the `useBuildController` hook and pre-fill the header input with the current query from the controller state.
 4. THE SearchResultsPage SHALL use the `useBuildController` hook to instantiate each controller exactly once per mount, relying on the hook's internal `useRef` to prevent duplicate factory invocations on re-renders.
 5. WHEN the RoutedInterface changes identity (a new routed turn produces a new interface), THE AppShell SHALL call `dispose()` on the previous interface, store the new RoutedInterface in its ref, and cause the SearchResultsPage to remount with fresh controllers by changing the React key.
 6. IF the RoutedInterface provided to SearchResultsPage is `null` or `undefined` at mount time, THEN THE SearchResultsPage SHALL NOT call any controller build functions and SHALL render nothing (return `null`).
@@ -112,7 +112,7 @@ The Search Results Page is the primary view for displaying product search result
 
 1. WHEN the SearchResultsPage renders, THE SearchResultsPage SHALL display a sidebar area on the left side of the content region with a visible boundary and the text "Facets (coming soon)".
 2. THE sidebar placeholder SHALL occupy a proportional width of 2/12 of the available page width (as defined by the page grid) and SHALL NOT cause the main content area to shift or resize when present.
-3. WHEN the viewport width is below the lg breakpoint (1024px), THE sidebar placeholder SHALL be hidden to preserve content area usability.
+3. WHEN the viewport width is below 768px, THE sidebar placeholder SHALL be hidden to preserve content area usability.
 4. THE sidebar placeholder SHALL be non-interactive — it SHALL NOT respond to click, focus, or other user input events.
 
 ### Requirement 8: Sort Placeholder
@@ -125,7 +125,6 @@ The Search Results Page is the primary view for displaying product search result
 2. WHEN the user clicks the SortPlaceholder select, THE SortPlaceholder SHALL display a toast notification with the text "Not supported yet" that auto-dismisses after 3 seconds.
 3. THE SortPlaceholder SHALL use a native `<select>` element (matching the PageSizeSelector pattern) with 8px padding. The bold "Sort by:" label SHALL be outside the select, to its left, with 8px gap.
 4. THE SortPlaceholder SHALL NOT trigger any controller actions or modify application state beyond displaying the toast notification.
-5. WHEN the viewport width is below the lg breakpoint (1024px), THE inline SortPlaceholder SHALL be hidden and replaced by a "Sort & Filters" pill button that opens the SortFiltersModal.
 
 ### Requirement 9: Page Size Selector
 
@@ -140,17 +139,3 @@ The Search Results Page is the primary view for displaying product search result
 5. THE PageSizeSelector SHALL be positioned to the right of the Pagination component, within the same horizontal row at the bottom of the main content area.
 6. THE PageSizeSelector SHALL include a visible bold label "Products per page:" associated with the select element via an HTML `<label>` element for accessibility.
 7. THE PageSizeSelector SHALL receive the `PaginationController` directly as a prop, following the same controller-passing pattern used by the Pagination and ProductGrid components.
-
-### Requirement 10: Sort & Filters Modal (Mobile)
-
-**User Story:** As a mobile user, I want to access sort and filter controls through a full-screen modal, so that I can refine results without the inline controls taking up too much screen space.
-
-#### Acceptance Criteria
-
-1. WHEN the viewport width is below the lg breakpoint (1024px), THE SearchResultsPage SHALL display a "Sort & Filters" pill button in the top row (replacing the inline SortPlaceholder).
-2. WHEN the user clicks the "Sort & Filters" button, THE SearchResultsPage SHALL open a full-screen modal dialog using the native `<dialog>` element with `showModal()`.
-3. THE SortFiltersModal SHALL contain a header with the title "Sort & Filters" and a close button (×) in the top-right corner.
-4. THE SortFiltersModal SHALL contain a scrollable content area with two sections: "Sort" (containing the SortPlaceholder component) and "Filters" (containing a "Filters coming soon" placeholder message).
-5. THE SortFiltersModal SHALL contain a fixed footer (outside the scrollable area, always visible) with a full-width "View results" button.
-6. WHEN the user clicks the close button, presses Escape, or clicks "View results", THE SortFiltersModal SHALL close and return focus to the triggering element.
-7. THE SortFiltersModal SHALL have an `aria-label` of "Sort and filters" for screen reader accessibility.

--- a/samples/thermidor/demo-react/.kiro/specs/search-results-page/requirements.md
+++ b/samples/thermidor/demo-react/.kiro/specs/search-results-page/requirements.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The Search Results Page is the primary view for displaying product search results in the `demo-react` Thermidor sample application. When the backend routes a user prompt as a commerce search or search query (via `ConverseController`), the app transitions to this page. It presents a three-column layout with a compact header (PromptInput only), a sidebar placeholder for future facets, and a main content area with a product grid and pagination controls. The page uses the persisted `RoutedInterface` from the AppShell to build `ProductListController` and `PaginationController` instances.
+The Search Results Page is the primary view for displaying product search results in the `demo-react` Thermidor sample application. When the backend routes a user prompt as a commerce search or search query (via `ConverseController`), the app transitions to this page. It presents a three-column layout (on desktop) with a compact header (PromptInput + back navigation), a sidebar placeholder for future facets, and a main content area with a product grid and pagination controls. On mobile (below the lg breakpoint of 1024px), the layout collapses to a single column with a modal for sort/filter controls. The page uses the persisted `RoutedInterface` from the AppShell to build `ProductListController` and `PaginationController` instances, and receives the current query via props.
 
 ## Glossary
 
@@ -10,12 +10,12 @@ The Search Results Page is the primary view for displaying product search result
 - **RoutedInterface**: A union type (`{ useCase: 'commerceSearch'; interface: CommerceInterface } | { useCase: 'search'; interface: SearchInterface }`) representing the interface created by the backend in response to a routed search query.
 - **ProductListController**: A Thermidor controller built with `buildProductListController({interface})` that exposes a `products: Product[]` array from the search response.
 - **PaginationController**: A Thermidor controller built with `buildPaginationController({interface})` that exposes page state (`page`, `pageSize`, `totalCount`, `totalPages`) and methods (`selectPage`, `setPageSize`).
-- **SearchBoxController**: A Thermidor controller built with `buildSearchBoxController({interface})` that exposes the current `query` and provides `setQuery`/`submit` methods.
 - **ProductCard**: A presentational component that renders a single product's image, name, brand, and price.
 - **ProductGrid**: A layout component that arranges ProductCard instances in a responsive CSS grid.
 - **Pagination**: A navigation component that renders page controls (previous, next, page numbers) based on PaginationController state.
 - **QuerySummaryPlaceholder**: A temporary component displaying the current query and result count, implemented without a dedicated controller since no QuerySummaryController exists in Thermidor yet.
 - **SortPlaceholder**: A non-functional dropdown element displaying a sort option label (e.g., "Sort by: Relevance"), positioned at the top-right of the product list area. It serves as a visual placeholder until a sort controller is available in Thermidor.
+- **SortFiltersModal**: A full-screen `<dialog>`-based modal shown on mobile (below lg breakpoint) that combines the Sort and Filters sections with a fixed "View results" button. Replaces the inline SortPlaceholder on narrow viewports.
 - **AppShell**: The parent component that manages the persisted RoutedInterface ref and passes it to SearchResultsPage.
 - **useBuildController**: A React hook that instantiates a Thermidor controller once (via `useRef`) and subscribes to its state via `useSyncExternalStore`.
 - **PageSizeSelector**: A dropdown control positioned adjacent to the Pagination component that allows users to change the number of products displayed per page by calling `paginationController.setPageSize(size)`.
@@ -28,7 +28,7 @@ The Search Results Page is the primary view for displaying product search result
 
 #### Acceptance Criteria
 
-1. WHEN the SearchResultsPage renders, THE SearchResultsPage SHALL display a header bar containing only a PromptInput component (the same component used on the landing page) configured without suggestion pills and with a single-row text area. The PromptInput SHALL occupy one third of the total available width and be horizontally centered within the header. The header SHALL NOT contain a logo element.
+1. WHEN the SearchResultsPage renders, THE SearchResultsPage SHALL display a header bar containing a "Back to conversation" navigation button and a PromptInput component (the same component used on the landing page) configured without suggestion pills and with a single-row text area. The PromptInput SHALL have a maximum width of 560px and be horizontally centered within the header. On viewports below the xl breakpoint (1280px), the back button SHALL wrap above the PromptInput. On xl+ viewports, the back button SHALL be absolutely positioned to the left of the centered input. The header SHALL NOT contain a logo element.
 2. WHEN the SearchResultsPage renders, THE SearchResultsPage SHALL display a sidebar region positioned to the left of the main content area, containing the visible text "Facets (coming soon)".
 3. WHEN the SearchResultsPage renders, THE SearchResultsPage SHALL display a main content area with the following top-to-bottom layout: a top row containing the QuerySummaryPlaceholder positioned at the left and the SortPlaceholder positioned at the right, followed by the ProductGrid component, followed by a bottom row with the Pagination aligned to the left and the PageSizeSelector aligned to the right.
 4. THE SearchResultsPage SHALL use a 12-column proportional grid layout with a 24px column gap: 1/12 empty left gutter, 2/12 facet sidebar, 8/12 main content, 1/12 empty right gutter. The header spans the full width above all columns.
@@ -45,9 +45,9 @@ The Search Results Page is the primary view for displaying product search result
 3. THE ProductCard SHALL display the product image sourced from `ec_thumbnails[0]` (falling back to `ec_images[0]` if `ec_thumbnails` is empty or undefined), `ec_name`, `ec_brand`, and `ec_price` formatted as a currency value.
 4. IF a product has neither `ec_thumbnails[0]` nor `ec_images[0]` available, THEN THE ProductCard SHALL render a placeholder image element of the same dimensions as a product image.
 5. WHEN a product has an `ec_promo_price` that is both defined and numerically less than `ec_price`, THE ProductCard SHALL display the original `ec_price` with a visible strikethrough style and the `ec_promo_price` as the current price.
-6. THE ProductGrid SHALL arrange ProductCard instances in a responsive CSS grid layout that displays a minimum of 1 column on viewports narrower than 600px and a maximum of 4 columns on viewports 1200px or wider.
+6. THE ProductGrid SHALL arrange ProductCard instances in a responsive CSS grid layout: 1 column by default, 2 columns at the sm breakpoint (640px), 3 columns at the md breakpoint (768px), and 4 columns at the xl breakpoint (1280px).
 7. IF `ec_name` text exceeds 2 lines within the ProductCard layout, THEN THE ProductCard SHALL truncate the text with an ellipsis and expose the full name via a `title` attribute.
-8. THE ProductCard SHALL display a pointer cursor on hover to indicate interactivity.
+8. THE ProductCard SHALL display a subtle elevation effect (box-shadow and border color change) on hover to indicate visual feedback, but SHALL NOT display a pointer cursor since the card is not currently interactive (no click handler or link).
 
 ### Requirement 3: Pagination Controls
 
@@ -73,7 +73,7 @@ The Search Results Page is the primary view for displaying product search result
 
 1. WHEN the SearchResultsPage mounts with a RoutedInterface, THE SearchResultsPage SHALL call `buildProductListController({interface: routedInterface.interface})` via the `useBuildController` hook and render product data from the resulting controller state.
 2. WHEN the SearchResultsPage mounts with a RoutedInterface, THE SearchResultsPage SHALL call `buildPaginationController({interface: routedInterface.interface})` via the `useBuildController` hook and render pagination controls from the resulting controller state.
-3. WHEN the SearchResultsPage mounts with a RoutedInterface, THE SearchResultsPage SHALL call `buildSearchBoxController({interface: routedInterface.interface})` via the `useBuildController` hook and pre-fill the header input with the current query from the controller state.
+3. WHEN the SearchResultsPage mounts, THE SearchResultsPage SHALL pre-fill the header PromptInput with the `query` prop provided by AppShell (sourced from `turn.prompt`). No `SearchBoxController` is built — the query is passed directly as a prop.
 4. THE SearchResultsPage SHALL use the `useBuildController` hook to instantiate each controller exactly once per mount, relying on the hook's internal `useRef` to prevent duplicate factory invocations on re-renders.
 5. WHEN the RoutedInterface changes identity (a new routed turn produces a new interface), THE AppShell SHALL call `dispose()` on the previous interface, store the new RoutedInterface in its ref, and cause the SearchResultsPage to remount with fresh controllers by changing the React key.
 6. IF the RoutedInterface provided to SearchResultsPage is `null` or `undefined` at mount time, THEN THE SearchResultsPage SHALL NOT call any controller build functions and SHALL render nothing (return `null`).
@@ -112,7 +112,7 @@ The Search Results Page is the primary view for displaying product search result
 
 1. WHEN the SearchResultsPage renders, THE SearchResultsPage SHALL display a sidebar area on the left side of the content region with a visible boundary and the text "Facets (coming soon)".
 2. THE sidebar placeholder SHALL occupy a proportional width of 2/12 of the available page width (as defined by the page grid) and SHALL NOT cause the main content area to shift or resize when present.
-3. WHEN the viewport width is below 768px, THE sidebar placeholder SHALL be hidden to preserve content area usability.
+3. WHEN the viewport width is below the lg breakpoint (1024px), THE sidebar placeholder SHALL be hidden to preserve content area usability.
 4. THE sidebar placeholder SHALL be non-interactive — it SHALL NOT respond to click, focus, or other user input events.
 
 ### Requirement 8: Sort Placeholder
@@ -125,6 +125,7 @@ The Search Results Page is the primary view for displaying product search result
 2. WHEN the user clicks the SortPlaceholder select, THE SortPlaceholder SHALL display a toast notification with the text "Not supported yet" that auto-dismisses after 3 seconds.
 3. THE SortPlaceholder SHALL use a native `<select>` element (matching the PageSizeSelector pattern) with 8px padding. The bold "Sort by:" label SHALL be outside the select, to its left, with 8px gap.
 4. THE SortPlaceholder SHALL NOT trigger any controller actions or modify application state beyond displaying the toast notification.
+5. WHEN the viewport width is below the lg breakpoint (1024px), THE inline SortPlaceholder SHALL be hidden and replaced by a "Sort & Filters" pill button that opens the SortFiltersModal.
 
 ### Requirement 9: Page Size Selector
 
@@ -139,3 +140,17 @@ The Search Results Page is the primary view for displaying product search result
 5. THE PageSizeSelector SHALL be positioned to the right of the Pagination component, within the same horizontal row at the bottom of the main content area.
 6. THE PageSizeSelector SHALL include a visible bold label "Products per page:" associated with the select element via an HTML `<label>` element for accessibility.
 7. THE PageSizeSelector SHALL receive the `PaginationController` directly as a prop, following the same controller-passing pattern used by the Pagination and ProductGrid components.
+
+### Requirement 10: Sort & Filters Modal (Mobile)
+
+**User Story:** As a mobile user, I want to access sort and filter controls through a full-screen modal, so that I can refine results without the inline controls taking up too much screen space.
+
+#### Acceptance Criteria
+
+1. WHEN the viewport width is below the lg breakpoint (1024px), THE SearchResultsPage SHALL display a "Sort & Filters" pill button in the top row (replacing the inline SortPlaceholder).
+2. WHEN the user clicks the "Sort & Filters" button, THE SearchResultsPage SHALL open a full-screen modal dialog using the native `<dialog>` element with `showModal()`.
+3. THE SortFiltersModal SHALL contain a header with the title "Sort & Filters" and a close button (×) in the top-right corner.
+4. THE SortFiltersModal SHALL contain a scrollable content area with two sections: "Sort" (containing the SortPlaceholder component) and "Filters" (containing a "Filters coming soon" placeholder message).
+5. THE SortFiltersModal SHALL contain a fixed footer (outside the scrollable area, always visible) with a full-width "View results" button.
+6. WHEN the user clicks the close button, presses Escape, or clicks "View results", THE SortFiltersModal SHALL close and return focus to the triggering element.
+7. THE SortFiltersModal SHALL have an `aria-label` of "Sort and filters" for screen reader accessibility.

--- a/samples/thermidor/demo-react/PLAN.md
+++ b/samples/thermidor/demo-react/PLAN.md
@@ -295,16 +295,23 @@ The app holds a single `ConverseController`. All prompts go through `controller.
 
 **Implementation guidance:**
 
-- Responsive breakpoints for the search results grid (5 columns → 3 → 2 → 1)
-- Mobile-friendly input and suggestion dropdown
-- Smooth transitions between views (optional CSS transitions)
-- Loading states for all async operations
-- Error handling (toast notifications for failures)
-- Accessibility basics: proper ARIA labels, focus management, keyboard navigation for suggestions
+- Responsive breakpoints aligned with `@coveo/atomic`: sm (640px), md (768px), lg (1024px), xl (1280px)
+- Product grid columns: 1 → 2 (sm) → 3 (md) → 4 (xl)
+- Mobile layout (below lg): single column, no sidebar, Sort & Filters modal, centered pagination
+- Sort & Filters modal on mobile: full-screen dialog with Sort section, Filters placeholder, and fixed "View results" button
+- Back-navigation button wraps below search box on screens < xl, absolutely positioned on xl+
+- Fixed max-width (560px) for the search box across all pages
+- Pill suggestions truncate with ellipsis and native title tooltip on narrow screens
+- Comparison table scrolls horizontally when too wide for viewport
+- CSS design tokens used consistently (no raw values)
+- View fade-in transition between pages
+- Loading states for async operations (spinner in submit button)
+- Error handling (toast notifications for unsupported features)
+- Accessibility: ARIA roles/labels on conversation log, comparison table, product carousel, next-actions bar; aria-live on streaming messages; aria-busy during streaming; keyboard-focusable carousel
 
-**Test requirements:** Visual regression tests or manual verification at key breakpoints.
+**Test requirements:** Visual verification at key breakpoints. All 246 unit tests pass.
 
-**Demo:** Demo looks polished on desktop and tablet. Error states are handled gracefully.
+**Demo:** Demo looks polished on desktop, tablet, and mobile. Error states are handled gracefully. Screen readers can navigate the conversation thread and comparison tables.
 
 ---
 

--- a/samples/thermidor/demo-react/src/a2ui/BundleDisplay/BundleDisplay.module.css
+++ b/samples/thermidor/demo-react/src/a2ui/BundleDisplay/BundleDisplay.module.css
@@ -150,3 +150,16 @@
   font-weight: 700;
   color: var(--color-text-primary);
 }
+
+.targetable {
+  cursor: crosshair;
+}
+
+.targetable:hover {
+  box-shadow: 0 0 0 2px var(--color-border-active);
+}
+
+.selected {
+  box-shadow: 0 0 0 2px var(--color-border-active);
+  opacity: 0.7;
+}

--- a/samples/thermidor/demo-react/src/a2ui/BundleDisplay/BundleDisplay.tsx
+++ b/samples/thermidor/demo-react/src/a2ui/BundleDisplay/BundleDisplay.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {useTargeting} from '../../context/targeting.js';
 import {formatPrice} from '../../utils.js';
 import styles from './BundleDisplay.module.css';
 import type {ParsedSurface} from '../types.js';
@@ -36,6 +37,8 @@ export function A2UIBundleDisplay({surface, allSurfaces}: A2UIBundleDisplayProps
 
   const bundles = (surface.componentProps.bundles as BundleTier[]) ?? [];
   const [activeTier, setActiveTier] = useState(bundles[0]?.bundleId ?? '');
+  const targeting = useTargeting();
+  const isTargetable = targeting?.isTargeting ?? false;
 
   if (bundles.length === 0) {
     return null;
@@ -77,27 +80,55 @@ export function A2UIBundleDisplay({surface, allSurfaces}: A2UIBundleDisplayProps
         <div className={styles.tierContent}>
           <p className={styles.description}>{activeBundle.description}</p>
           <div className={styles.itemList}>
-            {resolvedItems.map((item, i) => (
-              <div key={item.ec_product_id ?? i} className={styles.itemRow}>
-                {item.ec_image && (
-                  <img
-                    className={styles.itemImage}
-                    src={item.ec_image}
-                    alt={item.ec_name ?? 'Product'}
-                    loading="lazy"
-                  />
-                )}
-                <div className={styles.itemInfo}>
-                  <span className={styles.itemName}>{item.ec_name}</span>
-                  {item.ec_description && (
-                    <span className={styles.itemDescription}>{item.ec_description}</span>
+            {resolvedItems.map((item, i) => {
+              const productId = item.ec_product_id ?? '';
+              const isSelected = targeting?.selectedProductIds.has(productId) ?? false;
+
+              const rowClasses = [
+                styles.itemRow,
+                isTargetable ? styles.targetable : '',
+                isSelected ? styles.selected : '',
+              ]
+                .filter(Boolean)
+                .join(' ');
+
+              const interactiveProps = isTargetable
+                ? {
+                    role: 'button' as const,
+                    tabIndex: 0,
+                    onClick: () =>
+                      targeting!.onProductTargeted(productId, item.ec_name ?? '', item.ec_image),
+                    onKeyDown: (e: React.KeyboardEvent) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        targeting!.onProductTargeted(productId, item.ec_name ?? '', item.ec_image);
+                      }
+                    },
+                  }
+                : {};
+
+              return (
+                <div key={item.ec_product_id ?? i} className={rowClasses} {...interactiveProps}>
+                  {item.ec_image && (
+                    <img
+                      className={styles.itemImage}
+                      src={item.ec_image}
+                      alt={item.ec_name ?? 'Product'}
+                      loading="lazy"
+                    />
                   )}
-                  {item.ec_price !== undefined && (
-                    <span className={styles.itemPrice}>{formatPrice(item.ec_price)}</span>
-                  )}
+                  <div className={styles.itemInfo}>
+                    <span className={styles.itemName}>{item.ec_name}</span>
+                    {item.ec_description && (
+                      <span className={styles.itemDescription}>{item.ec_description}</span>
+                    )}
+                    {item.ec_price !== undefined && (
+                      <span className={styles.itemPrice}>{formatPrice(item.ec_price)}</span>
+                    )}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
           {resolvedItems.length > 0 && (
             <div className={styles.footer}>

--- a/samples/thermidor/demo-react/src/a2ui/ComparisonSummary/ComparisonSummary.tsx
+++ b/samples/thermidor/demo-react/src/a2ui/ComparisonSummary/ComparisonSummary.tsx
@@ -1,6 +1,5 @@
 import {useMemo} from 'react';
-import {marked} from 'marked';
-import DOMPurify from 'dompurify';
+import {renderMarkdown} from '../../utils.js';
 import styles from './ComparisonSummary.module.css';
 import type {ParsedSurface} from '../types.js';
 
@@ -13,12 +12,7 @@ export function A2UIComparisonSummary({surface}: A2UIComparisonSummaryProps) {
 
   const html = useMemo(() => {
     if (!text) return '';
-    try {
-      const raw = marked.parse(text, {breaks: true, gfm: true}) as string;
-      return DOMPurify.sanitize(raw);
-    } catch {
-      return DOMPurify.sanitize(text);
-    }
+    return renderMarkdown(text);
   }, [text]);
 
   if (!text) {

--- a/samples/thermidor/demo-react/src/a2ui/ComparisonTable/ComparisonTable.module.css
+++ b/samples/thermidor/demo-react/src/a2ui/ComparisonTable/ComparisonTable.module.css
@@ -53,11 +53,13 @@
   gap: var(--space-2);
   padding: var(--space-4);
   text-align: center;
+  min-width: 0;
 }
 
 .productImage {
-  width: 120px;
-  height: 120px;
+  width: 100%;
+  max-width: 120px;
+  aspect-ratio: 1;
   object-fit: cover;
   border-radius: var(--radius-sm);
   background: var(--color-bg-tertiary);
@@ -77,6 +79,8 @@
   font-size: var(--font-size-sm);
   color: var(--color-text-primary);
   line-height: 1.4;
+  min-width: 0;
+  word-break: break-word;
 }
 
 .priceValue {

--- a/samples/thermidor/demo-react/src/a2ui/ComparisonTable/ComparisonTable.module.css
+++ b/samples/thermidor/demo-react/src/a2ui/ComparisonTable/ComparisonTable.module.css
@@ -13,6 +13,8 @@
 
 .tableWrapper {
   position: relative;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .table {
@@ -21,6 +23,7 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   overflow: hidden;
+  min-width: 480px;
 }
 
 .row {

--- a/samples/thermidor/demo-react/src/a2ui/ComparisonTable/ComparisonTable.module.css
+++ b/samples/thermidor/demo-react/src/a2ui/ComparisonTable/ComparisonTable.module.css
@@ -30,6 +30,7 @@
   display: grid;
   grid-template-columns: 100px repeat(3, 1fr);
   border-bottom: 1px solid var(--color-border);
+  column-gap: 4px;
 }
 
 .row:last-child {
@@ -130,4 +131,17 @@
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
   text-align: center;
+}
+
+.targetable {
+  cursor: crosshair;
+}
+
+.targetable:hover {
+  box-shadow: inset 0 0 0 2px var(--color-border-active);
+}
+
+.selected {
+  box-shadow: inset 0 0 0 2px var(--color-border-active);
+  opacity: 0.7;
 }

--- a/samples/thermidor/demo-react/src/a2ui/ComparisonTable/ComparisonTable.tsx
+++ b/samples/thermidor/demo-react/src/a2ui/ComparisonTable/ComparisonTable.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {useTargeting} from '../../context/targeting.js';
 import {formatPrice} from '../../utils.js';
 import styles from './ComparisonTable.module.css';
 import type {ParsedSurface} from '../types.js';
@@ -21,6 +22,8 @@ interface ComparisonItem {
 
 export function A2UIComparisonTable({surface}: A2UIComparisonTableProps) {
   const heading = (surface.componentProps.heading as {literalString?: string})?.literalString ?? '';
+  const targeting = useTargeting();
+  const isTargetable = targeting?.isTargeting ?? false;
 
   const attributes = (surface.componentProps.attributes as string[]) ?? [
     'standout',
@@ -73,19 +76,47 @@ export function A2UIComparisonTable({surface}: A2UIComparisonTableProps) {
             <div className={styles.labelCell} role="columnheader">
               Product
             </div>
-            {visibleItems.map((item, i) => (
-              <div key={item.ec_product_id ?? i} className={styles.productCell} role="columnheader">
-                {item.ec_image && (
-                  <img
-                    className={styles.productImage}
-                    src={item.ec_image}
-                    alt={item.ec_name ?? 'Product'}
-                    loading="lazy"
-                  />
-                )}
-                <span className={styles.productName}>{item.ec_name}</span>
-              </div>
-            ))}
+            {visibleItems.map((item, i) => {
+              const productId = item.ec_product_id ?? '';
+              const isSelected = targeting?.selectedProductIds.has(productId) ?? false;
+
+              const cellClasses = [
+                styles.productCell,
+                isTargetable ? styles.targetable : '',
+                isSelected ? styles.selected : '',
+              ]
+                .filter(Boolean)
+                .join(' ');
+
+              const interactiveProps = isTargetable
+                ? {
+                    role: 'button' as const,
+                    tabIndex: 0,
+                    onClick: () =>
+                      targeting!.onProductTargeted(productId, item.ec_name ?? '', item.ec_image),
+                    onKeyDown: (e: React.KeyboardEvent) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        targeting!.onProductTargeted(productId, item.ec_name ?? '', item.ec_image);
+                      }
+                    },
+                  }
+                : {};
+
+              return (
+                <div key={item.ec_product_id ?? i} className={cellClasses} {...interactiveProps}>
+                  {item.ec_image && (
+                    <img
+                      className={styles.productImage}
+                      src={item.ec_image}
+                      alt={item.ec_name ?? 'Product'}
+                      loading="lazy"
+                    />
+                  )}
+                  <span className={styles.productName}>{item.ec_name}</span>
+                </div>
+              );
+            })}
           </div>
 
           <div className={styles.row} role="row">

--- a/samples/thermidor/demo-react/src/a2ui/ComparisonTable/ComparisonTable.tsx
+++ b/samples/thermidor/demo-react/src/a2ui/ComparisonTable/ComparisonTable.tsx
@@ -68,11 +68,13 @@ export function A2UIComparisonTable({surface}: A2UIComparisonTableProps) {
             ‹
           </button>
         )}
-        <div className={styles.table}>
-          <div className={styles.row}>
-            <div className={styles.labelCell}>Product</div>
+        <div className={styles.table} role="table" aria-label={heading || 'Product comparison'}>
+          <div className={styles.row} role="row">
+            <div className={styles.labelCell} role="columnheader">
+              Product
+            </div>
             {visibleItems.map((item, i) => (
-              <div key={item.ec_product_id ?? i} className={styles.productCell}>
+              <div key={item.ec_product_id ?? i} className={styles.productCell} role="columnheader">
                 {item.ec_image && (
                   <img
                     className={styles.productImage}
@@ -86,10 +88,16 @@ export function A2UIComparisonTable({surface}: A2UIComparisonTableProps) {
             ))}
           </div>
 
-          <div className={styles.row}>
-            <div className={styles.labelCell}>Price</div>
+          <div className={styles.row} role="row">
+            <div className={styles.labelCell} role="rowheader">
+              Price
+            </div>
             {visibleItems.map((item, i) => (
-              <div key={`price-${item.ec_product_id ?? i}`} className={styles.valueCell}>
+              <div
+                key={`price-${item.ec_product_id ?? i}`}
+                className={styles.valueCell}
+                role="cell"
+              >
                 <span className={styles.priceValue}>
                   {item.ec_price !== undefined ? formatPrice(item.ec_price) : '—'}
                 </span>
@@ -98,12 +106,18 @@ export function A2UIComparisonTable({surface}: A2UIComparisonTableProps) {
           </div>
 
           {displayAttributes.map((attr) => (
-            <div key={attr} className={styles.row}>
-              <div className={styles.labelCell}>{attributeLabels[attr] ?? attr}</div>
+            <div key={attr} className={styles.row} role="row">
+              <div className={styles.labelCell} role="rowheader">
+                {attributeLabels[attr] ?? attr}
+              </div>
               {visibleItems.map((item, i) => {
                 const value = item[attr];
                 return (
-                  <div key={`${attr}-${item.ec_product_id ?? i}`} className={styles.valueCell}>
+                  <div
+                    key={`${attr}-${item.ec_product_id ?? i}`}
+                    className={styles.valueCell}
+                    role="cell"
+                  >
                     {typeof value === 'string' ? value : '—'}
                   </div>
                 );

--- a/samples/thermidor/demo-react/src/a2ui/NextActionsBar/NextActionsBar.module.css
+++ b/samples/thermidor/demo-react/src/a2ui/NextActionsBar/NextActionsBar.module.css
@@ -5,6 +5,12 @@
   padding: var(--space-3) 0;
 }
 
+@media (max-width: 639px) {
+  .container {
+    justify-content: center;
+  }
+}
+
 .actionButton {
   padding: var(--space-2) var(--space-4);
   font-family: var(--font-sans);

--- a/samples/thermidor/demo-react/src/a2ui/NextActionsBar/NextActionsBar.tsx
+++ b/samples/thermidor/demo-react/src/a2ui/NextActionsBar/NextActionsBar.tsx
@@ -21,7 +21,7 @@ export function A2UINextActionsBar({surface, onAction}: A2UINextActionsBarProps)
   }
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} role="group" aria-label="Follow-up actions">
       {items.map((action, i) => (
         <button
           key={i}

--- a/samples/thermidor/demo-react/src/a2ui/ProductCard/ProductCard.module.css
+++ b/samples/thermidor/demo-react/src/a2ui/ProductCard/ProductCard.module.css
@@ -55,3 +55,16 @@ a.name:hover {
   color: var(--color-text-primary);
   margin-top: auto;
 }
+
+.targetable {
+  cursor: crosshair;
+}
+
+.targetable:hover {
+  box-shadow: 0 0 0 2px var(--color-border-active);
+}
+
+.selected {
+  box-shadow: 0 0 0 2px var(--color-border-active);
+  opacity: 0.7;
+}

--- a/samples/thermidor/demo-react/src/a2ui/ProductCard/ProductCard.test.tsx
+++ b/samples/thermidor/demo-react/src/a2ui/ProductCard/ProductCard.test.tsx
@@ -1,0 +1,54 @@
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {A2UIProductCard} from './ProductCard.js';
+import {TargetingProvider, type TargetingContext} from '../../context/targeting.js';
+
+vi.mock('../../utils.js', () => ({
+  formatPrice: (v: number) => `$${v.toFixed(2)}`,
+}));
+
+function renderWithTargeting(ui: React.ReactElement, targeting: TargetingContext) {
+  return render(<TargetingProvider value={targeting}>{ui}</TargetingProvider>);
+}
+
+describe('A2UIProductCard', () => {
+  it('suppresses link when targeting (renders span instead of anchor)', () => {
+    const targeting: TargetingContext = {
+      isTargeting: true,
+      onProductTargeted: vi.fn(),
+      selectedProductIds: new Set(),
+    };
+
+    renderWithTargeting(
+      <A2UIProductCard
+        ec_name="Gadget Pro"
+        ec_product_id="gadget-1"
+        clickUri="https://example.com/gadget"
+      />,
+      targeting
+    );
+
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByText('Gadget Pro').tagName).toBe('SPAN');
+  });
+
+  it('renders link when not targeting', () => {
+    const targeting: TargetingContext = {
+      isTargeting: false,
+      onProductTargeted: vi.fn(),
+      selectedProductIds: new Set(),
+    };
+
+    renderWithTargeting(
+      <A2UIProductCard
+        ec_name="Gadget Pro"
+        ec_product_id="gadget-1"
+        clickUri="https://example.com/gadget"
+      />,
+      targeting
+    );
+
+    const link = screen.getByRole('link');
+    expect(link.getAttribute('href')).toBe('https://example.com/gadget');
+  });
+});

--- a/samples/thermidor/demo-react/src/a2ui/ProductCard/ProductCard.tsx
+++ b/samples/thermidor/demo-react/src/a2ui/ProductCard/ProductCard.tsx
@@ -15,9 +15,9 @@ export function A2UIProductCard(props: A2UIProductCardProps) {
   const {ec_name, ec_brand, ec_price, ec_image, ec_product_id, clickUri} = props;
   const targeting = useTargeting();
 
-  const productId = ec_product_id ?? '';
-  const isSelected = targeting?.selectedProductIds.has(productId) ?? false;
-  const isTargetable = targeting?.isTargeting ?? false;
+  const productId = ec_product_id ?? ec_name;
+  const isSelected = productId ? (targeting?.selectedProductIds.has(productId) ?? false) : false;
+  const isTargetable = (targeting?.isTargeting ?? false) && !!productId;
 
   const cardClasses = [
     styles.card,
@@ -28,12 +28,13 @@ export function A2UIProductCard(props: A2UIProductCardProps) {
     .join(' ');
 
   const handleTarget = () => {
-    targeting!.onProductTargeted(productId, ec_name ?? '', ec_image);
+    targeting!.onProductTargeted(productId!, ec_name ?? '', ec_image);
   };
 
   const interactiveProps = isTargetable
     ? {
         role: 'button' as const,
+        'aria-pressed': isSelected,
         tabIndex: 0,
         onClick: handleTarget,
         onKeyDown: (e: React.KeyboardEvent) => {

--- a/samples/thermidor/demo-react/src/a2ui/ProductCard/ProductCard.tsx
+++ b/samples/thermidor/demo-react/src/a2ui/ProductCard/ProductCard.tsx
@@ -1,3 +1,4 @@
+import {useTargeting} from '../../context/targeting.js';
 import {formatPrice} from '../../utils.js';
 import styles from './ProductCard.module.css';
 
@@ -11,15 +12,46 @@ interface A2UIProductCardProps {
 }
 
 export function A2UIProductCard(props: A2UIProductCardProps) {
-  const {ec_name, ec_brand, ec_price, ec_image, clickUri} = props;
+  const {ec_name, ec_brand, ec_price, ec_image, ec_product_id, clickUri} = props;
+  const targeting = useTargeting();
+
+  const productId = ec_product_id ?? '';
+  const isSelected = targeting?.selectedProductIds.has(productId) ?? false;
+  const isTargetable = targeting?.isTargeting ?? false;
+
+  const cardClasses = [
+    styles.card,
+    isTargetable ? styles.targetable : '',
+    isSelected ? styles.selected : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const handleTarget = () => {
+    targeting!.onProductTargeted(productId, ec_name ?? '', ec_image);
+  };
+
+  const interactiveProps = isTargetable
+    ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        onClick: handleTarget,
+        onKeyDown: (e: React.KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleTarget();
+          }
+        },
+      }
+    : {};
 
   return (
-    <div className={styles.card}>
+    <div className={cardClasses} {...interactiveProps}>
       {ec_image && (
         <img className={styles.image} src={ec_image} alt={ec_name ?? 'Product'} loading="lazy" />
       )}
       <div className={styles.content}>
-        {clickUri ? (
+        {clickUri && !isTargetable ? (
           <a className={styles.name} href={clickUri} target="_blank" rel="noopener noreferrer">
             {ec_name}
           </a>

--- a/samples/thermidor/demo-react/src/a2ui/ProductCarousel/ProductCarousel.module.css
+++ b/samples/thermidor/demo-react/src/a2ui/ProductCarousel/ProductCarousel.module.css
@@ -22,6 +22,8 @@
   scroll-behavior: smooth;
   scrollbar-width: none;
   -ms-overflow-style: none;
+  padding: 4px;
+  margin: -4px;
 }
 
 .track::-webkit-scrollbar {

--- a/samples/thermidor/demo-react/src/a2ui/ProductCarousel/ProductCarousel.tsx
+++ b/samples/thermidor/demo-react/src/a2ui/ProductCarousel/ProductCarousel.tsx
@@ -72,7 +72,13 @@ export function A2UIProductCarousel({surface}: A2UIProductCarouselProps) {
             ‹
           </button>
         )}
-        <div className={styles.track} ref={trackRef}>
+        <div
+          className={styles.track}
+          ref={trackRef}
+          tabIndex={0}
+          role="region"
+          aria-label={heading}
+        >
           {items.map((item, i) => (
             <div className={styles.cardSlot} key={item.ec_product_id ?? i}>
               <A2UIProductCard

--- a/samples/thermidor/demo-react/src/a2ui/Skeleton/Skeleton.module.css
+++ b/samples/thermidor/demo-react/src/a2ui/Skeleton/Skeleton.module.css
@@ -1,6 +1,11 @@
 .skeleton {
-  border-radius: 8px;
-  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  border-radius: var(--radius-md);
+  background: linear-gradient(
+    90deg,
+    var(--color-bg-skeleton-highlight) 25%,
+    var(--color-bg-skeleton) 50%,
+    var(--color-bg-skeleton-highlight) 75%
+  );
   background-size: 200% 100%;
   animation: shimmer 1.5s infinite;
 }
@@ -18,7 +23,7 @@
 .carouselContainer {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
   overflow: hidden;
 }
 
@@ -29,7 +34,7 @@
 
 .carouselTrack {
   display: flex;
-  gap: 12px;
+  gap: var(--space-3);
   overflow: hidden;
 }
 
@@ -37,8 +42,8 @@
   flex: 0 0 160px;
   display: flex;
   flex-direction: column;
-  border: 1px solid #eee;
-  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
@@ -52,7 +57,7 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 12px;
+  padding: var(--space-3);
 }
 
 .carouselName {
@@ -69,11 +74,11 @@
 .bundleContainer {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 24px;
-  border-radius: 12px;
-  border: 1px solid #eee;
-  background: #f8f9fa;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
 }
 
 .bundleHeading {
@@ -83,15 +88,15 @@
 
 .bundleTabs {
   display: flex;
-  gap: 16px;
-  border-bottom: 1px solid #eee;
-  padding-bottom: 8px;
+  gap: var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: var(--space-2);
 }
 
 .bundleTab {
   width: 90px;
   height: 16px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .bundleDescription {
@@ -102,23 +107,23 @@
 .bundleItems {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .bundleRow {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 16px;
-  background: #fff;
-  border: 1px solid #eee;
-  border-radius: 8px;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
 }
 
 .bundleRowImage {
   width: 64px;
   height: 64px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
 }
 
@@ -146,14 +151,14 @@
 
 .bundleFooter {
   height: 48px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
 }
 
 /* ComparisonTable skeleton */
 .tableContainer {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--space-4);
   overflow: hidden;
 }
 
@@ -165,17 +170,17 @@
 .tableGrid {
   display: flex;
   flex-direction: column;
-  border: 1px solid #eee;
-  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
 .tableRow {
   display: grid;
   grid-template-columns: 100px repeat(3, minmax(0, 1fr));
-  border-bottom: 1px solid #eee;
-  padding: 16px;
-  gap: 12px;
+  border-bottom: 1px solid var(--color-border);
+  padding: var(--space-4);
+  gap: var(--space-3);
 }
 
 .tableRow:last-child {
@@ -191,13 +196,13 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .tableImage {
   width: 100px;
   height: 100px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .tableName {
@@ -214,8 +219,8 @@
 /* NextActionsBar skeleton */
 .actionsContainer {
   display: flex;
-  gap: 8px;
-  padding: 8px 0;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
   overflow: hidden;
 }
 
@@ -229,17 +234,17 @@
 .summaryContainer {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 16px;
-  border-radius: 8px;
-  border: 1px solid #eee;
-  background: #f8f9fa;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
 }
 
 .summaryHeader {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .summaryIcon {
@@ -267,8 +272,8 @@
 .genericContainer {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  padding: 16px;
-  border-radius: 12px;
-  border: 1px solid #eee;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
 }

--- a/samples/thermidor/demo-react/src/a2ui/SurfaceRenderer/SurfaceRenderer.module.css
+++ b/samples/thermidor/demo-react/src/a2ui/SurfaceRenderer/SurfaceRenderer.module.css
@@ -3,35 +3,3 @@
   flex-direction: column;
   gap: var(--space-3);
 }
-
-.card {
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: var(--space-4);
-  background: var(--color-bg-primary);
-}
-
-.entry {
-  display: flex;
-  gap: var(--space-2);
-  padding: var(--space-2) 0;
-  border-bottom: 1px solid var(--color-bg-tertiary);
-}
-
-.entry:last-child {
-  border-bottom: none;
-}
-
-.key {
-  font-weight: 600;
-  color: var(--color-text-secondary);
-  min-width: 100px;
-  font-size: var(--font-size-sm);
-}
-
-.value {
-  color: var(--color-text-primary);
-  font-size: var(--font-size-base);
-  word-break: break-word;
-  min-width: 0;
-}

--- a/samples/thermidor/demo-react/src/components/AppShell.bidirectional.test.tsx
+++ b/samples/thermidor/demo-react/src/components/AppShell.bidirectional.test.tsx
@@ -49,7 +49,6 @@ vi.mock('./ConversationPage/index.js', () => ({
       <span data-testid="turn-ids">{props.turns.map((t: Turn) => t.id).join(',')}</span>
       <span data-testid="can-go-back">{String(props.canGoBackToSearch)}</span>
       <button data-testid="back-btn" onClick={props.onBackToSearch} />
-      <button data-testid="reset-btn" onClick={props.onResetToLanding} />
       <button
         data-testid="conversation-submit"
         onClick={() => props.onSubmit('follow up question')}
@@ -423,7 +422,7 @@ describe('AppShell — bidirectional navigation flow', () => {
     expect(mockSubmit).toHaveBeenNthCalledWith(3, {prompt: 'follow up question'});
   });
 
-  it('search interface disposed only on explicit reset, not on view transitions', () => {
+  it('search interface is not disposed on view transitions', () => {
     const mockDispose = vi.fn();
     const routedInterface = {
       id: 'ri-1',
@@ -474,7 +473,7 @@ describe('AppShell — bidirectional navigation flow', () => {
     expect(screen.getByTestId('search-results-page')).toBeDefined();
     expect(mockDispose).not.toHaveBeenCalled();
 
-    // Back to conversation
+    // Back to conversation again
     act(() => {
       screen.getByTestId('search-submit-conversational').click();
     });
@@ -506,13 +505,6 @@ describe('AppShell — bidirectional navigation flow', () => {
     rerender(<AppShell />);
     expect(screen.getByTestId('conversation-page')).toBeDefined();
     expect(mockDispose).not.toHaveBeenCalled();
-
-    // Only dispose on explicit reset
-    act(() => {
-      screen.getByTestId('reset-btn').click();
-    });
-    expect(mockDispose).toHaveBeenCalledTimes(1);
-    expect(screen.getByTestId('landing-page')).toBeDefined();
   });
 
   it('"Back to conversation" button navigates from search to conversation without submitting', () => {

--- a/samples/thermidor/demo-react/src/components/AppShell.test.tsx
+++ b/samples/thermidor/demo-react/src/components/AppShell.test.tsx
@@ -45,7 +45,6 @@ vi.mock('./ConversationPage/index.js', () => ({
         onClick={props.onBackToSearch}
         disabled={!props.canGoBackToSearch}
       />
-      <button data-testid="reset-btn" onClick={props.onResetToLanding} />
     </div>
   ),
 }));
@@ -239,106 +238,6 @@ describe('AppShell', () => {
 
     mockConverseState = {
       turns: [makeTurn({id: 'turn-1', agentResponse: {text: 'Hello!'} as any})],
-      activeTurn: undefined,
-      isStreaming: false,
-    };
-
-    rerender(<AppShell />);
-    expect(screen.getByTestId('conversation-page')).toBeDefined();
-
-    const backBtn = screen.getByTestId('back-btn');
-    expect(backBtn.getAttribute('disabled')).not.toBeNull();
-  });
-
-  it('"Reset to landing" disposes interface, clears controller, and transitions to landing', () => {
-    const mockDispose = vi.fn();
-    const routedInterface = {
-      useCase: 'search' as const,
-      interface: {dispose: mockDispose},
-    };
-
-    mockConverseState = {
-      turns: [makeTurn({id: 'turn-1', routedInterface: routedInterface as any})],
-      activeTurn: undefined,
-      isStreaming: false,
-    };
-
-    const {rerender} = render(<AppShell />);
-    expect(screen.getByTestId('search-results-page')).toBeDefined();
-
-    act(() => {
-      screen.getByTestId('search-submit-btn').click();
-    });
-
-    mockConverseState = {
-      turns: [
-        makeTurn({id: 'turn-1', routedInterface: routedInterface as any}),
-        makeTurn({id: 'turn-2', agentResponse: {text: 'Hello!'} as any}),
-      ],
-      activeTurn: undefined,
-      isStreaming: false,
-    };
-
-    rerender(<AppShell />);
-    expect(screen.getByTestId('conversation-page')).toBeDefined();
-
-    act(() => {
-      screen.getByTestId('reset-btn').click();
-    });
-
-    expect(mockDispose).toHaveBeenCalledTimes(1);
-    expect(mockClear).toHaveBeenCalledTimes(1);
-    expect(screen.getByTestId('landing-page')).toBeDefined();
-  });
-
-  it('after reset, persisted interface ref is null (back button disabled on next conversation)', () => {
-    const mockDispose = vi.fn();
-    const routedInterface = {
-      useCase: 'search' as const,
-      interface: {dispose: mockDispose},
-    };
-
-    mockConverseState = {
-      turns: [makeTurn({id: 'turn-1', routedInterface: routedInterface as any})],
-      activeTurn: undefined,
-      isStreaming: false,
-    };
-
-    const {rerender} = render(<AppShell />);
-    expect(screen.getByTestId('search-results-page')).toBeDefined();
-
-    act(() => {
-      screen.getByTestId('search-submit-btn').click();
-    });
-
-    mockConverseState = {
-      turns: [
-        makeTurn({id: 'turn-1', routedInterface: routedInterface as any}),
-        makeTurn({id: 'turn-2', agentResponse: {text: 'Hello!'} as any}),
-      ],
-      activeTurn: undefined,
-      isStreaming: false,
-    };
-
-    rerender(<AppShell />);
-    expect(screen.getByTestId('conversation-page')).toBeDefined();
-
-    act(() => {
-      screen.getByTestId('reset-btn').click();
-    });
-
-    expect(screen.getByTestId('landing-page')).toBeDefined();
-
-    act(() => {
-      screen.getByTestId('submit-btn').click();
-    });
-
-    mockConverseState = {
-      turns: [
-        makeTurn({id: 'turn-1', routedInterface: routedInterface as any}),
-        makeTurn({id: 'turn-2', agentResponse: {text: 'Hello!'} as any}),
-        makeTurn({id: 'turn-3', agentResponse: {text: 'World!'} as any}),
-      ],
       activeTurn: undefined,
       isStreaming: false,
     };

--- a/samples/thermidor/demo-react/src/components/AppShell.tsx
+++ b/samples/thermidor/demo-react/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import {buildConverseController, type RoutedInterface, type Turn} from '@coveo/t
 import {useGenerativeInterface} from '../context/generative-interface.js';
 import {useBuildController} from '../hooks/use-build-controller.js';
 import {useAppState, deriveTransitionAction} from '../hooks/use-app-state.js';
+import type {TargetedProduct} from '../context/targeting.js';
 import {LandingPage} from './LandingPage/LandingPage.js';
 import {SearchResultsPage} from './SearchResultsPage/SearchResultsPage.js';
 import {ConversationPage} from './ConversationPage/index.js';
@@ -21,6 +22,7 @@ export function AppShell() {
   const lastObservedTurnIdRef = useRef<string | null>(null);
   const pendingNavigationRef = useRef(false);
   const [canGoBackToSearch, setCanGoBackToSearch] = useState(false);
+  const [targetedProducts, setTargetedProducts] = useState<TargetedProduct[]>([]);
 
   const persistAndNavigateToSearch = useCallback(
     (turn: Turn) => {
@@ -117,6 +119,7 @@ export function AppShell() {
       persistedInterfaceTurnIdRef.current = null;
       setCanGoBackToSearch(false);
     }
+    setTargetedProducts([]);
     controller.clear();
     dispatch({type: 'NAVIGATE_LANDING'});
   };
@@ -132,6 +135,8 @@ export function AppShell() {
             routedInterface={persistedInterfaceRef.current}
             query={persistedQueryRef.current}
             onBackToConversation={handleBackToConversation}
+            products={targetedProducts}
+            onProductsChange={setTargetedProducts}
           />
         </div>
       )}
@@ -144,7 +149,8 @@ export function AppShell() {
               turns={converseState.turns}
               onBackToSearch={handleBackToSearch}
               canGoBackToSearch={canGoBackToSearch}
-              onResetToLanding={handleResetToLanding}
+              products={targetedProducts}
+              onProductsChange={setTargetedProducts}
             />
           ) : (
             <LandingPage onSubmit={handleSubmit} isStreaming={converseState.isStreaming} />

--- a/samples/thermidor/demo-react/src/components/ConversationPage/AgentResponseBlock.module.css
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/AgentResponseBlock.module.css
@@ -1,5 +1,5 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-3);
 }

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.integration.test.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.integration.test.tsx
@@ -10,7 +10,8 @@ function renderPage(overrides: Partial<Parameters<typeof ConversationPage>[0]> =
     turns: [] as Turn[],
     onBackToSearch: vi.fn(),
     canGoBackToSearch: false,
-    onResetToLanding: vi.fn(),
+    products: [],
+    onProductsChange: vi.fn(),
   };
 
   return {
@@ -161,31 +162,6 @@ describe('ConversationPage integration', () => {
       renderPage({turns, canGoBackToSearch: true, onBackToSearch});
       fireEvent.click(screen.getByRole('button', {name: /Back to search results/}));
       expect(onBackToSearch).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('Reset button', () => {
-    it('is always visible regardless of canGoBackToSearch', () => {
-      const turns: Turn[] = [{id: 'turn-1', prompt: 'Hello', status: 'complete'}];
-
-      renderPage({turns, canGoBackToSearch: false});
-      expect(screen.getByRole('button', {name: 'Reset'})).toBeDefined();
-    });
-
-    it('is visible when canGoBackToSearch is true', () => {
-      const turns: Turn[] = [{id: 'turn-1', prompt: 'Hello', status: 'complete'}];
-
-      renderPage({turns, canGoBackToSearch: true});
-      expect(screen.getByRole('button', {name: 'Reset'})).toBeDefined();
-    });
-
-    it('calls onResetToLanding when clicked', () => {
-      const onResetToLanding = vi.fn();
-      const turns: Turn[] = [{id: 'turn-1', prompt: 'Hello', status: 'complete'}];
-
-      renderPage({turns, onResetToLanding});
-      fireEvent.click(screen.getByRole('button', {name: 'Reset'}));
-      expect(onResetToLanding).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.module.css
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.module.css
@@ -6,6 +6,7 @@
 
 .nav {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--space-3);
   padding: var(--space-4) var(--space-5);

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.module.css
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.module.css
@@ -73,7 +73,6 @@
 }
 
 .promptWrapper {
-  width: 33.333vw;
-  min-width: 400px;
-  max-width: 720px;
+  width: 100%;
+  max-width: 560px;
 }

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.module.css
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.module.css
@@ -4,54 +4,73 @@
   height: 100%;
 }
 
-.nav {
+.floatingBackButton {
+  position: fixed;
+  top: 24px;
+  right: 24px;
+  z-index: 100;
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  background: var(--color-bg-primary);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  box-shadow: 0 2px 8px var(--color-shadow);
+  opacity: 0.7;
+  transition:
+    opacity var(--transition-fast),
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.floatingBackButton:hover {
+  opacity: 1;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  border-color: var(--color-border-active);
+  box-shadow: 0 4px 12px var(--color-shadow);
+}
+
+.floatingBackButton:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.floatingBackButton svg {
+  width: 20px;
+  height: 20px;
+}
+
+.promptAtBottom {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.promptAtBottom > div {
+  display: flex;
+  flex-direction: column-reverse;
+  flex: 1;
+  min-height: 0;
   gap: var(--space-3);
-  padding: var(--space-4) var(--space-5);
-  min-height: var(--header-height);
+}
+
+.promptAtBottom > div > div:last-child {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
   border-bottom: 1px solid var(--color-border);
-  flex-shrink: 0;
-}
-
-.backButton {
-  background: var(--color-bg-primary);
-  border: 1px solid var(--color-border);
-  color: var(--color-text-primary);
-  cursor: pointer;
-  font-size: var(--font-size-sm);
-  padding: var(--space-2) var(--space-4);
-  border-radius: 999px;
-}
-
-.backButton:hover {
-  background: var(--color-surface-hover);
-}
-
-.backButton:focus-visible {
-  outline: 2px solid var(--color-focus);
-  outline-offset: 2px;
-}
-
-.resetButton {
-  background: var(--color-bg-primary);
-  border: 1px solid var(--color-border);
-  color: var(--color-text-primary);
-  cursor: pointer;
-  font-size: var(--font-size-sm);
-  padding: var(--space-2) var(--space-4);
-  border-radius: 999px;
-  margin-left: auto;
-}
-
-.resetButton:hover {
-  background: var(--color-surface-hover);
-}
-
-.resetButton:focus-visible {
-  outline: 2px solid var(--color-focus);
-  outline-offset: 2px;
+  padding-bottom: var(--space-3);
 }
 
 .scrollContainer {
@@ -63,17 +82,4 @@
 .scrollContent {
   max-width: 720px;
   margin: 0 auto;
-}
-
-.promptContainer {
-  flex-shrink: 0;
-  padding: var(--space-3) var(--space-6);
-  border-top: 1px solid var(--color-border);
-  display: flex;
-  justify-content: center;
-}
-
-.promptWrapper {
-  width: 100%;
-  max-width: 560px;
 }

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.module.css
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.module.css
@@ -8,7 +8,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  padding: 16px 24px;
+  padding: var(--space-4) var(--space-5);
   min-height: var(--header-height);
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.test.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.test.tsx
@@ -16,7 +16,8 @@ function renderPage(overrides: Partial<Parameters<typeof ConversationPage>[0]> =
     turns: [baseTurn],
     onBackToSearch: vi.fn(),
     canGoBackToSearch: false,
-    onResetToLanding: vi.fn(),
+    products: [],
+    onProductsChange: vi.fn(),
   };
 
   return render(<ConversationPage {...defaultProps} {...overrides} />);
@@ -24,13 +25,10 @@ function renderPage(overrides: Partial<Parameters<typeof ConversationPage>[0]> =
 
 describe('ConversationPage shell', () => {
   describe('PromptInput rendering', () => {
-    it('renders the PromptInput at the bottom of the page', () => {
+    it('renders the PromptInput', () => {
       renderPage();
       const prompt = screen.getByLabelText('Prompt');
       expect(prompt).toBeDefined();
-
-      const promptContainer = prompt.closest('[class*="promptContainer"]');
-      expect(promptContainer).not.toBeNull();
     });
   });
 
@@ -51,26 +49,6 @@ describe('ConversationPage shell', () => {
 
       fireEvent.click(screen.getByRole('button', {name: /Back to search results/}));
       expect(onBackToSearch).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('Reset button', () => {
-    it('is always visible regardless of canGoBackToSearch', () => {
-      renderPage({canGoBackToSearch: false});
-      expect(screen.getByRole('button', {name: 'Reset'})).toBeDefined();
-    });
-
-    it('is visible when canGoBackToSearch is true', () => {
-      renderPage({canGoBackToSearch: true});
-      expect(screen.getByRole('button', {name: 'Reset'})).toBeDefined();
-    });
-
-    it('calls onResetToLanding when clicked', () => {
-      const onResetToLanding = vi.fn();
-      renderPage({onResetToLanding});
-
-      fireEvent.click(screen.getByRole('button', {name: 'Reset'}));
-      expect(onResetToLanding).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -98,6 +76,18 @@ describe('ConversationPage shell', () => {
       renderPage({isStreaming: false});
       const textarea = screen.getByLabelText('Prompt') as HTMLTextAreaElement;
       expect(textarea.disabled).toBe(false);
+    });
+  });
+
+  describe('ProductTargeting integration', () => {
+    it('renders the attach button from ProductTargeting', () => {
+      renderPage();
+      expect(screen.getByRole('button', {name: /Attach product context/})).toBeDefined();
+    });
+
+    it('shows hint text "Attach product context" by default', () => {
+      renderPage();
+      expect(screen.getByText('Attach product context')).toBeDefined();
     });
   });
 });

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.tsx
@@ -64,7 +64,6 @@ export function ConversationPage({
   }, [turns, scrollToPrompt]);
 
   const handleAction = (text: string, _type: string) => {
-    void _type;
     if (text) {
       onSubmit(text);
     }

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.tsx
@@ -81,7 +81,13 @@ export function ConversationPage({
           Reset
         </button>
       </nav>
-      <div className={styles.scrollContainer} ref={containerRef} aria-busy={isStreaming}>
+      <div
+        className={styles.scrollContainer}
+        ref={containerRef}
+        aria-busy={isStreaming}
+        role="log"
+        aria-label="Conversation history"
+      >
         <div className={styles.scrollContent}>
           <ConversationThread turns={turns} onAction={handleAction} turnRefs={turnRefs} />
         </div>

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.tsx
@@ -81,7 +81,7 @@ export function ConversationPage({
           Reset
         </button>
       </nav>
-      <div className={styles.scrollContainer} ref={containerRef}>
+      <div className={styles.scrollContainer} ref={containerRef} aria-busy={isStreaming}>
         <div className={styles.scrollContent}>
           <ConversationThread turns={turns} onAction={handleAction} turnRefs={turnRefs} />
         </div>

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.tsx
@@ -1,7 +1,8 @@
 import type {Turn} from '@coveo/thermidor';
 import {useEffect, useRef} from 'react';
 import {useScrollAnchor} from '../../hooks/use-scroll-anchor.js';
-import {PromptInput} from '../PromptInput/PromptInput.js';
+import type {TargetedProduct} from '../../context/targeting.js';
+import {ProductTargeting} from '../ProductTargeting/ProductTargeting.js';
 import {ConversationThread} from './ConversationThread.js';
 import styles from './ConversationPage.module.css';
 
@@ -11,7 +12,8 @@ interface ConversationPageProps {
   turns: Turn[];
   onBackToSearch: () => void;
   canGoBackToSearch: boolean;
-  onResetToLanding: () => void;
+  products: TargetedProduct[];
+  onProductsChange: (products: TargetedProduct[]) => void;
 }
 
 export function ConversationPage({
@@ -20,7 +22,8 @@ export function ConversationPage({
   turns,
   onBackToSearch,
   canGoBackToSearch,
-  onResetToLanding,
+  products,
+  onProductsChange,
 }: ConversationPageProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const turnRefs = useRef<Map<string, HTMLDivElement>>(new Map());
@@ -71,32 +74,53 @@ export function ConversationPage({
 
   return (
     <section className={styles.page}>
-      <nav className={styles.nav} aria-label="Conversation navigation">
-        {canGoBackToSearch && (
-          <button type="button" className={styles.backButton} onClick={onBackToSearch}>
-            &larr; Back to search results
-          </button>
-        )}
-        <button type="button" className={styles.resetButton} onClick={onResetToLanding}>
-          Reset
+      <div className={styles.promptAtBottom}>
+        <ProductTargeting
+          products={products}
+          onProductsChange={onProductsChange}
+          onSubmit={onSubmit}
+          isStreaming={isStreaming}
+          promptProps={{clearOnSubmit: true}}
+        >
+          <div
+            className={styles.scrollContainer}
+            ref={containerRef}
+            aria-busy={isStreaming}
+            role="log"
+            aria-label="Conversation history"
+          >
+            <div className={styles.scrollContent}>
+              <ConversationThread turns={turns} onAction={handleAction} turnRefs={turnRefs} />
+            </div>
+          </div>
+        </ProductTargeting>
+      </div>
+      {canGoBackToSearch && (
+        <button
+          type="button"
+          className={styles.floatingBackButton}
+          onClick={onBackToSearch}
+          title="Back to search results"
+          aria-label="Back to search results"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="8" y1="6" x2="21" y2="6" />
+            <line x1="8" y1="12" x2="21" y2="12" />
+            <line x1="8" y1="18" x2="21" y2="18" />
+            <line x1="3" y1="6" x2="3.01" y2="6" />
+            <line x1="3" y1="12" x2="3.01" y2="12" />
+            <line x1="3" y1="18" x2="3.01" y2="18" />
+          </svg>
         </button>
-      </nav>
-      <div
-        className={styles.scrollContainer}
-        ref={containerRef}
-        aria-busy={isStreaming}
-        role="log"
-        aria-label="Conversation history"
-      >
-        <div className={styles.scrollContent}>
-          <ConversationThread turns={turns} onAction={handleAction} turnRefs={turnRefs} />
-        </div>
-      </div>
-      <div className={styles.promptContainer}>
-        <div className={styles.promptWrapper}>
-          <PromptInput onSubmit={onSubmit} disabled={isStreaming} clearOnSubmit />
-        </div>
-      </div>
+      )}
     </section>
   );
 }

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationThread.module.css
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationThread.module.css
@@ -1,14 +1,13 @@
 .thread {
   display: flex;
   flex-direction: column;
-  gap: 0;
   width: 100%;
 }
 
 .turnWrapper {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4, 16px);
+  gap: var(--space-4);
   width: 100%;
 }
 

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationThread.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationThread.tsx
@@ -20,6 +20,8 @@ export function ConversationThread({turns, onAction, turnRefs}: ConversationThre
         <div key={turn.id}>
           <div
             className={styles.turnWrapper}
+            role="article"
+            aria-label={`Turn ${index + 1}`}
             ref={(el) => {
               if (el) {
                 turnRefs.current.set(turn.id, el);

--- a/samples/thermidor/demo-react/src/components/ConversationPage/StreamingMessage.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/StreamingMessage.tsx
@@ -18,5 +18,11 @@ export function StreamingMessage({messages}: StreamingMessageProps) {
     return null;
   }
 
-  return <div className={styles.messageText} dangerouslySetInnerHTML={{__html: html}} />;
+  return (
+    <div
+      className={styles.messageText}
+      aria-live="polite"
+      dangerouslySetInnerHTML={{__html: html}}
+    />
+  );
 }

--- a/samples/thermidor/demo-react/src/components/ConversationPage/StreamingMessage.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/StreamingMessage.tsx
@@ -1,7 +1,5 @@
 import {useMemo} from 'react';
-import {marked} from 'marked';
-import DOMPurify from 'dompurify';
-import {assembleMessages, type AgentMessage} from '../../utils.js';
+import {assembleMessages, renderMarkdown, type AgentMessage} from '../../utils.js';
 import styles from './StreamingMessage.module.css';
 
 export interface StreamingMessageProps {
@@ -13,12 +11,7 @@ export function StreamingMessage({messages}: StreamingMessageProps) {
 
   const html = useMemo(() => {
     if (!text) return '';
-    try {
-      const raw = marked.parse(text, {breaks: true, gfm: true}) as string;
-      return DOMPurify.sanitize(raw);
-    } catch {
-      return DOMPurify.sanitize(text);
-    }
+    return renderMarkdown(text);
   }, [text]);
 
   if (!text) {

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ThinkingBlock.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ThinkingBlock.tsx
@@ -1,6 +1,5 @@
-import {marked} from 'marked';
-import DOMPurify from 'dompurify';
 import type {ReasoningStep, ToolCallStep} from '@coveo/thermidor';
+import {renderMarkdown} from '../../utils.js';
 import styles from './ThinkingBlock.module.css';
 
 export interface ThinkingBlockProps {
@@ -10,15 +9,6 @@ export interface ThinkingBlockProps {
 
 function isToolCall(step: ReasoningStep): step is ToolCallStep {
   return step.type === 'tool-call';
-}
-
-function renderReasoningMarkdown(content: string): string {
-  try {
-    const raw = marked.parse(content, {breaks: true, gfm: true}) as string;
-    return DOMPurify.sanitize(raw);
-  } catch {
-    return DOMPurify.sanitize(content);
-  }
 }
 
 function formatArgs(args: string): string {
@@ -86,7 +76,7 @@ export function ThinkingBlock({reasoningSteps, isStreaming}: ThinkingBlockProps)
                 key={`reasoning-${index}`}
                 className={styles.reasoningBlock}
                 dangerouslySetInnerHTML={{
-                  __html: renderReasoningMarkdown(step.content),
+                  __html: renderMarkdown(step.content),
                 }}
               />
             );

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ThinkingBlock.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ThinkingBlock.tsx
@@ -63,7 +63,7 @@ export function ThinkingBlock({reasoningSteps, isStreaming}: ThinkingBlockProps)
   const summaryContent = getSummaryContent(reasoningSteps, isStreaming);
 
   return (
-    <details className={styles.details}>
+    <details className={styles.details} aria-label="Agent reasoning process">
       <summary className={styles.summary}>
         <span className={styles.chevron} aria-hidden="true" />
         {summaryContent}

--- a/samples/thermidor/demo-react/src/components/ConversationPage/TurnSeparator.module.css
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/TurnSeparator.module.css
@@ -1,7 +1,7 @@
 .separator {
   width: 100%;
   height: 0;
-  margin: var(--space-6, 24px) 0;
+  margin: var(--space-6) 0;
   border: none;
-  border-top: 1px solid var(--color-border, #e5e7eb);
+  border-top: 1px solid var(--color-border);
 }

--- a/samples/thermidor/demo-react/src/components/ConversationPage/UserPromptBubble.module.css
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/UserPromptBubble.module.css
@@ -3,7 +3,7 @@
   max-width: 80%;
   padding: var(--space-3) var(--space-4);
   background: var(--color-bg-user-prompt);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-lg) 0 var(--radius-lg) var(--radius-lg);
   font-size: var(--font-size-md);
   line-height: 1.5;
   color: var(--color-text-primary);

--- a/samples/thermidor/demo-react/src/components/ConversationPage/UserPromptBubble.module.css
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/UserPromptBubble.module.css
@@ -9,3 +9,33 @@
   color: var(--color-text-primary);
   word-break: break-word;
 }
+
+.promptText {
+  margin: 0;
+}
+
+.separator {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: var(--space-2) 0;
+}
+
+.contextSection {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.contextLabel {
+  display: block;
+  margin-bottom: var(--space-1);
+}
+
+.productList {
+  margin: 0;
+  padding-left: var(--space-4);
+  list-style-type: disc;
+}
+
+.productItem {
+  line-height: 1.4;
+}

--- a/samples/thermidor/demo-react/src/components/ConversationPage/UserPromptBubble.module.css
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/UserPromptBubble.module.css
@@ -2,7 +2,7 @@
   margin-left: auto;
   max-width: 80%;
   padding: var(--space-3) var(--space-4);
-  background: var(--color-bg-user-prompt, #e3f2fd);
+  background: var(--color-bg-user-prompt);
   border-radius: var(--radius-lg);
   font-size: var(--font-size-md);
   line-height: 1.5;

--- a/samples/thermidor/demo-react/src/components/ConversationPage/UserPromptBubble.test.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/UserPromptBubble.test.tsx
@@ -3,14 +3,38 @@ import {describe, it, expect} from 'vitest';
 import {UserPromptBubble} from './UserPromptBubble.js';
 
 describe('UserPromptBubble', () => {
-  it('displays the prompt text', () => {
+  it('displays the prompt text without context', () => {
     render(<UserPromptBubble prompt="What are the best running shoes?" />);
     expect(screen.getByText('What are the best running shoes?')).toBeDefined();
+    expect(screen.queryByText('Products:')).toBeNull();
   });
 
   it('applies the bubble class for right-alignment styling', () => {
     const {container} = render(<UserPromptBubble prompt="hello" />);
     const bubble = container.firstElementChild as HTMLElement;
     expect(bubble.className).toContain('bubble');
+  });
+
+  it('renders prompt with one product showing separator and list', () => {
+    render(<UserPromptBubble prompt="Compare these [ADDITIONAL CONTEXT: Widget Pro]" />);
+    expect(screen.getByText('Compare these')).toBeDefined();
+    expect(screen.getByText('Products:')).toBeDefined();
+    expect(screen.getByText('Widget Pro')).toBeDefined();
+  });
+
+  it('renders prompt with multiple products showing all names', () => {
+    render(
+      <UserPromptBubble prompt="Which is better? [ADDITIONAL CONTEXT: Widget Pro, Gadget X, Super Item]" />
+    );
+    expect(screen.getByText('Which is better?')).toBeDefined();
+    expect(screen.getByText('Widget Pro')).toBeDefined();
+    expect(screen.getByText('Gadget X')).toBeDefined();
+    expect(screen.getByText('Super Item')).toBeDefined();
+  });
+
+  it('handles empty prompt text with only context', () => {
+    render(<UserPromptBubble prompt="[ADDITIONAL CONTEXT: Widget Pro]" />);
+    expect(screen.getByText('Products:')).toBeDefined();
+    expect(screen.getByText('Widget Pro')).toBeDefined();
   });
 });

--- a/samples/thermidor/demo-react/src/components/ConversationPage/UserPromptBubble.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/UserPromptBubble.tsx
@@ -4,6 +4,42 @@ interface UserPromptBubbleProps {
   prompt: string;
 }
 
+const CONTEXT_PATTERN = /\s*\[ADDITIONAL CONTEXT:\s*(.+?)\]$/;
+
+function parsePrompt(prompt: string): {text: string; products: string[]} {
+  const match = prompt.match(CONTEXT_PATTERN);
+  if (!match) {
+    return {text: prompt, products: []};
+  }
+  const text = prompt.slice(0, match.index).trim();
+  const products = match[1]
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean);
+  return {text, products};
+}
+
 export function UserPromptBubble({prompt}: UserPromptBubbleProps) {
-  return <div className={styles.bubble}>{prompt}</div>;
+  const {text, products} = parsePrompt(prompt);
+
+  return (
+    <div className={styles.bubble}>
+      {text && <p className={styles.promptText}>{text}</p>}
+      {products.length > 0 && (
+        <>
+          <hr className={styles.separator} />
+          <div className={styles.contextSection}>
+            <strong className={styles.contextLabel}>Products:</strong>
+            <ul className={styles.productList}>
+              {products.map((name, i) => (
+                <li key={i} className={styles.productItem}>
+                  {name}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      )}
+    </div>
+  );
 }

--- a/samples/thermidor/demo-react/src/components/ConversationPage/UserPromptBubble.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/UserPromptBubble.tsx
@@ -11,7 +11,7 @@ function parsePrompt(prompt: string): {text: string; products: string[]} {
   if (!match) {
     return {text: prompt, products: []};
   }
-  const text = prompt.slice(0, match.index).trim();
+  const text = prompt.slice(0, match.index ?? prompt.length).trim();
   const products = match[1]
     .split(',')
     .map((name) => name.trim())

--- a/samples/thermidor/demo-react/src/components/LandingPage/LandingPage.module.css
+++ b/samples/thermidor/demo-react/src/components/LandingPage/LandingPage.module.css
@@ -4,7 +4,7 @@
   align-items: center;
   justify-content: center;
   min-height: 100%;
-  padding: var(--space-6);
+  padding: var(--space-6) var(--space-4);
 }
 
 .content {
@@ -12,6 +12,7 @@
   flex-direction: column;
   align-items: center;
   width: 100%;
+  max-width: 560px;
 }
 
 .title {
@@ -24,10 +25,8 @@
 
 .inputWrapper {
   width: 100%;
-  max-width: 560px;
 }
 
 .pillsWrapper {
   width: 100%;
-  max-width: 560px;
 }

--- a/samples/thermidor/demo-react/src/components/LandingPage/LandingPage.module.css
+++ b/samples/thermidor/demo-react/src/components/LandingPage/LandingPage.module.css
@@ -23,9 +23,11 @@
 }
 
 .inputWrapper {
-  width: 33.333vw;
+  width: 100%;
+  max-width: 560px;
 }
 
 .pillsWrapper {
-  width: 33.333vw;
+  width: 100%;
+  max-width: 560px;
 }

--- a/samples/thermidor/demo-react/src/components/LandingPage/LandingPage.tsx
+++ b/samples/thermidor/demo-react/src/components/LandingPage/LandingPage.tsx
@@ -1,4 +1,3 @@
-import {useState} from 'react';
 import {SECTION_ACTIONS, type SuggestionItem} from '../SuggestionsDropdown/index.js';
 import {PromptInput} from '../PromptInput/PromptInput.js';
 import {SuggestionPills} from '../SuggestionPills/SuggestionPills.js';
@@ -12,8 +11,6 @@ interface LandingPageProps {
 
 export function LandingPage({onSubmit, isStreaming}: LandingPageProps) {
   const {sections} = useSuggestions({inputValue: '', context: 'landing'});
-  const [inputValue, setInputValue] = useState('');
-  const [inputKey, setInputKey] = useState(0);
 
   const handleSuggestionSelect = (item: SuggestionItem, sectionId: string) => {
     const action = SECTION_ACTIONS[sectionId];
@@ -22,29 +19,21 @@ export function LandingPage({onSubmit, isStreaming}: LandingPageProps) {
     }
   };
 
-  const handlePillSelect = (suggestion: string) => {
-    setInputValue(suggestion);
-    setInputKey((k) => k + 1);
-    onSubmit(suggestion);
-  };
-
   return (
     <section className={styles.page}>
       <div className={styles.content}>
         <h1 className={styles.title}>What can I help you find?</h1>
         <div className={styles.inputWrapper}>
           <PromptInput
-            key={inputKey}
             onSubmit={onSubmit}
             disabled={isStreaming}
             placeholder="Search for products or ask a question..."
-            initialValue={inputValue}
             suggestions={sections}
             onSuggestionSelect={handleSuggestionSelect}
           />
         </div>
         <div className={styles.pillsWrapper}>
-          <SuggestionPills onSelect={handlePillSelect} disabled={isStreaming} />
+          <SuggestionPills onSelect={onSubmit} disabled={isStreaming} />
         </div>
       </div>
     </section>

--- a/samples/thermidor/demo-react/src/components/LandingPage/LandingPage.tsx
+++ b/samples/thermidor/demo-react/src/components/LandingPage/LandingPage.tsx
@@ -27,7 +27,7 @@ export function LandingPage({onSubmit, isStreaming}: LandingPageProps) {
           <PromptInput
             onSubmit={onSubmit}
             disabled={isStreaming}
-            placeholder="Search for products or ask a question..."
+            placeholder="Ask anything..."
             suggestions={sections}
             onSuggestionSelect={handleSuggestionSelect}
           />

--- a/samples/thermidor/demo-react/src/components/ProductTargeting/ProductTargeting.module.css
+++ b/samples/thermidor/demo-react/src/components/ProductTargeting/ProductTargeting.module.css
@@ -1,0 +1,268 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: var(--space-4) var(--space-5);
+}
+
+.promptArea {
+  position: relative;
+  border: 1px solid var(--color-border, #e0e0e0);
+  border-radius: 12px;
+  background: var(--color-surface, #fff);
+  transition: box-shadow 0.15s ease;
+  max-width: 560px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.promptArea:focus-within {
+  box-shadow: 0 0 0 2px var(--color-border-active, #1976d2);
+}
+
+.promptArea :global(.wrapper) {
+  position: static;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.promptArea :global(.textarea),
+.promptArea textarea {
+  border: none;
+  border-radius: 12px 12px 0 0;
+  box-shadow: none;
+  min-height: 44px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.promptArea :global(.textarea):disabled,
+.promptArea textarea:disabled {
+  opacity: 1;
+  background: transparent;
+}
+
+.promptArea:has(textarea:disabled) {
+  opacity: 0.6;
+  background: var(--color-bg-secondary, #f5f5f5);
+}
+
+.promptArea :global(.textarea):focus,
+.promptArea textarea:focus {
+  border: none;
+  box-shadow: none;
+}
+
+.promptArea button[aria-label='Submit'],
+.promptArea button[aria-label='Clear'] {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  min-height: 42px;
+  padding: 6px 8px;
+  border-top: 1px solid var(--color-border, #e0e0e0);
+  gap: 8px;
+  overflow: visible;
+}
+
+.attachButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 4px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-secondary, #666);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.attachButton:hover:not(:disabled) {
+  background: var(--color-hover, #f5f5f5);
+  color: var(--color-text-primary, #333);
+}
+
+.attachButton:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.attachButtonActive {
+  background: var(--color-primary-light, #e3f2fd);
+  border-color: var(--color-primary, #1976d2);
+  color: var(--color-primary, #1976d2);
+}
+
+.attachButtonActive:hover:not(:disabled) {
+  background: var(--color-primary-lighter, #bbdefb);
+}
+
+.attachButton svg {
+  width: 16px;
+  height: 16px;
+}
+
+.separator {
+  width: 1px;
+  height: 20px;
+  background: var(--color-border, #e0e0e0);
+  flex-shrink: 0;
+}
+
+.pillsArea {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+  overflow: visible;
+}
+
+.hintText {
+  font-size: 13px;
+  color: var(--color-text-muted, #bbb);
+  font-style: italic;
+  white-space: nowrap;
+}
+
+.pill {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: opacity 0.15s ease;
+}
+
+.pill:hover .pillThumbnail,
+.pill:hover .pillPlaceholder {
+  opacity: 0.7;
+}
+
+.pill:hover .pillBadge {
+  opacity: 1;
+}
+
+.pill:focus-visible {
+  outline: 2px solid var(--color-primary, #1976d2);
+  outline-offset: 1px;
+}
+
+.pillDisabled {
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.pillThumbnail {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  object-fit: cover;
+  transition: opacity 0.15s ease;
+}
+
+.pillPlaceholder {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  background: var(--color-border, #ccc);
+  transition: opacity 0.15s ease;
+}
+
+.pillBadge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--color-text-secondary, #666);
+  color: #fff;
+  font-size: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+.clearButton {
+  margin-left: auto;
+  padding: 2px 10px;
+  border: 1px solid var(--color-border, #e0e0e0);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text-secondary, #666);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.clearButton:hover:not(:disabled) {
+  background: var(--color-surface-hover, #f5f5f5);
+  color: var(--color-text-primary, #333);
+  border-color: var(--color-text-secondary, #666);
+}
+
+.clearButton:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.clearButton:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.doneButton {
+  margin-left: auto;
+  padding: 2px 10px;
+  border: 1px solid var(--color-primary, #1976d2);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-primary, #1976d2);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.doneButton:hover {
+  background: var(--color-primary, #1976d2);
+  color: #fff;
+}
+
+.doneButton:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.targetingActive {
+  cursor: crosshair;
+}

--- a/samples/thermidor/demo-react/src/components/ProductTargeting/ProductTargeting.test.tsx
+++ b/samples/thermidor/demo-react/src/components/ProductTargeting/ProductTargeting.test.tsx
@@ -1,0 +1,149 @@
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {ProductTargeting, type ProductTargetingProps} from './ProductTargeting.js';
+import type {TargetedProduct} from '../../context/targeting.js';
+
+vi.mock('../PromptInput/PromptInput.js', () => ({
+  PromptInput: ({onSubmit, disabled}: {onSubmit: (prompt: string) => void; disabled?: boolean}) => (
+    <input
+      data-testid="mock-prompt-input"
+      disabled={disabled}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          onSubmit((e.target as HTMLInputElement).value);
+        }
+      }}
+    />
+  ),
+}));
+
+const defaultProps: ProductTargetingProps = {
+  products: [],
+  onProductsChange: vi.fn(),
+  onSubmit: vi.fn(),
+  isStreaming: false,
+  children: <div data-testid="children">Content</div>,
+};
+
+function renderComponent(overrides: Partial<ProductTargetingProps> = {}) {
+  const props = {...defaultProps, ...overrides};
+  return render(<ProductTargeting {...props} />);
+}
+
+describe('ProductTargeting', () => {
+  it('renders toolbar with hint text "Attach product context" when no products attached', () => {
+    renderComponent();
+    expect(screen.getByText('Attach product context')).toBeDefined();
+  });
+
+  it('toggling attach button changes hint text to "Select products to attach"', () => {
+    renderComponent();
+
+    const attachButton = screen.getByRole('button', {name: /attach product context/i});
+    fireEvent.click(attachButton);
+
+    expect(screen.getByText('Select products to attach')).toBeDefined();
+  });
+
+  it('adding products shows pills (thumbnail images)', () => {
+    const products: TargetedProduct[] = [
+      {id: '1', name: 'Product A', thumbnail: 'https://example.com/a.png'},
+      {id: '2', name: 'Product B', thumbnail: 'https://example.com/b.png'},
+    ];
+    renderComponent({products});
+
+    const images = screen.getAllByRole('img');
+    expect(images).toHaveLength(2);
+    expect(images[0].getAttribute('alt')).toBe('Product A');
+    expect(images[1].getAttribute('alt')).toBe('Product B');
+  });
+
+  it('removing pill (clicking it) calls onProductsChange with the product removed', () => {
+    const onProductsChange = vi.fn();
+    const products: TargetedProduct[] = [
+      {id: '1', name: 'Product A', thumbnail: 'https://example.com/a.png'},
+      {id: '2', name: 'Product B', thumbnail: 'https://example.com/b.png'},
+    ];
+    renderComponent({products, onProductsChange});
+
+    const pill = screen.getByRole('button', {name: 'Remove Product A'});
+    fireEvent.click(pill);
+
+    expect(onProductsChange).toHaveBeenCalledWith([
+      {id: '2', name: 'Product B', thumbnail: 'https://example.com/b.png'},
+    ]);
+  });
+
+  it('clear button removes all products (calls onProductsChange([]))', () => {
+    const onProductsChange = vi.fn();
+    const products: TargetedProduct[] = [
+      {id: '1', name: 'Product A', thumbnail: 'https://example.com/a.png'},
+    ];
+    renderComponent({products, onProductsChange});
+
+    const clearButton = screen.getByRole('button', {name: /clear/i});
+    fireEvent.click(clearButton);
+
+    expect(onProductsChange).toHaveBeenCalledWith([]);
+  });
+
+  it('submit appends context string when products are attached', () => {
+    const onSubmit = vi.fn();
+    const products: TargetedProduct[] = [
+      {id: '1', name: 'Widget X'},
+      {id: '2', name: 'Gadget Y'},
+    ];
+    renderComponent({products, onSubmit});
+
+    const input = screen.getByTestId('mock-prompt-input');
+    fireEvent.change(input, {target: {value: 'Tell me about these'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      'Tell me about these [ADDITIONAL CONTEXT: Widget X, Gadget Y]'
+    );
+  });
+
+  it('submit without products passes prompt as-is', () => {
+    const onSubmit = vi.fn();
+    renderComponent({products: [], onSubmit});
+
+    const input = screen.getByTestId('mock-prompt-input');
+    fireEvent.change(input, {target: {value: 'Hello world'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
+
+    expect(onSubmit).toHaveBeenCalledWith('Hello world');
+  });
+
+  it('auto-exits targeting on streaming (when isStreaming changes to true)', () => {
+    const {rerender} = render(<ProductTargeting {...defaultProps} isStreaming={false} />);
+
+    const attachButton = screen.getByRole('button', {name: /attach product context/i});
+    fireEvent.click(attachButton);
+    expect(screen.queryByText('Select products to attach')).not.toBeNull();
+
+    rerender(<ProductTargeting {...defaultProps} isStreaming={true} />);
+
+    expect(screen.queryByText('Select products to attach')).toBeNull();
+  });
+
+  it('attach button is disabled when streaming', () => {
+    renderComponent({isStreaming: true});
+
+    const attachButton = screen.getByRole('button', {name: /attach product context/i});
+    expect((attachButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('pills are not removable when streaming (click does nothing)', () => {
+    const onProductsChange = vi.fn();
+    const products: TargetedProduct[] = [
+      {id: '1', name: 'Product A', thumbnail: 'https://example.com/a.png'},
+    ];
+    renderComponent({products, onProductsChange, isStreaming: true});
+
+    const pill = screen.getByRole('button', {name: 'Remove Product A'});
+    fireEvent.click(pill);
+
+    expect(onProductsChange).not.toHaveBeenCalled();
+  });
+});

--- a/samples/thermidor/demo-react/src/components/ProductTargeting/ProductTargeting.tsx
+++ b/samples/thermidor/demo-react/src/components/ProductTargeting/ProductTargeting.tsx
@@ -53,6 +53,8 @@ export function ProductTargeting({
 
   const handleProductTargeted = useCallback(
     (productId: string, productName: string, productThumbnail?: string) => {
+      if (!productId) return;
+
       const existing = products.find((p) => p.id === productId);
       if (existing) {
         onProductsChange(products.filter((p) => p.id !== productId));

--- a/samples/thermidor/demo-react/src/components/ProductTargeting/ProductTargeting.tsx
+++ b/samples/thermidor/demo-react/src/components/ProductTargeting/ProductTargeting.tsx
@@ -1,0 +1,190 @@
+import {useCallback, useEffect, useMemo, type ReactNode} from 'react';
+import {PromptInput} from '../PromptInput/PromptInput.js';
+import {TargetingProvider, type TargetedProduct} from '../../context/targeting.js';
+import {useTargetingMode} from '../../hooks/use-targeting-mode.js';
+import type {SuggestionSection, SuggestionItem} from '../SuggestionsDropdown/index.js';
+import styles from './ProductTargeting.module.css';
+
+export interface ProductTargetingProps {
+  products: TargetedProduct[];
+  onProductsChange: (products: TargetedProduct[]) => void;
+  onSubmit: (prompt: string) => void;
+  isStreaming: boolean;
+  disabled?: boolean;
+  promptProps?: {
+    initialValue?: string;
+    clearOnSubmit?: boolean;
+    placeholder?: string;
+    suggestions?: SuggestionSection[];
+    onSuggestionSelect?: (item: SuggestionItem, sectionId: string) => void;
+  };
+  children: ReactNode;
+}
+
+export function ProductTargeting({
+  products,
+  onProductsChange,
+  onSubmit,
+  isStreaming,
+  disabled = false,
+  promptProps,
+  children,
+}: ProductTargetingProps) {
+  const {isTargeting, stopTargeting, toggleTargeting} = useTargetingMode();
+
+  useEffect(() => {
+    if (isStreaming) {
+      stopTargeting();
+    }
+  }, [isStreaming, stopTargeting]);
+
+  const handleSubmitWithContext = useCallback(
+    (prompt: string) => {
+      stopTargeting();
+      if (products.length > 0) {
+        const names = products.map((p) => p.name).join(', ');
+        onSubmit(`${prompt} [ADDITIONAL CONTEXT: ${names}]`);
+      } else {
+        onSubmit(prompt);
+      }
+    },
+    [products, onSubmit, stopTargeting]
+  );
+
+  const handleProductTargeted = useCallback(
+    (productId: string, productName: string, productThumbnail?: string) => {
+      const existing = products.find((p) => p.id === productId);
+      if (existing) {
+        onProductsChange(products.filter((p) => p.id !== productId));
+      } else {
+        onProductsChange([
+          ...products,
+          {id: productId, name: productName, thumbnail: productThumbnail},
+        ]);
+      }
+    },
+    [products, onProductsChange]
+  );
+
+  const handleRemovePill = useCallback(
+    (productId: string) => {
+      if (isStreaming) return;
+      onProductsChange(products.filter((p) => p.id !== productId));
+    },
+    [products, onProductsChange, isStreaming]
+  );
+
+  const handleClearAll = useCallback(() => {
+    onProductsChange([]);
+  }, [onProductsChange]);
+
+  const selectedProductIds = useMemo(() => new Set(products.map((p) => p.id)), [products]);
+
+  const targetingContextValue = useMemo(
+    () => ({
+      isTargeting,
+      onProductTargeted: handleProductTargeted,
+      selectedProductIds,
+    }),
+    [isTargeting, handleProductTargeted, selectedProductIds]
+  );
+
+  const hintText = isTargeting ? 'Select products to attach' : 'Attach product context';
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.promptArea}>
+        <PromptInput
+          {...promptProps}
+          onSubmit={handleSubmitWithContext}
+          disabled={disabled || isStreaming}
+        />
+        <div className={styles.toolbar}>
+          <button
+            type="button"
+            className={`${styles.attachButton} ${isTargeting ? styles.attachButtonActive : ''}`}
+            onClick={toggleTargeting}
+            disabled={isStreaming}
+            aria-label={isTargeting ? 'Stop targeting' : 'Attach product context'}
+            aria-pressed={isTargeting}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={isTargeting ? '2.5' : '2'}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+            </svg>
+          </button>
+          <span className={styles.separator} />
+          <span className={styles.pillsArea}>
+            {products.length === 0 ? (
+              <>
+                <span className={styles.hintText}>{hintText}</span>
+                {isTargeting && (
+                  <button type="button" className={styles.doneButton} onClick={stopTargeting}>
+                    Done
+                  </button>
+                )}
+              </>
+            ) : (
+              <>
+                {products.map((product) => (
+                  <span
+                    key={product.id}
+                    className={`${styles.pill} ${isStreaming ? styles.pillDisabled : ''}`}
+                    title={`${product.name} — click to remove`}
+                    tabIndex={isStreaming ? -1 : 0}
+                    role="button"
+                    aria-label={`Remove ${product.name}`}
+                    onClick={() => handleRemovePill(product.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleRemovePill(product.id);
+                      }
+                    }}
+                  >
+                    {product.thumbnail ? (
+                      <img
+                        src={product.thumbnail}
+                        alt={product.name}
+                        className={styles.pillThumbnail}
+                      />
+                    ) : (
+                      <span className={styles.pillPlaceholder} />
+                    )}
+                    <span className={styles.pillBadge} aria-hidden="true">
+                      ×
+                    </span>
+                  </span>
+                ))}
+                {isTargeting ? (
+                  <button type="button" className={styles.doneButton} onClick={stopTargeting}>
+                    Done
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className={styles.clearButton}
+                    onClick={handleClearAll}
+                    disabled={isStreaming}
+                  >
+                    Clear
+                  </button>
+                )}
+              </>
+            )}
+          </span>
+        </div>
+      </div>
+      <TargetingProvider value={targetingContextValue}>
+        <div className={isTargeting ? styles.targetingActive : undefined}>{children}</div>
+      </TargetingProvider>
+    </div>
+  );
+}

--- a/samples/thermidor/demo-react/src/components/PromptInput/PromptInput.tsx
+++ b/samples/thermidor/demo-react/src/components/PromptInput/PromptInput.tsx
@@ -137,6 +137,11 @@ export function PromptInput({
   }
 
   function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Tab' && showDropdown) {
+      setShowDropdown(false);
+      return;
+    }
+
     if (e.key === 'Escape' && showDropdown) {
       e.preventDefault();
       setShowDropdown(false);
@@ -233,6 +238,7 @@ export function PromptInput({
           }}
           aria-label="Clear"
           style={{visibility: value && !disabled ? 'visible' : 'hidden'}}
+          tabIndex={value && !disabled ? 0 : -1}
         >
           <svg
             viewBox="0 0 24 24"
@@ -253,6 +259,7 @@ export function PromptInput({
           onClick={submit}
           disabled={disabled || !value.trim()}
           aria-label="Submit"
+          tabIndex={!disabled && value.trim() ? 0 : -1}
         >
           {disabled ? (
             <svg

--- a/samples/thermidor/demo-react/src/components/PromptInput/PromptInput.tsx
+++ b/samples/thermidor/demo-react/src/components/PromptInput/PromptInput.tsx
@@ -29,7 +29,7 @@ interface PromptInputProps {
 export function PromptInput({
   onSubmit,
   disabled = false,
-  placeholder = 'Search for products or ask a question...',
+  placeholder = 'Ask anything...',
   initialValue = '',
   clearOnSubmit = false,
   autoFocus = false,

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/FacetSidebar.test.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/FacetSidebar.test.tsx
@@ -34,6 +34,8 @@ describe('Facet sidebar placeholder', () => {
     isStreaming: false,
     routedInterface: {useCase: 'search', interface: {id: 'mock'}} as any,
     onBackToConversation: vi.fn(),
+    products: [] as any[],
+    onProductsChange: vi.fn(),
   };
 
   it('renders text "Facets (coming soon)"', () => {

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/PageSizeSelector/PageSizeSelector.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/PageSizeSelector/PageSizeSelector.module.css
@@ -1,26 +1,26 @@
 .container {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .label {
-  font-size: var(--font-size-sm, 14px);
-  color: var(--color-text-muted, #666);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
   white-space: nowrap;
 }
 
 .select {
-  padding: 6px 12px;
-  border: 1px solid var(--color-border, #ccc);
-  border-radius: var(--radius-md, 6px);
-  background: var(--color-surface, #fff);
-  color: var(--color-text, #333);
-  font-size: var(--font-size-sm, 14px);
+  padding: 6px var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
   cursor: pointer;
-  transition: border-color 150ms ease;
+  transition: border-color var(--transition-fast);
 }
 
 .select:hover {
-  border-color: var(--color-border-hover, #999);
+  border-color: var(--color-border-hover);
 }

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/Pagination/Pagination.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/Pagination/Pagination.module.css
@@ -1,8 +1,8 @@
 .pagination {
   display: flex;
   align-items: center;
-  gap: var(--space-2, 8px);
-  padding: var(--space-4, 16px) 0;
+  gap: var(--space-2);
+  padding: var(--space-4) 0;
   flex-wrap: wrap;
 }
 
@@ -12,18 +12,18 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--color-border, #ccc);
-  border-radius: var(--radius-md, 6px);
-  background: var(--color-bg-primary, #fff);
-  color: var(--color-text-primary, #333);
-  font-size: 18px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-lg);
   line-height: 1;
   cursor: pointer;
-  transition: border-color 150ms ease;
+  transition: border-color var(--transition-fast);
 }
 
 .navButton:hover:not(:disabled) {
-  border-color: var(--color-border-active, #666);
+  border-color: var(--color-border-active);
 }
 
 .navButton:disabled {
@@ -34,7 +34,7 @@
 .pages {
   display: flex;
   align-items: center;
-  gap: var(--space-1, 4px);
+  gap: var(--space-1);
 }
 
 .pageButton {
@@ -43,25 +43,25 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--space-1, 4px) var(--space-2, 8px);
-  border: 1px solid var(--color-border, #ccc);
-  border-radius: var(--radius-md, 6px);
-  background: var(--color-bg-primary, #fff);
-  color: var(--color-text-primary, #333);
-  font-size: var(--font-size-sm, 14px);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
   cursor: pointer;
   transition:
-    background-color 150ms ease,
-    border-color 150ms ease;
+    background-color var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .pageButton:hover:not(.active) {
-  border-color: var(--color-border-active, #666);
+  border-color: var(--color-border-active);
 }
 
 .pageButton.active {
-  background: var(--color-primary, #1d4ed8);
-  border-color: var(--color-primary, #1d4ed8);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
   color: #fff;
   font-weight: 600;
   pointer-events: none;
@@ -73,6 +73,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: var(--font-size-sm, 14px);
-  color: var(--color-text-muted, #666);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
 }

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductCard/ProductCard.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductCard/ProductCard.module.css
@@ -5,7 +5,6 @@
   border-radius: var(--radius-lg);
   overflow: hidden;
   background: var(--color-bg-primary);
-  cursor: pointer;
   transition:
     box-shadow var(--transition-normal),
     border-color var(--transition-normal);

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductCard/ProductCard.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductCard/ProductCard.module.css
@@ -36,7 +36,7 @@
 .imagePlaceholder {
   width: 100%;
   height: 100%;
-  background: var(--color-bg-secondary, #f5f5f5);
+  background: var(--color-bg-secondary);
   border-radius: var(--radius-sm);
 }
 

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductCard/ProductCard.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductCard/ProductCard.module.css
@@ -89,3 +89,16 @@
   color: var(--color-text-muted);
   text-decoration: line-through;
 }
+
+.targetable {
+  cursor: crosshair;
+}
+
+.targetable:hover {
+  box-shadow: 0 0 0 2px var(--color-border-active);
+}
+
+.selected {
+  box-shadow: 0 0 0 2px var(--color-border-active);
+  opacity: 0.7;
+}

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductCard/ProductCard.test.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductCard/ProductCard.test.tsx
@@ -1,63 +1,84 @@
-import {render, screen} from '@testing-library/react';
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
 import {ProductCard} from './ProductCard.js';
-import type {Product} from '../utils.js';
+import {TargetingProvider, type TargetingContext} from '../../../context/targeting.js';
+import type {Product} from '@coveo/thermidor';
 
-function buildProduct(overrides: Partial<Product> = {}): Product {
-  return {
-    ec_thumbnails: ['https://example.com/thumb.jpg'],
-    ec_name: 'Wireless Headphones',
-    ec_brand: 'Acme Audio',
-    ec_price: 99.99,
-    ...overrides,
-  };
+vi.mock('../utils.js', () => ({
+  resolveProductImage: () => 'https://example.com/img.jpg',
+}));
+
+const mockProduct = {
+  permanentid: 'prod-123',
+  ec_name: 'Test Widget',
+  ec_brand: 'Acme',
+  ec_price: 29.99,
+} as Product;
+
+function renderWithTargeting(ui: React.ReactElement, targeting: TargetingContext) {
+  return render(<TargetingProvider value={targeting}>{ui}</TargetingProvider>);
 }
 
 describe('ProductCard', () => {
-  it('renders name, brand, and formatted price', () => {
-    render(<ProductCard product={buildProduct()} />);
+  it('renders normally without context (no role="button", no tabIndex)', () => {
+    render(<ProductCard product={mockProduct} />);
 
-    expect(screen.getByText('Wireless Headphones')).toBeDefined();
-    expect(screen.getByText('Acme Audio')).toBeDefined();
-    expect(screen.getByText('$99.99')).toBeDefined();
+    const card = screen.getByRole('article');
+    expect(card.tagName).toBe('ARTICLE');
+    expect(card.getAttribute('tabindex')).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
   });
 
-  it('shows placeholder when no image available', () => {
-    const product = buildProduct({
-      ec_thumbnails: undefined,
-      ec_images: undefined,
-    });
-    render(<ProductCard product={product} />);
+  it('becomes clickable with context (has role="button", tabIndex=0 when isTargeting is true)', () => {
+    const targeting: TargetingContext = {
+      isTargeting: true,
+      onProductTargeted: vi.fn(),
+      selectedProductIds: new Set(),
+    };
 
-    expect(screen.getByLabelText('No image available')).toBeDefined();
-    expect(screen.queryByRole('img')).toBeNull();
+    renderWithTargeting(<ProductCard product={mockProduct} />, targeting);
+
+    const card = screen.getByRole('button');
+    expect(card.getAttribute('tabindex')).toBe('0');
   });
 
-  it('shows promo price with strikethrough on original', () => {
-    const product = buildProduct({
-      ec_price: 99.99,
-      ec_promo_price: 79.99,
-    });
-    render(<ProductCard product={product} />);
+  it('clicking ProductCard in targeting mode calls onProductTargeted with correct args', () => {
+    const onProductTargeted = vi.fn();
+    const targeting: TargetingContext = {
+      isTargeting: true,
+      onProductTargeted,
+      selectedProductIds: new Set(),
+    };
 
-    expect(screen.getByText('$79.99')).toBeDefined();
-    expect(screen.getByText('$99.99')).toBeDefined();
+    renderWithTargeting(<ProductCard product={mockProduct} />, targeting);
 
-    const originalPriceEl = screen.getByText('$99.99');
-    expect(originalPriceEl.className).toContain('originalPrice');
+    const card = screen.getByRole('button');
+    fireEvent.click(card);
+
+    expect(onProductTargeted).toHaveBeenCalledWith(
+      'prod-123',
+      'Test Widget',
+      'https://example.com/img.jpg'
+    );
   });
 
-  it('displays title attribute with full product name', () => {
-    render(<ProductCard product={buildProduct()} />);
+  it('clicking a selected ProductCard in targeting mode calls onProductTargeted (for toggle/removal)', () => {
+    const onProductTargeted = vi.fn();
+    const targeting: TargetingContext = {
+      isTargeting: true,
+      onProductTargeted,
+      selectedProductIds: new Set(['prod-123']),
+    };
 
-    const heading = screen.getByRole('heading', {level: 3});
-    expect(heading.getAttribute('title')).toBe('Wireless Headphones');
-  });
+    renderWithTargeting(<ProductCard product={mockProduct} />, targeting);
 
-  it('shows "\u2014" when price is undefined', () => {
-    const product = buildProduct({ec_price: undefined});
-    render(<ProductCard product={product} />);
+    const card = screen.getByRole('button');
+    fireEvent.click(card);
 
-    expect(screen.getByText('\u2014')).toBeDefined();
+    expect(onProductTargeted).toHaveBeenCalledWith(
+      'prod-123',
+      'Test Widget',
+      'https://example.com/img.jpg'
+    );
   });
 });

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductCard/ProductCard.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductCard/ProductCard.tsx
@@ -1,4 +1,5 @@
 import type {Product} from '@coveo/thermidor';
+import {useTargeting} from '../../../context/targeting.js';
 import {resolveProductImage} from '../utils.js';
 import styles from './ProductCard.module.css';
 
@@ -12,13 +13,48 @@ function formatPrice(value: number): string {
 
 export function ProductCard({product}: ProductCardProps) {
   const imageUrl = resolveProductImage(product);
+  const targeting = useTargeting();
 
   const {ec_name: name, ec_brand: brand, ec_price: price, ec_promo_price: promoPrice} = product;
 
   const hasPromo = promoPrice !== undefined && price !== undefined && promoPrice < price;
 
+  const isSelected = targeting?.selectedProductIds.has(product.permanentid ?? '') ?? false;
+  const isTargetable = targeting?.isTargeting ?? false;
+
+  const cardClasses = [
+    styles.card,
+    isTargetable ? styles.targetable : '',
+    isSelected ? styles.selected : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const interactiveProps = isTargetable
+    ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        onClick: () =>
+          targeting!.onProductTargeted(
+            product.permanentid ?? '',
+            product.ec_name ?? '',
+            imageUrl ?? undefined
+          ),
+        onKeyDown: (e: React.KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            targeting!.onProductTargeted(
+              product.permanentid ?? '',
+              product.ec_name ?? '',
+              imageUrl ?? undefined
+            );
+          }
+        },
+      }
+    : {};
+
   return (
-    <article className={styles.card}>
+    <article className={cardClasses} {...interactiveProps}>
       <div className={styles.imageWrapper}>
         {imageUrl ? (
           <img className={styles.image} src={imageUrl} alt={name ?? ''} />

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductCard/ProductCard.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductCard/ProductCard.tsx
@@ -1,4 +1,4 @@
-import type {Product} from '../utils.js';
+import type {Product} from '@coveo/thermidor';
 import {resolveProductImage} from '../utils.js';
 import styles from './ProductCard.module.css';
 
@@ -13,10 +13,7 @@ function formatPrice(value: number): string {
 export function ProductCard({product}: ProductCardProps) {
   const imageUrl = resolveProductImage(product);
 
-  const name = product.ec_name as string | undefined;
-  const brand = product.ec_brand as string | undefined;
-  const price = product.ec_price as number | undefined;
-  const promoPrice = product.ec_promo_price as number | undefined;
+  const {ec_name: name, ec_brand: brand, ec_price: price, ec_promo_price: promoPrice} = product;
 
   const hasPromo = promoPrice !== undefined && price !== undefined && promoPrice < price;
 

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductGrid/ProductGrid.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductGrid/ProductGrid.module.css
@@ -4,19 +4,19 @@
   gap: var(--space-4);
 }
 
-@media (min-width: 600px) {
+@media (min-width: 640px) {
   .grid {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
-@media (min-width: 900px) {
+@media (min-width: 768px) {
   .grid {
     grid-template-columns: repeat(3, 1fr);
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1280px) {
   .grid {
     grid-template-columns: repeat(4, 1fr);
   }

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductGrid/ProductGrid.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductGrid/ProductGrid.module.css
@@ -1,7 +1,7 @@
 .grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 @media (min-width: 600px) {
@@ -24,6 +24,6 @@
 
 .empty {
   text-align: center;
-  color: var(--color-text-secondary, #6b7280);
-  padding: 2rem;
+  color: var(--color-text-secondary);
+  padding: var(--space-6);
 }

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductGrid/ProductGrid.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/ProductGrid/ProductGrid.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useSyncExternalStore} from 'react';
 import type {ProductListController} from '@coveo/thermidor';
 import {ProductCard} from '../ProductCard/ProductCard.js';
-import type {Product} from '../utils.js';
 import styles from './ProductGrid.module.css';
 
 interface ProductGridProps {
@@ -16,7 +15,7 @@ export function ProductGrid({controller}: ProductGridProps) {
   const getSnapshot = useCallback(() => controller.state, [controller]);
   const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
-  const products = state.products as unknown as Product[];
+  const {products} = state;
 
   if (products.length === 0) {
     return <p className={styles.empty}>No results found</p>;
@@ -25,7 +24,7 @@ export function ProductGrid({controller}: ProductGridProps) {
   return (
     <div className={styles.grid}>
       {products.map((product, index) => (
-        <ProductCard key={(product.permanentid as string | undefined) ?? index} product={product} />
+        <ProductCard key={product.permanentid ?? index} product={product} />
       ))}
     </div>
   );

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/QuerySummaryPlaceholder/QuerySummaryPlaceholder.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/QuerySummaryPlaceholder/QuerySummaryPlaceholder.module.css
@@ -1,6 +1,6 @@
 .summary {
   margin: 0;
-  font-size: 14px;
-  color: var(--color-text-muted, #666);
+  font-size: var(--font-size-base);
+  color: var(--color-text-muted);
   text-align: left;
 }

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
@@ -79,6 +79,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--space-4);
 }
 
 .sortFiltersButton {

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
@@ -46,7 +46,7 @@
   }
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1150px) {
   .header {
     flex-wrap: nowrap;
     justify-content: center;

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
@@ -2,18 +2,18 @@
   display: grid;
   grid-template-rows: auto 1fr;
   grid-template-columns: 1fr 2fr 8fr 1fr;
-  column-gap: 24px;
+  column-gap: var(--space-5);
   min-height: 100vh;
 }
 
 .header {
   grid-column: 1 / -1;
-  padding: 16px 24px;
+  padding: var(--space-4) var(--space-5);
   min-height: var(--header-height);
-  border-bottom: 1px solid var(--color-border, #e5e7eb);
+  border-bottom: 1px solid var(--color-border);
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: var(--space-4);
   position: relative;
 }
 
@@ -24,43 +24,43 @@
 
 .backToConversation {
   position: absolute;
-  left: 24px;
+  left: var(--space-5);
   top: 50%;
   transform: translateY(-50%);
   width: auto;
   margin: 0;
-  background: var(--color-bg-primary, #fff);
-  border: 1px solid var(--color-border, #e5e7eb);
-  color: var(--color-text-primary, #333);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
   cursor: pointer;
-  font-size: 14px;
-  padding: 8px 16px;
+  font-size: var(--font-size-base);
+  padding: var(--space-2) var(--space-4);
   border-radius: 999px;
   white-space: nowrap;
   flex-shrink: 0;
 
   &:hover {
-    background: var(--color-surface-hover, #f3f4f6);
+    background: var(--color-surface-hover);
   }
 
   &:focus-visible {
-    outline: 2px solid var(--color-focus, #2563eb);
+    outline: 2px solid var(--color-focus);
     outline-offset: 2px;
   }
 }
 
 .sidebar {
   grid-column: 2;
-  padding: 24px 0;
-  border-right: 1px solid var(--color-border, #e5e7eb);
+  padding: var(--space-5) 0;
+  border-right: 1px solid var(--color-border);
 }
 
 .main {
   grid-column: 3;
-  padding: 24px 0;
+  padding: var(--space-5) 0;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--space-5);
 }
 
 .topRow {
@@ -73,20 +73,20 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 24px;
+  gap: var(--space-5);
   flex-wrap: wrap;
 }
 
 .toast {
   position: fixed;
-  bottom: 24px;
+  bottom: var(--space-5);
   left: 50%;
   transform: translateX(-50%);
-  background: var(--color-neutral-dark, #333);
-  color: var(--color-on-neutral-dark, #fff);
-  padding: 12px 24px;
-  border-radius: 8px;
-  font-size: 14px;
+  background: var(--color-neutral-dark);
+  color: var(--color-on-neutral-dark);
+  padding: var(--space-3) var(--space-5);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
   box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
   animation: toast-in 200ms ease-out;
   z-index: 1000;
@@ -116,6 +116,6 @@
 
   .main {
     grid-column: 1;
-    padding: 24px 16px;
+    padding: var(--space-5) var(--space-4);
   }
 }

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
@@ -12,24 +12,21 @@
   min-height: var(--header-height);
   border-bottom: 1px solid var(--color-border);
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-4);
-  position: relative;
+  justify-content: center;
+  gap: var(--space-3);
 }
 
 .header > * {
   width: 100%;
   max-width: 560px;
-  margin: 0 auto;
 }
 
 .backToConversation {
-  position: absolute;
-  left: var(--space-5);
-  top: 50%;
-  transform: translateY(-50%);
   width: auto;
-  margin: 0;
+  max-width: none;
+  order: -1;
   background: var(--color-bg-primary);
   border: 1px solid var(--color-border);
   color: var(--color-text-primary);
@@ -38,7 +35,6 @@
   padding: var(--space-2) var(--space-4);
   border-radius: 999px;
   white-space: nowrap;
-  flex-shrink: 0;
 
   &:hover {
     background: var(--color-surface-hover);
@@ -47,6 +43,21 @@
   &:focus-visible {
     outline: 2px solid var(--color-focus);
     outline-offset: 2px;
+  }
+}
+
+@media (min-width: 900px) {
+  .header {
+    flex-wrap: nowrap;
+    justify-content: center;
+    position: relative;
+  }
+
+  .backToConversation {
+    position: absolute;
+    left: var(--space-5);
+    top: 50%;
+    transform: translateY(-50%);
   }
 }
 

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
@@ -46,7 +46,7 @@
   }
 }
 
-@media (min-width: 1150px) {
+@media (min-width: 1280px) {
   .header {
     flex-wrap: nowrap;
     justify-content: center;
@@ -136,7 +136,7 @@
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 1023px) {
   .page {
     grid-template-columns: 1fr;
     column-gap: 0;

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
@@ -1,64 +1,59 @@
+.searchLayout {
+}
+
+.floatingBackButton {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 50%;
+  background: var(--color-bg-primary);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  box-shadow: 0 2px 8px var(--color-shadow);
+  opacity: 0.7;
+  transition:
+    opacity var(--transition-fast),
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.floatingBackButton:hover {
+  opacity: 1;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  border-color: var(--color-border-active);
+  box-shadow: 0 4px 12px var(--color-shadow);
+}
+
+.floatingBackButton:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.floatingBackButton svg {
+  width: 20px;
+  height: 20px;
+}
+
 .page {
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: 1fr;
   grid-template-columns: 1fr 2fr 8fr 1fr;
   column-gap: var(--space-5);
   min-height: 100vh;
-}
-
-.header {
-  grid-column: 1 / -1;
-  padding: var(--space-4) var(--space-5);
-  min-height: var(--header-height);
-  border-bottom: 1px solid var(--color-border);
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-3);
-}
-
-.header > * {
-  width: 100%;
-  max-width: 560px;
-}
-
-.backToConversation {
-  width: auto;
-  max-width: none;
-  order: -1;
-  background: var(--color-bg-primary);
-  border: 1px solid var(--color-border);
-  color: var(--color-text-primary);
-  cursor: pointer;
-  font-size: var(--font-size-base);
-  padding: var(--space-2) var(--space-4);
-  border-radius: 999px;
-  white-space: nowrap;
-
-  &:hover {
-    background: var(--color-surface-hover);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--color-focus);
-    outline-offset: 2px;
-  }
-}
-
-@media (min-width: 1280px) {
-  .header {
-    flex-wrap: nowrap;
-    justify-content: center;
-    position: relative;
-  }
-
-  .backToConversation {
-    position: absolute;
-    left: var(--space-5);
-    top: 50%;
-    transform: translateY(-50%);
-  }
+  border-top: 1px solid var(--color-border);
+  margin-top: var(--space-2);
 }
 
 .sidebar {
@@ -162,4 +157,9 @@
   .desktopOnly {
     display: none;
   }
+}
+
+.muted {
+  opacity: 0.4;
+  pointer-events: none;
 }

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
@@ -18,7 +18,8 @@
 }
 
 .header > * {
-  width: 33.333%;
+  width: 100%;
+  max-width: 560px;
   margin: 0 auto;
 }
 

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
@@ -81,6 +81,25 @@
   justify-content: space-between;
 }
 
+.sortFiltersButton {
+  display: none;
+  padding: var(--space-2) var(--space-4);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color var(--transition-fast);
+}
+
+.sortFiltersButton:hover {
+  border-color: var(--color-border-active);
+}
+
 .bottomRow {
   display: flex;
   align-items: center;
@@ -133,5 +152,13 @@
 
   .bottomRow {
     justify-content: center;
+  }
+
+  .sortFiltersButton {
+    display: inline-flex;
+  }
+
+  .desktopOnly {
+    display: none;
   }
 }

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.module.css
@@ -130,4 +130,8 @@
     grid-column: 1;
     padding: var(--space-5) var(--space-4);
   }
+
+  .bottomRow {
+    justify-content: center;
+  }
 }

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.test.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.test.tsx
@@ -26,7 +26,6 @@ vi.mock('@coveo/thermidor', async (importOriginal) => {
         totalCount: 0,
         totalPages: 0,
       }),
-    buildSearchBoxController: () => createMockController({query: ''}),
   };
 });
 
@@ -60,7 +59,7 @@ describe('SearchResultsPage integration', () => {
     expect(screen.getByText('Facets (coming soon)')).toBeDefined();
   });
 
-  it('builds all 3 controllers via mock interface and renders without errors', () => {
+  it('builds controllers via mock interface and renders without errors', () => {
     renderPage();
 
     expect(screen.getByText('No results found')).toBeDefined();

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.test.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.test.tsx
@@ -34,6 +34,9 @@ describe('SearchResultsPage integration', () => {
     onSubmit: vi.fn(),
     isStreaming: false,
     routedInterface: {useCase: 'search', interface: {id: 'mock'}} as any,
+    products: [] as any[],
+    onProductsChange: vi.fn(),
+    onBackToConversation: vi.fn(),
   };
 
   function renderPage(overrides = {}) {
@@ -42,15 +45,11 @@ describe('SearchResultsPage integration', () => {
     return {...result, props};
   }
 
-  it('renders header with PromptInput', () => {
+  it('renders PromptInput via ProductTargeting', () => {
     renderPage();
-
-    const header = document.querySelector('header');
-    expect(header).not.toBeNull();
 
     const textarea = screen.getByLabelText('Prompt');
     expect(textarea).toBeDefined();
-    expect(header!.contains(textarea)).toBe(true);
   });
 
   it('renders sidebar with "Facets (coming soon)" text', () => {
@@ -67,7 +66,14 @@ describe('SearchResultsPage integration', () => {
 
   it('returns null when routedInterface is null', () => {
     const {container} = render(
-      <SearchResultsPage onSubmit={vi.fn()} isStreaming={false} routedInterface={null as any} />
+      <SearchResultsPage
+        onSubmit={vi.fn()}
+        isStreaming={false}
+        routedInterface={null as any}
+        onBackToConversation={vi.fn()}
+        products={[]}
+        onProductsChange={vi.fn()}
+      />
     );
 
     expect(container.firstChild).toBeNull();
@@ -89,6 +95,9 @@ describe('SearchResultsPage suggestions integration', () => {
     onSubmit: vi.fn(),
     isStreaming: false,
     routedInterface: {useCase: 'search', interface: {id: 'mock'}} as any,
+    products: [] as any[],
+    onProductsChange: vi.fn(),
+    onBackToConversation: vi.fn(),
   };
 
   function renderPage(overrides = {}) {
@@ -151,6 +160,9 @@ describe('SearchResultsPage PageSizeSelector integration', () => {
     onSubmit: vi.fn(),
     isStreaming: false,
     routedInterface: {useCase: 'search', interface: {id: 'mock'}} as any,
+    products: [] as any[],
+    onProductsChange: vi.fn(),
+    onBackToConversation: vi.fn(),
   };
 
   function renderPage(overrides = {}) {
@@ -185,6 +197,8 @@ describe('SearchResultsPage "Back to conversation" button', () => {
     isStreaming: false,
     routedInterface: {useCase: 'search', interface: {id: 'mock'}} as any,
     onBackToConversation: vi.fn(),
+    products: [] as any[],
+    onProductsChange: vi.fn(),
   };
 
   function renderPage(overrides = {}) {

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.tsx
@@ -174,19 +174,19 @@ function SearchResultsPageContent({
             pageSize={paginationState.pageSize ?? 0}
             productCount={productListState.products?.length ?? 0}
           />
-          <span className={styles.desktopOnly}>
+          <span className={`${styles.desktopOnly} ${isTargeting ? styles.muted : ''}`}>
             <SortPlaceholder onToast={showToast} />
           </span>
           <button
             type="button"
-            className={styles.sortFiltersButton}
+            className={`${styles.sortFiltersButton} ${isTargeting ? styles.muted : ''}`}
             onClick={() => setSortFiltersOpen(true)}
           >
             Sort & Filters
           </button>
         </div>
         <ProductGrid controller={productListController} />
-        <div className={styles.bottomRow}>
+        <div className={`${styles.bottomRow} ${isTargeting ? styles.muted : ''}`}>
           <Pagination controller={paginationController} />
           <PageSizeSelector controller={paginationController} />
         </div>

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.tsx
@@ -1,4 +1,4 @@
-import {useState, useRef, useEffect} from 'react';
+import {useState, useRef, useEffect, useCallback} from 'react';
 import type {RoutedInterface} from '@coveo/thermidor';
 import {buildProductListController, buildPaginationController} from '@coveo/thermidor';
 import {SECTION_ACTIONS, type SuggestionItem} from '../SuggestionsDropdown/index.js';
@@ -9,6 +9,7 @@ import {ProductGrid} from './ProductGrid/ProductGrid.js';
 import {Pagination} from './Pagination/Pagination.js';
 import {QuerySummaryPlaceholder} from './QuerySummaryPlaceholder/QuerySummaryPlaceholder.js';
 import {SortPlaceholder} from './SortPlaceholder/SortPlaceholder.js';
+import {SortFiltersModal} from './SortFiltersModal/SortFiltersModal.js';
 import {PageSizeSelector} from './PageSizeSelector/PageSizeSelector.js';
 import styles from './SearchResultsPage.module.css';
 
@@ -48,6 +49,7 @@ function SearchResultsPageInner({
   });
 
   const [toast, setToast] = useState<string | null>(null);
+  const [sortFiltersOpen, setSortFiltersOpen] = useState(false);
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -63,6 +65,8 @@ function SearchResultsPageInner({
     setToast('Not supported yet');
     toastTimerRef.current = setTimeout(() => setToast(null), 3000);
   };
+
+  const closeSortFilters = useCallback(() => setSortFiltersOpen(false), []);
 
   const handleSuggestionSelect = (item: SuggestionItem, sectionId: string) => {
     const action = SECTION_ACTIONS[sectionId];
@@ -99,7 +103,16 @@ function SearchResultsPageInner({
             pageSize={paginationState.pageSize ?? 0}
             productCount={productListState.products?.length ?? 0}
           />
-          <SortPlaceholder onToast={showToast} />
+          <span className={styles.desktopOnly}>
+            <SortPlaceholder onToast={showToast} />
+          </span>
+          <button
+            type="button"
+            className={styles.sortFiltersButton}
+            onClick={() => setSortFiltersOpen(true)}
+          >
+            Sort & Filters
+          </button>
         </div>
         <ProductGrid controller={productListController} />
         <div className={styles.bottomRow}>
@@ -107,6 +120,8 @@ function SearchResultsPageInner({
           <PageSizeSelector controller={paginationController} />
         </div>
       </main>
+
+      <SortFiltersModal open={sortFiltersOpen} onClose={closeSortFilters} onToast={showToast} />
 
       {toast && (
         <div className={styles.toast} role="status" aria-live="polite">

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.tsx
@@ -2,7 +2,8 @@ import {useState, useRef, useEffect, useCallback} from 'react';
 import type {RoutedInterface} from '@coveo/thermidor';
 import {buildProductListController, buildPaginationController} from '@coveo/thermidor';
 import {SECTION_ACTIONS, type SuggestionItem} from '../SuggestionsDropdown/index.js';
-import {PromptInput} from '../PromptInput/PromptInput.js';
+import {ProductTargeting} from '../ProductTargeting/ProductTargeting.js';
+import {useTargeting, type TargetedProduct} from '../../context/targeting.js';
 import {useSuggestions} from '../../hooks/use-suggestions.js';
 import {useBuildController} from '../../hooks/use-build-controller.js';
 import {ProductGrid} from './ProductGrid/ProductGrid.js';
@@ -19,6 +20,8 @@ interface SearchResultsPageProps {
   routedInterface: RoutedInterface;
   query?: string;
   onBackToConversation: () => void;
+  products: TargetedProduct[];
+  onProductsChange: (products: TargetedProduct[]) => void;
 }
 
 export function SearchResultsPage(props: SearchResultsPageProps) {
@@ -35,6 +38,8 @@ function SearchResultsPageInner({
   routedInterface,
   query,
   onBackToConversation,
+  products,
+  onProductsChange,
 }: SearchResultsPageProps) {
   const [productListController, productListState] = useBuildController(() =>
     buildProductListController({interface: routedInterface.interface})
@@ -78,21 +83,87 @@ function SearchResultsPageInner({
   };
 
   return (
-    <div className={styles.page} data-testid="search-results-page">
-      <header className={styles.header}>
-        <button type="button" className={styles.backToConversation} onClick={onBackToConversation}>
-          &larr; Back to conversation
-        </button>
-        <PromptInput
-          onSubmit={onSubmit}
-          disabled={isStreaming}
-          initialValue={query ?? ''}
-          suggestions={sections}
-          onSuggestionSelect={handleSuggestionSelect}
+    <div className={styles.searchLayout}>
+      <ProductTargeting
+        products={products}
+        onProductsChange={onProductsChange}
+        onSubmit={onSubmit}
+        isStreaming={isStreaming}
+        promptProps={{
+          initialValue: query ?? '',
+          suggestions: sections,
+          onSuggestionSelect: handleSuggestionSelect,
+        }}
+      >
+        <SearchResultsPageContent
+          query={query}
+          productListController={productListController}
+          productListState={productListState}
+          paginationController={paginationController}
+          paginationState={paginationState}
+          showToast={showToast}
+          sortFiltersOpen={sortFiltersOpen}
+          setSortFiltersOpen={setSortFiltersOpen}
+          closeSortFilters={closeSortFilters}
+          toast={toast}
         />
-      </header>
+      </ProductTargeting>
+      <button
+        type="button"
+        className={styles.floatingBackButton}
+        onClick={onBackToConversation}
+        title="Back to conversation"
+        aria-label="Back to conversation"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+      </button>
+    </div>
+  );
+}
 
-      <aside className={styles.sidebar}>Facets (coming soon)</aside>
+interface SearchResultsPageContentProps {
+  query?: string;
+  productListController: ReturnType<typeof buildProductListController>;
+  productListState: ReturnType<typeof buildProductListController>['state'];
+  paginationController: ReturnType<typeof buildPaginationController>;
+  paginationState: ReturnType<typeof buildPaginationController>['state'];
+  showToast: () => void;
+  sortFiltersOpen: boolean;
+  setSortFiltersOpen: (open: boolean) => void;
+  closeSortFilters: () => void;
+  toast: string | null;
+}
+
+function SearchResultsPageContent({
+  query,
+  productListController,
+  productListState,
+  paginationController,
+  paginationState,
+  showToast,
+  sortFiltersOpen,
+  setSortFiltersOpen,
+  closeSortFilters,
+  toast,
+}: SearchResultsPageContentProps) {
+  const targeting = useTargeting();
+  const isTargeting = targeting?.isTargeting ?? false;
+
+  return (
+    <div className={styles.page} data-testid="search-results-page">
+      <aside className={`${styles.sidebar} ${isTargeting ? styles.muted : ''}`}>
+        Facets (coming soon)
+      </aside>
 
       <main className={styles.main}>
         <div className={styles.topRow}>

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SearchResultsPage.tsx
@@ -1,10 +1,6 @@
 import {useState, useRef, useEffect} from 'react';
 import type {RoutedInterface} from '@coveo/thermidor';
-import {
-  buildProductListController,
-  buildPaginationController,
-  buildSearchBoxController,
-} from '@coveo/thermidor';
+import {buildProductListController, buildPaginationController} from '@coveo/thermidor';
 import {SECTION_ACTIONS, type SuggestionItem} from '../SuggestionsDropdown/index.js';
 import {PromptInput} from '../PromptInput/PromptInput.js';
 import {useSuggestions} from '../../hooks/use-suggestions.js';
@@ -45,12 +41,9 @@ function SearchResultsPageInner({
   const [paginationController, paginationState] = useBuildController(() =>
     buildPaginationController({interface: routedInterface.interface})
   );
-  const [, searchBoxState] = useBuildController(() =>
-    buildSearchBoxController({interface: routedInterface.interface})
-  );
 
   const {sections} = useSuggestions({
-    inputValue: searchBoxState.query ?? '',
+    inputValue: query ?? '',
     context: 'search-results',
   });
 
@@ -100,7 +93,7 @@ function SearchResultsPageInner({
       <main className={styles.main}>
         <div className={styles.topRow}>
           <QuerySummaryPlaceholder
-            query={searchBoxState.query ?? ''}
+            query={query ?? ''}
             totalCount={paginationState.totalCount ?? 0}
             firstResult={(paginationState.page ?? 0) * (paginationState.pageSize ?? 0)}
             pageSize={paginationState.pageSize ?? 0}

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SortFiltersModal/SortFiltersModal.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SortFiltersModal/SortFiltersModal.module.css
@@ -1,0 +1,108 @@
+.dialog {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: var(--color-bg-primary);
+  display: flex;
+  flex-direction: column;
+}
+
+.dialog::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4) var(--space-5);
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.closeButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.closeButton:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.scrollContent {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.placeholder {
+  margin: 0;
+  font-size: var(--font-size-base);
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.footer {
+  flex-shrink: 0;
+  padding: var(--space-4) var(--space-5);
+  border-top: 1px solid var(--color-border);
+}
+
+.viewResultsButton {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  color: #fff;
+  background: var(--color-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.viewResultsButton:hover {
+  opacity: 0.9;
+}

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SortFiltersModal/SortFiltersModal.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SortFiltersModal/SortFiltersModal.module.css
@@ -9,6 +9,9 @@
   padding: 0;
   border: none;
   background: var(--color-bg-primary);
+}
+
+.dialog[open] {
   display: flex;
   flex-direction: column;
 }

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SortFiltersModal/SortFiltersModal.test.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SortFiltersModal/SortFiltersModal.test.tsx
@@ -1,0 +1,77 @@
+import {render, screen, fireEvent} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {SortFiltersModal} from './SortFiltersModal.js';
+
+// jsdom/happy-dom don't implement showModal/close on <dialog>.
+// Mock them so we can verify they're called correctly.
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+    this.dispatchEvent(new Event('close'));
+  });
+});
+
+describe('SortFiltersModal', () => {
+  it('calls showModal when open transitions to true', () => {
+    const {rerender} = render(
+      <SortFiltersModal open={false} onClose={vi.fn()} onToast={vi.fn()} />
+    );
+
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+
+    rerender(<SortFiltersModal open={true} onClose={vi.fn()} onToast={vi.fn()} />);
+
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls dialog.close when the close button is clicked', () => {
+    render(<SortFiltersModal open={true} onClose={vi.fn()} onToast={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Close'}));
+
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+  });
+
+  it('calls dialog.close when "View results" button is clicked', () => {
+    render(<SortFiltersModal open={true} onClose={vi.fn()} onToast={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'View results'}));
+
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+  });
+
+  it('calls onClose when the dialog fires the native close event', () => {
+    const onClose = vi.fn();
+    render(<SortFiltersModal open={true} onClose={onClose} onToast={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', {name: 'Close'}));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls dialog.close when open transitions from true to false', () => {
+    const {rerender} = render(<SortFiltersModal open={true} onClose={vi.fn()} onToast={vi.fn()} />);
+
+    rerender(<SortFiltersModal open={false} onClose={vi.fn()} onToast={vi.fn()} />);
+
+    expect(HTMLDialogElement.prototype.close).toHaveBeenCalled();
+  });
+
+  it('renders the Sort and Filters sections', () => {
+    render(<SortFiltersModal open={true} onClose={vi.fn()} onToast={vi.fn()} />);
+
+    expect(screen.getByText('Sort & Filters')).toBeDefined();
+    expect(screen.getByText('Sort')).toBeDefined();
+    expect(screen.getByText('Filters')).toBeDefined();
+    expect(screen.getByText('Filters coming soon')).toBeDefined();
+  });
+
+  it('has an accessible aria-label on the dialog', () => {
+    render(<SortFiltersModal open={true} onClose={vi.fn()} onToast={vi.fn()} />);
+
+    expect(screen.getByRole('dialog', {name: 'Sort and filters'})).toBeDefined();
+  });
+});

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SortFiltersModal/SortFiltersModal.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SortFiltersModal/SortFiltersModal.tsx
@@ -1,0 +1,59 @@
+import {useEffect, useRef} from 'react';
+import {SortPlaceholder} from '../SortPlaceholder/SortPlaceholder.js';
+import styles from './SortFiltersModal.module.css';
+
+interface SortFiltersModalProps {
+  open: boolean;
+  onClose: () => void;
+  onToast: () => void;
+}
+
+export function SortFiltersModal({open, onClose, onToast}: SortFiltersModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (open && !dialog.open) {
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleClose = () => onClose();
+    dialog.addEventListener('close', handleClose);
+    return () => dialog.removeEventListener('close', handleClose);
+  }, [onClose]);
+
+  return (
+    <dialog ref={dialogRef} className={styles.dialog} aria-label="Sort and filters">
+      <div className={styles.header}>
+        <h2 className={styles.title}>Sort & Filters</h2>
+        <button type="button" className={styles.closeButton} onClick={onClose} aria-label="Close">
+          &times;
+        </button>
+      </div>
+      <div className={styles.scrollContent}>
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>Sort</h3>
+          <SortPlaceholder onToast={onToast} />
+        </section>
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>Filters</h3>
+          <p className={styles.placeholder}>Filters coming soon</p>
+        </section>
+      </div>
+      <div className={styles.footer}>
+        <button type="button" className={styles.viewResultsButton} onClick={onClose}>
+          View results
+        </button>
+      </div>
+    </dialog>
+  );
+}

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SortFiltersModal/SortFiltersModal.tsx
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SortFiltersModal/SortFiltersModal.tsx
@@ -31,11 +31,20 @@ export function SortFiltersModal({open, onClose, onToast}: SortFiltersModalProps
     return () => dialog.removeEventListener('close', handleClose);
   }, [onClose]);
 
+  const handleClose = () => {
+    dialogRef.current?.close();
+  };
+
   return (
     <dialog ref={dialogRef} className={styles.dialog} aria-label="Sort and filters">
       <div className={styles.header}>
         <h2 className={styles.title}>Sort & Filters</h2>
-        <button type="button" className={styles.closeButton} onClick={onClose} aria-label="Close">
+        <button
+          type="button"
+          className={styles.closeButton}
+          onClick={handleClose}
+          aria-label="Close"
+        >
           &times;
         </button>
       </div>
@@ -50,7 +59,7 @@ export function SortFiltersModal({open, onClose, onToast}: SortFiltersModalProps
         </section>
       </div>
       <div className={styles.footer}>
-        <button type="button" className={styles.viewResultsButton} onClick={onClose}>
+        <button type="button" className={styles.viewResultsButton} onClick={handleClose}>
           View results
         </button>
       </div>

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/SortPlaceholder/SortPlaceholder.module.css
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/SortPlaceholder/SortPlaceholder.module.css
@@ -1,26 +1,26 @@
 .container {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .label {
-  font-size: 14px;
-  color: var(--color-text-muted, #666);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
   white-space: nowrap;
 }
 
 .select {
-  padding: 8px;
-  border: 1px solid var(--color-border, #ccc);
-  border-radius: 6px;
-  background: var(--color-surface, #fff);
-  color: var(--color-text, #333);
-  font-size: 14px;
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
   cursor: pointer;
-  transition: border-color 150ms ease;
+  transition: border-color var(--transition-fast);
 }
 
 .select:hover {
-  border-color: var(--color-border-hover, #999);
+  border-color: var(--color-border-hover);
 }

--- a/samples/thermidor/demo-react/src/components/SearchResultsPage/utils.ts
+++ b/samples/thermidor/demo-react/src/components/SearchResultsPage/utils.ts
@@ -1,8 +1,6 @@
-export interface Product {
-  ec_thumbnails?: string[];
-  ec_images?: string[];
-  [key: string]: unknown;
-}
+import type {Product} from '@coveo/thermidor';
+
+export type {Product} from '@coveo/thermidor';
 
 export function resolveProductImage(product: Product): string | null {
   if (product.ec_thumbnails?.length) return product.ec_thumbnails[0];

--- a/samples/thermidor/demo-react/src/components/SuggestionPills/SuggestionPills.module.css
+++ b/samples/thermidor/demo-react/src/components/SuggestionPills/SuggestionPills.module.css
@@ -7,8 +7,6 @@
 }
 
 .pill {
-  display: inline-flex;
-  align-items: center;
   padding: var(--space-2) var(--space-4);
   font-family: var(--font-sans);
   font-size: var(--font-size-sm);
@@ -25,6 +23,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
   max-width: 100%;
 }
 

--- a/samples/thermidor/demo-react/src/components/SuggestionPills/SuggestionPills.module.css
+++ b/samples/thermidor/demo-react/src/components/SuggestionPills/SuggestionPills.module.css
@@ -23,6 +23,9 @@
     border-color var(--transition-fast),
     color var(--transition-fast);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 
 .pill:hover {

--- a/samples/thermidor/demo-react/src/components/SuggestionPills/SuggestionPills.tsx
+++ b/samples/thermidor/demo-react/src/components/SuggestionPills/SuggestionPills.tsx
@@ -30,6 +30,7 @@ export function SuggestionPills({
           className={styles.pill}
           onClick={() => onSelect(suggestion)}
           disabled={disabled}
+          title={suggestion}
         >
           {suggestion}
         </button>

--- a/samples/thermidor/demo-react/src/components/SuggestionsDropdown/SuggestionItemRow.module.css
+++ b/samples/thermidor/demo-react/src/components/SuggestionsDropdown/SuggestionItemRow.module.css
@@ -2,7 +2,7 @@
   display: flex;
   align-items: flex-start;
   gap: var(--space-2);
-  padding: 6px var(--space-3);
+  padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: background var(--transition-fast);

--- a/samples/thermidor/demo-react/src/components/SuggestionsDropdown/SuggestionSectionGroup.module.css
+++ b/samples/thermidor/demo-react/src/components/SuggestionsDropdown/SuggestionSectionGroup.module.css
@@ -6,7 +6,7 @@
 .header {
   display: flex;
   align-items: center;
-  padding: 4px var(--space-3);
+  padding: var(--space-1) var(--space-3);
 }
 
 .headerTitle {

--- a/samples/thermidor/demo-react/src/components/SuggestionsDropdown/SuggestionsDropdown.tsx
+++ b/samples/thermidor/demo-react/src/components/SuggestionsDropdown/SuggestionsDropdown.tsx
@@ -9,7 +9,6 @@ interface SuggestionsDropdownProps {
   onSelect: (item: SuggestionItem, sectionId: string) => void;
   visible: boolean;
   activeIndex?: number;
-  inputValue?: string;
 }
 
 export function SuggestionsDropdown({

--- a/samples/thermidor/demo-react/src/components/views.test.tsx
+++ b/samples/thermidor/demo-react/src/components/views.test.tsx
@@ -84,6 +84,8 @@ describe('SearchResultsPage', () => {
         isStreaming={false}
         routedInterface={mockRoutedInterface}
         onBackToConversation={vi.fn()}
+        products={[]}
+        onProductsChange={vi.fn()}
       />
     );
     expect(screen.getByTestId('search-results-page')).toBeDefined();
@@ -96,6 +98,8 @@ describe('SearchResultsPage', () => {
         isStreaming={false}
         routedInterface={mockRoutedInterface}
         onBackToConversation={vi.fn()}
+        products={[]}
+        onProductsChange={vi.fn()}
       />
     );
     expect(screen.getByText('Facets (coming soon)')).toBeDefined();
@@ -109,6 +113,8 @@ describe('SearchResultsPage', () => {
         isStreaming={false}
         routedInterface={mockRoutedInterface}
         onBackToConversation={vi.fn()}
+        products={[]}
+        onProductsChange={vi.fn()}
       />
     );
 
@@ -126,6 +132,8 @@ describe('SearchResultsPage', () => {
         isStreaming={true}
         routedInterface={mockRoutedInterface}
         onBackToConversation={vi.fn()}
+        products={[]}
+        onProductsChange={vi.fn()}
       />
     );
     expect((screen.getByLabelText('Prompt') as HTMLInputElement).disabled).toBe(true);
@@ -147,7 +155,8 @@ describe('ConversationPage', () => {
         turns={[baseTurn]}
         onBackToSearch={vi.fn()}
         canGoBackToSearch={true}
-        onResetToLanding={vi.fn()}
+        products={[]}
+        onProductsChange={vi.fn()}
       />
     );
     expect(screen.getByLabelText('Prompt')).toBeDefined();
@@ -162,7 +171,8 @@ describe('ConversationPage', () => {
         turns={[baseTurn]}
         onBackToSearch={vi.fn()}
         canGoBackToSearch={true}
-        onResetToLanding={vi.fn()}
+        products={[]}
+        onProductsChange={vi.fn()}
       />
     );
 
@@ -181,7 +191,8 @@ describe('ConversationPage', () => {
         turns={[baseTurn]}
         onBackToSearch={vi.fn()}
         canGoBackToSearch={true}
-        onResetToLanding={vi.fn()}
+        products={[]}
+        onProductsChange={vi.fn()}
       />
     );
     expect((screen.getByLabelText('Prompt') as HTMLTextAreaElement).disabled).toBe(true);
@@ -196,7 +207,8 @@ describe('ConversationPage', () => {
         turns={[baseTurn]}
         onBackToSearch={onBackToSearch}
         canGoBackToSearch={true}
-        onResetToLanding={vi.fn()}
+        products={[]}
+        onProductsChange={vi.fn()}
       />
     );
 
@@ -213,26 +225,10 @@ describe('ConversationPage', () => {
         turns={[baseTurn]}
         onBackToSearch={vi.fn()}
         canGoBackToSearch={false}
-        onResetToLanding={vi.fn()}
+        products={[]}
+        onProductsChange={vi.fn()}
       />
     );
     expect(screen.queryByRole('button', {name: /Back to search results/})).toBeNull();
-  });
-
-  it('calls onResetToLanding when "Reset" button is clicked', () => {
-    const onReset = vi.fn();
-    render(
-      <ConversationPage
-        onSubmit={vi.fn()}
-        isStreaming={false}
-        turns={[baseTurn]}
-        onBackToSearch={vi.fn()}
-        canGoBackToSearch={false}
-        onResetToLanding={onReset}
-      />
-    );
-
-    fireEvent.click(screen.getByRole('button', {name: 'Reset'}));
-    expect(onReset).toHaveBeenCalled();
   });
 });

--- a/samples/thermidor/demo-react/src/components/views.test.tsx
+++ b/samples/thermidor/demo-react/src/components/views.test.tsx
@@ -48,13 +48,12 @@ describe('LandingPage', () => {
     expect(onSubmit).toHaveBeenCalledWith('hello world');
   });
 
-  it('sets textarea value and submits when a suggestion pill is clicked', () => {
+  it('submits when a suggestion pill is clicked', () => {
     const onSubmit = vi.fn();
     render(<LandingPage onSubmit={onSubmit} isStreaming={false} />);
 
     fireEvent.click(screen.getByRole('button', {name: 'kayaks'}));
 
-    expect((screen.getByLabelText('Prompt') as HTMLTextAreaElement).value).toBe('kayaks');
     expect(onSubmit).toHaveBeenCalledWith('kayaks');
   });
 

--- a/samples/thermidor/demo-react/src/context/targeting.tsx
+++ b/samples/thermidor/demo-react/src/context/targeting.tsx
@@ -1,0 +1,21 @@
+import {createContext, useContext} from 'react';
+
+export interface TargetedProduct {
+  id: string;
+  name: string;
+  thumbnail?: string;
+}
+
+export interface TargetingContext {
+  isTargeting: boolean;
+  onProductTargeted: (productId: string, productName: string, productThumbnail?: string) => void;
+  selectedProductIds: Set<string>;
+}
+
+const TargetingCtx = createContext<TargetingContext | null>(null);
+
+export const TargetingProvider = TargetingCtx.Provider;
+
+export function useTargeting(): TargetingContext | null {
+  return useContext(TargetingCtx);
+}

--- a/samples/thermidor/demo-react/src/hooks/use-targeting-mode.test.ts
+++ b/samples/thermidor/demo-react/src/hooks/use-targeting-mode.test.ts
@@ -1,0 +1,106 @@
+import {describe, it, expect} from 'vitest';
+import {renderHook, act} from '@testing-library/react';
+import {useTargetingMode} from './use-targeting-mode.js';
+
+describe('useTargetingMode', () => {
+  it('initializes with targeting off', () => {
+    const {result} = renderHook(() => useTargetingMode());
+    expect(result.current.isTargeting).toBe(false);
+  });
+
+  it('startTargeting sets isTargeting to true', () => {
+    const {result} = renderHook(() => useTargetingMode());
+
+    act(() => {
+      result.current.startTargeting();
+    });
+
+    expect(result.current.isTargeting).toBe(true);
+  });
+
+  it('stopTargeting sets isTargeting to false', () => {
+    const {result} = renderHook(() => useTargetingMode());
+
+    act(() => {
+      result.current.startTargeting();
+    });
+
+    act(() => {
+      result.current.stopTargeting();
+    });
+
+    expect(result.current.isTargeting).toBe(false);
+  });
+
+  it('toggleTargeting flips the state', () => {
+    const {result} = renderHook(() => useTargetingMode());
+
+    act(() => {
+      result.current.toggleTargeting();
+    });
+
+    expect(result.current.isTargeting).toBe(true);
+
+    act(() => {
+      result.current.toggleTargeting();
+    });
+
+    expect(result.current.isTargeting).toBe(false);
+  });
+
+  it('Escape key exits targeting mode when active', () => {
+    const {result} = renderHook(() => useTargetingMode());
+
+    act(() => {
+      result.current.startTargeting();
+    });
+
+    expect(result.current.isTargeting).toBe(true);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+    });
+
+    expect(result.current.isTargeting).toBe(false);
+  });
+
+  it('Escape key does nothing when targeting is not active', () => {
+    const {result} = renderHook(() => useTargetingMode());
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+    });
+
+    expect(result.current.isTargeting).toBe(false);
+  });
+
+  it('non-Escape keys do not exit targeting mode', () => {
+    const {result} = renderHook(() => useTargetingMode());
+
+    act(() => {
+      result.current.startTargeting();
+    });
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
+    });
+
+    expect(result.current.isTargeting).toBe(true);
+  });
+
+  it('cleans up the listener on unmount', () => {
+    const {result, unmount} = renderHook(() => useTargetingMode());
+
+    act(() => {
+      result.current.startTargeting();
+    });
+
+    unmount();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+    });
+
+    // No error thrown means listener was cleaned up successfully
+  });
+});

--- a/samples/thermidor/demo-react/src/hooks/use-targeting-mode.ts
+++ b/samples/thermidor/demo-react/src/hooks/use-targeting-mode.ts
@@ -1,0 +1,44 @@
+import {useCallback, useEffect, useState} from 'react';
+
+interface UseTargetingModeReturn {
+  isTargeting: boolean;
+  startTargeting: () => void;
+  stopTargeting: () => void;
+  toggleTargeting: () => void;
+}
+
+export function useTargetingMode(): UseTargetingModeReturn {
+  const [isTargeting, setIsTargeting] = useState(false);
+
+  const startTargeting = useCallback(() => {
+    setIsTargeting(true);
+  }, []);
+
+  const stopTargeting = useCallback(() => {
+    setIsTargeting(false);
+  }, []);
+
+  const toggleTargeting = useCallback(() => {
+    setIsTargeting((prev) => !prev);
+  }, []);
+
+  useEffect(() => {
+    if (!isTargeting) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsTargeting(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isTargeting]);
+
+  return {isTargeting, startTargeting, stopTargeting, toggleTargeting};
+}

--- a/samples/thermidor/demo-react/src/index.css
+++ b/samples/thermidor/demo-react/src/index.css
@@ -26,15 +26,25 @@
 
   --color-border: #e2e8f0;
   --color-border-active: #3b82f6;
+  --color-border-hover: #94a3b8;
+
+  --color-primary: #1d4ed8;
+  --color-surface: #ffffff;
+  --color-surface-hover: #f3f4f6;
+  --color-focus: #2563eb;
+  --color-neutral-dark: #333333;
+  --color-on-neutral-dark: #ffffff;
 
   --color-success: #10b981;
   --color-processing: #f59e0b;
   --color-error: #ef4444;
   --color-shadow: rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
 
   /* Typography */
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --font-size-xs: 12px;
   --font-size-sm: 13px;
   --font-size-base: 14px;
   --font-size-md: 15px;

--- a/samples/thermidor/demo-react/src/index.css
+++ b/samples/thermidor/demo-react/src/index.css
@@ -63,6 +63,12 @@
 
   /* Layout */
   --header-height: 84px;
+
+  /* Breakpoints (aligned with @coveo/atomic) */
+  --breakpoint-sm: 640px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 1024px;
+  --breakpoint-xl: 1280px;
 }
 
 *,

--- a/samples/thermidor/demo-react/src/utils.ts
+++ b/samples/thermidor/demo-react/src/utils.ts
@@ -1,7 +1,6 @@
-export interface AgentMessage {
-  content: string;
-  role: string;
-}
+import type {AgentMessage} from '@coveo/thermidor';
+
+export type {AgentMessage} from '@coveo/thermidor';
 
 /** Concatenate message contents in arrival order, separating distinct messages with newlines */
 export function assembleMessages(messages: AgentMessage[]): string {

--- a/samples/thermidor/demo-react/src/utils.ts
+++ b/samples/thermidor/demo-react/src/utils.ts
@@ -1,4 +1,6 @@
 import type {AgentMessage} from '@coveo/thermidor';
+import {marked} from 'marked';
+import DOMPurify from 'dompurify';
 
 export type {AgentMessage} from '@coveo/thermidor';
 
@@ -10,4 +12,14 @@ export function assembleMessages(messages: AgentMessage[]): string {
 /** Format price as currency string with 2 decimals */
 export function formatPrice(price: number): string {
   return `$${price.toFixed(2)}`;
+}
+
+/** Render a markdown string to sanitized HTML */
+export function renderMarkdown(text: string): string {
+  try {
+    const raw = marked.parse(text, {breaks: true, gfm: true}) as string;
+    return DOMPurify.sanitize(raw);
+  } catch {
+    return DOMPurify.sanitize(text);
+  }
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5924

This PR polishes up the demo (improving responsiveness, accessibility, styling, and code). Notably, the Sort component (and eventually facets) are now collapsed into a modal accessible by activating a buton at smaller responsive breakpoints (similar to Atomic behavior).

Most importantly, however, this PR adds the product targetting feature which was hinted at in the UX mockups.

We could probably make this feature more convenient to implement by bringing back some of its logic into the converse controller. This will be done in a subsequent step.

Demo:

https://github.com/user-attachments/assets/513001df-aaeb-4f35-90dc-28cb9bf7d499

