### PR TITLE
chore(deps): adopt catalog for @rollup/plugin-json

### DIFF
--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "29.0.3",
-    "@rollup/plugin-json": "6.1.0",
+    "@rollup/plugin-json": "catalog:",
     "@rollup/plugin-node-resolve": "16.0.3",
     "@rollup/plugin-typescript": "12.3.0",
     "@types/node": "catalog:",

--- a/packages/coveo-analytics/package.json
+++ b/packages/coveo-analytics/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@rollup/plugin-alias": "5.1.1",
     "@rollup/plugin-commonjs": "24.1.0",
-    "@rollup/plugin-json": "6.1.0",
+    "@rollup/plugin-json": "catalog:",
     "@rollup/plugin-node-resolve": "15.3.1",
     "@rollup/plugin-replace": "5.0.7",
     "@rollup/plugin-terser": "0.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ catalogs:
     '@reduxjs/toolkit':
       specifier: 2.12.0
       version: 2.12.0
+    '@rollup/plugin-json':
+      specifier: 6.1.0
+      version: 6.1.0
     '@rollup/plugin-replace':
       specifier: 6.0.3
       version: 6.0.3
@@ -605,7 +608,7 @@ importers:
         specifier: 29.0.3
         version: 29.0.3(rollup@4.62.2)
       '@rollup/plugin-json':
-        specifier: 6.1.0
+        specifier: 'catalog:'
         version: 6.1.0(rollup@4.62.2)
       '@rollup/plugin-node-resolve':
         specifier: 16.0.3
@@ -672,7 +675,7 @@ importers:
         specifier: 24.1.0
         version: 24.1.0(rollup@3.29.5)
       '@rollup/plugin-json':
-        specifier: 6.1.0
+        specifier: 'catalog:'
         version: 6.1.0(rollup@3.29.5)
       '@rollup/plugin-node-resolve':
         specifier: 15.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,6 +65,7 @@ catalog:
   '@react-router/serve': 7.14.2
   '@reduxjs/toolkit': 2.12.0
   'react-router': 7.14.2
+  '@rollup/plugin-json': 6.1.0
   '@rollup/plugin-replace': 6.0.3
   '@rollup/plugin-url': 8.0.2
   '@stencil/core': 4.20.0


### PR DESCRIPTION
Part of the `coveo.analytics` dependency-alignment series (wave A). Stacked on #8107.

## Problem
`coveo.analytics` declared its own `@rollup/plugin-json` version, diverging from the one used by `@coveo/atomic-react`.

## Solution
- Added `@rollup/plugin-json: 6.1.0` to the `pnpm-workspace.yaml` catalog.
- Switched `coveo.analytics` and `@coveo/atomic-react` to `@rollup/plugin-json: catalog:`.

Verification: rebuilt `coveo.analytics` and compared SHA-256 of every emitted artifact against the baseline — **0 of 62 files changed**. `pnpm --filter coveo.analytics test` green.

No changeset: published `dependencies` unchanged (build-time dependency only) and artifacts are byte-identical.