### PR TITLE
fix(analytics): stop shipping the React Native toolchain to consumers

### DIFF
--- a/.changeset/analytics-drop-react-native-toolchain.md
+++ b/.changeset/analytics-drop-react-native-toolchain.md
@@ -1,0 +1,5 @@
+---
+"coveo.analytics": minor
+---
+
+Removed `react-native-get-random-values` from the runtime dependencies. The polyfill is already inlined into `dist/react-native.es.js` at build time, but shipping it as a dependency pulled `react-native`, `metro` and `image-size` into every consumer install, including plain web projects. React Native consumers keep the same behavior with no action required.

--- a/packages/coveo-analytics/package.json
+++ b/packages/coveo-analytics/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "cross-fetch": "3.2.0",
-    "react-native-get-random-values": "1.11.0",
     "uuid": "catalog:"
   },
   "devDependencies": {
@@ -51,6 +50,7 @@
     "fetch-mock": "9.11.0",
     "jsdom": "catalog:",
     "node-fetch": "2.7.0",
+    "react-native-get-random-values": "1.11.0",
     "rollup": "catalog:",
     "rollup-plugin-copy": "3.5.0",
     "rollup-plugin-serve": "1.1.1",

--- a/packages/coveo-analytics/rollup.config.mjs
+++ b/packages/coveo-analytics/rollup.config.mjs
@@ -65,6 +65,32 @@ const versionReplaceInDeclaration = () => ({
 });
 
 /**
+ * Rollup inlines the `react-native-get-random-values` polyfill into the bundle, but the emitted
+ * declaration keeps the bare side-effect import, which consumers cannot resolve unless they install
+ * the package themselves. Strip it so the polyfill can stay a `devDependency` instead of dragging
+ * the whole React Native toolchain into every consumer install.
+ */
+const stripPolyfillImportFromDeclaration = () => ({
+  name: 'strip-polyfill-import-from-declaration',
+  writeBundle() {
+    const declaration = resolve(__dirname, './dist/definitions/react-native/index.d.ts');
+    if (!existsSync(declaration)) {
+      return;
+    }
+    const stripped = readFileSync(declaration, 'utf8').replace(
+      /^import ['"]react-native-get-random-values['"];\r?\n?/gm,
+      ''
+    );
+    if (stripped.includes('react-native-get-random-values')) {
+      this.error(
+        'Failed to strip the react-native-get-random-values import from react-native/index.d.ts. Publishing it would break consumers who typecheck our declarations without the package installed.'
+      );
+    }
+    writeFileSync(declaration, stripped);
+  },
+});
+
+/**
  * @param {{sourceFileName: string, aliasFileName: string}} options
  */
 const aliasFile = ({sourceFileName, aliasFileName}) => {
@@ -194,6 +220,7 @@ const reactNativeConfig = {
       target: 'es6',
     }),
     versionReplaceInDeclaration(),
+    stripPolyfillImportFromDeclaration(),
   ],
 };
 

--- a/packages/coveo-analytics/src/react-native/index.ts
+++ b/packages/coveo-analytics/src/react-native/index.ts
@@ -4,4 +4,7 @@ export {
   ReactNativeStorage,
 } from './react-native-runtime';
 export * from '../coveoua/headless';
+// Rollup inlines this polyfill into dist/react-native.es.js, so it is a devDependency rather than a
+// dependency: shipping it would drag the whole React Native toolchain into every consumer install.
+// The import must stay here for the polyfill to end up in the bundle.
 import 'react-native-get-random-values';

--- a/packages/coveo-analytics/src/react-native/react-native.spec.ts
+++ b/packages/coveo-analytics/src/react-native/react-native.spec.ts
@@ -1,3 +1,5 @@
+import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
 import {vi} from 'vitest';
 import CoveoAnalyticsClient from '../client/analytics';
 import {ReactNativeRuntime} from './react-native-runtime';
@@ -27,5 +29,12 @@ describe('ReactNativeRuntime', () => {
     vi.spyOn(runtimeEnvironment.storage, 'setItem');
     await client.setCurrentVisitorId('testVisitorId');
     expect(runtimeEnvironment.storage.setItem).toHaveBeenCalled();
+  });
+});
+
+describe('react-native entrypoint', () => {
+  it('should import the getRandomValues polyfill so that Rollup inlines it into the bundle', () => {
+    const entrypoint = readFileSync(resolve(process.cwd(), 'src/react-native/index.ts'), 'utf8');
+    expect(entrypoint).toContain("import 'react-native-get-random-values';");
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -683,9 +683,6 @@ importers:
       cross-fetch:
         specifier: 3.2.0
         version: 3.2.0(encoding@0.1.13)
-      react-native-get-random-values:
-        specifier: 1.11.0
-        version: 1.11.0(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))
       uuid:
         specifier: 'catalog:'
         version: 14.0.1
@@ -723,6 +720,9 @@ importers:
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0(encoding@0.1.13)
+      react-native-get-random-values:
+        specifier: 1.11.0
+        version: 1.11.0(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))
       rollup:
         specifier: 'catalog:'
         version: 4.62.2


### PR DESCRIPTION
[KIT-5958](https://coveord.atlassian.net/browse/KIT-5958)

## Problem

`coveo.analytics` listed `react-native-get-random-values` in its runtime `dependencies`. That package declares `react-native` as a peer with no `peerDependenciesMeta`, so npm 7+ auto-installs the whole React Native toolchain:

```
coveo.analytics
  └─ react-native-get-random-values@1.11.0
       └─ react-native@0.86.0        (non-optional peer)
            └─ @react-native/community-cli-plugin
                 └─ metro@0.84.4
                      └─ image-size@1.2.1
```

`@coveo/headless` depends on `coveo.analytics`, so plain web consumers inherited `react-native`, `metro` and `image-size`, and Snyk flagged `image-size` through a chain that never runs in their application.

## Solution

Moved `react-native-get-random-values` to `devDependencies`. Rollup already inlines the polyfill into `dist/react-native.es.js`, so it is only needed at build time.

Moving it alone was not enough: the emitted `dist/definitions/react-native/index.d.ts` kept the bare `import 'react-native-get-random-values';` verbatim, which fails to resolve for consumers who typecheck our declarations without the module installed. Added a `writeBundle` plugin that strips that side-effect import from the emitted declaration, following the same pattern as the neighbouring `versionReplaceInDeclaration()`. It errors out if the specifier survives, so we cannot silently publish an unresolvable import again. The import stays in `src/react-native/index.ts`, guarded by a new test, since removing it would drop the polyfill from the bundle.

No breaking change: React Native consumers get the same runtime behavior with no action required, so this ships as a `minor`.

## Testing

- 700 unit tests pass (699 existing + 1 new guard).
- `dist/react-native.es.js` still contains the inlined polyfill and its external imports remain exactly `react-native` and `cross-fetch`. Artifact checksums were compared against a pre-change build: the only difference is the stripped line in the react-native declaration.
- Packed the tarball into a scratch project without the polyfill installed and typechecked `import {ReactNativeRuntime} from 'coveo.analytics/react-native'` with `skipLibCheck: false` + `noUncheckedSideEffectImports: true`: clean. Re-adding the import line to the installed declaration reproduces the resolution error, confirming the harness is meaningful.
- Confirmed the resulting install pulls in neither `react-native`, `metro`, `image-size` nor the polyfill.
- Re-verified all of the above after rebasing onto the `@rollup/plugin-typescript` migration, and confirmed `version.d.ts` still gets its version patched.

## Notes for the reviewer

One correction to the ticket: it attributes the failure to `skipLibCheck: false` alone. On TypeScript 5.9 the actual trigger is `noUncheckedSideEffectImports: true`, reported as TS2307 rather than TS2882; `skipLibCheck: false` is necessary but not sufficient. I could not reproduce any error without it across `Node10`/`Node16`/`NodeNext`/`Bundler` resolution. That narrows real-world exposure further than the ticket estimated but does not change the fix.

The ticket also floats an optional `peerDependency` and calls it breaking. It is not — I verified that a packed build with an optional peer installs no polyfill, emits no peer warning and typechecks clean. What was breaking in that proposal is leaving the declaration import in place, which is unrelated to the peer entry. We deliberately left the peer entry out here since it is purely documentary while the polyfill is inlined; it can be added any time, and the piece that would genuinely need a major is dropping the inlining altogether.

A React Native runtime smoke test (AC5) was not run, since it needs a device or simulator. The bundle-level evidence above shows the polyfill is unchanged in the shipped artifact.

This does not clear `image-size` from ui-kit's own dependency tree, since `less` pulls it in as well. The win is for consumers.

[KIT-5958]: https://coveord.atlassian.net/browse/KIT-5958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ