### PR TITLE
chore(thermidor): scope test:dts inputs for turbo affected

### DIFF
--- a/packages/thermidor/turbo.json
+++ b/packages/thermidor/turbo.json
@@ -3,10 +3,26 @@
   "tasks": {
     "test:dts": {
       "dependsOn": ["build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml",
+        "!docs/**"
+      ],
       "outputs": []
     },
     "test:dts:ci": {
       "dependsOn": ["build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml",
+        "!docs/**"
+      ],
       "outputs": []
     }
   }


### PR DESCRIPTION
Stacked on #8141 (which is stacked on #8140).

## Problem
Thermidor's `test:dts`/`test:dts:ci` tasks aren't defined in the root
`turbo.json` and had no `inputs` baseline, defaulting to hashing every
file in the package. `test:dts:ci` is invoked directly with
`turbo test:dts:ci --affected` in CI, so a docs-only change (e.g. the
ADR template edit in #8132) would still mark Thermidor affected for
that check even with #8140/#8141 in place.

## Solution
Scope `inputs` on both tasks to exclude the shared markdown/meta
patterns plus `docs/**` (architecture/glossary/examples prose — verified
none of it is read by build or test scripts).

Verified locally: a docs-only diff to `docs/architecture.md` now yields
an empty `turbo test:dts:ci --affected` selection.
