### PR TITLE
chore(chromatic): untrace everything but atomic

### DIFF
--- a/packages/atomic/chromatic.config.json
+++ b/packages/atomic/chromatic.config.json
@@ -4,27 +4,11 @@
   "outputDir": "dist-storybook",
   "exitOnceUploaded": true,
   "untraced": [
+    "package.json",
+    "pnpm-lock.yaml",
     "/virtual:*",
-    "packages/atomic-angular/**/package.json",
-    "packages/atomic-cdn-smoke/package.json",
-    "packages/atomic-hosted-page/package.json",
-    "packages/atomic-react/package.json",
-    "packages/auth/package.json",
-    "packages/coveo-analytics/package.json",
-    "packages/create-atomic/package.json",
-    "packages/create-atomic-component/**/package.json",
-    "packages/create-atomic-component-project/**/package.json",
-    "packages/create-atomic-result-component/**/package.json",
-    "packages/create-atomic-rollup-plugin/package.json",
-    "packages/create-atomic-template/package.json",
-    "packages/create-ui/package.json",
-    "packages/headless-react/package.json",
-    "packages/mock-converse-api/package.json",
-    "packages/pkg-new-template/package.json",
-    "packages/quantic/package.json",
-    "packages/relay-playground/package.json",
-    "packages/shopify/package.json",
-    "packages/thermidor/package.json"
+    "packages/*",
+    "!packages/atomic/**/*"
   ],
   "onlyChanged": true
 }

--- a/packages/atomic/chromatic.config.json
+++ b/packages/atomic/chromatic.config.json
@@ -7,8 +7,8 @@
     "package.json",
     "pnpm-lock.yaml",
     "/virtual:*",
-    "packages/*",
-    "!packages/atomic/**/*"
+    "packages/**",
+    "!packages/atomic/**"
   ],
   "onlyChanged": true
 }


### PR DESCRIPTION
Change tactics regarding Chromatic optimization.
Instead of sniping out what blocks Chromatic TurboSnap, let's start with a wide umbrella, then address the case where snapshots _should_ have changed and haven't