### PR TITLE
fix(deps): adopt catalog for @rollup/plugin-terser

### DIFF
--- a/packages/coveo-analytics/package.json
+++ b/packages/coveo-analytics/package.json
@@ -46,7 +46,7 @@
     "@rollup/plugin-json": "catalog:",
     "@rollup/plugin-node-resolve": "15.3.1",
     "@rollup/plugin-replace": "5.0.7",
-    "@rollup/plugin-terser": "0.4.4",
+    "@rollup/plugin-terser": "catalog:",
     "@types/node": "6.14.13",
     "fetch-mock": "9.11.0",
     "jsdom": "catalog:",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "16.0.3",
     "@rollup/plugin-replace": "catalog:",
-    "@rollup/plugin-terser": "1.0.0",
+    "@rollup/plugin-terser": "catalog:",
     "@rollup/plugin-typescript": "12.3.0",
     "@vitest/browser-playwright": "catalog:",
     "jsdom": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ catalogs:
     '@rollup/plugin-replace':
       specifier: 6.0.3
       version: 6.0.3
+    '@rollup/plugin-terser':
+      specifier: 1.0.0
+      version: 1.0.0
     '@rollup/plugin-url':
       specifier: 8.0.2
       version: 8.0.2
@@ -684,8 +687,8 @@ importers:
         specifier: 5.0.7
         version: 5.0.7(rollup@3.29.5)
       '@rollup/plugin-terser':
-        specifier: 0.4.4
-        version: 0.4.4(rollup@3.29.5)
+        specifier: 'catalog:'
+        version: 1.0.0(rollup@3.29.5)
       '@types/node':
         specifier: 6.14.13
         version: 6.14.13
@@ -1223,7 +1226,7 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3(rollup@4.62.2)
       '@rollup/plugin-terser':
-        specifier: 1.0.0
+        specifier: 'catalog:'
         version: 1.0.0(rollup@4.62.2)
       '@rollup/plugin-typescript':
         specifier: 12.3.0
@@ -6986,15 +6989,6 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
-  '@rollup/plugin-terser@0.4.4':
-    resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -14295,9 +14289,6 @@ packages:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -14873,9 +14864,6 @@ packages:
   serialize-error@2.1.0:
     resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
     engines: {node: '>=0.10.0'}
-
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   serialize-javascript@7.0.7:
     resolution: {integrity: sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==}
@@ -22080,9 +22068,9 @@ snapshots:
     optionalDependencies:
       rollup: 4.62.2
 
-  '@rollup/plugin-terser@0.4.4(rollup@3.29.5)':
+  '@rollup/plugin-terser@1.0.0(rollup@3.29.5)':
     dependencies:
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.7
       smob: 1.6.2
       terser: 5.48.0
     optionalDependencies:
@@ -31492,10 +31480,6 @@ snapshots:
 
   quick-lru@4.0.1: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   range-parser@1.2.1: {}
 
   range-parser@1.3.0: {}
@@ -32239,10 +32223,6 @@ snapshots:
       - supports-color
 
   serialize-error@2.1.0: {}
-
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
 
   serialize-javascript@7.0.7: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,6 +67,7 @@ catalog:
   'react-router': 7.14.2
   '@rollup/plugin-json': 6.1.0
   '@rollup/plugin-replace': 6.0.3
+  '@rollup/plugin-terser': 1.0.0
   '@rollup/plugin-url': 8.0.2
   '@stencil/core': 4.20.0
   '@testing-library/react': 16.3.2


### PR DESCRIPTION
Part of the `coveo.analytics` dependency-alignment series (wave B1). Stacked on #8106.

## Problem
`coveo.analytics` pinned an older `@rollup/plugin-terser`, which pulled in `serialize-javascript@6.0.2` — affected by [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq). `@coveo/relay` used a different version of the same plugin.

## Solution
- Added `@rollup/plugin-terser: 1.0.0` to the catalog.
- Switched `coveo.analytics` and `@coveo/relay` to `@rollup/plugin-terser: catalog:`.

Verification:
- `serialize-javascript@6.0.2` is gone from the lockfile (only `7.0.7` remains), resolving the advisory.
- Minified output is unaffected: `coveoua.js` is the same 115398 bytes and SHA-256 of every emitted artifact matches the baseline — **0 of 62 files changed**.
- `pnpm --filter coveo.analytics test` green.

No changeset: published `dependencies` unchanged and artifacts are byte-identical.