### PR TITLE
fix(atomic): use instant scroll on Safari to prevent stale layer rendering

### DIFF
--- a/.changeset/fix-safari-scroll-to-top.md
+++ b/.changeset/fix-safari-scroll-to-top.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Fixed a Safari rendering bug where smooth scrolling during page navigation could cause stale visual layers (white rectangles or previous-page content) to appear over search results. `scrollToTop()` no longer forces `behavior: 'smooth'`, instead deferring to the CSS `scroll-behavior` property on the scroll container (which defaults to instant). Users who want smooth scrolling can opt in via CSS.

--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.spec.ts
@@ -250,16 +250,14 @@ describe('atomic-commerce-interface', () => {
         );
       });
 
-      it('should cause the element matching the scrollContainer selector to be smoothly scrolled into view when possible', async () => {
+      it('should cause the element matching the scrollContainer selector to be scrolled into view when possible', async () => {
         const element = await setupElement();
         const scrollIntoViewSpy = vi.spyOn(element, 'scrollIntoView');
         const event = new CustomEvent('atomic/scrollToTop');
 
         element.dispatchEvent(event);
 
-        expect(scrollIntoViewSpy).toHaveBeenCalledExactlyOnceWith({
-          behavior: 'smooth',
-        });
+        expect(scrollIntoViewSpy).toHaveBeenCalledExactlyOnceWith();
       });
     });
   });

--- a/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-interface/atomic-commerce-interface.ts
@@ -508,7 +508,7 @@ export class AtomicCommerceInterface
       return;
     }
 
-    scrollContainerElement.scrollIntoView({behavior: 'smooth'});
+    scrollContainerElement.scrollIntoView();
   }
 
   private updateHash() {

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.spec.ts
@@ -152,16 +152,14 @@ describe('atomic-commerce-recommendation-interface', () => {
         );
       });
 
-      it('should cause the element matching the scrollContainer selector to be smoothly scrolled into view when possible', async () => {
+      it('should cause the element matching the scrollContainer selector to be scrolled into view when possible', async () => {
         const element = await setupElement();
         const scrollIntoViewSpy = vi.spyOn(element, 'scrollIntoView');
         const event = new CustomEvent('atomic/scrollToTop', {});
 
         element.dispatchEvent(event);
 
-        expect(scrollIntoViewSpy).toHaveBeenCalledExactlyOnceWith({
-          behavior: 'smooth',
-        });
+        expect(scrollIntoViewSpy).toHaveBeenCalledExactlyOnceWith();
       });
     });
   });

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-interface/atomic-commerce-recommendation-interface.ts
@@ -260,7 +260,7 @@ export class AtomicCommerceRecommendationInterface
       return;
     }
 
-    scrollContainerElement.scrollIntoView({behavior: 'smooth'});
+    scrollContainerElement.scrollIntoView();
   }
 
   private async internalInitialization(initEngine: () => void) {

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.spec.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.spec.ts
@@ -229,7 +229,7 @@ describe('atomic-search-interface', () => {
         );
       });
 
-      it('should cause the element matching the scrollContainer selector to be smoothly scrolled into view when possible', async () => {
+      it('should cause the element matching the scrollContainer selector to be scrolled into view when possible', async () => {
         const element = await setupElement();
         await element.initialize(searchEngineConfig);
 
@@ -238,9 +238,7 @@ describe('atomic-search-interface', () => {
 
         element.dispatchEvent(event);
 
-        expect(scrollIntoViewSpy).toHaveBeenCalledExactlyOnceWith({
-          behavior: 'smooth',
-        });
+        expect(scrollIntoViewSpy).toHaveBeenCalledExactlyOnceWith();
       });
     });
   });

--- a/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.ts
+++ b/packages/atomic/src/components/search/atomic-search-interface/atomic-search-interface.ts
@@ -305,7 +305,7 @@ export class AtomicSearchInterface
       return;
     }
 
-    scrollContainerElement.scrollIntoView({behavior: 'smooth'});
+    scrollContainerElement.scrollIntoView();
   }
 
   /**

--- a/packages/atomic/src/utils/device-utils.spec.ts
+++ b/packages/atomic/src/utils/device-utils.spec.ts
@@ -1,13 +1,10 @@
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {afterEach, describe, expect, it, vi} from 'vitest';
 import {hasKeyboard, isIOS, isMacOS} from './device-utils';
 
 describe('device-utils', () => {
-  beforeEach(() => {
-    // No setup needed - vi.restoreAllMocks() will handle cleanup
-  });
-
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe('#isIOS', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5963

## Summary

`scrollToTop()` no longer forces `behavior: 'smooth'`. It now uses `scrollIntoView()`, which defers scroll behavior to the CSS `scroll-behavior` property on the scroll container (defaults to instant). Users who want smooth scrolling can opt in by setting `scroll-behavior: smooth` on their scroll container.

## Problem

Safari/WebKit caches a rasterized snapshot of the page for smooth scroll animations. When DOM content changes mid-animation (new results loading while scrolling), Safari sometimes fails to invalidate the cached layer, leaving white rectangles or stale content visible until the user interacts with the page.

Reproduced on Safari 17.6, 26.4, 26.5, and 26.6. Chrome and Firefox are unaffected. The issue appears fixed in Safari Technology Preview (upcoming Safari 27), but has not been backported to the 26.x line.

The hardcoded `behavior: 'smooth'` was originally added (342080a) before Safari even supported smooth scrolling (Safari 15.4, 2022). When Safari did add support, the implementation was buggy and remained so through v26.x. Rather than branching per-browser with UA sniffing, the correct fix is to stop forcing a scroll behavior in JS and let CSS handle it, which is arguably how we should have implemented it from the start.

## Changes

- Replaced `scrollIntoView({behavior: 'smooth'})` with `scrollIntoView()` in `scrollToTop()` across all three interface components (`atomic-search-interface`, `atomic-commerce-interface`, `atomic-commerce-recommendation-interface`)
- Updated unit test assertions accordingly
- Added `vi.unstubAllGlobals()` to `device-utils.spec.ts` teardown (pre-existing cleanup issue)

## Testing

- Manually verified on Safari 26.6: white rectangle no longer appears when navigating pages
- Manually verified on Chrome: scroll-to-top works as expected
- Unit tests updated and passing
