### PR TITLE
chore(deps): adopt catalog for @rollup/plugin-replace

### DIFF
--- a/packages/coveo-analytics/package.json
+++ b/packages/coveo-analytics/package.json
@@ -45,7 +45,7 @@
     "@rollup/plugin-commonjs": "24.1.0",
     "@rollup/plugin-json": "catalog:",
     "@rollup/plugin-node-resolve": "15.3.1",
-    "@rollup/plugin-replace": "5.0.7",
+    "@rollup/plugin-replace": "catalog:",
     "@rollup/plugin-terser": "catalog:",
     "@types/node": "6.14.13",
     "fetch-mock": "9.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,8 +684,8 @@ importers:
         specifier: 15.3.1
         version: 15.3.1(rollup@3.29.5)
       '@rollup/plugin-replace':
-        specifier: 5.0.7
-        version: 5.0.7(rollup@3.29.5)
+        specifier: 'catalog:'
+        version: 6.0.3(rollup@3.29.5)
       '@rollup/plugin-terser':
         specifier: 'catalog:'
         version: 1.0.0(rollup@3.29.5)
@@ -22047,19 +22047,19 @@ snapshots:
     optionalDependencies:
       rollup: 4.62.2
 
-  '@rollup/plugin-replace@5.0.7(rollup@3.29.5)':
-    dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@3.29.5)
-      magic-string: 0.30.21
-    optionalDependencies:
-      rollup: 3.29.5
-
   '@rollup/plugin-replace@5.0.7(rollup@4.62.2)':
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.62.2
+
+  '@rollup/plugin-replace@6.0.3(rollup@3.29.5)':
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@3.29.5)
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 3.29.5
 
   '@rollup/plugin-replace@6.0.3(rollup@4.62.2)':
     dependencies:


### PR DESCRIPTION
Part of the `coveo.analytics` dependency-alignment series (wave B2). Stacked on #8108.

## Problem
`coveo.analytics` declared its own `@rollup/plugin-replace` version while the monorepo catalog already had an entry for it, so the package silently opted out of the shared version.

## Solution
Switched `coveo.analytics` to the existing catalog entry (`@rollup/plugin-replace: 6.0.3`). No new catalog entry needed.

Verification: SHA-256 of every emitted artifact matches the baseline — **0 of 62 files changed**. `pnpm --filter coveo.analytics test` green.

No changeset: published `dependencies` unchanged and artifacts are byte-identical.