### PR TITLE
feat(deps): adopt catalog for uuid

### DIFF
--- a/.changeset/cajs-uuid.md
+++ b/.changeset/cajs-uuid.md
@@ -1,0 +1,7 @@
+---
+'coveo.analytics': minor
+---
+
+Update `uuid` from 9 to 14, and stop declaring `@types/uuid`, which is redundant now that `uuid` ships its own type declarations.
+
+`uuid` is bundled into the distributed files, so no emitted JavaScript imports it at runtime and behavior is unchanged. The published type declarations are also unchanged. What changes is the installed dependency set: `@types/uuid` is no longer pulled in, and `uuid` resolves to 14.

--- a/.changeset/relay-uuid.md
+++ b/.changeset/relay-uuid.md
@@ -1,0 +1,5 @@
+---
+'@coveo/relay': patch
+---
+
+Update `uuid` from 13 to 14. The npm entry points import `uuid` at runtime rather than bundling it, so consumers will resolve version 14. Only `v4` and `validate` are used, and both are unchanged between the two versions.

--- a/packages/coveo-analytics/package.json
+++ b/packages/coveo-analytics/package.json
@@ -35,10 +35,9 @@
     "clean": "node ../../utils/ci/rm-rf.mjs dist coverage"
   },
   "dependencies": {
-    "@types/uuid": "9.0.8",
     "cross-fetch": "3.2.0",
     "react-native-get-random-values": "1.11.0",
-    "uuid": "9.0.1"
+    "uuid": "catalog:"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "5.1.1",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@coveo/explorer-messenger": "0.5.0",
-    "uuid": "13.0.2"
+    "uuid": "catalog:"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "catalog:",

--- a/packages/shopify/package.json
+++ b/packages/shopify/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@coveo/headless": "workspace:*",
     "@coveo/relay": "workspace:*",
-    "uuid": "^14.0.0"
+    "uuid": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ catalogs:
     typedoc:
       specifier: 0.28.20
       version: 0.28.20
+    uuid:
+      specifier: 14.0.1
+      version: 14.0.1
     vite:
       specifier: 8.1.5
       version: 8.1.5
@@ -677,9 +680,6 @@ importers:
 
   packages/coveo-analytics:
     dependencies:
-      '@types/uuid':
-        specifier: 9.0.8
-        version: 9.0.8
       cross-fetch:
         specifier: 3.2.0
         version: 3.2.0(encoding@0.1.13)
@@ -687,8 +687,8 @@ importers:
         specifier: 1.11.0
         version: 1.11.0(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))
       uuid:
-        specifier: 9.0.1
-        version: 9.0.1
+        specifier: 'catalog:'
+        version: 14.0.1
     devDependencies:
       '@rollup/plugin-alias':
         specifier: 5.1.1
@@ -1235,8 +1235,8 @@ importers:
         specifier: 0.5.0
         version: 0.5.0
       uuid:
-        specifier: 13.0.2
-        version: 13.0.2
+        specifier: 'catalog:'
+        version: 14.0.1
     devDependencies:
       '@rollup/plugin-node-resolve':
         specifier: 'catalog:'
@@ -1312,7 +1312,7 @@ importers:
         specifier: workspace:*
         version: link:../relay
       uuid:
-        specifier: ^14.0.0
+        specifier: 'catalog:'
         version: 14.0.1
     devDependencies:
       '@types/node':
@@ -7983,9 +7983,6 @@ packages:
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/wait-on@5.3.4':
     resolution: {integrity: sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==}
@@ -15981,10 +15978,6 @@ packages:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  uuid@13.0.2:
-    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
-    hasBin: true
-
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
@@ -15996,11 +15989,6 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
@@ -22934,8 +22922,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/uuid@10.0.0': {}
-
-  '@types/uuid@9.0.8': {}
 
   '@types/wait-on@5.3.4':
     dependencies:
@@ -33066,15 +33052,11 @@ snapshots:
 
   uuid@11.1.1: {}
 
-  uuid@13.0.2: {}
-
   uuid@14.0.1: {}
 
   uuid@3.4.0: {}
 
   uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -103,6 +103,7 @@ catalog:
   tslib: 2.8.1
   typedoc: 0.28.20
   typescript: 6.0.3
+  uuid: 14.0.1
   vite: 8.1.5
   vitest: 4.1.9
   yaml: 2.9.0


### PR DESCRIPTION
Part of the `coveo.analytics` dependency-alignment series (wave F, final). Stacked on #8117.

> [!IMPORTANT]
> This is the only wave that changes the **published `dependencies`** of `coveo.analytics`, and it touches two other published packages. Please confirm the three decisions in "Decisions needing sign-off" below before this is taken out of draft.

## Problem
Four `uuid` majors were declared across the monorepo and there was no catalog entry:

| Package | Before |
|---|---|
| `coveo.analytics` | `9.0.1` |
| `@coveo/relay` | `13.0.2` |
| `@coveo/shopify` | `^14.0.0` |

`coveo.analytics` additionally declared `@types/uuid: 9.0.8` in `dependencies`.

## Solution
- Added a `uuid: 14.0.1` catalog entry and moved all three packages onto `uuid: catalog:`.
- Dropped `@types/uuid` from `coveo.analytics`.

`@types/uuid` was in `dependencies` rather than `devDependencies` deliberately, not by mistake: the published `dist/definitions/plugins/BasePlugin.d.ts` contains `import { v4 as uuidv4 } from 'uuid';`, so consumers need `uuid`'s types to resolve. From uuid 10 onward the package ships its own declarations (`types: "./dist/index.d.ts"`), which makes the separate types package redundant. `uuid` itself stays in `dependencies` for exactly that reason.

## Why this is lower risk than the version jump suggests
`uuid` is **fully bundled** into the distributed files. I grepped the whole `dist` tree for `require("uuid")` / `from "uuid"` in emitted JavaScript: zero matches, the only reference is the declaration file above. So no consumer resolves `uuid` at runtime through this package.

Only three entry points are used — `v4`, `v5` and `validate` — all unchanged in 14.

## Verification
- Lockfile: `uuid@9.0.1` and `uuid@13.0.2` are gone, `@types/uuid@9.0.8` is gone. Remaining `uuid@11.1.1`/`8.3.2`/`3.4.0` and `@types/uuid@10.0.0` are transitive from unrelated packages.
- **54 artifacts before, 54 after. 12 changed, all `.js`/`.mjs`/`.cjs`/`.map` — zero `.d.ts` files changed**, including `BasePlugin.d.ts`, which is byte-identical.
- `tsc --noEmit --skipLibCheck` on the emitted `library.d.ts`: clean.
- Tests: `coveo.analytics` 699 passed, `@coveo/relay` 133 passed, `@coveo/shopify` 30 passed.
- `pnpm run build` 62/62 tasks. `pnpm run knip` exit 0. `pnpm run package-compatibility` exit 0. `pnpm run lint:check` exit 0.

## Decisions needing sign-off
1. **Target version.** I picked `14.0.1` (current latest) so all three packages land on one version. The alternative is `13.0.2`, which is what `relay` already used and would leave `shopify` needing a range widening instead.
2. **`@coveo/shopify` range narrowing.** Its `^14.0.0` becomes an exact `14.0.1` pin, which is a semver-visible narrowing for its consumers. Consistent with how the catalog works everywhere else in the repo, but worth a conscious yes.
3. **Changeset bumps.** `minor` for `coveo.analytics` because its published dependency set changes; `patch` for `relay` and `shopify`. Happy to make it a `patch` across the board if you consider a bundled-dependency swap non-user-visible.

## Note on React Native
`src/react-native/index.ts` imports `react-native-get-random-values` to polyfill `crypto.getRandomValues`. Newer `uuid` prefers `crypto.randomUUID` and falls back to `getRandomValues`, so the polyfill is still the operative path on React Native. I could not exercise this on a real RN runtime — worth a smoke test if you have one handy.