### PR TITLE
chore(ci): fix the cleanup task after quantic e2e tests

### DIFF
--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -112,6 +112,7 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/setup-sfdx
       - name: Delete Quantic scratch orgs
+        run: |
           umask 077
           printf '%s\n' "$SFDX_AUTH_JWT_KEY" > server.key
           trap 'rm -f -- server.key' EXIT

--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -111,8 +111,16 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/setup-sfdx
-      - run: |
-          pnpm exec ts-node scripts/build/delete-org.ts --scratch-org-def-path=./config/lws-disabled-scratch-def.json
-          pnpm exec ts-node scripts/build/delete-org.ts --scratch-org-def-path=./config/lws-enabled-scratch-def.json
+      - name: Delete Quantic scratch orgs
+        run: |
+          printf '%s\n' "$SFDX_AUTH_JWT_KEY" > server.key
+          trap 'rm -f -- server.key' EXIT
+          pnpm exec ts-node scripts/build/delete-org.ts
         shell: bash
         working-directory: ./packages/quantic
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
+          SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
+          SFDX_AUTH_JWT_KEY_FILE: server.key
+          SFDX_AUTH_JWT_USERNAME: rdaccess@coveo.com

--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -112,7 +112,7 @@ jobs:
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/setup-sfdx
       - name: Delete Quantic scratch orgs
-        run: |
+          umask 077
           printf '%s\n' "$SFDX_AUTH_JWT_KEY" > server.key
           trap 'rm -f -- server.key' EXIT
           pnpm exec ts-node scripts/build/delete-org.ts

--- a/packages/quantic/scripts/build/delete-org.ts
+++ b/packages/quantic/scripts/build/delete-org.ts
@@ -69,6 +69,7 @@ async function deleteScratchOrgs(log: StepLogger, options: Options) {
   deletedOrgUsernames.forEach((username) => {
     log(`Organization ${username} deleted successfully.`);
   });
+}
 
 (async function () {
   try {

--- a/packages/quantic/scripts/build/delete-org.ts
+++ b/packages/quantic/scripts/build/delete-org.ts
@@ -1,41 +1,85 @@
 import {StepLogger, StepsRunner} from './util/log';
-import {
-  getOrgNameFromScratchDefFile,
-  getScratchOrgDefPath,
-} from './util/scratchOrgDefUtils';
 import * as sfdx from './util/sfdx-commands';
+import {SfdxJWTAuth, authorizeOrg} from './util/sfdx-commands';
+
+const COMMIT_SHA_PREFIX_LENGTH = 6;
 
 interface Options {
-  alias: string;
+  jwt: SfdxJWTAuth;
+  scratchOrgName: string;
 }
 
-const deleteScratchOrg = async (log: StepLogger, options: Options) => {
-  log(`Deleting ${options.alias} organization...`);
+function ensureEnvVariables() {
+  [
+    'COMMIT_SHA',
+    'SFDX_AUTH_CLIENT_ID',
+    'SFDX_AUTH_JWT_KEY_FILE',
+    'SFDX_AUTH_JWT_USERNAME',
+  ].forEach((variable) => {
+    if (!process.env[variable]) {
+      throw new Error(`The environment variable ${variable} must be defined.`);
+    }
+  });
+}
 
-  if (await sfdx.orgExists(options.alias)) {
-    await sfdx.deleteOrg(options.alias);
+function getCiOrgName() {
+  return `quantic-${process.env.COMMIT_SHA!.substring(
+    0,
+    COMMIT_SHA_PREFIX_LENGTH
+  )}`;
+}
+
+async function authorizeDevHub(log: StepLogger, options: Options) {
+  log(`Authorizing Dev Hub user: ${options.jwt.username}`);
+  await authorizeOrg({
+    username: options.jwt.username,
+    isScratchOrg: false,
+    jwtClientId: options.jwt.clientId,
+    jwtKeyFile: options.jwt.keyFile,
+  });
+  log('Dev Hub authorization successful.');
+}
+
+async function deleteScratchOrgs(log: StepLogger, options: Options) {
+  log(
+    `Searching the Dev Hub for active ${options.scratchOrgName} scratch organizations...`
+  );
+
+  const {foundOrgUsernames, deletedOrgUsernames} =
+    await sfdx.deleteActiveScratchOrgs({
+      devHubUsername: options.jwt.username,
+      scratchOrgName: options.scratchOrgName,
+      jwtClientId: options.jwt.clientId,
+      jwtKeyFile: options.jwt.keyFile,
+    });
+
+  if (foundOrgUsernames.length === 0) {
+    console.warn(
+      `Could not find an active scratch organization named ${options.scratchOrgName} to delete.`
+    );
+    return;
   }
 
-  log('Organization deleted successfully');
-};
-
-const resetOrgAlias = async (log: StepLogger, options: Options) => {
-  log(`Resetting ${options.alias} alias...`);
-  await sfdx.setAlias(options.alias, '');
-  log('Alias reset successfully');
-};
+  deletedOrgUsernames.forEach((username) => {
+    log(`Organization ${username} deleted successfully.`);
+  });
+}
 
 (async function () {
   try {
-    const scratchOrgDefPath = getScratchOrgDefPath(process.argv);
-    const orgName = getOrgNameFromScratchDefFile(scratchOrgDefPath);
+    ensureEnvVariables();
     const options = {
-      alias: orgName,
+      jwt: {
+        clientId: process.env.SFDX_AUTH_CLIENT_ID!,
+        keyFile: process.env.SFDX_AUTH_JWT_KEY_FILE!,
+        username: process.env.SFDX_AUTH_JWT_USERNAME!,
+      },
+      scratchOrgName: getCiOrgName(),
     };
 
     await new StepsRunner()
-      .add(async (log) => await deleteScratchOrg(log, options))
-      .add(async (log) => await resetOrgAlias(log, options))
+      .add(async (log) => await authorizeDevHub(log, options))
+      .add(async (log) => await deleteScratchOrgs(log, options))
       .run();
   } catch (error) {
     console.error('Failed to complete');

--- a/packages/quantic/scripts/build/delete-org.ts
+++ b/packages/quantic/scripts/build/delete-org.ts
@@ -60,10 +60,15 @@ async function deleteScratchOrgs(log: StepLogger, options: Options) {
     return;
   }
 
+  if (deletedOrgUsernames.length !== foundOrgUsernames.length) {
+    console.warn(
+      `Deleted ${deletedOrgUsernames.length}/${foundOrgUsernames.length} scratch org(s) named ${options.scratchOrgName}.`
+    );
+  }
+
   deletedOrgUsernames.forEach((username) => {
     log(`Organization ${username} deleted successfully.`);
   });
-}
 
 (async function () {
   try {

--- a/packages/quantic/scripts/build/util/sfdx-commands.ts
+++ b/packages/quantic/scripts/build/util/sfdx-commands.ts
@@ -162,15 +162,21 @@ interface DeleteActiveScratchOrgsArguments {
   jwtKeyFile: string;
 }
 
+export interface DeleteActiveScratchOrgsResult {
+  foundOrgUsernames: string[];
+  deletedOrgUsernames: string[];
+}
+
 export async function deleteActiveScratchOrgs(
   args: DeleteActiveScratchOrgsArguments
-): Promise<void> {
-  const usernames = await getActiveScratchOrgUsernames(
+): Promise<DeleteActiveScratchOrgsResult> {
+  const foundOrgUsernames = await getActiveScratchOrgUsernames(
     args.devHubUsername,
     args.scratchOrgName
   );
+  const deletedOrgUsernames: string[] = [];
 
-  for (const username of usernames) {
+  for (const username of foundOrgUsernames) {
     try {
       await authorizeOrg({
         username,
@@ -179,11 +185,14 @@ export async function deleteActiveScratchOrgs(
         jwtKeyFile: args.jwtKeyFile,
       });
       await deleteOrg(username);
+      deletedOrgUsernames.push(username);
     } catch (error) {
       console.warn(`Failed to delete organization ${username}`);
       console.warn(JSON.stringify(error));
     }
   }
+
+  return {foundOrgUsernames, deletedOrgUsernames};
 }
 
 interface DeleteOldScratchOrgsArguments {

--- a/packages/quantic/scripts/build/util/sfdx-commands.ts
+++ b/packages/quantic/scripts/build/util/sfdx-commands.ts
@@ -188,7 +188,7 @@ export async function deleteActiveScratchOrgs(
       deletedOrgUsernames.push(username);
     } catch (error) {
       console.warn(`Failed to delete organization ${username}`);
-      console.warn(JSON.stringify(error));
+      console.warn(error instanceof Error ? error.stack ?? error.message : String(error));
     }
   }
 


### PR DESCRIPTION
### SFINT-6877

We used to basically run the command `sf org list` to list locally available scratch orgs after the e2e tests created an org, assuming it would be available to then trigger the command to delete it.

But since these two steps run on different runners, there is no locally available registered scratch orgs.

So this PR swaps to using the remote query after authenticated the dev hub : `sf data query -q "select OrgName from ActiveScratchOrg"`.

The names we use for the scratch orgs are `quantic-<SHA_prefix_6>`.

I specifically looked for the cleanup phase of the CI of this PR and I can see the scratch orgs were correctly deleted:

```
[1/2] Authorizing Dev Hub user: 
[1/2] Dev Hub authorization successful.
[2/2] Searching the Dev Hub for active quantic-51b5aa scratch organizations...
[2/2] Organization test-pxguo6z8hbcp@example.com deleted successfully.
[2/2] Organization test-w70o2s3wufrq@example.com deleted successfully.
```