### PR TITLE
chore(ci): cancel superseded CI runs with PR-scoped concurrency j:KIT-5964

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,15 @@ on:
   pull_request:
   merge_group:
 
+# Cancel superseded in-progress runs for the same PR when new commits are pushed.
+# For pull_request events, github.ref is refs/pull/<number>/merge (stable per PR),
+# so a new push cancels the previous run. For merge_group events, github.ref is a
+# unique merge-queue ref and cancel-in-progress is false, so merge-queue runs are
+# never cancelled and the queue keeps working.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
   merge_group:
 
-# test rapid commit
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   merge_group:
 
+# test rapid commit
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,6 @@ on:
   pull_request:
   merge_group:
 
-# Cancel superseded in-progress runs for the same PR when new commits are pushed.
-# For pull_request events, github.ref is refs/pull/<number>/merge (stable per PR),
-# so a new push cancels the previous run. For merge_group events, github.ref is a
-# unique merge-queue ref and cancel-in-progress is false, so merge-queue runs are
-# never cancelled and the queue keeps working.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Motivation

`ci.yml` has no `concurrency` control, so pushing new commits to a PR leaves the previous full CI run (build, Windows build, sharded Playwright/Storybook, e2e, etc.) running to completion on already-replaced code. That wastes runner minutes and slows feedback on the latest commit.

## Changes

Add a workflow-level `concurrency` group to `.github/workflows/ci.yml`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- `cancel-in-progress` is enabled **only** for `pull_request` events. For `pull_request`, `github.ref` is `refs/pull/<number>/merge` (stable across pushes to the same PR), so a new push supersedes and cancels the previous in-progress run.
- `merge_group` (merge queue) runs get a **unique** ref and `cancel-in-progress` evaluates to `false`, so they are **never cancelled** — the merge queue keeps working and the `is-valid` / `is-valid-merge-queue` required checks still resolve.
- Deliberately avoids the KIT-5637 failure mode (this cancels rather than queues, uses a per-PR ref, and `ci.yml` has no long-waiting 24–48h jobs that could hold the group). `cd.yml` is untouched.

https://coveord.atlassian.net/browse/KIT-5964