### PR TITLE
chore(deps): adopt catalog for @rollup/plugin-node-resolve

### DIFF
--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "29.0.3",
     "@rollup/plugin-json": "catalog:",
-    "@rollup/plugin-node-resolve": "16.0.3",
+    "@rollup/plugin-node-resolve": "catalog:",
     "@rollup/plugin-typescript": "12.3.0",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/packages/coveo-analytics/package.json
+++ b/packages/coveo-analytics/package.json
@@ -44,7 +44,7 @@
     "@rollup/plugin-alias": "5.1.1",
     "@rollup/plugin-commonjs": "24.1.0",
     "@rollup/plugin-json": "catalog:",
-    "@rollup/plugin-node-resolve": "15.3.1",
+    "@rollup/plugin-node-resolve": "catalog:",
     "@rollup/plugin-replace": "catalog:",
     "@rollup/plugin-terser": "catalog:",
     "@types/node": "6.14.13",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -47,7 +47,7 @@
     "uuid": "13.0.2"
   },
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "16.0.3",
+    "@rollup/plugin-node-resolve": "catalog:",
     "@rollup/plugin-replace": "catalog:",
     "@rollup/plugin-terser": "catalog:",
     "@rollup/plugin-typescript": "12.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ catalogs:
     '@rollup/plugin-json':
       specifier: 6.1.0
       version: 6.1.0
+    '@rollup/plugin-node-resolve':
+      specifier: 16.0.3
+      version: 16.0.3
     '@rollup/plugin-replace':
       specifier: 6.0.3
       version: 6.0.3
@@ -614,7 +617,7 @@ importers:
         specifier: 'catalog:'
         version: 6.1.0(rollup@4.62.2)
       '@rollup/plugin-node-resolve':
-        specifier: 16.0.3
+        specifier: 'catalog:'
         version: 16.0.3(rollup@4.62.2)
       '@rollup/plugin-typescript':
         specifier: 12.3.0
@@ -681,8 +684,8 @@ importers:
         specifier: 'catalog:'
         version: 6.1.0(rollup@3.29.5)
       '@rollup/plugin-node-resolve':
-        specifier: 15.3.1
-        version: 15.3.1(rollup@3.29.5)
+        specifier: 'catalog:'
+        version: 16.0.3(rollup@3.29.5)
       '@rollup/plugin-replace':
         specifier: 'catalog:'
         version: 6.0.3(rollup@3.29.5)
@@ -1220,7 +1223,7 @@ importers:
         version: 13.0.2
     devDependencies:
       '@rollup/plugin-node-resolve':
-        specifier: 16.0.3
+        specifier: 'catalog:'
         version: 16.0.3(rollup@4.62.2)
       '@rollup/plugin-replace':
         specifier: 'catalog:'
@@ -6953,15 +6956,6 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
-  '@rollup/plugin-node-resolve@15.3.1':
-    resolution: {integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^2.78.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -22027,7 +22021,7 @@ snapshots:
     optionalDependencies:
       rollup: 4.62.2
 
-  '@rollup/plugin-node-resolve@15.3.1(rollup@3.29.5)':
+  '@rollup/plugin-node-resolve@16.0.3(rollup@3.29.5)':
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@3.29.5)
       '@types/resolve': 1.20.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,6 +66,7 @@ catalog:
   '@reduxjs/toolkit': 2.12.0
   'react-router': 7.14.2
   '@rollup/plugin-json': 6.1.0
+  '@rollup/plugin-node-resolve': 16.0.3
   '@rollup/plugin-replace': 6.0.3
   '@rollup/plugin-terser': 1.0.0
   '@rollup/plugin-url': 8.0.2


### PR DESCRIPTION
Part of the `coveo.analytics` dependency-alignment series (wave B3). Stacked on #8109.

## Problem
Three packages (`coveo.analytics`, `@coveo/relay`, `@coveo/atomic-react`) each declared their own `@rollup/plugin-node-resolve` version, so the monorepo resolved multiple copies of the same build plugin.

## Solution
- Added `@rollup/plugin-node-resolve: 16.0.3` to the catalog.
- Switched all three packages to `@rollup/plugin-node-resolve: catalog:`.

Verification: SHA-256 of every emitted artifact matches the baseline — **0 of 62 files changed**. `pnpm --filter coveo.analytics test` green. Peer range confirmed compatible with the rollup 3 currently used by the repo.

No changeset: published `dependencies` unchanged and artifacts are byte-identical.