### PR TITLE
chore(quantic): scope custom sub-task inputs for turbo affected

### DIFF
--- a/packages/quantic/turbo.json
+++ b/packages/quantic/turbo.json
@@ -7,10 +7,12 @@
         "build:doc",
         "babel:headless"
       ],
+      "inputs": ["$TURBO_EXTENDS$", "!.kiro/**"],
       "outputs":[]
     },
     "build:staticresources": {
       "dependsOn": ["^build", "babel:headless"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!**/LICENSE*", "!**/.vscode/**", "!**/catalog-info*.yaml", "!.kiro/**"],
       "outputs": [
         "force-app/main/default/staticresources/coveobueno/**",
         "force-app/main/default/staticresources/coveoheadless/**",
@@ -21,10 +23,12 @@
     },
     "build:doc": {
       "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!**/LICENSE*", "!**/.vscode/**", "!**/catalog-info*.yaml", "!.kiro/**", "!docs/adr/**"],
       "outputs": ["docs/out/**"]
     },
     "babel:headless": {
       "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!**/LICENSE*", "!**/.vscode/**", "!**/catalog-info*.yaml", "!.kiro/**"],
       "outputs": [
         ".tmp/quantic-compiled/**"
       ]
@@ -38,22 +42,27 @@
       "outputs": []
     },
     "test": {
+      "inputs": ["$TURBO_EXTENDS$", "!.kiro/**"],
       "outputs": [],
       "dependsOn": ["test:unit", "lint:check:tests", "validate:types", "validate:types:build-scripts"]
     },
     "test:unit": {
       "dependsOn": ["build"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!**/LICENSE*", "!**/.vscode/**", "!**/catalog-info*.yaml", "!.kiro/**"],
       "outputs": []
     },
     "validate:types": {
       "dependsOn": ["build"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!**/LICENSE*", "!**/.vscode/**", "!**/catalog-info*.yaml", "!.kiro/**"],
       "outputs": []
     },
     "validate:types:build-scripts": {
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!**/LICENSE*", "!**/.vscode/**", "!**/catalog-info*.yaml", "!.kiro/**"],
       "outputs": []
     },
     "lint:check:tests": {
       "dependsOn": ["build"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md", "!**/LICENSE*", "!**/.vscode/**", "!**/catalog-info*.yaml", "!.kiro/**"],
       "outputs": []
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -1,9 +1,19 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
+  "futureFlags": {
+    "affectedUsingTaskInputs": true
+  },
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml"
+      ],
       "outputs": [
         "dist/**",
         "cdn/**",
@@ -32,10 +42,24 @@
     },
     "test": {
       "dependsOn": ["build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml"
+      ],
       "outputs": []
     },
     "functional-test": {
       "dependsOn": ["build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml"
+      ],
       "outputs": []
     },
     "test:watch": {


### PR DESCRIPTION
Stacked on #8140 — base for `futureFlags.affectedUsingTaskInputs` and the
shared markdown/meta `inputs` exclusion.

## Problem
Quantic's `build` task depends on custom sub-tasks (`build:doc`,
`build:staticresources`, `babel:headless`) that aren't defined in the
root `turbo.json`. Even with #8140's flag enabled, these sub-tasks had
no `inputs` baseline of their own and defaulted to hashing every file
in the package — which is why #8132 (an ADR template markdown-only
change) still triggered Quantic's full unit test suite and E2E workflow.

## Solution
Scope `inputs` on every Quantic-specific sub-task (`build:doc`,
`build:staticresources`, `babel:headless`, `test:unit`, `validate:types`,
`validate:types:build-scripts`, `lint:check:tests`) to exclude the same
markdown/meta patterns as the shared root baseline, plus `.kiro/**`
(agent config, not build-relevant).

Verified locally with isolated before/after commits: a docs-only change
to `docs/adr/ADR-template.md` now yields an empty `turbo build/test
--affected` selection for Quantic, while a genuine source change under
`force-app/` still correctly selects it.
