### PR TITLE
refactor(coveo.analytics): build with @rollup/plugin-typescript

### DIFF
--- a/.changeset/cajs-rollup-plugin-typescript.md
+++ b/.changeset/cajs-rollup-plugin-typescript.md
@@ -1,0 +1,5 @@
+---
+'coveo.analytics': patch
+---
+
+Build the package with `@rollup/plugin-typescript` instead of the unmaintained `rollup-plugin-typescript2`. Emitted bundles are equivalent but not byte-identical, and eight redundant duplicate declaration files under `dist/definitions/src` and `dist/definitions/bundle` are no longer emitted. The `types` entry and every declaration reachable from it are unchanged.

--- a/knip.js
+++ b/knip.js
@@ -63,11 +63,6 @@ export default {
       // `bundle/browser-fetch.ts` is reachable only through the Rollup alias that
       // swaps out `cross-fetch` for browser builds.
       entry: ['src/**/*.ts', 'bundle/browser-fetch.ts'],
-      ignoreDependencies: [
-        // Required by rollup-plugin-typescript2, which forces `importHelpers`.
-        // Never imported from source, so Knip cannot trace it.
-        'tslib',
-      ],
       // These modules intentionally expose two public bindings for the same
       // value: a named export plus a `default`, or a short plugin alias such as
       // `EC = ECPlugin`. Both spellings are part of the published API and are

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
       "react-dom": "catalog:",
       "typescript": "catalog:",
       "coveo.analytics>typescript": "5.0.4",
-      "@rollup/pluginutils@4.2.1>picomatch": "2.3.1",
       "html-minifier": "npm:html-minifier-terser@^7.2.0",
       "@angular/core": "catalog:",
       "@angular/common": "catalog:"

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -48,7 +48,7 @@
     "@rollup/plugin-commonjs": "29.0.3",
     "@rollup/plugin-json": "catalog:",
     "@rollup/plugin-node-resolve": "catalog:",
-    "@rollup/plugin-typescript": "12.3.0",
+    "@rollup/plugin-typescript": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/packages/coveo-analytics/package.json
+++ b/packages/coveo-analytics/package.json
@@ -47,6 +47,7 @@
     "@rollup/plugin-node-resolve": "catalog:",
     "@rollup/plugin-replace": "catalog:",
     "@rollup/plugin-terser": "catalog:",
+    "@rollup/plugin-typescript": "catalog:",
     "@types/node": "6.14.13",
     "fetch-mock": "9.11.0",
     "jsdom": "catalog:",
@@ -54,8 +55,6 @@
     "rollup": "3.29.5",
     "rollup-plugin-copy": "3.5.0",
     "rollup-plugin-serve": "1.1.1",
-    "rollup-plugin-typescript2": "0.34.1",
-    "tslib": "2.8.1",
     "typescript": "5.0.4",
     "vitest": "catalog:"
   }

--- a/packages/coveo-analytics/rollup.config.mjs
+++ b/packages/coveo-analytics/rollup.config.mjs
@@ -1,4 +1,4 @@
-import typescript from 'rollup-plugin-typescript2';
+import typescript from '@rollup/plugin-typescript';
 import terser from '@rollup/plugin-terser';
 import serve from 'rollup-plugin-serve';
 import commonjs from '@rollup/plugin-commonjs';
@@ -7,6 +7,7 @@ import alias from '@rollup/plugin-alias';
 import json from '@rollup/plugin-json';
 import replace from '@rollup/plugin-replace';
 import copy from 'rollup-plugin-copy';
+import {existsSync, readFileSync, writeFileSync} from 'fs';
 import {parse, resolve} from 'path';
 import packageJson from './package.json' with {type: 'json'};
 import * as url from 'url';
@@ -29,7 +30,7 @@ const browserFetch = () =>
 
 const tsPlugin = () =>
   typescript({
-    useTsconfigDeclarationDir: true,
+    tsconfig: './tsconfig.json',
   });
 
 const versionReplace = () =>
@@ -39,6 +40,29 @@ const versionReplace = () =>
     delimiters: ["'", "'"],
     local: JSON.stringify(packageJson.version), // replaces 'local' in src/version.ts
   });
+
+/**
+ * `@rollup/plugin-typescript` emits declarations from the on-disk sources, so the
+ * `local` placeholder in `src/version.ts` survives into `version.d.ts` even though
+ * `versionReplace` rewrites it in the bundles. Patch the emitted declaration so the
+ * published types keep announcing the real version.
+ */
+const versionReplaceInDeclaration = () => ({
+  name: 'version-replace-in-declaration',
+  writeBundle() {
+    const declaration = resolve(__dirname, './dist/definitions/version.d.ts');
+    if (!existsSync(declaration)) {
+      return;
+    }
+    const contents = readFileSync(declaration, 'utf8');
+    writeFileSync(
+      declaration,
+      contents
+        .replace("'local'", `'${packageJson.version}'`)
+        .replace('"local"', `"${packageJson.version}"`)
+    );
+  },
+});
 
 /**
  * @param {{sourceFileName: string, aliasFileName: string}} options
@@ -140,8 +164,8 @@ const browserModulesConfig = {
     nodeResolve({preferBuiltins: true}),
     versionReplace(),
     typescript({
-      useTsconfigDeclarationDir: true,
-      tsconfigOverride: {compilerOptions: {target: 'es6'}},
+      tsconfig: './tsconfig.json',
+      target: 'es6',
     }),
     aliasFile({
       sourceFileName: './dist/browser.mjs',
@@ -166,9 +190,10 @@ const reactNativeConfig = {
     commonjs(),
     json(),
     typescript({
-      useTsconfigDeclarationDir: true,
-      tsconfigOverride: {compilerOptions: {target: 'es6'}},
+      tsconfig: './tsconfig.json',
+      target: 'es6',
     }),
+    versionReplaceInDeclaration(),
   ],
 };
 

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -50,7 +50,7 @@
     "@rollup/plugin-node-resolve": "catalog:",
     "@rollup/plugin-replace": "catalog:",
     "@rollup/plugin-terser": "catalog:",
-    "@rollup/plugin-typescript": "12.3.0",
+    "@rollup/plugin-typescript": "catalog:",
     "@vitest/browser-playwright": "catalog:",
     "jsdom": "catalog:",
     "playwright": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ catalogs:
     '@rollup/plugin-terser':
       specifier: 1.0.0
       version: 1.0.0
+    '@rollup/plugin-typescript':
+      specifier: 12.3.0
+      version: 12.3.0
     '@rollup/plugin-url':
       specifier: 8.0.2
       version: 8.0.2
@@ -187,7 +190,6 @@ overrides:
   react-dom: 19.2.7
   typescript: 6.0.3
   coveo.analytics>typescript: 5.0.4
-  '@rollup/pluginutils@4.2.1>picomatch': 2.3.1
   html-minifier: npm:html-minifier-terser@^7.2.0
   '@angular/core': 21.2.17
   '@angular/common': 21.2.17
@@ -620,7 +622,7 @@ importers:
         specifier: 'catalog:'
         version: 16.0.3(rollup@4.62.2)
       '@rollup/plugin-typescript':
-        specifier: 12.3.0
+        specifier: 'catalog:'
         version: 12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)
       '@types/node':
         specifier: 'catalog:'
@@ -692,6 +694,9 @@ importers:
       '@rollup/plugin-terser':
         specifier: 'catalog:'
         version: 1.0.0(rollup@3.29.5)
+      '@rollup/plugin-typescript':
+        specifier: 'catalog:'
+        version: 12.3.0(rollup@3.29.5)(tslib@2.8.1)(typescript@5.0.4)
       '@types/node':
         specifier: 6.14.13
         version: 6.14.13
@@ -713,12 +718,6 @@ importers:
       rollup-plugin-serve:
         specifier: 1.1.1
         version: 1.1.1
-      rollup-plugin-typescript2:
-        specifier: 0.34.1
-        version: 0.34.1(rollup@3.29.5)(typescript@5.0.4)
-      tslib:
-        specifier: 2.8.1
-        version: 2.8.1
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -1232,7 +1231,7 @@ importers:
         specifier: 'catalog:'
         version: 1.0.0(rollup@4.62.2)
       '@rollup/plugin-typescript':
-        specifier: 12.3.0
+        specifier: 'catalog:'
         version: 12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
@@ -7018,10 +7017,6 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/pluginutils@4.2.1':
-    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
-    engines: {node: '>= 8.0.0'}
-
   '@rollup/pluginutils@5.4.0':
     resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
     engines: {node: '>=14.0.0'}
@@ -10748,10 +10743,6 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
-  find-cache-dir@3.3.2:
-    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
-    engines: {node: '>=8'}
-
   find-cache-directory@6.0.0:
     resolution: {integrity: sha512-CvFd5ivA6HcSHbD+59P7CyzINHXzwhuQK8RY7CxJZtgDSAtRlHiCaQpZQ2lMR/WRyUIEmzUvL6G2AGurMfegZA==}
     engines: {node: '>=20'}
@@ -10866,10 +10857,6 @@ packages:
 
   from@0.1.7:
     resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
-
-  fs-extra@10.1.0:
-    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
-    engines: {node: '>=12'}
 
   fs-extra@11.3.6:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
@@ -13754,10 +13741,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
-
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
@@ -14672,12 +14655,6 @@ packages:
 
   rollup-plugin-string@3.0.0:
     resolution: {integrity: sha512-vqyzgn9QefAgeKi+Y4A7jETeIAU1zQmS6VotH6bzm/zmUQEnYkpIGRaOBPY41oiWYV4JyBoGAaBjYMYuv+6wVw==}
-
-  rollup-plugin-typescript2@0.34.1:
-    resolution: {integrity: sha512-P4cHLtGikESmqi1CA+tdMDUv8WbQV48mzPYt77TSTOPJpERyZ9TXdDgjSDix8Fkqce6soYz3+fa4lrC93IEkcw==}
-    peerDependencies:
-      rollup: '>=1.26.3'
-      typescript: 6.0.3
 
   rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
@@ -22078,6 +22055,15 @@ snapshots:
     optionalDependencies:
       rollup: 4.62.2
 
+  '@rollup/plugin-typescript@12.3.0(rollup@3.29.5)(tslib@2.8.1)(typescript@5.0.4)':
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@3.29.5)
+      resolve: 1.22.12
+      typescript: 5.0.4
+    optionalDependencies:
+      rollup: 3.29.5
+      tslib: 2.8.1
+
   '@rollup/plugin-typescript@12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)':
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
@@ -22094,11 +22080,6 @@ snapshots:
       mime: 3.0.0
     optionalDependencies:
       rollup: 4.62.2
-
-  '@rollup/pluginutils@4.2.1':
-    dependencies:
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
 
   '@rollup/pluginutils@5.4.0(rollup@3.29.5)':
     dependencies:
@@ -26527,12 +26508,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-cache-dir@3.3.2:
-    dependencies:
-      commondir: 1.0.1
-      make-dir: 3.1.0
-      pkg-dir: 4.2.0
-
   find-cache-directory@6.0.0:
     dependencies:
       common-path-prefix: 3.0.0
@@ -26633,12 +26608,6 @@ snapshots:
   fresh@2.0.0: {}
 
   from@0.1.7: {}
-
-  fs-extra@10.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.1
-      universalify: 2.0.1
 
   fs-extra@11.3.6:
     dependencies:
@@ -30925,8 +30894,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
-
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
@@ -31990,16 +31957,6 @@ snapshots:
   rollup-plugin-string@3.0.0:
     dependencies:
       rollup-pluginutils: 2.8.2
-
-  rollup-plugin-typescript2@0.34.1(rollup@3.29.5)(typescript@5.0.4):
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      find-cache-dir: 3.3.2
-      fs-extra: 10.1.0
-      rollup: 3.29.5
-      semver: 7.8.5
-      tslib: 2.8.1
-      typescript: 5.0.4
 
   rollup-pluginutils@2.8.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,6 +69,7 @@ catalog:
   '@rollup/plugin-node-resolve': 16.0.3
   '@rollup/plugin-replace': 6.0.3
   '@rollup/plugin-terser': 1.0.0
+  '@rollup/plugin-typescript': 12.3.0
   '@rollup/plugin-url': 8.0.2
   '@stencil/core': 4.20.0
   '@testing-library/react': 16.3.2


### PR DESCRIPTION
Part of the `coveo.analytics` dependency-alignment series (wave C). Stacked on #8110.

## Problem
`coveo.analytics` was the only package in the monorepo still building with `rollup-plugin-typescript2`. That plugin is unmaintained, is not used anywhere else in the repo, and dragged in a legacy `@rollup/pluginutils@4.2.1` that forced a root `pnpm.overrides` entry pinning `picomatch@2.3.1`. It also kept `tslib` as a direct dependency.

## Solution
- Replaced `rollup-plugin-typescript2` with `@rollup/plugin-typescript` (added to the catalog at `12.3.0`, also adopted by `@coveo/relay` and `@coveo/atomic-react`).
- Removed the `tslib` dependency (no longer needed) and its now-stale `ignoreDependencies` entry in `knip.js`.
- Removed the root `@rollup/pluginutils@4.2.1>picomatch` override. Lockfile confirms `rollup-plugin-typescript2`, `@rollup/pluginutils@4.2.1` and `picomatch@2.3.1` are all gone.
- Added a `versionReplaceInDeclaration()` rollup plugin (`writeBundle` hook) in `rollup.config.mjs` to preserve the published behavior of `libVersion` in the emitted declarations — see below.

## Verification and behavior deltas
This is the first PR in the series where emitted bytes change, so it carries a patch changeset.

1. **`libVersion` in declarations (regression found and fixed).** `@rollup/plugin-typescript` emitted `export declare const libVersion = "local";` where the published package has `"2.30.56"`. The new `versionReplaceInDeclaration()` plugin restores the correct value. Without this fix the change would have shipped a wrong version constant in the types.
2. **Duplicate declaration files dropped: 62 → 54 artifacts.** The 8 removed files are redundant re-declarations that the old plugin emitted twice:
   - `definitions/bundle/browser-fetch.d.ts`
   - `definitions/src/coveoua/{browser,headless,library,plugins,simpleanalytics}.d.ts`
   - `definitions/src/react-native/{index,react-native-runtime}.d.ts`

   The canonical `definitions/coveoua/*.d.ts` and `definitions/react-native/*.d.ts` files are still emitted, and `package.json` `types`/`exports` never pointed at the dropped paths.
3. **10 of the remaining 54 artifacts differ**, all from the new emitter formatting. The only semantic diff in the declarations is a union member reordering in `definitions/client/runtimeEnvironment.d.ts` (`AnalyticsFetchClient | AnalyticsBeaconClient` → reversed), which is type-equivalent.
4. `pnpm exec tsc --noEmit --skipLibCheck dist/definitions/coveoua/library.d.ts` exits 0.
5. `pnpm --filter coveo.analytics test` green (699 tests). `pnpm run build`, `pnpm run knip`, `pnpm run package-compatibility` and `pnpm run lint:check` all pass at the monorepo level.