### PR TITLE
chore: remove TODOs whose blocking work is complete

### DIFF
--- a/.changeset/cleanup-resolved-todos.md
+++ b/.changeset/cleanup-resolved-todos.md
@@ -1,0 +1,6 @@
+---
+'@coveo/create-atomic-component-project': patch
+'@coveo/atomic': patch
+---
+
+Remove TODO comments and workarounds whose blocking work is already complete. `ResultTemplateProvider` now imports `atomic-result-link` directly instead of relying on the element being registered elsewhere, and the internal `componentOnReady` readiness fallbacks no longer depend on types from `@stencil/core/internal`.

--- a/packages/atomic/src/components/common/atomic-smart-snippet-expandable-answer/atomic-smart-snippet-expandable-answer.spec.ts
+++ b/packages/atomic/src/components/common/atomic-smart-snippet-expandable-answer/atomic-smart-snippet-expandable-answer.spec.ts
@@ -1,17 +1,13 @@
 import type {i18n} from 'i18next';
 import {html} from 'lit';
-import {beforeEach, describe, expect, it} from 'vitest';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {fixture} from '@/vitest-utils/testing-helpers/fixture';
 import {createTestI18n} from '@/vitest-utils/testing-helpers/i18n-utils';
 import {AtomicSmartSnippetExpandableAnswer} from './atomic-smart-snippet-expandable-answer';
 import './atomic-smart-snippet-expandable-answer';
 
 // Mock atomic-smart-snippet-answer to prevent actual rendering
-// TODO: uncomment when PR #6781 is merged
-// vi.mock(
-//   '../atomic-smart-snippet-answer/atomic-smart-snippet-answer',
-//   () => ({})
-// );
+vi.mock('../atomic-smart-snippet-answer/atomic-smart-snippet-answer', () => ({}));
 
 describe('atomic-smart-snippet-expandable-answer', () => {
   async function setElementHeight(element: AtomicSmartSnippetExpandableAnswer, height: number) {

--- a/packages/atomic/src/components/common/checkbox.spec.ts
+++ b/packages/atomic/src/components/common/checkbox.spec.ts
@@ -130,7 +130,6 @@ describe('#renderCheckbox', () => {
     expect(button).toHaveClass('test-class');
     expect(button).toHaveClass(
       'w-4',
-      // TODO: KIT-3907
       'h-4',
       'grid',
       'place-items-center',

--- a/packages/atomic/src/components/common/formats/format-common.ts
+++ b/packages/atomic/src/components/common/formats/format-common.ts
@@ -1,4 +1,4 @@
-import type {HTMLStencilElement} from '@stencil/core/internal';
+import type {ComponentOnReadyElement} from '@/src/utils/dom-utils';
 import {buildCustomEvent} from '@/src/utils/event-utils';
 
 export type NumberFormatter = (value: number, languages: string[]) => string;
@@ -14,7 +14,7 @@ export const dispatchNumberFormatEvent = async (formatter: NumberFormatter, elem
   if (element.parentElement && 'updateComplete' in element.parentElement) {
     await (element.parentElement as {updateComplete: Promise<boolean>}).updateComplete;
   } else if ('componentOnReady' in element.parentElement!) {
-    await (element.parentElement as HTMLStencilElement).componentOnReady();
+    await (element.parentElement as ComponentOnReadyElement).componentOnReady();
   }
   const handled = !element.dispatchEvent(event);
   if (!handled) {

--- a/packages/atomic/src/components/common/item-list/item-list-common.ts
+++ b/packages/atomic/src/components/common/item-list/item-list-common.ts
@@ -88,31 +88,6 @@ export class ItemListCommon {
     this.props.nextNewItemTarget.focusOnNextTarget();
   }
 
-  // TODO - KIT-4227 refactor this method using requestAnimationFrame instead of defer, e.g.,
-  // public async focusOnFirstResultAfterNextSearch2() {
-  //   window.requestAnimationFrame(() => {
-  //     return new Promise<void>((resolve) => {
-  //       if (this.props.getIsLoading()) {
-  //         this.firstResultEl = undefined;
-  //       }
-
-  //       const unsub = this.props.engineSubscribe(async () => {
-  //         window.requestAnimationFrame(() => {
-  //           if (!this.props.getIsLoading() && this.firstResultEl) {
-  //             const elementToFocus =
-  //               getFirstFocusableDescendant(this.firstResultEl) ??
-  //               this.firstResultEl;
-  //             this.props.nextNewItemTarget.setTarget(elementToFocus);
-  //             this.props.nextNewItemTarget.focus();
-  //             this.firstResultEl = undefined;
-  //             unsub();
-  //             resolve();
-  //           }
-  //         });
-  //       });
-  //     });
-  //   });
-  // }
   public async focusOnFirstResultAfterNextSearch() {
     await defer();
     return new Promise<void>((resolve) => {

--- a/packages/atomic/src/components/common/item-list/result-template-provider.ts
+++ b/packages/atomic/src/components/common/item-list/result-template-provider.ts
@@ -1,9 +1,8 @@
 import {buildResultTemplatesManager, type Result, type Template} from '@coveo/headless';
 import type {ItemTarget} from '@/src/components/common/layout/item-layout-utils';
+import '@/src/components/search/atomic-result-link/atomic-result-link';
 import type {AnyBindings} from '../interface/bindings';
 import {TemplateProvider, type TemplateProviderProps} from '../template-provider/template-provider';
-// TODO: add this import once this class isn't used in Stencil components anymore
-// import '@/src/components/search/atomic-result-link/atomic-result-link';
 
 export class ResultTemplateProvider extends TemplateProvider<Result> {
   constructor(

--- a/packages/atomic/src/components/common/suggestions/suggestions-events.ts
+++ b/packages/atomic/src/components/common/suggestions/suggestions-events.ts
@@ -1,6 +1,5 @@
-import type {HTMLStencilElement} from '@stencil/core/internal';
 import type {LitElement} from 'lit';
-import {closest} from '../../../utils/dom-utils';
+import {closest, type ComponentOnReadyElement} from '../../../utils/dom-utils';
 import {buildCustomEvent} from '../../../utils/event-utils';
 import type {AnyBindings} from '../interface/bindings';
 import type {SearchBoxSuggestionsEvent} from './suggestions-types';
@@ -52,7 +51,7 @@ const dispatchSearchBoxSuggestionsEventEventually = async <
   if (isLitElementLoosely(interfaceElement)) {
     await interfaceElement.updateComplete;
   } else if ('componentOnReady' in interfaceElement) {
-    await (interfaceElement as HTMLStencilElement).componentOnReady();
+    await (interfaceElement as ComponentOnReadyElement).componentOnReady();
   }
   element.dispatchEvent(buildCustomEvent('atomic/searchBoxSuggestion/register', event));
 };

--- a/packages/atomic/src/components/search/atomic-field-condition/atomic-field-condition.ts
+++ b/packages/atomic/src/components/search/atomic-field-condition/atomic-field-condition.ts
@@ -77,8 +77,9 @@ export class AtomicFieldCondition
     const result = this.getResult();
 
     if (!result || !this.conditions.every((condition) => condition(result))) {
-      // TODO: Replace this.hidden = true with this.remove() once all Search components are migrated from Stencil to Lit.
-      // Currently using hidden to avoid breaking Stencil initialization event system in mixed Stencil/Lit component trees.
+      // TODO V4: Replace this.hidden = true with this.remove().
+      // Removing the element instead of hiding it changes the DOM contract for consumers,
+      // so it must wait for a major version.
       this.hidden = true;
       return html``;
     }

--- a/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
@@ -196,8 +196,6 @@ export const WithDependsOn: Story = {
     'depends-on-filetype': 'YouTubeVideo',
   },
   play: async (context) => {
-    //TODO: Fix component registration race condition #6480
-    await customElements.whenDefined('atomic-facet');
     await play(context);
     const {canvas, step} = context;
     await step('Select YouTubeVideo in filetype facet', async () => {

--- a/packages/atomic/src/components/search/atomic-timeframe-facet/atomic-timeframe-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-timeframe-facet/atomic-timeframe-facet.new.stories.tsx
@@ -236,8 +236,6 @@ export const WithDependsOn: Story = {
     }));
   },
   play: async (context) => {
-    //TODO: Fix component registration race condition #6480
-    await customElements.whenDefined('atomic-facet');
     await play(context);
     const {canvas, step} = context;
     await step('Select YouTubeVideo in filetype facet', async () => {

--- a/packages/atomic/src/mixins/children-update-complete-mixin.ts
+++ b/packages/atomic/src/mixins/children-update-complete-mixin.ts
@@ -1,5 +1,5 @@
-import type {HTMLStencilElement} from '@stencil/core/internal';
 import {LitElement} from 'lit';
+import type {ComponentOnReadyElement} from '@/src/utils/dom-utils';
 import type {Constructor} from './mixin-common';
 
 export const ChildrenUpdateCompleteMixin = <T extends Constructor<LitElement>>(superClass: T) => {
@@ -24,7 +24,7 @@ export const ChildrenUpdateCompleteMixin = <T extends Constructor<LitElement>>(s
             }
             await child.updateComplete;
           } else if ('componentOnReady' in child) {
-            await (child as HTMLStencilElement).componentOnReady();
+            await (child as ComponentOnReadyElement).componentOnReady();
           }
         })
       );

--- a/packages/atomic/src/utils/dom-utils.ts
+++ b/packages/atomic/src/utils/dom-utils.ts
@@ -1,3 +1,15 @@
+/**
+ * An element that signals readiness through `componentOnReady` rather than Lit's `updateComplete`.
+ *
+ * @remarks
+ * Atomic components are all Lit-based, but consumers may still place components built with
+ * other libraries (such as Stencil) inside an Atomic component tree, so the readiness
+ * fallbacks that rely on this contract must be preserved.
+ */
+export interface ComponentOnReadyElement extends HTMLElement {
+  componentOnReady(): Promise<this>;
+}
+
 export function rectEquals(r1: DOMRect, r2: DOMRect) {
   return r1.x === r2.x && r1.y === r2.y && r1.width === r2.width && r1.height === r2.height;
 }

--- a/packages/create-atomic-component-project/template/readme.md
+++ b/packages/create-atomic-component-project/template/readme.md
@@ -4,8 +4,6 @@ This is a starter project for building web components for Coveo Atomic using Ste
 
 ## Getting Started
 
-<!-- TODO CDX-1358: Insert instruction to create other components -->
-
 If you used `npm init @coveo/atomic-component` or `npm init @coveo/atomic-result-component`, your component should already be in `src/components`.
 You can use either of these commands at the root of your project to add another component.
 
@@ -15,10 +13,6 @@ Visit [Create a custom component](https://docs.coveo.com/en/atomic/latest/cc-sea
 
 You can test your component locally by adding it to `src/pages/index.html`.
 The code of the component should already be included. You just need to add the component tag to the markup of the page.
-
-<!--
-    TODO CDX-1356: tldr best practices and/or doc link.
--->
 
 ## Using a custom component
 

--- a/packages/headless/src/features/pagination/pagination-analytics-actions.ts
+++ b/packages/headless/src/features/pagination/pagination-analytics-actions.ts
@@ -34,7 +34,6 @@ export const logPagePrevious = (): LegacySearchAction =>
     })
   );
 
-// TODO KIT-2983
 export const browseResults = (): SearchAction => ({
   actionCause: SearchPageEvents.browseResults,
 });


### PR DESCRIPTION
## Problem

A codebase-wide audit found 327 TODO markers, 240 of which reference a ticket. Cross-checking every referenced Jira ticket (via the `jira` CLI) and GitHub issue revealed a set of TODOs whose blocking work has since been finished, so the comments now point reviewers at work that no longer exists. Two of them also describe workarounds that are no longer needed, and one gave a rationale that is factually wrong now that the Stencil to Lit migration is complete.

## Solution

Only TODOs where the blocking work is verifiably complete are touched. Each one was confirmed against the ticket/issue status **and** against the code before removal.

**Stencil to Lit migration complete**

- `ResultTemplateProvider` now imports `atomic-result-link` directly. The default template built the element via `document.createElement` and markup strings without importing its definition, relying on the autoloader or an incidental import to register it.
- The three `componentOnReady` readiness fallbacks now use a local `ComponentOnReadyElement` type in `dom-utils.ts` instead of `HTMLStencilElement` from the deep internal path `@stencil/core/internal`. Runtime behaviour is unchanged: consumers may still nest non-Lit components inside an Atomic tree, and the existing tests that assert this fallback still pass.
- `atomic-field-condition` kept a TODO claiming `hidden` was used "to avoid breaking Stencil initialization event system in mixed Stencil/Lit component trees". That is no longer true, so the comment now states the actual reason it must wait: switching to `remove()` changes the DOM contract for consumers.

**Completed GitHub issues**

- PR #6781 (merged): restored the `vi.mock` in `atomic-smart-snippet-expandable-answer.spec.ts`.
- Issue #6480 (closed as completed): removed the `customElements.whenDefined('atomic-facet')` race-condition workaround from the two facet stories the issue explicitly named.

**Completed Jira tickets**

- KIT-4227 (Completed): removed the 24-line commented-out alternative implementation from `item-list-common.ts`.
- KIT-3907, KIT-2983 (Completed): removed leftover bare markers.
- CDX-1356, CDX-1358 (Completed): removed template readme placeholders whose content is already present.

### Deliberately out of scope

- **No skipped test is unskipped.** The 84 skips are untouched.
- **KIT-4893** (`NonceBindings`) is now dead code, but the ticket is *Rejected* and `Bindings` is public API, so removing it is a v4 breaking change.
- **`@stencil/core` cannot be dropped** from Atomic's dependencies yet: `VNode` still appears in the public `SearchBoxSuggestionElement.content` and `FacetValueFormat.content` types, and its own docs already flag it for v4.
- **`set.ts`** ("Replace by `Set.prototype.intersection` in July 2025") needs the TS `lib` raised from ES2024 to ES2025, which changes the supported-browser baseline for a published package.
- **KIT-5109 / `pr:report`** is legitimately stale (pnpm migration is Completed) but re-enabling it changes CI behaviour and the script has an unrelated stray statement, so it deserves its own PR.
- Tickets that are *Rejected*, *On Hold*, *Postponed*, or *New* were left alone, including several where the ticket is Completed but the described work demonstrably is not (KIT-3199, KIT-3368, KIT-2844, KIT-4974, KIT-2585).

## Tests

- `@coveo/atomic` full unit suite: 7289 passed, 84 skipped. The only 6 failures are in `storybook-utils/documentation/resolve-github-path.spec.ts`, which this branch does not touch (pre-existing `tree/` vs `blob/` assertion mismatch on `main`).
- `@coveo/headless` pagination suite: 52 passed.
- `@coveo/atomic` and `@coveo/headless` builds pass; `lint:check` is clean.
- The two story changes affect Storybook interaction tests, so Chromatic/CI should confirm them.