### PR TITLE
chore(ci): gate Chromatic with repository variable

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -245,6 +245,7 @@ jobs:
           CHANNELS: ${{ needs.release.outputs.published == 'true' && 'private,preview' || 'private' }}
   chromatic-update-main:
     name: 'Update Chromatic baseline on main'
+    if: vars.RUN_CHROMATIC == 'true'
     runs-on: ubuntu-latest
     env:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,7 @@ jobs:
   chromatic:
     name: 'Run Chromatic visual tests on Atomic'
     needs: affected
+    if: vars.RUN_CHROMATIC == 'true'
     runs-on: ubuntu-latest
     env:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
## Motivation

Chromatic should only consume CI resources when visual testing is explicitly enabled for the repository.

## Changes

- Gate the CI visual-test job unless the repository variable `RUN_CHROMATIC` equals `true`.
- Gate the CD baseline-update job behind the same repository variable.
- Leave Chromatic disabled when the variable is unset or has another value.

## Validation

- `pnpm run lint:fix`
- `pnpm exec oxfmt --check .github/workflows/ci.yml .github/workflows/cd.yml`
- Parsed both workflow files as YAML.
- [x] No new product features or bug fixes are included in this PR
- [x] Public API surface is unchanged

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changeset not required because no public package source code was modified