### PR TITLE
feat(coveo-analytics): send click events with fetch keepalive instead of the Beacon API

### DIFF
--- a/.changeset/beacon-fetch-keepalive.md
+++ b/.changeset/beacon-fetch-keepalive.md
@@ -1,0 +1,8 @@
+---
+'coveo.analytics': minor
+'@coveo/headless': patch
+---
+
+Click events, and the events replayed when a page unloads, are now sent with `fetch` and `keepalive: true` instead of `navigator.sendBeacon`. The Beacon API accepts no headers, so a `preprocessRequest` hook could not add any to click events; hooks now receive the same mutable request options as for every other analytics event, and header mutations are applied to the outgoing request.
+
+The `analyticsBeacon` value of `preprocessRequest`'s `clientOrigin` parameter still identifies those events, and the request URL and body format are unchanged. The value is deprecated and will be merged into `analyticsFetch` in a future major version.

--- a/.changeset/beacon-fetch-keepalive.md
+++ b/.changeset/beacon-fetch-keepalive.md
@@ -1,6 +1,5 @@
 ---
 'coveo.analytics': minor
-'@coveo/headless': patch
 ---
 
 Click events, and the events replayed when a page unloads, are now sent with `fetch` and `keepalive: true` instead of `navigator.sendBeacon`. The Beacon API accepts no headers, so a `preprocessRequest` hook could not add any to click events; hooks now receive the same mutable request options as for every other analytics event, and header mutations are applied to the outgoing request.

--- a/packages/coveo-analytics/docs/technical-overview.md
+++ b/packages/coveo-analytics/docs/technical-overview.md
@@ -131,12 +131,18 @@ The `baseMeasurementProtocolMapper` includes the mappings to be done for every p
 
 `serviceMeasurementProtocolMapper` is similar, but contains stuff for the Service use case.
 
-### Beacon VS Fetch, and the buffer
+### Keepalive VS Fetch, and the buffer
 
-If you try to send an event with `fetch` and a redirection happens, the event will get canceled because the browser waits for the response and it will never actually send the event. To fix this, you need to use `navigator.sendBeacon`.
+If you try to send an event with a plain `fetch` and a redirection happens, the event will get canceled because the browser waits for the response and it will never actually send the event. To fix this, the request must be sent with `keepalive: true`, which tells the browser to complete it even after the page is gone.
 
 To simplify the whole thing, we introduce a mini-buffer that holds the event.".
 
-The trick here is to flush the buffer with a `setTimeout(flush, 0)` so that the event is sent as soon as the thread is available. But on a `beforeunload` event, triggered when a redirection happen, flush the events with the `beacon`.
+The trick here is to flush the buffer with a `setTimeout(flush, 0)` so that the event is sent as soon as the thread is available. But on a `beforeunload` event, triggered when a redirection happen, flush the events with the keepalive client.
 
-This ensures that we use `beacon` on the right occasion, and `fetch` for the rest of the times.
+This ensures that we use `keepalive` on the right occasion, and a regular `fetch` for the rest of the times.
+
+The keepalive client lives in `analyticsBeaconClient.ts` and still reports `analyticsBeacon` as its `clientOrigin` to `preprocessRequest`, for backward compatibility: it used `navigator.sendBeacon` until the Beacon API was dropped in favor of `fetch`. The Beacon API accepts no headers, so a `preprocessRequest` hook could not add any to click events; with `fetch`, hooks receive and can mutate the same request options as for any other event.
+
+Browsers cap the cumulative body size of all in-flight `keepalive` requests to 64 KiB. When flushing the buffer would exceed that budget, the oversized event is sent without the flag rather than not being sent at all.
+
+Note that browser bundles alias the `cross-fetch` dependency to the native `fetch` (see `bundle/browser-fetch.ts`). This matters because the `whatwg-fetch` ponyfill that `cross-fetch` would otherwise provide ignores `keepalive`.

--- a/packages/coveo-analytics/docs/technical-overview.md
+++ b/packages/coveo-analytics/docs/technical-overview.md
@@ -20,7 +20,7 @@ The "runtime" is a small wrapper around features that are only available in Node
 
 The "fetchClient" is using a standard "fetch" to send the event.
 
-The "beaconClient" is used to send "beacons" from the navigator. This "beacon" has _no response validation from the browser_ (send and forget), so it is especially useful when the event is sent on an outgoing click.
+The "keepaliveClient" is used for events that must survive a page unload, such as an outgoing click. It sends them with `fetch` and `keepalive: true`, and ignores the response (send and forget).
 
 Everything related to "Measurement Protocol Mapping" contain all the logic to map human-readable attribute to the Measurement Protocol condensed format.
 
@@ -141,7 +141,7 @@ The trick here is to flush the buffer with a `setTimeout(flush, 0)` so that the 
 
 This ensures that we use `keepalive` on the right occasion, and a regular `fetch` for the rest of the times.
 
-The keepalive client lives in `analyticsBeaconClient.ts` and still reports `analyticsBeacon` as its `clientOrigin` to `preprocessRequest`, for backward compatibility: it used `navigator.sendBeacon` until the Beacon API was dropped in favor of `fetch`. The Beacon API accepts no headers, so a `preprocessRequest` hook could not add any to click events; with `fetch`, hooks receive and can mutate the same request options as for any other event.
+The keepalive client lives in `analyticsKeepaliveClient.ts` and still reports `analyticsBeacon` as its `clientOrigin` to `preprocessRequest`, for backward compatibility: it used `navigator.sendBeacon` until the Beacon API was dropped in favor of `fetch`. The Beacon API accepts no headers, so a `preprocessRequest` hook could not add any to click events; with `fetch`, hooks receive and can mutate the same request options as for any other event.
 
 Browsers cap the cumulative body size of all in-flight `keepalive` requests to 64 KiB. When flushing the buffer would exceed that budget, the oversized event is sent without the flag rather than not being sent at all.
 

--- a/packages/coveo-analytics/functional/ec-events.spec.ts
+++ b/packages/coveo-analytics/functional/ec-events.spec.ts
@@ -1,7 +1,7 @@
 import {DefaultEventResponse} from '../src/events';
 import type {getCurrentClient} from '../src/coveoua/library';
 import coveoua from '../src/coveoua/browser';
-import {mockFetch} from '../tests/fetchMock';
+import {decodeEventBody, mockFetch} from '../tests/fetchMock';
 
 declare const self: any;
 const getClient: typeof getCurrentClient = (self.coveoanalytics as any).getCurrentClient;
@@ -40,7 +40,7 @@ describe('ec events', () => {
     const address = new RegExp('/rest/v15/analytics');
     fetchMock.reset();
     fetchMock.post(address, (url, {body}) => {
-      const parsedBody = JSON.parse(body!.toString());
+      const parsedBody = JSON.parse(decodeEventBody(body!.toString()));
       const visitorId = parsedBody.cid;
       return {
         visitId: 'firsttimevisiting',
@@ -1048,7 +1048,7 @@ describe('ec events', () => {
   });
 
   const getParsedBody = (): any[] => {
-    return fetchMock.calls().map(([, {body}]: any) => JSON.parse(body.toString()));
+    return fetchMock.calls().map(([, {body}]: any) => JSON.parse(decodeEventBody(body.toString())));
   };
 
   const changeDocumentLocation = (url: string) => {

--- a/packages/coveo-analytics/src/caseAssist/caseAssistClient.spec.ts
+++ b/packages/coveo-analytics/src/caseAssist/caseAssistClient.spec.ts
@@ -8,7 +8,7 @@ import {
   DocumentSuggestion,
   FieldSuggestion,
 } from './caseAssistActions';
-import {mockFetch, lastCallBody} from '../../tests/fetchMock';
+import {mockFetch, lastCallBody, decodeEventBody} from '../../tests/fetchMock';
 import {TicketProperties} from '../plugins/svc';
 const {fetchMock, fetchMockBeforeEach} = mockFetch();
 import doNotTrack from '../donottrack';
@@ -125,7 +125,7 @@ describe('CaseAssistClient', () => {
     doc: PartialDocumentInformation,
     meta = {}
   ) => {
-    const body: string = lastCallBody(fetchMock);
+    const body: string = decodeEventBody(lastCallBody(fetchMock));
     const customData = {...meta};
     expect(JSON.parse(body.toString())).toMatchObject({
       actionCause,

--- a/packages/coveo-analytics/src/client/analytics.spec.ts
+++ b/packages/coveo-analytics/src/client/analytics.spec.ts
@@ -11,7 +11,7 @@ import {CoveoAnalyticsClient} from './analytics';
 import {IAnalyticsRequestOptions} from './analyticsRequestClient';
 import {CookieAndLocalStorage, CookieStorage, NullStorage} from '../storage';
 import HistoryStore from '../history';
-import {mockFetch} from '../../tests/fetchMock';
+import {decodeEventBody, mockFetch} from '../../tests/fetchMock';
 import {BrowserRuntime, NoopRuntime} from './runtimeEnvironment';
 import * as doNotTrack from '../donottrack';
 import {Cookie} from '../cookieutils';
@@ -65,8 +65,14 @@ describe('Analytics', () => {
 
   const endpointForEventType = (eventType: EventType, endpoint: string = `${anEndpoint}/rest`) =>
     `${endpoint}/${A_VERSION}/analytics/${eventType}?visitor=${aVisitorId}`;
+  // Click events go through the keepalive client, which uses its own query parameters.
+  const keepaliveEndpointForEventType = (eventType: EventType) =>
+    `${anEndpoint}/rest/${A_VERSION}/analytics/${eventType}?access_token=${aToken}&visitorId=${aVisitorId}&discardVisitInfo=true`;
   const mockFetchRequestForEventType = (eventType: EventType) => {
-    const address = endpointForEventType(eventType);
+    const address =
+      eventType === EventType.click
+        ? keepaliveEndpointForEventType(eventType)
+        : endpointForEventType(eventType);
     fetchMock.post(address, eventResponse);
   };
 
@@ -662,7 +668,7 @@ describe('Analytics', () => {
 
   const getParsedBodyCalls = (): any[] => {
     return fetchMock.calls().map(([, {body}]: any) => {
-      return JSON.parse(body.toString());
+      return JSON.parse(decodeEventBody(body.toString()));
     });
   };
 });

--- a/packages/coveo-analytics/src/client/analyticsBeaconClient.spec.ts
+++ b/packages/coveo-analytics/src/client/analyticsBeaconClient.spec.ts
@@ -1,4 +1,5 @@
-import {vi} from 'vitest';
+import {vi, type Mock} from 'vitest';
+import * as CrossFetch from 'cross-fetch';
 import {AnalyticsBeaconClient} from './analyticsBeaconClient';
 import {EventType} from '../events';
 import {
@@ -12,67 +13,59 @@ describe('AnalyticsBeaconClient', () => {
   const token = '👛';
   const currentVisitorId = 'mockVisitorId';
 
-  const originalSendBeacon = navigator.sendBeacon;
-  const sendBeaconMock = vi.fn();
-  beforeAll(() => {
-    navigator.sendBeacon = sendBeaconMock;
-  });
-
-  afterAll(() => {
-    navigator.sendBeacon = originalSendBeacon;
-  });
+  const fetchMock = CrossFetch.fetch as unknown as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchMock.mockReset().mockResolvedValue({ok: true});
   });
 
-  it('can send an event', async () => {
-    const eventType: EventType = EventType.custom;
-
-    const client = new AnalyticsBeaconClient({
+  const buildClient = (preprocessRequest?: PreprocessAnalyticsRequest) =>
+    new AnalyticsBeaconClient({
       baseUrl,
       token,
       visitorIdProvider: {
         getCurrentVisitorId: () => Promise.resolve(currentVisitorId),
-        setCurrentVisitorId: (visitorId) => {},
+        setCurrentVisitorId: () => {},
       },
+      preprocessRequest,
     });
 
-    await client.sendEvent(eventType, {
-      wow: 'ok',
-    });
+  const getFetchFirstCallUrl = (): string => fetchMock.mock.calls[0][0];
+  const getFetchFirstCallOptions = (): RequestInit => fetchMock.mock.calls[0][1];
+  const getFetchFirstCallBody = (): string => getFetchFirstCallOptions().body as string;
 
-    expect(sendBeaconMock).toHaveBeenCalledWith(
-      `${baseUrl}/analytics/custom?access_token=👛&visitorId=${currentVisitorId}&discardVisitInfo=true`,
-      expect.anything()
+  it('can send an event', async () => {
+    await buildClient().sendEvent(EventType.custom, {wow: 'ok'});
+
+    expect(getFetchFirstCallUrl()).toBe(
+      `${baseUrl}/analytics/custom?access_token=👛&visitorId=${currentVisitorId}&discardVisitInfo=true`
     );
-    expect(await getSendBeaconFirstCallBlobArgument()).toBe(
-      `customEvent=${encodeURIComponent('{"wow":"ok"}')}`
-    );
+    expect(getFetchFirstCallBody()).toBe(`customEvent=${encodeURIComponent('{"wow":"ok"}')}`);
+  });
+
+  it('sends the event with fetch and keepalive instead of the Beacon API', async () => {
+    await buildClient().sendEvent(EventType.click, {actionCause: 'documentOpen'});
+
+    expect(getFetchFirstCallOptions()).toMatchObject({
+      method: 'POST',
+      keepalive: true,
+      credentials: 'include',
+      mode: 'cors',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+    });
   });
 
   it('can send a collect event with the proper payload', async () => {
-    const eventType: EventType = EventType.collect;
-
-    const client = new AnalyticsBeaconClient({
-      baseUrl,
-      token,
-      visitorIdProvider: {
-        getCurrentVisitorId: () => Promise.resolve(currentVisitorId),
-        setCurrentVisitorId: (visitorId) => {},
-      },
-    });
-
-    await client.sendEvent(eventType, {
+    await buildClient().sendEvent(EventType.collect, {
       pr1a: 'value',
       'to encode': 'to encode',
     });
 
-    expect(sendBeaconMock).toHaveBeenCalledWith(
-      `${baseUrl}/analytics/collect?visitorId=${currentVisitorId}&discardVisitInfo=true`,
-      expect.anything()
+    expect(getFetchFirstCallUrl()).toBe(
+      `${baseUrl}/analytics/collect?visitorId=${currentVisitorId}&discardVisitInfo=true`
     );
-    expect(await getSendBeaconFirstCallBlobArgument()).toBe(
+    expect(getFetchFirstCallBody()).toBe(
       `access_token=${encodeURIComponent('👛')}&collectEvent=${encodeURIComponent(
         '{"pr1a":"value","to encode":"to encode"}'
       )}`
@@ -80,58 +73,46 @@ describe('AnalyticsBeaconClient', () => {
   });
 
   it('can send a collect event with a more complex payload', async () => {
-    const eventType: EventType = EventType.collect;
+    await buildClient().sendEvent(EventType.collect, {value: {subvalue: 'ok'}});
 
-    const client = new AnalyticsBeaconClient({
-      baseUrl,
-      token,
-      visitorIdProvider: {
-        getCurrentVisitorId: () => {
-          return Promise.resolve(currentVisitorId);
-        },
-        setCurrentVisitorId: (visitorId) => {},
-      },
-    });
-
-    await client.sendEvent(eventType, {
-      value: {
-        subvalue: 'ok',
-      },
-    });
-
-    expect(sendBeaconMock).toHaveBeenCalledWith(
-      `${baseUrl}/analytics/collect?visitorId=${currentVisitorId}&discardVisitInfo=true`,
-      expect.anything()
+    expect(getFetchFirstCallUrl()).toBe(
+      `${baseUrl}/analytics/collect?visitorId=${currentVisitorId}&discardVisitInfo=true`
     );
-    expect(await getSendBeaconFirstCallBlobArgument()).toBe(
+    expect(getFetchFirstCallBody()).toBe(
       `access_token=${encodeURIComponent('👛')}&collectEvent=${encodeURIComponent('{"value":{"subvalue":"ok"}}')}`
     );
   });
 
-  describe('allows to preprocessRequest', () => {
-    const setupClient = (preprocessRequest: PreprocessAnalyticsRequest) => {
-      return new AnalyticsBeaconClient({
-        baseUrl,
-        token,
-        visitorIdProvider: {
-          getCurrentVisitorId: () => {
-            return Promise.resolve(currentVisitorId);
-          },
-          setCurrentVisitorId: () => {},
-        },
-        preprocessRequest,
-      });
-    };
+  it('should not reject when the request fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock.mockRejectedValue(new Error('network down'));
 
+    await expect(buildClient().sendEvent(EventType.click, {})).resolves.toBeUndefined();
+
+    consoleError.mockRestore();
+  });
+
+  describe('when the keepalive body size limit is exceeded', () => {
+    it('sends the event without keepalive', async () => {
+      const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await buildClient().sendEvent(EventType.click, {actionCause: 'a'.repeat(64 * 1024)});
+
+      expect(getFetchFirstCallOptions().keepalive).toBe(false);
+      expect(consoleWarn).toHaveBeenCalled();
+
+      consoleWarn.mockRestore();
+    });
+  });
+
+  describe('allows to preprocessRequest', () => {
     it('to modify the origin and the body of the request', async () => {
       let clientOrigin: AnalyticsClientOrigin;
       const processedRequest: IAnalyticsRequestOptions = {
         url: 'https://www.myownanalytics.com/endpoint',
-        body: JSON.stringify({
-          test: 'custom',
-        }),
+        body: JSON.stringify({test: 'custom'}),
       };
-      const client = setupClient((_request, type) => {
+      const client = buildClient((_request, type) => {
         clientOrigin = type;
         return processedRequest;
       });
@@ -139,12 +120,48 @@ describe('AnalyticsBeaconClient', () => {
       await client.sendEvent(EventType.collect, {});
 
       expect(clientOrigin!).toBe('analyticsBeacon');
-      expect(sendBeaconMock).toHaveBeenCalledWith(processedRequest.url, expect.anything());
-      expect(await getSendBeaconFirstCallBlobArgument()).toContain('%22test%22%3A%22custom%22');
+      expect(getFetchFirstCallUrl()).toBe(processedRequest.url);
+      expect(getFetchFirstCallBody()).toContain('%22test%22%3A%22custom%22');
+    });
+
+    it('to modify the headers of a click event', async () => {
+      const client = buildClient((request) => {
+        request.headers = {
+          ...request.headers,
+          'x-apigee-api-key': 'my-api-key',
+        };
+        return request;
+      });
+
+      await client.sendEvent(EventType.click, {actionCause: 'documentOpen'});
+
+      expect(getFetchFirstCallOptions().headers).toEqual({
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'x-apigee-api-key': 'my-api-key',
+      });
+    });
+
+    it('to receive the same option shape as the fetch client', async () => {
+      let receivedRequest: IAnalyticsRequestOptions | undefined;
+      const client = buildClient((request) => {
+        receivedRequest = request;
+        return request;
+      });
+
+      await client.sendEvent(EventType.click, {actionCause: 'documentOpen'});
+
+      expect(receivedRequest).toEqual({
+        url: `${baseUrl}/analytics/click?access_token=👛&visitorId=${currentVisitorId}&discardVisitInfo=true`,
+        credentials: 'include',
+        mode: 'cors',
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: JSON.stringify({actionCause: 'documentOpen'}),
+      });
     });
 
     it('to modify the request body as a JSON string for a collect event', async () => {
-      const client = setupClient((request) => {
+      const client = buildClient((request) => {
         const bodyShouldBeAvailableAsJSONString = JSON.parse(request.body as string);
         expect(bodyShouldBeAvailableAsJSONString).toEqual({foo: 'bar'});
         bodyShouldBeAvailableAsJSONString.foo = 'baz';
@@ -153,13 +170,14 @@ describe('AnalyticsBeaconClient', () => {
       });
 
       await client.sendEvent(EventType.collect, {foo: 'bar'});
-      expect(await getSendBeaconFirstCallBlobArgument()).toBe(
+
+      expect(getFetchFirstCallBody()).toBe(
         'access_token=%F0%9F%91%9B&collectEvent=%7B%22foo%22%3A%22baz%22%7D'
       );
     });
 
     it('to modify the request body as a JSON string for a click event', async () => {
-      const client = setupClient((request) => {
+      const client = buildClient((request) => {
         const bodyParsedAsJSON = JSON.parse(request.body as string);
         expect(bodyParsedAsJSON).toEqual({actionCause: 'foo'});
         bodyParsedAsJSON.actionCause = 'bar';
@@ -168,13 +186,14 @@ describe('AnalyticsBeaconClient', () => {
       });
 
       await client.sendEvent(EventType.click, {actionCause: 'foo'});
-      expect(await getSendBeaconFirstCallBlobArgument()).toContain(
+
+      expect(getFetchFirstCallBody()).toContain(
         `clickEvent=${encodeURIComponent('{"actionCause":"bar"}')}`
       );
     });
 
     it('to augment the request body as a JSON string for a click event', async () => {
-      const client = setupClient((request) => {
+      const client = buildClient((request) => {
         const bodyParsedAsJSON = JSON.parse(request.body as string);
         bodyParsedAsJSON.aNewProperty = 'bar';
         request.body = JSON.stringify(bodyParsedAsJSON);
@@ -182,33 +201,26 @@ describe('AnalyticsBeaconClient', () => {
       });
 
       await client.sendEvent(EventType.click, {actionCause: 'foo'});
-      expect(await getSendBeaconFirstCallBlobArgument()).toContain(
+
+      expect(getFetchFirstCallBody()).toContain(
         `clickEvent=${encodeURIComponent('{"actionCause":"foo","aNewProperty":"bar"}')}`
       );
     });
 
     it('should keep original request body if preprocessRequest returns an invalid JSON string', async () => {
-      const client = setupClient((request) => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const client = buildClient((request) => {
         request.body = 'invalid JSON string';
         return request;
       });
 
       await client.sendEvent(EventType.click, {actionCause: 'bar'});
-      expect(await getSendBeaconFirstCallBlobArgument()).toContain(
+
+      expect(getFetchFirstCallBody()).toContain(
         `clickEvent=${encodeURIComponent(`{"actionCause":"bar"}`)}`
       );
+
+      consoleError.mockRestore();
     });
   });
-
-  const getSendBeaconFirstCallBlobArgument = async () => {
-    const blobArgument: Blob = sendBeaconMock.mock.calls[0][1];
-    expect(blobArgument.size).toBeGreaterThan(0);
-    return new Promise((resolve) => {
-      const reader = new FileReader();
-      reader.addEventListener('loadend', () => {
-        resolve(reader.result);
-      });
-      reader.readAsText(blobArgument);
-    });
-  };
 });

--- a/packages/coveo-analytics/src/client/analyticsBeaconClient.ts
+++ b/packages/coveo-analytics/src/client/analyticsBeaconClient.ts
@@ -1,17 +1,34 @@
 import {
   AnalyticsRequestClient,
   IAnalyticsClientOptions,
+  IAnalyticsRequestOptions,
   PreprocessAnalyticsRequest,
 } from './analyticsRequestClient';
 import {EventType, IRequestPayload} from '../events';
+import {fetch} from 'cross-fetch';
 
+// Browsers cap the cumulative body size of all in-flight `keepalive` requests to 64 KiB.
+// Past that budget, requests are rejected outright, so oversized events are sent without
+// the flag rather than not being sent at all.
+const keepaliveBodyLimitInBytes = 64 * 1024;
+let inFlightKeepaliveBodyInBytes = 0;
+
+/**
+ * Sends events that must survive a page unload, such as click events and the events
+ * replayed on `beforeunload`.
+ *
+ * Despite its name, this client no longer relies on the Beacon API: it uses `fetch` with
+ * `keepalive: true`, which offers the same delivery guarantee while allowing a
+ * `preprocessRequest` hook to alter headers. The `analyticsBeacon` client origin is kept
+ * so that existing hooks branching on it keep working.
+ */
 export class AnalyticsBeaconClient implements AnalyticsRequestClient {
   constructor(private opts: IAnalyticsClientOptions) {}
 
   public async sendEvent(eventType: EventType, originalPayload: IRequestPayload): Promise<void> {
     if (!this.isAvailable()) {
       throw new Error(
-        `navigator.sendBeacon is not supported in this browser. Consider adding a polyfill like "sendbeacon-polyfill".`
+        `fetch is not supported in this browser. Consider adding a polyfill like "whatwg-fetch".`
       );
     }
 
@@ -19,55 +36,91 @@ export class AnalyticsBeaconClient implements AnalyticsRequestClient {
 
     const paramsFragments = await this.getQueryParamsForEventType(eventType);
 
-    const {url, payload} = await this.preProcessRequestAsPotentialJSONString(
-      `${baseUrl}/analytics/${eventType}?${paramsFragments}`,
+    const defaultOptions: IAnalyticsRequestOptions = {
+      url: `${baseUrl}/analytics/${eventType}?${paramsFragments}`,
+      credentials: 'include',
+      mode: 'cors',
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body: JSON.stringify(originalPayload),
+    };
+
+    const {options, payload} = await this.preProcessRequestAsPotentialJSONString(
+      defaultOptions,
       originalPayload,
       preprocessRequest
     );
 
-    const parsedRequestData = this.encodeForEventType(eventType, payload);
-    const body = new Blob([parsedRequestData], {
-      type: 'application/x-www-form-urlencoded',
+    this.sendWithKeepalive({
+      ...options,
+      body: this.encodeForEventType(eventType, payload),
     });
-
-    navigator.sendBeacon(url, body as any); // https://github.com/microsoft/TypeScript/issues/38715
-    return;
   }
 
   public isAvailable() {
-    return 'sendBeacon' in navigator;
+    return typeof fetch === 'function';
   }
 
   public deleteHttpCookieVisitorId() {
     return Promise.resolve();
   }
 
-  private async preProcessRequestAsPotentialJSONString(
-    originalURL: string,
-    originalPayload: IRequestPayload,
-    preprocessRequest?: PreprocessAnalyticsRequest
-  ): Promise<{url: string; payload: IRequestPayload}> {
-    let returnedUrl = originalURL;
-    let returnedPayload = originalPayload;
+  /**
+   * Deliberately not awaited: callers such as the `beforeunload` handler must not block on
+   * the response, and the Beacon API they replace never surfaced one either.
+   */
+  private sendWithKeepalive({url, ...requestOptions}: IAnalyticsRequestOptions) {
+    const bodyInBytes = this.getBodySizeInBytes(requestOptions.body as string);
+    const keepalive = inFlightKeepaliveBodyInBytes + bodyInBytes <= keepaliveBodyLimitInBytes;
 
-    if (preprocessRequest) {
-      const processedRequest = await preprocessRequest(
-        {url: originalURL, body: JSON.stringify(originalPayload)},
-        'analyticsBeacon'
+    if (keepalive) {
+      inFlightKeepaliveBodyInBytes += bodyInBytes;
+    } else {
+      console.warn(
+        `The keepalive body size limit of ${keepaliveBodyLimitInBytes} bytes is reached. The event is sent without keepalive and may be cancelled if the page unloads.`
       );
-      const {url: processedURL, body: processedBody} = processedRequest;
-      returnedUrl = processedURL || originalURL;
-      try {
-        returnedPayload = JSON.parse(processedBody as string);
-      } catch (e) {
-        console.error('Unable to process the request body as a JSON string', e);
-      }
     }
 
-    return {
-      payload: returnedPayload,
-      url: returnedUrl,
+    const releaseBudget = () => {
+      if (keepalive) {
+        inFlightKeepaliveBodyInBytes -= bodyInBytes;
+      }
     };
+
+    fetch(url, {...requestOptions, keepalive}).then(releaseBudget, (error) => {
+      releaseBudget();
+      console.error('An error has occurred when sending the event.', error);
+    });
+  }
+
+  private getBodySizeInBytes(body: string) {
+    return typeof TextEncoder === 'undefined' ? body.length : new TextEncoder().encode(body).length;
+  }
+
+  private async preProcessRequestAsPotentialJSONString(
+    defaultOptions: IAnalyticsRequestOptions,
+    originalPayload: IRequestPayload,
+    preprocessRequest?: PreprocessAnalyticsRequest
+  ): Promise<{options: IAnalyticsRequestOptions; payload: IRequestPayload}> {
+    if (!preprocessRequest) {
+      return {options: defaultOptions, payload: originalPayload};
+    }
+
+    const processedRequest = await preprocessRequest(defaultOptions, 'analyticsBeacon');
+    const options: IAnalyticsRequestOptions = {
+      ...defaultOptions,
+      ...processedRequest,
+      url: processedRequest.url || defaultOptions.url,
+    };
+
+    let payload = originalPayload;
+    try {
+      payload = JSON.parse(options.body as string);
+    } catch (e) {
+      console.error('Unable to process the request body as a JSON string', e);
+    }
+
+    return {options, payload};
   }
 
   private encodeForEventType(eventType: EventType, payload: IRequestPayload): string {

--- a/packages/coveo-analytics/src/client/analyticsKeepaliveClient.spec.ts
+++ b/packages/coveo-analytics/src/client/analyticsKeepaliveClient.spec.ts
@@ -1,6 +1,6 @@
 import {vi, type Mock} from 'vitest';
 import * as CrossFetch from 'cross-fetch';
-import {AnalyticsBeaconClient} from './analyticsBeaconClient';
+import {AnalyticsKeepaliveClient} from './analyticsKeepaliveClient';
 import {EventType} from '../events';
 import {
   AnalyticsClientOrigin,
@@ -8,7 +8,7 @@ import {
   PreprocessAnalyticsRequest,
 } from './analyticsRequestClient';
 
-describe('AnalyticsBeaconClient', () => {
+describe('AnalyticsKeepaliveClient', () => {
   const baseUrl = 'https://bloup.com';
   const token = '👛';
   const currentVisitorId = 'mockVisitorId';
@@ -21,7 +21,7 @@ describe('AnalyticsBeaconClient', () => {
   });
 
   const buildClient = (preprocessRequest?: PreprocessAnalyticsRequest) =>
-    new AnalyticsBeaconClient({
+    new AnalyticsKeepaliveClient({
       baseUrl,
       token,
       visitorIdProvider: {

--- a/packages/coveo-analytics/src/client/analyticsKeepaliveClient.ts
+++ b/packages/coveo-analytics/src/client/analyticsKeepaliveClient.ts
@@ -15,14 +15,13 @@ let inFlightKeepaliveBodyInBytes = 0;
 
 /**
  * Sends events that must survive a page unload, such as click events and the events
- * replayed on `beforeunload`.
+ * replayed on `beforeunload`, using `fetch` with `keepalive: true`.
  *
- * Despite its name, this client no longer relies on the Beacon API: it uses `fetch` with
- * `keepalive: true`, which offers the same delivery guarantee while allowing a
- * `preprocessRequest` hook to alter headers. The `analyticsBeacon` client origin is kept
+ * This replaces the Beacon API, which accepted no headers and therefore prevented a
+ * `preprocessRequest` hook from altering them. The `analyticsBeacon` client origin is kept
  * so that existing hooks branching on it keep working.
  */
-export class AnalyticsBeaconClient implements AnalyticsRequestClient {
+export class AnalyticsKeepaliveClient implements AnalyticsRequestClient {
   constructor(private opts: IAnalyticsClientOptions) {}
 
   public async sendEvent(eventType: EventType, originalPayload: IRequestPayload): Promise<void> {

--- a/packages/coveo-analytics/src/client/analyticsRequestClient.ts
+++ b/packages/coveo-analytics/src/client/analyticsRequestClient.ts
@@ -17,6 +17,14 @@ export interface IAnalyticsClientOptions {
   preprocessRequest?: PreprocessAnalyticsRequest;
 }
 
+/**
+ * The client that issues the request being preprocessed.
+ *
+ * `analyticsBeacon` identifies events that must survive a page unload, such as click events.
+ * Those events are sent with `fetch` and `keepalive: true` rather than the Beacon API, so
+ * they now support header mutations. The value itself is deprecated and will be merged into
+ * `analyticsFetch` in a future major version.
+ */
 export type AnalyticsClientOrigin = 'analyticsFetch' | 'analyticsBeacon';
 
 export type PreprocessAnalyticsRequest = (

--- a/packages/coveo-analytics/src/client/runtimeEnvironment.spec.ts
+++ b/packages/coveo-analytics/src/client/runtimeEnvironment.spec.ts
@@ -1,0 +1,45 @@
+import {vi, type Mock} from 'vitest';
+import * as CrossFetch from 'cross-fetch';
+import {BrowserRuntime} from './runtimeEnvironment';
+import {EventType} from '../events';
+import {IAnalyticsClientOptions} from './analyticsRequestClient';
+import {BufferedRequest} from './analytics';
+
+describe('BrowserRuntime', () => {
+  const fetchMock = CrossFetch.fetch as unknown as Mock;
+
+  const clientOptions: IAnalyticsClientOptions = {
+    baseUrl: 'https://bloup.com',
+    token: 'token',
+    visitorIdProvider: {
+      getCurrentVisitorId: () => Promise.resolve('visitor-id'),
+      setCurrentVisitorId: () => {},
+    },
+  };
+
+  beforeEach(() => {
+    fetchMock.mockReset().mockResolvedValue({ok: true});
+  });
+
+  it('should send click events with the keepalive client', () => {
+    const runtime = new BrowserRuntime(clientOptions, () => []);
+
+    expect(runtime.getClientDependingOnEventType(EventType.click)).not.toBe(runtime.client);
+    expect(runtime.getClientDependingOnEventType(EventType.view)).toBe(runtime.client);
+  });
+
+  it('should flush the buffered requests with fetch and keepalive on beforeunload', async () => {
+    const bufferedRequests: Array<BufferedRequest> = [
+      {eventType: EventType.click, payload: {actionCause: 'documentOpen'}},
+    ];
+    new BrowserRuntime(clientOptions, () => bufferedRequests);
+
+    window.dispatchEvent(new Event('beforeunload'));
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toContain('/analytics/click');
+    expect(options.keepalive).toBe(true);
+    expect(options.body).toContain(`clickEvent=${encodeURIComponent('{"actionCause"')}`);
+  });
+});

--- a/packages/coveo-analytics/src/client/runtimeEnvironment.ts
+++ b/packages/coveo-analytics/src/client/runtimeEnvironment.ts
@@ -1,5 +1,5 @@
 import {WebStorage, NullStorage, CookieAndLocalStorage} from '../storage';
-import {AnalyticsBeaconClient} from './analyticsBeaconClient';
+import {AnalyticsKeepaliveClient} from './analyticsKeepaliveClient';
 import {hasLocalStorage, hasCookieStorage} from '../detector';
 import {
   AnalyticsRequestClient,
@@ -19,7 +19,7 @@ export interface IRuntimeEnvironment {
 export class BrowserRuntime implements IRuntimeEnvironment {
   public storage: WebStorage;
   public client: AnalyticsFetchClient;
-  private beaconClient: AnalyticsBeaconClient;
+  private keepaliveClient: AnalyticsKeepaliveClient;
 
   constructor(
     clientOptions: IAnalyticsClientOptions,
@@ -34,18 +34,18 @@ export class BrowserRuntime implements IRuntimeEnvironment {
       this.storage = new NullStorage();
     }
     this.client = new AnalyticsFetchClient(clientOptions);
-    this.beaconClient = new AnalyticsBeaconClient(clientOptions);
+    this.keepaliveClient = new AnalyticsKeepaliveClient(clientOptions);
     window.addEventListener('beforeunload', () => {
       const requests = getUnprocessedRequests();
       for (let {eventType, payload} of requests) {
-        this.beaconClient.sendEvent(eventType, payload);
+        this.keepaliveClient.sendEvent(eventType, payload);
       }
     });
   }
 
   public getClientDependingOnEventType(eventType: EventType) {
-    return eventType === 'click' && this.beaconClient.isAvailable()
-      ? this.beaconClient
+    return eventType === 'click' && this.keepaliveClient.isAvailable()
+      ? this.keepaliveClient
       : this.client;
   }
 }

--- a/packages/coveo-analytics/src/insight/insightClient.spec.ts
+++ b/packages/coveo-analytics/src/insight/insightClient.spec.ts
@@ -1,6 +1,6 @@
 import {vi} from 'vitest';
 import type {Mock} from 'vitest';
-import {lastCallBody, mockFetch} from '../../tests/fetchMock';
+import {decodeEventBody, lastCallBody, mockFetch} from '../../tests/fetchMock';
 import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
 import {
@@ -124,7 +124,7 @@ describe('InsightClient', () => {
     doc: PartialDocumentInformation,
     meta = {}
   ) => {
-    const body: string = lastCallBody(fetchMock);
+    const body: string = decodeEventBody(lastCallBody(fetchMock));
     const customData = {foo: 'bar', ...meta};
     expect(JSON.parse(body.toString())).toMatchObject({
       actionCause,

--- a/packages/coveo-analytics/src/searchPage/searchPageClient.spec.ts
+++ b/packages/coveo-analytics/src/searchPage/searchPageClient.spec.ts
@@ -17,7 +17,7 @@ import {
 } from './searchPageEvents';
 import CoveoAnalyticsClient from '../client/analytics';
 import {NoopAnalytics} from '../client/noopAnalytics';
-import {mockFetch, lastCallBody} from '../../tests/fetchMock';
+import {mockFetch, lastCallBody, decodeEventBody} from '../../tests/fetchMock';
 import doNotTrack from '../donottrack';
 import {Cookie} from '../cookieutils';
 
@@ -132,7 +132,7 @@ describe('SearchPageClient', () => {
   });
 
   const expectMatchPayload = (actionCause: SearchPageEvents, meta = {}) => {
-    const body: string = lastCallBody(fetchMock);
+    const body: string = decodeEventBody(lastCallBody(fetchMock));
     const customData = {
       foo: 'bar',
       genQaMetadata: 'bar',
@@ -184,7 +184,7 @@ describe('SearchPageClient', () => {
     doc: PartialDocumentInformation,
     meta = {}
   ) => {
-    const body: string = lastCallBody(fetchMock);
+    const body: string = decodeEventBody(lastCallBody(fetchMock));
     const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
     expect(JSON.parse(body)).toEqual({
       anonymous: false,
@@ -206,7 +206,7 @@ describe('SearchPageClient', () => {
     meta = {},
     eventType = CustomEventsTypes[actionCause]
   ) => {
-    const body: string = lastCallBody(fetchMock);
+    const body: string = decodeEventBody(lastCallBody(fetchMock));
     const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
     expect(JSON.parse(body)).toEqual({
       anonymous: false,
@@ -228,7 +228,7 @@ describe('SearchPageClient', () => {
     eventType: string,
     meta = {}
   ) => {
-    const body: string = lastCallBody(fetchMock);
+    const body: string = decodeEventBody(lastCallBody(fetchMock));
     const customData = {foo: 'bar', ...customDataFromMiddleware, ...meta};
     expect(JSON.parse(body)).toEqual({
       anonymous: false,

--- a/packages/coveo-analytics/tests/fetchMock.ts
+++ b/packages/coveo-analytics/tests/fetchMock.ts
@@ -19,3 +19,13 @@ export function lastCallBody(fetchMock: fm.FetchMockSandbox): string {
   const {body} = res!;
   return body!.toString();
 }
+
+/**
+ * Events sent through the keepalive client, such as click events, are form-encoded as
+ * `<eventType>Event=<uri-encoded JSON>`. Returns the JSON payload of such a body, or the
+ * body itself when it is already JSON.
+ */
+export function decodeEventBody(body: string): string {
+  const encodedEvent = /(?:^|&)\w+Event=(.*)$/.exec(body);
+  return encodedEvent ? decodeURIComponent(encodedEvent[1]) : body;
+}

--- a/packages/headless/src/app/engine-configuration.ts
+++ b/packages/headless/src/app/engine-configuration.ts
@@ -24,7 +24,11 @@ export interface EngineConfiguration {
   /**
    * Allows for augmenting a Platform request before it is sent.
    * @param request Request to be augmented
-   * @param clientOrigin The origin of the client, can be "analyticsFetch", "analyticsBeacon" or "searchApiFetch"
+   * @param clientOrigin The origin of the client, can be "analyticsFetch", "analyticsBeacon" or "searchApiFetch".
+   * The "analyticsBeacon" origin identifies analytics events that must survive a page unload, such as click events.
+   * Those events are now sent with `fetch` and `keepalive` rather than the Beacon API, so headers set on them are
+   * applied to the outgoing request. The value is deprecated and will be merged into "analyticsFetch" in a future
+   * major version.
    *
    * @returns Augmented request
    */


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-5957

## Motivation

Following support case SUPPORT-00140338, a customer routing analytics traffic through an Apigee gateway can no longer add their API key to click events. The cause is structural rather than a regression: the beacon client calls `preprocessRequest({url, body}, 'analyticsBeacon')` and only reads `url` and `body` back, because `navigator.sendBeacon` accepts no headers at all. Any header a hook sets on a click event is discarded by design.

## Changes

- Click events, and the events replayed on `beforeunload`, are now sent with `fetch` and `keepalive: true` instead of `navigator.sendBeacon`. The client passes the full request options to `preprocessRequest` and spreads the result over the defaults, the way `AnalyticsFetchClient` already does, so header mutations reach the outgoing request.
- Renamed `AnalyticsBeaconClient` to `AnalyticsKeepaliveClient` (and its file to `analyticsKeepaliveClient.ts`) since it no longer uses the Beacon API. The class is not exported from any package entrypoint; it surfaces in the emitted declarations only through `BrowserRuntime.getClientDependingOnEventType`, which is reachable solely by deep-importing `dist/definitions`.
- The request URL, the query parameters and the form-encoded body are left untouched, so nothing changes on the wire besides the transport and the headers. Converging the body with the JSON that `AnalyticsFetchClient` sends is deliberately left out: it is a server-visible change that should be confirmed with the analytics backend team first.
- `analyticsBeacon` stays the `clientOrigin` reported for these events, so hooks branching on it keep working. It is documented as deprecated in `AnalyticsClientOrigin` and in the Headless `preprocessRequest` doc comment, to be merged into `analyticsFetch` in a future major version.
- The response is ignored and errors are swallowed, keeping the fire-and-forget contract the Beacon API had. In particular, `sendClickEvent` resolution timing is unchanged and the click path does not gain the `visitorId` refresh `AnalyticsFetchClient` performs.
- Browsers cap the cumulative body size of all in-flight `keepalive` requests to 64 KiB. The client tracks that budget and sends an oversized event without the flag, with a warning, rather than letting the browser reject it.
- Tests that assert click payloads were reading them as JSON, which only worked because jsdom has no `sendBeacon` and clicks fell back to the fetch client. They now decode the form-encoded body through a shared `decodeEventBody` helper, so they exercise the path that actually runs in a browser.

## Validation

- `pnpm turbo run coveo.analytics#test`: 706 tests pass, including new coverage for header mutation on click events, for the option shape handed to `preprocessRequest`, for the keepalive budget fallback, and for the `beforeunload` flush.
- `pnpm turbo run coveo.analytics#build` and `tsc --noEmit` pass.
- Headless analytics tests pass (169 across 13 files) against the modified package.
- Verified the browser bundles resolve `fetch` to `globalThis.fetch` rather than the `whatwg-fetch` ponyfill, which ignores `keepalive`. This is what `bundle/browser-fetch.ts` aliases `cross-fetch` to, and `keepalive` is present in `dist/coveoua.browser.js` and `dist/browser.mjs` with no `XMLHttpRequest` fallback inlined.

Not verified: acceptance criterion 4, that click events are still delivered when the page unloads immediately after the click, in Chrome, Firefox and Safari. That needs a manual pass in a real browser.

## Compatibility note for reviewers

`sendBeacon` is Baseline "widely available" (since April 2018); `keepalive` is Baseline "newly available" (since November 2024, Firefox 133 being the last to ship). Browsers older than that ignore the flag, so a click immediately followed by a navigation could be lost — most plausibly on Firefox ESR channels older than 133. If that exposure matters, the change can be made strictly non-regressive by feature-detecting `keepalive` and falling back to `sendBeacon`.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`feat(<scope>): <description>`)
- [x] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code