### PR TITLE
fix(deps): adopt catalog for rollup

### DIFF
--- a/.changeset/cajs-rollup-4.md
+++ b/.changeset/cajs-rollup-4.md
@@ -1,0 +1,5 @@
+---
+'coveo.analytics': patch
+---
+
+Bundle with Rollup 4. Emitted JavaScript changes because the newer bundler generates slightly different output; the published type declarations are unchanged.

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -54,7 +54,7 @@
     "@types/react-dom": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "rollup": "4.62.2",
+    "rollup": "catalog:",
     "rollup-plugin-polyfill-node": "^0.13.0"
   },
   "peerDependencies": {

--- a/packages/coveo-analytics/package.json
+++ b/packages/coveo-analytics/package.json
@@ -52,7 +52,7 @@
     "fetch-mock": "9.11.0",
     "jsdom": "catalog:",
     "node-fetch": "2.7.0",
-    "rollup": "3.29.5",
+    "rollup": "catalog:",
     "rollup-plugin-copy": "3.5.0",
     "rollup-plugin-serve": "1.1.1",
     "tslib": "catalog:",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -54,7 +54,7 @@
     "@vitest/browser-playwright": "catalog:",
     "jsdom": "catalog:",
     "playwright": "catalog:",
-    "rollup": "4.62.2",
+    "rollup": "catalog:",
     "typedoc": "catalog:",
     "vitest": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ catalogs:
     react-router:
       specifier: 7.14.2
       version: 7.14.2
+    rollup:
+      specifier: 4.62.2
+      version: 4.62.2
     rollup-plugin-node-polyfills:
       specifier: 0.2.1
       version: 0.2.1
@@ -645,7 +648,7 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       rollup:
-        specifier: 4.62.2
+        specifier: 'catalog:'
         version: 4.62.2
       rollup-plugin-polyfill-node:
         specifier: ^0.13.0
@@ -683,25 +686,25 @@ importers:
     devDependencies:
       '@rollup/plugin-alias':
         specifier: 5.1.1
-        version: 5.1.1(rollup@3.29.5)
+        version: 5.1.1(rollup@4.62.2)
       '@rollup/plugin-commonjs':
         specifier: 'catalog:'
-        version: 29.0.3(rollup@3.29.5)
+        version: 29.0.3(rollup@4.62.2)
       '@rollup/plugin-json':
         specifier: 'catalog:'
-        version: 6.1.0(rollup@3.29.5)
+        version: 6.1.0(rollup@4.62.2)
       '@rollup/plugin-node-resolve':
         specifier: 'catalog:'
-        version: 16.0.3(rollup@3.29.5)
+        version: 16.0.3(rollup@4.62.2)
       '@rollup/plugin-replace':
         specifier: 'catalog:'
-        version: 6.0.3(rollup@3.29.5)
+        version: 6.0.3(rollup@4.62.2)
       '@rollup/plugin-terser':
         specifier: 'catalog:'
-        version: 1.0.0(rollup@3.29.5)
+        version: 1.0.0(rollup@4.62.2)
       '@rollup/plugin-typescript':
         specifier: 'catalog:'
-        version: 12.3.0(rollup@3.29.5)(tslib@2.8.1)(typescript@6.0.3)
+        version: 12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.4
@@ -715,8 +718,8 @@ importers:
         specifier: 2.7.0
         version: 2.7.0(encoding@0.1.13)
       rollup:
-        specifier: 3.29.5
-        version: 3.29.5
+        specifier: 'catalog:'
+        version: 4.62.2
       rollup-plugin-copy:
         specifier: 3.5.0
         version: 3.5.0
@@ -1251,7 +1254,7 @@ importers:
         specifier: 'catalog:'
         version: 1.60.0
       rollup:
-        specifier: 4.62.2
+        specifier: 'catalog:'
         version: 4.62.2
       typedoc:
         specifier: 'catalog:'
@@ -14638,11 +14641,6 @@ packages:
   rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
 
-  rollup@3.29.5:
-    resolution: {integrity: sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.62.2:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -21835,21 +21833,9 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-alias@5.1.1(rollup@3.29.5)':
+  '@rollup/plugin-alias@5.1.1(rollup@4.62.2)':
     optionalDependencies:
-      rollup: 3.29.5
-
-  '@rollup/plugin-commonjs@29.0.3(rollup@3.29.5)':
-    dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@3.29.5)
-      commondir: 1.0.1
-      estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.5)
-      is-reference: 1.2.1
-      magic-string: 0.30.21
-      picomatch: 4.0.5
-    optionalDependencies:
-      rollup: 3.29.5
+      rollup: 4.62.2
 
   '@rollup/plugin-commonjs@29.0.3(rollup@4.62.2)':
     dependencies:
@@ -21871,27 +21857,11 @@ snapshots:
     optionalDependencies:
       rollup: 4.62.2
 
-  '@rollup/plugin-json@6.1.0(rollup@3.29.5)':
-    dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@3.29.5)
-    optionalDependencies:
-      rollup: 3.29.5
-
   '@rollup/plugin-json@6.1.0(rollup@4.62.2)':
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
     optionalDependencies:
       rollup: 4.62.2
-
-  '@rollup/plugin-node-resolve@16.0.3(rollup@3.29.5)':
-    dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@3.29.5)
-      '@types/resolve': 1.20.2
-      deepmerge: 4.3.1
-      is-module: 1.0.0
-      resolve: 1.22.12
-    optionalDependencies:
-      rollup: 3.29.5
 
   '@rollup/plugin-node-resolve@16.0.3(rollup@4.62.2)':
     dependencies:
@@ -21910,27 +21880,12 @@ snapshots:
     optionalDependencies:
       rollup: 4.62.2
 
-  '@rollup/plugin-replace@6.0.3(rollup@3.29.5)':
-    dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@3.29.5)
-      magic-string: 0.30.21
-    optionalDependencies:
-      rollup: 3.29.5
-
   '@rollup/plugin-replace@6.0.3(rollup@4.62.2)':
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.62.2
-
-  '@rollup/plugin-terser@1.0.0(rollup@3.29.5)':
-    dependencies:
-      serialize-javascript: 7.0.7
-      smob: 1.6.2
-      terser: 5.48.0
-    optionalDependencies:
-      rollup: 3.29.5
 
   '@rollup/plugin-terser@1.0.0(rollup@4.62.2)':
     dependencies:
@@ -21939,15 +21894,6 @@ snapshots:
       terser: 5.48.0
     optionalDependencies:
       rollup: 4.62.2
-
-  '@rollup/plugin-typescript@12.3.0(rollup@3.29.5)(tslib@2.8.1)(typescript@6.0.3)':
-    dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@3.29.5)
-      resolve: 1.22.12
-      typescript: 6.0.3
-    optionalDependencies:
-      rollup: 3.29.5
-      tslib: 2.8.1
 
   '@rollup/plugin-typescript@12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)':
     dependencies:
@@ -21965,14 +21911,6 @@ snapshots:
       mime: 3.0.0
     optionalDependencies:
       rollup: 4.62.2
-
-  '@rollup/pluginutils@5.4.0(rollup@3.29.5)':
-    dependencies:
-      '@types/estree': 1.0.9
-      estree-walker: 2.0.2
-      picomatch: 4.0.5
-    optionalDependencies:
-      rollup: 3.29.5
 
   '@rollup/pluginutils@5.4.0(rollup@4.62.2)':
     dependencies:
@@ -31634,10 +31572,6 @@ snapshots:
   rollup-pluginutils@2.8.2:
     dependencies:
       estree-walker: 0.6.1
-
-  rollup@3.29.5:
-    optionalDependencies:
-      fsevents: 2.3.3
 
   rollup@4.62.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,6 +97,7 @@ catalog:
   rxjs: 7.8.2
   react: 19.2.7
   react-dom: 19.2.7
+  rollup: 4.62.2
   rollup-plugin-string: 3.0.0
   rollup-plugin-node-polyfills: 0.2.1
   tslib: 2.8.1


### PR DESCRIPTION
Part of the `coveo.analytics` dependency-alignment series (wave E). Stacked on #8116.

## Problem
`coveo.analytics` was pinned to `rollup@3.29.5` and was the **only** consumer of Rollup 3 in the monorepo, so the lockfile carried two majors (`3.29.5` and `4.62.2`). It was also the only path to a live high-severity advisory:

```
rollup high GHSA-mw96-cpmx-2vgc >=3.0.0 <3.30.0 -> >=3.30.0
    3.29.5 ['packages__coveo-analytics>rollup']
```

`rollup` had no catalog entry at all, so `@coveo/relay` and `@coveo/atomic-react` each declared `4.62.2` independently.

## Solution
- Added a `rollup: 4.62.2` catalog entry.
- Moved `coveo.analytics`, `@coveo/relay` and `@coveo/atomic-react` onto `rollup: catalog:`.

`relay` and `atomic-react` were already on `4.62.2`, so `coveo.analytics` is the only package whose resolved version changes. I went to 4 rather than the minimal `3.30.x` bump so the repo collapses to a single rollup major instead of clearing the advisory and leaving the split in place.

## Verification
- Lockfile now resolves exactly one rollup: `4.62.2`. `pnpm audit` reports **0 rollup advisories**.
- **54 artifacts before, 54 after, same file set. 12 changed, all `.js`/`.mjs`/`.cjs`/`.map` — zero `.d.ts` files changed.**
- Sizes are stable: `coveoua.js` 115394 → 115400 bytes, `library.cjs` 1211605 → 1211579, `browser.mjs` 153123 → 152974.
- `pnpm --filter coveo.analytics test`: 699 tests, 17 files, all green.
- `pnpm run build` 62/62 tasks, which exercises the `relay` and `atomic-react` bundles too. `pnpm run knip` exit 0. `pnpm run package-compatibility` exit 0. `pnpm run lint:check` exit 0.
- No `rollup.config.mjs` changes were needed; the config is already Rollup 4 compatible. The one remaining build warning (`Rollup 'sourcemap' option must be set to generate source maps`) is pre-existing and unrelated.

Patch changeset included since emitted JavaScript changes.