### PR TITLE
chore(atomic): scope custom sub-task inputs for turbo affected

### DIFF
--- a/packages/atomic/turbo.json
+++ b/packages/atomic/turbo.json
@@ -20,10 +20,26 @@
     },
     "pre:storybook": {
       "dependsOn": ["build:cem", "build:locales", "build:assets", "build:indexes"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml",
+        "!licenses/**"
+      ],
       "outputs": []
     },
     "build:storybook": {
       "dependsOn": ["^build", "pre:storybook"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml",
+        "!licenses/**"
+      ],
       "outputs": ["./dist-storybook/**"],
       "env": ["STORYBOOK_INVOKED_BY"]
     },
@@ -91,14 +107,38 @@
     },
     "tsc:check": {
       "dependsOn": ["^build", "build:locales"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml",
+        "!licenses/**"
+      ],
       "outputs": []
     },
     "test:lit": {
       "dependsOn": ["^build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml",
+        "!licenses/**"
+      ],
       "outputs": ["coverage/**"]
     },
     "test:storybook": {
       "dependsOn": ["^build", "build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.md",
+        "!**/LICENSE*",
+        "!**/.vscode/**",
+        "!**/catalog-info*.yaml",
+        "!licenses/**"
+      ],
       "outputs": []
     },
     "dev": {


### PR DESCRIPTION
Stacked on #8141 (which is stacked on #8140).

## Problem
Atomic's `build` task graph depends on custom sub-tasks (`pre:storybook`,
`build:storybook`, `tsc:check`, `test:lit`, `test:storybook`) that aren't
defined in the root `turbo.json`. Even with #8140's flag enabled, these
had no `inputs` baseline and defaulted to hashing every file in the
package — including `README.md`, `CHANGELOG.md`, `LICENSE`, and
`licenses/` (third-party license text shipped in the npm tarball but
not consumed by any build script).

Because `pre:storybook` sits in the dependency chain for several other
tasks, an unrelated docs change anywhere in the package still marked
the whole `build`/`test` graph as affected — even for tasks like
`build:cem`/`build:lit`/`build:cdn` that already had strict, correctly
scoped `inputs`.

## Solution
Scope `inputs` on `pre:storybook`, `build:storybook`, `tsc:check`,
`test:lit`, and `test:storybook` to exclude the same markdown/meta
patterns as the root baseline, plus `licenses/**`.

Verified locally with isolated before/after commits: a docs-only diff
to `README.md` now yields an empty `turbo build/test:lit/test:storybook/
tsc:check --affected` selection, while a real source change (editing a
`.spec.ts` file) still correctly selects `test:lit`.
