### PR TITLE
test(atomic): disable unstable Chromatic snapshots

### DIFF
--- a/packages/atomic/src/components/insight/atomic-insight-numeric-facet/atomic-insight-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/insight/atomic-insight-numeric-facet/atomic-insight-numeric-facet.new.stories.tsx
@@ -149,6 +149,7 @@ const meta: Meta = {
       handles: events,
     },
     msw: {handlers: [...insightApiHarness.handlers]},
+    chromatic: {disableSnapshot: true},
   },
   argTypes: {
     ...argTypes,

--- a/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
@@ -135,6 +135,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    chromatic: {disableSnapshot: true},
     actions: {
       handles: events,
     },

--- a/packages/atomic/src/components/search/atomic-quickview-modal/atomic-quickview-modal.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-quickview-modal/atomic-quickview-modal.new.stories.tsx
@@ -94,6 +94,9 @@ const meta: Meta = {
 export default meta;
 
 export const Default: Story = {
+  parameters: {
+    chromatic: {disableSnapshot: true},
+  },
   play: async (context) => {
     await play(context);
     const {canvasElement, step, userEvent} = context;

--- a/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-facet/atomic-rating-facet.new.stories.tsx
@@ -33,6 +33,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    chromatic: {disableSnapshot: true},
     msw: {
       handlers: [...searchApiHarness.handlers],
     },

--- a/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-rating-range-facet/atomic-rating-range-facet.new.stories.tsx
@@ -32,6 +32,7 @@ const meta: Meta = {
   decorators: [decorator],
   parameters: {
     ...parameters,
+    chromatic: {disableSnapshot: true},
     msw: {
       handlers: [...searchApiHarness.handlers],
     },


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-5965

## Motivation

Known unstable facet and quickview snapshots create visual-regression noise while the underlying stories are stabilized in KIT-5956.

## Changes

- Disable Chromatic snapshots for the Search Numeric Facet stories.
- Disable Chromatic snapshots for the RatingFacet and RatingRangeFacet stories.
- Disable the snapshot for Quickview Modal → Default.
- Keep story rendering, interaction tests, and accessibility tests enabled.

## Validation

- [x] All four changed stories pass the project story validator.
- [x] `pnpm run lint:fix` passes.
- [x] `pnpm run lint:check` passes.
- [x] No production code was modified (story files only).
- [x] Changes cover the intended scenarios.

## Checklist

- [x] PR title follows Conventional Commits 1.0.0.
- [x] No changeset is included because this PR modifies test stories only.