### PR TITLE
ci: upload playwright reports when tests fail

### DIFF
--- a/.github/actions/playwright-atomic-hosted-pages/action.yml
+++ b/.github/actions/playwright-atomic-hosted-pages/action.yml
@@ -13,7 +13,7 @@ runs:
       working-directory: packages/atomic-hosted-page
       shell: bash
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-      if: ${{ inputs.uploadArtifacts == 'true' }}
+      if: ${{ !cancelled() && inputs.uploadArtifacts == 'true' }}
       with:
         name: atomic-hosted-page-playwright-report
         path: packages/atomic-hosted-page/playwright-report/

--- a/.github/actions/playwright-atomic-theming/action.yml
+++ b/.github/actions/playwright-atomic-theming/action.yml
@@ -13,7 +13,7 @@ runs:
       working-directory: packages/atomic
       shell: bash
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-      if: ${{ inputs.uploadArtifacts == 'true' }}
+      if: ${{ !cancelled() && inputs.uploadArtifacts == 'true' }}
       with:
         name: atomic-theming-playwright-report
         path: packages/atomic/playwright-report/


### PR DESCRIPTION
## Problem

The Playwright report of the `atomic-hosted-page` job is only uploaded when the tests pass, which is exactly when nobody needs it. The `upload-artifact` step in `playwright-atomic-hosted-pages` is gated on `inputs.uploadArtifacts == 'true'` only, and composite-action steps are skipped once a previous step fails, so a failing test run discards the report and traces.

Observed in the failed run of #8107 (`Run e2e tests for Atomic Hosted Page`):

```
##[end-action id=__self_2.__run;outcome=failure;conclusion=failure
##[start-action display=Run actions/upload-artifact@...
##[end-action id=__self_2.__actions_upload-artifact;outcome=skipped;conclusion=skipped
```

`playwright-atomic-theming` has the same gate. `playwright-atomic` is unaffected because its test step uses `continue-on-error` and re-raises the failure after uploading, and `playwright-quantic` already guards with `cancelled() || failure() || success()`.

## Solution

Added `!cancelled()` to the upload condition of both actions, so the report is uploaded on success and on failure, but not on cancellation. This makes the traces from a failing hosted-page run (`trace: 'on-first-retry'`, embedded in the HTML report) actually available for debugging.