### PR TITLE
chore(ci): scope turbo affected to task inputs, exclude docs/meta files

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,9 +1,19 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
+  "futureFlags": {
+    "affectedUsingTaskInputs": true
+  },
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml"
+      ],
       "outputs": [
         "dist/**",
         "cdn/**",
@@ -32,10 +42,24 @@
     },
     "test": {
       "dependsOn": ["build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml"
+      ],
       "outputs": []
     },
     "functional-test": {
       "dependsOn": ["build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml"
+      ],
       "outputs": []
     },
     "test:watch": {


### PR DESCRIPTION
## Problem
`turbo --affected`, used across CI (`ci.yml`) to decide which packages'
build/test/e2e jobs to run, operates at the package level by default: if
*any* file inside a package's folder changes, the whole package is marked
affected, regardless of relevance. This caused #8132 (an ADR template
markdown-only change) to trigger Quantic's full unit test suite and its
E2E workflow (Salesforce scratch org setup included).

## Solution
- Enable `futureFlags.affectedUsingTaskInputs` in the root `turbo.json`,
  which makes `--affected` respect each task's `inputs` globs instead of
  hashing the whole package folder.
- Add a shared `inputs` baseline (`$TURBO_DEFAULT$` minus `*.md`,
  `LICENSE*`, `.vscode/**`, `catalog-info*.yaml`) to the root `build`,
  `test`, and `functional-test` tasks. Every package that doesn't
  override these tasks' `inputs` inherits this automatically.

Verified locally with isolated before/after commits that a docs-only
change (e.g. editing `docs/adr/ADR-template.md`) no longer selects any
package for `turbo build --affected` / `turbo test --affected`, while a
real source change still does.

Package-specific gaps — custom sub-tasks (e.g. Quantic's `build:doc`,
Atomic's `build:storybook`) that don't inherit from a root task and
therefore default to hashing everything — are addressed in follow-up,
stacked PRs rather than bundled here.
