### PR TITLE
test(atomic): exclude quickview modal a11y dialog story from chromatic

### DIFF
--- a/packages/atomic/src/components/search/atomic-quickview-modal/atomic-quickview-modal.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-quickview-modal/atomic-quickview-modal.new.stories.tsx
@@ -116,6 +116,9 @@ export const Closed: Story = {
 export const A11yDialog: Story = {
   tags: ['a11y', 'test', '!dev'],
   name: 'A11y Dialog',
+  parameters: {
+    chromatic: {disableSnapshot: true},
+  },
   play: async (context) => {
     await play(context);
     await testDialogA11y(context, {triggerLabel: 'Quick View'});


### PR DESCRIPTION
## Problem

The `Search/Quickview Modal > A11y Dialog` story is an interaction-driven accessibility test story (tagged `a11y`, `test`, `!dev`). It opens the modal through a user interaction, which makes its rendered output timing-dependent and produces unnecessary Chromatic snapshots/diffs. Visual coverage for this component is already provided by the `Default` story.

## Solution

Set `chromatic: {disableSnapshot: true}` on the `A11yDialog` story parameters so it is skipped during visual regression testing, while still running as an a11y/e2e test. This matches the existing convention used in `atomic-generated-answer-feedback-modal`, `atomic-focus-trap`, and `atomic-icon` stories.