### PR TITLE
refactor(coveo.analytics): build with TypeScript 6

### DIFF
--- a/.changeset/cajs-typescript.md
+++ b/.changeset/cajs-typescript.md
@@ -1,0 +1,5 @@
+---
+'coveo.analytics': patch
+---
+
+Update to TypeScript 6. The newer compiler emits slightly different JavaScript; the published type declarations are unchanged.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
       "react": "catalog:",
       "react-dom": "catalog:",
       "typescript": "catalog:",
-      "coveo.analytics>typescript": "5.0.4",
       "html-minifier": "npm:html-minifier-terser@^7.2.0",
       "@angular/core": "catalog:",
       "@angular/common": "catalog:"

--- a/packages/atomic-angular/package.json
+++ b/packages/atomic-angular/package.json
@@ -21,7 +21,7 @@
     "@coveo/headless": "workspace:*",
     "@types/node": "catalog:",
     "ng-packagr": "20.3.2",
-    "tslib": "2.8.1",
+    "tslib": "catalog:",
     "typescript": "catalog:",
     "vite": "^8.0.0"
   },

--- a/packages/coveo-analytics/package.json
+++ b/packages/coveo-analytics/package.json
@@ -48,14 +48,15 @@
     "@rollup/plugin-replace": "catalog:",
     "@rollup/plugin-terser": "catalog:",
     "@rollup/plugin-typescript": "catalog:",
-    "@types/node": "6.14.13",
+    "@types/node": "catalog:",
     "fetch-mock": "9.11.0",
     "jsdom": "catalog:",
     "node-fetch": "2.7.0",
     "rollup": "3.29.5",
     "rollup-plugin-copy": "3.5.0",
     "rollup-plugin-serve": "1.1.1",
-    "typescript": "5.0.4",
+    "tslib": "catalog:",
+    "typescript": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/packages/coveo-analytics/src/client/analytics.ts
+++ b/packages/coveo-analytics/src/client/analytics.ts
@@ -286,7 +286,10 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     }
   }
 
-  async getParameters(eventType: EventType | string, ...payload: VariableArgumentsPayload) {
+  async getParameters(
+    eventType: EventType | string,
+    ...payload: VariableArgumentsPayload
+  ): Promise<VariableArgumentsPayload> {
     return await this.resolveParameters(eventType, ...payload);
   }
 
@@ -338,7 +341,10 @@ export class CoveoAnalyticsClient implements AnalyticsClient, VisitorIdProvider 
     return null;
   }
 
-  async resolveParameters(eventType: EventType | string, ...payload: VariableArgumentsPayload) {
+  async resolveParameters(
+    eventType: EventType | string,
+    ...payload: VariableArgumentsPayload
+  ): Promise<VariableArgumentsPayload> {
     const {
       variableLengthArgumentsNames = [],
       addVisitorIdParameter = false,

--- a/packages/coveo-analytics/tsconfig.json
+++ b/packages/coveo-analytics/tsconfig.json
@@ -3,6 +3,8 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "target": "es5",
+    "ignoreDeprecations": "6.0",
+    "rootDir": "./src",
     "declarationDir": "./dist/definitions",
     "declaration": true,
     "noImplicitAny": true,
@@ -10,7 +12,8 @@
     "sourceMap": true,
     "skipLibCheck": true,
     "strict": true,
-    "lib": ["es5", "dom", "scripthost", "es6"]
+    "lib": ["es5", "dom", "scripthost", "es6"],
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.spec.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ catalogs:
     rxjs:
       specifier: 7.8.2
       version: 7.8.2
+    tslib:
+      specifier: 2.8.1
+      version: 2.8.1
     typedoc:
       specifier: 0.28.20
       version: 0.28.20
@@ -192,7 +195,6 @@ overrides:
   react: 19.2.7
   react-dom: 19.2.7
   typescript: 6.0.3
-  coveo.analytics>typescript: 5.0.4
   html-minifier: npm:html-minifier-terser@^7.2.0
   '@angular/core': 21.2.18
   '@angular/common': 21.2.18
@@ -516,7 +518,7 @@ importers:
         specifier: 20.3.2
         version: 20.3.2(@angular/compiler-cli@21.2.18(@angular/compiler@21.2.18)(typescript@6.0.3))(tailwindcss@4.3.2)(tslib@2.8.1)(typescript@6.0.3)
       tslib:
-        specifier: 2.8.1
+        specifier: 'catalog:'
         version: 2.8.1
       typescript:
         specifier: 6.0.3
@@ -699,10 +701,10 @@ importers:
         version: 1.0.0(rollup@3.29.5)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@3.29.5)(tslib@2.8.1)(typescript@5.0.4)
+        version: 12.3.0(rollup@3.29.5)(tslib@2.8.1)(typescript@6.0.3)
       '@types/node':
-        specifier: 6.14.13
-        version: 6.14.13
+        specifier: 'catalog:'
+        version: 24.12.4
       fetch-mock:
         specifier: 9.11.0
         version: 9.11.0(node-fetch@2.7.0(encoding@0.1.13))
@@ -721,12 +723,15 @@ importers:
       rollup-plugin-serve:
         specifier: 1.1.1
         version: 1.1.1
+      tslib:
+        specifier: 'catalog:'
+        version: 2.8.1
       typescript:
-        specifier: 5.0.4
-        version: 5.0.4
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@types/node@6.14.13)(@vitest/browser-playwright@4.1.9)(jsdom@28.1.0)(msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4))(vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(jsdom@28.1.0)(msw@2.15.0(@types/node@24.12.4)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
 
   packages/create-atomic:
     dependencies:
@@ -790,10 +795,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: 'catalog:'
-        version: 30.3.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@6.14.13)(typescript@6.0.3))
+        version: 30.3.0(@types/node@26.1.0)(ts-node@10.9.2(@types/node@26.1.0)(typescript@6.0.3))
       jest-cli:
         specifier: 'catalog:'
-        version: 30.3.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@6.14.13)(typescript@6.0.3))
+        version: 30.3.0(@types/node@26.1.0)(ts-node@10.9.2(@types/node@26.1.0)(typescript@6.0.3))
       puppeteer:
         specifier: 'catalog:'
         version: 24.43.1(typescript@6.0.3)
@@ -7883,9 +7888,6 @@ packages:
 
   '@types/node@26.1.0':
     resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
-
-  '@types/node@6.14.13':
-    resolution: {integrity: sha512-J1F0XJ/9zxlZel5ZlbeSuHW2OpabrUAqpFuC2sm2I3by8sERQ8+KCjNKUcq8QHuzpGMWiJpo9ZxeHrqrP2KzQw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -15751,11 +15753,6 @@ packages:
     peerDependencies:
       typescript: 6.0.3
 
-  typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
-    hasBin: true
-
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -19395,14 +19392,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.0
 
-  '@inquirer/confirm@6.1.1(@types/node@6.14.13)':
-    dependencies:
-      '@inquirer/core': 11.2.1(@types/node@6.14.13)
-      '@inquirer/type': 4.0.7(@types/node@6.14.13)
-    optionalDependencies:
-      '@types/node': 6.14.13
-    optional: true
-
   '@inquirer/core@10.3.2(@types/node@24.12.4)':
     dependencies:
       '@inquirer/ansi': 1.0.2
@@ -19452,19 +19441,6 @@ snapshots:
       signal-exit: 4.1.0
     optionalDependencies:
       '@types/node': 26.1.0
-
-  '@inquirer/core@11.2.1(@types/node@6.14.13)':
-    dependencies:
-      '@inquirer/ansi': 2.0.7
-      '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@6.14.13)
-      cli-width: 4.1.0
-      fast-wrap-ansi: 0.2.2
-      mute-stream: 3.0.0
-      signal-exit: 4.1.0
-    optionalDependencies:
-      '@types/node': 6.14.13
-    optional: true
 
   '@inquirer/editor@4.2.23(@types/node@24.12.4)':
     dependencies:
@@ -19660,11 +19636,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.0
 
-  '@inquirer/type@4.0.7(@types/node@6.14.13)':
-    optionalDependencies:
-      '@types/node': 6.14.13
-    optional: true
-
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -19693,7 +19664,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -19702,7 +19673,7 @@ snapshots:
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       jest-message-util: 30.3.0
       jest-util: 30.3.0
@@ -19715,14 +19686,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@26.1.0)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@26.1.0)(ts-node@10.9.2(@types/node@26.1.0)(typescript@6.0.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -19751,14 +19722,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
+      jest-config: 30.3.0(@types/node@26.1.0)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -19787,49 +19758,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@26.1.0)(typescript@6.0.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@6.14.13)(typescript@6.0.3))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 6.14.13
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@6.14.13)(typescript@6.0.3))
+      jest-config: 30.3.0(@types/node@26.1.0)(ts-node@10.9.2(@types/node@26.1.0)(typescript@6.0.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -19857,14 +19793,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-mock: 29.7.0
 
   '@jest/environment@30.3.0':
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-mock: 30.3.0
 
   '@jest/expect-utils@29.7.0':
@@ -19897,7 +19833,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -19906,7 +19842,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.4.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -19933,12 +19869,12 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-regex-util: 30.0.1
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-regex-util: 30.4.0
 
   '@jest/reporters@29.7.0':
@@ -19949,7 +19885,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -19978,7 +19914,7 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -20101,7 +20037,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -20111,7 +20047,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -20121,7 +20057,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -22004,11 +21940,11 @@ snapshots:
     optionalDependencies:
       rollup: 4.62.2
 
-  '@rollup/plugin-typescript@12.3.0(rollup@3.29.5)(tslib@2.8.1)(typescript@5.0.4)':
+  '@rollup/plugin-typescript@12.3.0(rollup@3.29.5)(tslib@2.8.1)(typescript@6.0.3)':
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@3.29.5)
       resolve: 1.22.12
-      typescript: 5.0.4
+      typescript: 6.0.3
     optionalDependencies:
       rollup: 3.29.5
       tslib: 2.8.1
@@ -22783,11 +22719,11 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -22797,11 +22733,11 @@ snapshots:
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 5.1.1
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/debug@4.1.13':
     dependencies:
@@ -22829,14 +22765,14 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -22858,16 +22794,16 @@ snapshots:
 
   '@types/fs-extra@8.1.5':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 6.0.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/hast@3.0.4':
     dependencies:
@@ -22877,7 +22813,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/inquirer@9.0.10':
     dependencies:
@@ -22906,7 +22842,7 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -22919,7 +22855,7 @@ snapshots:
   '@types/liftoff@4.0.3':
     dependencies:
       '@types/fined': 1.1.5
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/linkify-it@5.0.0': {}
 
@@ -22948,7 +22884,7 @@ snapshots:
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       form-data: 4.0.6
 
   '@types/node@12.20.55': {}
@@ -22961,15 +22897,13 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
-  '@types/node@6.14.13': {}
-
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/npm-package-arg@6.1.4': {}
 
   '@types/npm-registry-fetch@8.0.9':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       '@types/node-fetch': 2.6.13
       '@types/npm-package-arg': 6.1.4
       '@types/npmlog': 7.0.0
@@ -22977,11 +22911,11 @@ snapshots:
 
   '@types/npmlog@7.0.0':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/pacote@11.1.8':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       '@types/npm-registry-fetch': 8.0.9
       '@types/npmlog': 7.0.0
       '@types/ssri': 7.1.5
@@ -23009,11 +22943,11 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -23022,25 +22956,25 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       '@types/send': 0.17.6
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/ssri@7.1.5':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/stack-utils@2.0.3': {}
 
@@ -23048,7 +22982,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -23062,11 +22996,11 @@ snapshots:
 
   '@types/wait-on@5.3.4':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -23076,7 +23010,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
     optional: true
 
   '@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@6.0.3))(eslint@7.32.0)(typescript@6.0.3)':
@@ -23508,20 +23442,6 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.1.9(msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4))(playwright@1.62.0-alpha-1783623505000)(vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)':
-    dependencies:
-      '@vitest/browser': 4.1.9(msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4))(vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
-      '@vitest/mocker': 4.1.9(msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4))(vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
-      playwright: 1.62.0-alpha-1783623505000
-      tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@6.14.13)(@vitest/browser-playwright@4.1.9)(jsdom@28.1.0)(msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4))(vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/browser@4.1.9(msw@2.15.0(@types/node@24.12.4)(typescript@6.0.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.7)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
       '@blazediff/core': 1.9.1
@@ -23592,24 +23512,6 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.9(msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4))(vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)':
-    dependencies:
-      '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.9(msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4))(vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
-      '@vitest/utils': 4.1.9
-      magic-string: 0.30.21
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@6.14.13)(@vitest/browser-playwright@4.1.9)(jsdom@28.1.0)(msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4))(vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -23664,15 +23566,6 @@ snapshots:
     optionalDependencies:
       msw: 2.15.0(@types/node@26.1.0)(typescript@6.0.3)
       vite: 8.1.5(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)
-
-  '@vitest/mocker@4.1.9(msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4))(vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.15.0(@types/node@6.14.13)(typescript@5.0.4)
-      vite: 8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -24752,7 +24645,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -24769,7 +24662,7 @@ snapshots:
 
   chromium-edge-launcher@0.3.0:
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -27556,7 +27449,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -27582,7 +27475,7 @@ snapshots:
       '@jest/expect': 30.3.0
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -27660,25 +27553,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@6.14.13)(typescript@6.0.3)):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@6.14.13)(typescript@6.0.3))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@6.14.13)(typescript@6.0.3))
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@26.1.0)(ts-node@10.9.2(@types/node@26.1.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
@@ -27705,37 +27579,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 26.1.0
-      ts-node: 10.9.2(@types/node@26.1.0)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@26.1.0)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.7)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 6.14.13
       ts-node: 10.9.2(@types/node@26.1.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -27774,6 +27617,39 @@ snapshots:
       - supports-color
     optional: true
 
+  jest-config@30.3.0(@types/node@26.1.0)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 26.1.0
+      ts-node: 10.9.2(@types/node@24.12.4)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    optional: true
+
   jest-config@30.3.0(@types/node@26.1.0)(ts-node@10.9.2(@types/node@26.1.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
@@ -27802,103 +27678,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.0
       ts-node: 10.9.2(@types/node@26.1.0)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@24.12.4)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.7)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 6.14.13
-      ts-node: 10.9.2(@types/node@24.12.4)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-    optional: true
-
-  jest-config@30.3.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@26.1.0)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.7)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 6.14.13
-      ts-node: 10.9.2(@types/node@26.1.0)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@6.14.13)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.7)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 6.14.13
-      ts-node: 10.9.2(@types/node@6.14.13)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -27954,7 +27733,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -27968,7 +27747,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -27977,7 +27756,7 @@ snapshots:
       '@jest/environment': 30.3.0
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jest-validate: 30.3.0
@@ -27988,7 +27767,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -28003,7 +27782,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -28093,19 +27872,19 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-util: 29.7.0
 
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-util: 30.3.0
 
   jest-mock@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-util: 30.4.1
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -28166,7 +27945,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -28192,7 +27971,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -28221,7 +28000,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -28248,7 +28027,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -28320,7 +28099,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -28329,7 +28108,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -28338,7 +28117,7 @@ snapshots:
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -28366,7 +28145,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -28377,7 +28156,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -28386,20 +28165,20 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 6.14.13
+      '@types/node': 26.1.0
       '@ungap/structured-clone': 1.3.2
       jest-util: 30.3.0
       merge-stream: 2.0.0
@@ -28437,19 +28216,6 @@ snapshots:
       '@jest/types': 30.3.0
       import-local: 3.2.0
       jest-cli: 30.3.0(@types/node@26.1.0)(ts-node@10.9.2(@types/node@26.1.0)(typescript@6.0.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@6.14.13)(typescript@6.0.3)):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@6.14.13)(typescript@6.0.3))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@6.14.13)(ts-node@10.9.2(@types/node@6.14.13)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -30016,32 +29782,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
-
-  msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4):
-    dependencies:
-      '@inquirer/confirm': 6.1.1(@types/node@6.14.13)
-      '@mswjs/interceptors': 0.41.9
-      '@open-draft/deferred-promise': 3.0.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.14.2
-      headers-polyfill: 5.0.1
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.11.11
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.8.0
-      until-async: 3.0.2
-      yargs: 17.7.3
-    optionalDependencies:
-      typescript: 5.0.4
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   multicast-dns@7.2.5:
     dependencies:
@@ -33006,25 +32746,6 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@6.14.13)(typescript@6.0.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 6.14.13
-      acorn: 8.17.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 6.0.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
   ts-simple-type@2.0.0-next.0: {}
 
   tsconfck@3.1.6(typescript@6.0.3):
@@ -33182,8 +32903,6 @@ snapshots:
       minimatch: 10.2.5
       typescript: 6.0.3
       yaml: 2.9.0
-
-  typescript@5.0.4: {}
 
   typescript@6.0.3: {}
 
@@ -33597,23 +33316,6 @@ snapshots:
       terser: 5.48.0
       yaml: 2.9.0
 
-  vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.5
-      postcss: 8.5.20
-      rolldown: 1.1.5
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 6.14.13
-      esbuild: 0.28.1
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      less: 4.6.7
-      sass: 1.101.0
-      terser: 5.48.0
-      yaml: 2.9.0
-
   vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(jsdom@28.1.0)(msw@2.15.0(@types/node@24.12.4)(typescript@6.0.3))(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.7)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
@@ -33728,35 +33430,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.0
       '@vitest/browser-playwright': 4.1.9(msw@2.15.0(@types/node@26.1.0)(typescript@6.0.3))(playwright@1.62.0-alpha-1783623505000)(vite@8.1.5(@types/node@26.1.0)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
-      jsdom: 28.1.0
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.9(@types/node@6.14.13)(@vitest/browser-playwright@4.1.9)(jsdom@28.1.0)(msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4))(vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4))(vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.3.0
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 6.14.13
-      '@vitest/browser-playwright': 4.1.9(msw@2.15.0(@types/node@6.14.13)(typescript@5.0.4))(playwright@1.62.0-alpha-1783623505000)(vite@8.1.5(@types/node@6.14.13)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.9)
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,6 +99,7 @@ catalog:
   react-dom: 19.2.7
   rollup-plugin-string: 3.0.0
   rollup-plugin-node-polyfills: 0.2.1
+  tslib: 2.8.1
   typedoc: 0.28.20
   typescript: 6.0.3
   vite: 8.1.5


### PR DESCRIPTION
Part of the `coveo.analytics` dependency-alignment series (wave D). Stacked on #8112.

## Problem
`coveo.analytics` was the last package still pinned to its own TypeScript. The workspace integration (#8072) added a root override, `"coveo.analytics>typescript": "5.0.4"`, to hold it back while the rest of the monorepo moved to the catalog. Its `@types/node` was also frozen at `6.14.13` — a 2018-era release that was additionally being used to satisfy peer ranges for unrelated packages in the lockfile.

## Solution
- Removed the `coveo.analytics>typescript` override and moved `typescript` and `@types/node` onto the catalog (`6.0.3` and `24.12.4`).
- Added three tsconfig options required by the newer compiler.
- Re-added `tslib` as a new catalog entry (`2.8.1`), shared with `@coveo/atomic-angular`.
- Added explicit return types to two methods to preserve the published type surface.

### tsconfig changes
| Option | Why |
|---|---|
| `rootDir: "./src"` | avoids `TS5011` |
| `types: ["node"]` | avoids `TS2304: Cannot find name 'global'`, which appears once `@types/node` is no longer 6.14.13 |
| `ignoreDeprecations: "6.0"` | silences `TS5107` for `target: es5` and `moduleResolution: node10` |

`target: es5` and `moduleResolution: node10` both stop functioning in TypeScript 7. Modernizing them changes the published browser-support target, so that is deliberately **not** in scope here — it needs its own decision and changeset.

### Why `tslib` returns
#8111 retired `tslib`. It comes back here, and the reason is specific: with `ignoreDeprecations: "6.0"` set, the compiler emits `TS2354` and requires the helper module instead of inlining helpers. I probed six tsconfig variants — every configuration with `ignoreDeprecations` set (or with `moduleResolution: Bundler`) needs `tslib`; every configuration without it emits `TS5107` instead. Declaring `tslib` is the cleaner of the two.

Rollup still inlines the helpers, so **no `dist` artifact imports `tslib` at runtime** — verified by grepping the whole `dist` tree for `require("tslib")` / `from "tslib"`: zero matches.

### Type regression found and fixed
The newer compiler inferred `Promise<any>` for `getParameters` and `resolveParameters` where 5.0.4 inferred `Promise<VariableArgumentsPayload>`. That would have silently widened two public method signatures. Both now carry explicit return type annotations, and the emitted declarations are byte-identical to the baseline as a result.

## Verification
- **54 artifacts before, 54 after. 12 changed, all `.js`/`.mjs`/`.cjs`/`.map` — zero `.d.ts` files changed.** The entire published type surface is preserved.
- `coveoua.js` 115398 → 115394 bytes (compiler downlevels slightly differently).
- `pnpm --filter coveo.analytics test`: 699 tests, 17 files, all green.
- `tsc --noEmit --skipLibCheck` on the emitted `library.d.ts`: clean.
- `pnpm run build` 62/62 tasks. `pnpm run knip` exit 0. `pnpm run package-compatibility` exit 0. `pnpm run lint:check` exit 0.
- `@types/node@6.14.13` is now gone from the lockfile entirely (0 references), which is most of the ~450-line lockfile reduction.

Patch changeset included since emitted JavaScript changes.