### PR TITLE
chore(areas): add area for create-ui package

### DIFF
--- a/.areas/create-ui.yml
+++ b/.areas/create-ui.yml
@@ -1,0 +1,5 @@
+description: Coveo UI project scaffolding CLI
+file_patterns:
+  - packages/create-ui/**
+reviewers:
+  dxui: ~


### PR DESCRIPTION
## Problem

`packages/create-ui` had no entry in `.areas`, so PRs touching it only matched the catch-all `root` area (`packages/*`) and got no dedicated review requirement like the other packages.

## Solution

Add `.areas/create-ui.yml` covering `packages/create-ui/**` with `dxui` as a non-blocking reviewer, matching the convention used by the other package areas (bueno, relay, thermidor).