### PR TITLE
ci: add Quantic E2E bypass switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,7 +633,11 @@ jobs:
   e2e-quantic:
     name: 'Run Quantic E2E tests'
     needs: affected
-    if: contains(needs.affected.outputs.projects, '@coveo/quantic') && !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-quantic'))
+    if: >-
+      contains(needs.affected.outputs.projects, '@coveo/quantic') &&
+      vars.SKIP_QUANTIC_E2E != 'true' &&
+      !(github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'skip-quantic'))
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-5961

## Motivation

Salesforce scratch-org exhaustion can fail Quantic E2E setup and block pull requests and merge-queue entries. Maintainers need an incident switch that does not require a code commit.

## Changes

- Skip the entire Quantic E2E reusable workflow when the repository Actions variable `SKIP_QUANTIC_E2E` is exactly `true`.
- Apply the switch to both pull-request and merge-group runs.
- Preserve the existing PR-specific `skip-quantic` label.
- Leave default CI behavior unchanged when the variable is absent or has another value.

## Validation

- `pnpm run lint:fix`
- Parsed `.github/workflows/ci.yml` as YAML.
- `git diff --check`
- Confirmed the aggregate CI validity jobs accept skipped dependencies.

## Checklist

- [x] PR title follows Conventional Commits 1.0.0.
- [x] Public API surface is unchanged.
- [x] No changeset is required because no public package source code changed.