### PR TITLE
test(chromatic): use source files for all monorepo source

### DIFF
--- a/packages/atomic/.storybook/main.ts
+++ b/packages/atomic/.storybook/main.ts
@@ -103,13 +103,14 @@ const externalizeDependencies = (configType: 'DEVELOPMENT' | 'PRODUCTION' | unde
         return null;
       }
 
-      // For all testing, we want to use the local versions of all packages to ensure everything is properly bundled together for testing
-      if (isVitest || isChromatic || isPlaywright) {
+      // For most testing, we want to use the local versions of all packages to ensure everything is properly bundled together for testing
+      if (isVitest || isPlaywright) {
         return null;
       }
 
       // For local Storybook development, we want to use local packages source to allow for easier debugging and HMR.
-      if (configType === 'DEVELOPMENT') {
+      // We also want to use local packages for Chromatic builds to ensure TurboSnap can "resolves" changes in dependency of Atomic.
+      if (configType === 'DEVELOPMENT' || isChromatic) {
         return {
           id: packageMapping.local,
         };

--- a/packages/atomic/chromatic.config.json
+++ b/packages/atomic/chromatic.config.json
@@ -3,12 +3,7 @@
   "buildCommand": "turbo run build:storybook --filter=@coveo/atomic --",
   "outputDir": "dist-storybook",
   "exitOnceUploaded": true,
-  "untraced": [
-    "package.json",
-    "pnpm-lock.yaml",
-    "/virtual:*",
-    "packages/**",
-    "!packages/atomic/**"
-  ],
-  "onlyChanged": true
+  "untraced": ["package.json", "pnpm-lock.yaml", "/virtual:*", "packages/coveo-analytics/**/*"],
+  "onlyChanged": true,
+  "traceChanged": "expanded"
 }


### PR DESCRIPTION
Chromatic relies on tree shaking to "TurboSnap" stories.
Here, we were using the build output for part of our monorepo, which can trigger more builds than necessary.

To fix this:
1. Whenever possible, use the local source files
2. When this is not an option (or yet an option), ignore the changes that go on there.
3. We keep the monorepo package.json/pnpm-lock.yaml exclusion for now to ensures the numerous changes that may occur doesn't trigger more builds