### PR TITLE
chore(deps): add catalog candidate reporting script

### DIFF
--- a/docs/adr/0003-catalog-first-dependency-management-with-automated-reporting.md
+++ b/docs/adr/0003-catalog-first-dependency-management-with-automated-reporting.md
@@ -1,0 +1,45 @@
+---
+status: Proposed
+date: 2025-07-30
+related:
+  - scripts/report-catalog-candidates.mjs
+  - pnpm-workspace.yaml
+---
+
+# Catalog-first dependency management with automated reporting
+
+## Context and Problem Statement
+
+Dependencies hardcoded across multiple packages drift silently. There is no way to discover which ones could be promoted to the pnpm workspace catalog or which packages bypass an existing catalog entry.
+
+## Decision Drivers
+
+- Version drift should be surfaced proactively.
+- The catalog should be the single source of truth for shared versions.
+- Tooling should fit existing conventions (`scripts/`, ESM, `packages.mjs` helpers).
+
+## Considered Options
+
+### Option A: Reporting script
+
+A script that scans all packages, groups hardcoded dependencies by semver divergence, and outputs structured JSON.
+
+- **Pros:** Immediate visibility, zero new infra, actionable categories.
+- **Cons:** Informational only — does not auto-fix.
+
+### Option B: Lint rule enforcing `catalog:` usage
+
+- **Pros:** Enforces compliance at commit time.
+- **Cons:** Only catches existing catalog entries, blocks workflow, requires custom plugin.
+
+## Decision Outcome
+
+Option A — introduce `scripts/report-catalog-candidates.mjs`.
+
+A lightweight reporting tool fits the problem better than enforcement. It surfaces both promotion candidates and bypass violations without blocking developers.
+
+## Consequences
+
+- **Positive:** Drift becomes visible before it causes problems. Catalog promotion candidates are obvious.
+- **Negative:** Without periodic execution, drift can still accumulate.
+- **Neutral:** The script has no side effects and can be removed at any time.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "package-compatibility": "node ./scripts/ci/package-compatibility.mjs",
     "pr:report": "echo 'TODO KIT-5109: pr:report must be reactivated after pnpm has been merged in main'",
     "report:bundle-size:time-series": "node ./scripts/reports/bundle-size/time-series.mjs",
+    "report:catalog:candidates": "node ./scripts/report-catalog-candidates.mjs",
     "pre-commit": "lint-staged",
     "changeset": "changeset",
     "version-packages": "changeset version",
@@ -49,7 +50,8 @@
     "semver": "7.8.5",
     "turbo": "2.10.2",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "yaml": "catalog:"
   },
   "engines": {
     "node": "^22.14.0 || ^24.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.9)(jsdom@28.1.0)(msw@2.15.0(@types/node@24.12.4)(typescript@6.0.3))(vite@8.1.5(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
+      yaml:
+        specifier: 'catalog:'
+        version: 2.9.0
 
   packages/atomic:
     dependencies:

--- a/scripts/report-catalog-candidates.mjs
+++ b/scripts/report-catalog-candidates.mjs
@@ -1,0 +1,253 @@
+/**
+ * Reports third-party dependencies that appear (with hardcoded versions)
+ * in more than one package's `package.json`, grouped by version divergence
+ * and catalog membership.
+ *
+ * Outputs structured JSON to stdout.
+ *
+ * Usage:
+ *   node scripts/report-catalog-candidates.mjs
+ */
+
+import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+import {
+  getAllPackageDirs,
+  getPackageManifestFromPackagePath,
+  getPackagePathFromPackageDir,
+  workspacesRoot,
+} from './packages.mjs';
+
+import {parse as parseYaml} from 'yaml';
+
+/** @type {string[]} */
+const DEP_TYPES = ['dependencies', 'devDependencies', 'peerDependencies'];
+
+/**
+ * @typedef DepOccurrence
+ * @property {string} packageDir - Relative path under `packages/`.
+ * @property {string} version - Raw version string from the manifest.
+ * @property {string} depType - One of `dependencies`, `devDependencies`, `peerDependencies`.
+ */
+
+/**
+ * @typedef ParsedVersion
+ * @property {number} major
+ * @property {number} minor
+ * @property {number} patch
+ */
+
+/**
+ * Strips a leading semver range prefix from a version string.
+ *
+ * @param {string} version
+ * @returns {string}
+ */
+function stripRangePrefix(version) {
+  return version.replace(/^[>=<~^]+/, '');
+}
+
+/**
+ * Attempts to parse a version string into major, minor, and patch numbers.
+ * Returns `null` if the version cannot be parsed.
+ *
+ * @param {string} version
+ * @returns {ParsedVersion | null}
+ */
+function parseSemver(version) {
+  const stripped = stripRangePrefix(version);
+  const match = stripped.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    return null;
+  }
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+/**
+ * Reads the catalog from `pnpm-workspace.yaml`.
+ *
+ * @returns {Record<string, string>}
+ */
+function readCatalog() {
+  const workspaceYamlPath = resolve(workspacesRoot, 'pnpm-workspace.yaml');
+  const content = readFileSync(workspaceYamlPath, 'utf-8');
+  const parsed = parseYaml(content);
+  return parsed.catalog ?? {};
+}
+
+/**
+ * Collects all hardcoded dependency occurrences across the monorepo.
+ *
+ * @returns {Map<string, DepOccurrence[]>}
+ */
+function collectDependencies() {
+  /** @type {Map<string, DepOccurrence[]>} */
+  const depMap = new Map();
+  const dirs = getAllPackageDirs();
+
+  for (const dir of dirs) {
+    const fullPath = getPackagePathFromPackageDir(dir);
+    const manifest = getPackageManifestFromPackagePath(fullPath);
+
+    for (const depType of DEP_TYPES) {
+      const deps = /** @type {Record<string, string> | undefined} */ (manifest[depType]);
+      if (!deps) continue;
+
+      for (const [name, version] of Object.entries(deps)) {
+        if (version.startsWith('workspace:') || version.startsWith('catalog:')) {
+          continue;
+        }
+
+        if (!depMap.has(name)) {
+          depMap.set(name, []);
+        }
+        depMap.get(name).push({packageDir: dir, version, depType});
+      }
+    }
+  }
+
+  return depMap;
+}
+
+/**
+ * Determines the divergence category for a set of occurrences.
+ *
+ * @param {DepOccurrence[]} occurrences
+ * @returns {'different-majors' | 'different-minors' | 'different-patches' | 'exact-same'}
+ */
+function classifyDivergence(occurrences) {
+  const versions = [...new Set(occurrences.map((o) => o.version))];
+
+  if (versions.length === 1) {
+    return 'exact-same';
+  }
+
+  const parsed = versions.map(parseSemver);
+
+  if (parsed.some((p) => p === null)) {
+    return 'different-majors';
+  }
+
+  const majors = new Set(parsed.map((p) => p.major));
+  if (majors.size > 1) {
+    return 'different-majors';
+  }
+
+  const minors = new Set(parsed.map((p) => p.minor));
+  if (minors.size > 1) {
+    return 'different-minors';
+  }
+
+  return 'different-patches';
+}
+
+/**
+ * Converts a list of entries into the JSON-friendly array format,
+ * split by catalog membership.
+ *
+ * @param {Array<{name: string, occurrences: DepOccurrence[]}>} entries
+ * @param {Record<string, string>} catalog
+ * @returns {{notInCatalog: Array<{name: string, versions: Record<string, Array<{package: string, depType: string}>>}>, inCatalog: Array<{name: string, versions: Record<string, Array<{package: string, depType: string}>>}>}}
+ */
+function buildCategorySection(entries, catalog) {
+  const notInCatalog = entries.filter((e) => !(e.name in catalog));
+  const inCatalog = entries.filter((e) => e.name in catalog);
+
+  return {
+    notInCatalog: notInCatalog.map(buildEntryObject),
+    inCatalog: inCatalog.map(buildEntryObject),
+  };
+}
+
+/**
+ * Converts a single entry into the JSON-friendly object format.
+ *
+ * @param {{name: string, occurrences: DepOccurrence[]}} entry
+ * @returns {{name: string, versions: Record<string, Array<{package: string, depType: string}>>}}
+ */
+function buildEntryObject({name, occurrences}) {
+  /** @type {Record<string, Array<{package: string, depType: string}>>} */
+  const versions = {};
+
+  for (const occ of occurrences) {
+    if (!versions[occ.version]) {
+      versions[occ.version] = [];
+    }
+    versions[occ.version].push({package: occ.packageDir, depType: occ.depType});
+  }
+
+  return {name, versions};
+}
+
+/**
+ * Main entry point. Collects dependencies, classifies divergence, and
+ * outputs a structured JSON report to stdout.
+ */
+function main() {
+  const catalog = readCatalog();
+  const depMap = collectDependencies();
+
+  /** @type {Array<{name: string, occurrences: DepOccurrence[]}>} */
+  const differentMajors = [];
+  /** @type {Array<{name: string, occurrences: DepOccurrence[]}>} */
+  const differentMinors = [];
+  /** @type {Array<{name: string, occurrences: DepOccurrence[]}>} */
+  const differentPatches = [];
+  /** @type {Array<{name: string, occurrences: DepOccurrence[]}>} */
+  const exactSame = [];
+
+  for (const [name, occurrences] of depMap) {
+    if (occurrences.length < 2) continue;
+
+    const category = classifyDivergence(occurrences);
+    const entry = {name, occurrences};
+
+    switch (category) {
+      case 'different-majors':
+        differentMajors.push(entry);
+        break;
+      case 'different-minors':
+        differentMinors.push(entry);
+        break;
+      case 'different-patches':
+        differentPatches.push(entry);
+        break;
+      case 'exact-same':
+        exactSame.push(entry);
+        break;
+    }
+  }
+
+  const sortByName = (a, b) => a.name.localeCompare(b.name);
+  differentMajors.sort(sortByName);
+  differentMinors.sort(sortByName);
+  differentPatches.sort(sortByName);
+  exactSame.sort(sortByName);
+
+  const total =
+    differentMajors.length + differentMinors.length + differentPatches.length + exactSame.length;
+
+  const report = {
+    summary: {
+      total,
+      differentMajors: differentMajors.length,
+      differentMinors: differentMinors.length,
+      differentPatches: differentPatches.length,
+      exactSame: exactSame.length,
+    },
+    categories: {
+      differentMajors: buildCategorySection(differentMajors, catalog),
+      differentMinors: buildCategorySection(differentMinors, catalog),
+      differentPatches: buildCategorySection(differentPatches, catalog),
+      exactSame: buildCategorySection(exactSame, catalog),
+    },
+  };
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+main();

--- a/scripts/report-catalog-candidates.mjs
+++ b/scripts/report-catalog-candidates.mjs
@@ -76,7 +76,7 @@ function readCatalog() {
   const workspaceYamlPath = resolve(workspacesRoot, 'pnpm-workspace.yaml');
   const content = readFileSync(workspaceYamlPath, 'utf-8');
   const parsed = parseYaml(content);
-  return parsed.catalog ?? {};
+  return parsed?.catalog ?? {};
 }
 
 /**
@@ -142,7 +142,8 @@ function classifyDivergence(occurrences) {
     return 'different-minors';
   }
 
-  return 'different-patches';
+  const patches = new Set(parsed.map((p) => p.patch));
+  return patches.size > 1 ? 'different-patches' : 'exact-same';
 }
 
 /**

--- a/scripts/report-catalog-candidates.mjs
+++ b/scripts/report-catalog-candidates.mjs
@@ -207,8 +207,8 @@ function main() {
     }
 
     const entry = {
-      _catalog: catalog[name] ?? null,
       _issues: issues,
+      _catalog: catalog[name] ?? null,
     };
 
     for (const occ of occurrences) {

--- a/scripts/report-catalog-candidates.mjs
+++ b/scripts/report-catalog-candidates.mjs
@@ -22,7 +22,6 @@ const DEP_TYPES = ['dependencies', 'devDependencies', 'peerDependencies'];
  * @typedef DepOccurrence
  * @property {string} package - Relative path from workspace root (e.g., `packages/atomic`, `samples/headless/search`, `.`).
  * @property {string} version - Raw version string from the manifest.
- * @property {string} depType - One of `dependencies`, `devDependencies`, `peerDependencies`.
  */
 
 /**
@@ -99,7 +98,6 @@ function getAllWorkspacePackagePaths() {
     }
   }
 
-  // Include the root package.json
   results.push({label: '.', fullPath: workspacesRoot});
 
   return results;
@@ -130,7 +128,7 @@ function collectDependencies() {
         if (!depMap.has(name)) {
           depMap.set(name, []);
         }
-        depMap.get(name).push({package: label, version, depType});
+        depMap.get(name).push({package: label, version});
       }
     }
   }
@@ -172,44 +170,6 @@ function classifyDivergence(occurrences) {
 }
 
 /**
- * Converts a list of entries into the JSON-friendly array format,
- * split by catalog membership.
- *
- * @param {Array<{name: string, occurrences: DepOccurrence[]}>} entries
- * @param {Record<string, string>} catalog
- * @returns {{notInCatalog: Array<{name: string, versions: Record<string, Array<{package: string, depType: string}>>}>, inCatalog: Array<{name: string, versions: Record<string, Array<{package: string, depType: string}>>}>}}
- */
-function buildCategorySection(entries, catalog) {
-  const notInCatalog = entries.filter((e) => !(e.name in catalog));
-  const inCatalog = entries.filter((e) => e.name in catalog);
-
-  return {
-    notInCatalog: notInCatalog.map(buildEntryObject),
-    inCatalog: inCatalog.map(buildEntryObject),
-  };
-}
-
-/**
- * Converts a single entry into the JSON-friendly object format.
- *
- * @param {{name: string, occurrences: DepOccurrence[]}} entry
- * @returns {{name: string, versions: Record<string, Array<{package: string, depType: string}>>}}
- */
-function buildEntryObject({name, occurrences}) {
-  /** @type {Record<string, Array<{package: string, depType: string}>>} */
-  const versions = {};
-
-  for (const occ of occurrences) {
-    if (!versions[occ.version]) {
-      versions[occ.version] = [];
-    }
-    versions[occ.version].push({package: occ.package, depType: occ.depType});
-  }
-
-  return {name, versions};
-}
-
-/**
  * Main entry point. Collects dependencies, classifies divergence, and
  * outputs a structured JSON report to stdout.
  */
@@ -217,61 +177,57 @@ function main() {
   const catalog = readCatalog();
   const depMap = collectDependencies();
 
-  /** @type {Array<{name: string, occurrences: DepOccurrence[]}>} */
-  const differentMajors = [];
-  /** @type {Array<{name: string, occurrences: DepOccurrence[]}>} */
-  const differentMinors = [];
-  /** @type {Array<{name: string, occurrences: DepOccurrence[]}>} */
-  const differentPatches = [];
-  /** @type {Array<{name: string, occurrences: DepOccurrence[]}>} */
-  const exactSame = [];
+  const counts = {
+    'different-majors': 0,
+    'different-minors': 0,
+    'different-patches': 0,
+    'exact-same': 0,
+    'bypasses-catalog': 0,
+  };
+
+  /** @type {Record<string, object>} */
+  const entries = {};
 
   for (const [name, occurrences] of depMap) {
     if (occurrences.length < 2) continue;
 
-    const category = classifyDivergence(occurrences);
-    const entry = {name, occurrences};
+    const divergence = classifyDivergence(occurrences);
 
-    switch (category) {
-      case 'different-majors':
-        differentMajors.push(entry);
-        break;
-      case 'different-minors':
-        differentMinors.push(entry);
-        break;
-      case 'different-patches':
-        differentPatches.push(entry);
-        break;
-      case 'exact-same':
-        exactSame.push(entry);
-        break;
+    const issues = [divergence];
+    if (name in catalog) {
+      issues.push('bypasses-catalog');
+    }
+
+    const entry = {
+      _catalog: catalog[name] ?? null,
+      _issues: issues,
+    };
+
+    for (const occ of occurrences) {
+      entry[occ.package] = occ.version;
+    }
+
+    entries[name] = entry;
+
+    counts[divergence]++;
+    if (issues.includes('bypasses-catalog')) {
+      counts['bypasses-catalog']++;
     }
   }
 
-  const sortByName = (a, b) => a.name.localeCompare(b.name);
-  differentMajors.sort(sortByName);
-  differentMinors.sort(sortByName);
-  differentPatches.sort(sortByName);
-  exactSame.sort(sortByName);
-
-  const total =
-    differentMajors.length + differentMinors.length + differentPatches.length + exactSame.length;
+  const sortedKeys = Object.keys(entries).sort();
+  const total = Object.values(counts).reduce((sum, n) => sum + n, 0);
 
   const report = {
-    summary: {
+    _summary: {
       total,
-      differentMajors: differentMajors.length,
-      differentMinors: differentMinors.length,
-      differentPatches: differentPatches.length,
-      exactSame: exactSame.length,
-    },
-    categories: {
-      differentMajors: buildCategorySection(differentMajors, catalog),
-      differentMinors: buildCategorySection(differentMinors, catalog),
-      differentPatches: buildCategorySection(differentPatches, catalog),
-      exactSame: buildCategorySection(exactSame, catalog),
+      ...counts,
     },
   };
+
+  for (const key of sortedKeys) {
+    report[key] = entries[key];
+  }
 
   console.log(JSON.stringify(report, null, 2));
 }

--- a/scripts/report-catalog-candidates.mjs
+++ b/scripts/report-catalog-candidates.mjs
@@ -9,14 +9,9 @@
  *   node scripts/report-catalog-candidates.mjs
  */
 
-import {readFileSync} from 'node:fs';
+import {existsSync, readFileSync, globSync} from 'node:fs';
 import {resolve} from 'node:path';
-import {
-  getAllPackageDirs,
-  getPackageManifestFromPackagePath,
-  getPackagePathFromPackageDir,
-  workspacesRoot,
-} from './packages.mjs';
+import {getPackageManifestFromPackagePath, workspacesRoot} from './packages.mjs';
 
 import {parse as parseYaml} from 'yaml';
 
@@ -25,7 +20,7 @@ const DEP_TYPES = ['dependencies', 'devDependencies', 'peerDependencies'];
 
 /**
  * @typedef DepOccurrence
- * @property {string} packageDir - Relative path under `packages/`.
+ * @property {string} package - Relative path from workspace root (e.g., `packages/atomic`, `samples/headless/search`, `.`).
  * @property {string} version - Raw version string from the manifest.
  * @property {string} depType - One of `dependencies`, `devDependencies`, `peerDependencies`.
  */
@@ -80,6 +75,37 @@ function readCatalog() {
 }
 
 /**
+ * Resolves all workspace package directories from `pnpm-workspace.yaml`,
+ * including the root.
+ *
+ * @returns {Array<{label: string, fullPath: string}>}
+ */
+function getAllWorkspacePackagePaths() {
+  const workspaceYamlPath = resolve(workspacesRoot, 'pnpm-workspace.yaml');
+  const content = readFileSync(workspaceYamlPath, 'utf-8');
+  const parsed = parseYaml(content);
+  const patterns = parsed.packages ?? [];
+
+  /** @type {Array<{label: string, fullPath: string}>} */
+  const results = [];
+
+  for (const pattern of patterns) {
+    const matches = globSync(pattern, {cwd: workspacesRoot});
+    for (const match of matches) {
+      const fullPath = resolve(workspacesRoot, match);
+      if (existsSync(resolve(fullPath, 'package.json'))) {
+        results.push({label: match, fullPath});
+      }
+    }
+  }
+
+  // Include the root package.json
+  results.push({label: '.', fullPath: workspacesRoot});
+
+  return results;
+}
+
+/**
  * Collects all hardcoded dependency occurrences across the monorepo.
  *
  * @returns {Map<string, DepOccurrence[]>}
@@ -87,10 +113,9 @@ function readCatalog() {
 function collectDependencies() {
   /** @type {Map<string, DepOccurrence[]>} */
   const depMap = new Map();
-  const dirs = getAllPackageDirs();
+  const packages = getAllWorkspacePackagePaths();
 
-  for (const dir of dirs) {
-    const fullPath = getPackagePathFromPackageDir(dir);
+  for (const {label, fullPath} of packages) {
     const manifest = getPackageManifestFromPackagePath(fullPath);
 
     for (const depType of DEP_TYPES) {
@@ -105,7 +130,7 @@ function collectDependencies() {
         if (!depMap.has(name)) {
           depMap.set(name, []);
         }
-        depMap.get(name).push({packageDir: dir, version, depType});
+        depMap.get(name).push({package: label, version, depType});
       }
     }
   }
@@ -178,7 +203,7 @@ function buildEntryObject({name, occurrences}) {
     if (!versions[occ.version]) {
       versions[occ.version] = [];
     }
-    versions[occ.version].push({package: occ.packageDir, depType: occ.depType});
+    versions[occ.version].push({package: occ.package, depType: occ.depType});
   }
 
   return {name, versions};

--- a/scripts/report-catalog-candidates.mjs
+++ b/scripts/report-catalog-candidates.mjs
@@ -189,9 +189,17 @@ function main() {
   const entries = {};
 
   for (const [name, occurrences] of depMap) {
-    if (occurrences.length < 2) continue;
+    if (occurrences.length < 2 && !(name in catalog)) continue;
 
-    const divergence = classifyDivergence(occurrences);
+    // When the dependency is in the catalog, include the catalog version
+    // in divergence classification so we compare against what the catalog
+    // prescribes, not just among the hardcoded occurrences themselves.
+    const versionsToClassify =
+      name in catalog
+        ? [...occurrences, {package: '_catalog', version: catalog[name]}]
+        : occurrences;
+
+    const divergence = classifyDivergence(versionsToClassify);
 
     const issues = [divergence];
     if (name in catalog) {


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-5975

## Motivation

Dependencies hardcoded across multiple packages drift silently. This adds
tooling to surface catalog promotion candidates and bypass violations.

## Changes

- Add `scripts/report-catalog-candidates.mjs` — scans all packages and
  outputs a structured JSON report grouped by semver divergence and catalog
  membership.
- Add `yaml` as a root devDependency (`catalog:`) for YAML parsing.
- Add ADR 0003 documenting the catalog-first dependency management decision.

## Validation

- Script runs successfully via `pnpm exec node scripts/report-catalog-candidates.mjs`
- Output is valid JSON with expected structure
- No new features or bug fixes are included in this PR

## Output

```json
{
  "_summary": {
    "total": 25,
    "different-majors": 8,
    "different-minors": 3,
    "different-patches": 0,
    "exact-same": 3,
    "bypasses-catalog": 11
  },
  "@angular/common": {
    "_issues": [
      "different-majors",
      "bypasses-catalog"
    ],
    "_catalog": "21.2.18",
    "packages/atomic-angular/projects/atomic-angular": "14 - 21"
  },
  "@angular/core": {
    "_issues": [
      "different-majors",
      "bypasses-catalog"
    ],
    "_catalog": "21.2.18",
    "packages/atomic-angular/projects/atomic-angular": "14 - 21"
  },
  "@msw/playwright": {
    "_issues": [
      "exact-same",
      "bypasses-catalog"
    ],
    "_catalog": "0.6.7",
    "packages/atomic-cdn-smoke": "0.6.7"
  },
  "@reduxjs/toolkit": {
    "_issues": [
      "exact-same",
      "bypasses-catalog"
    ],
    "_catalog": "2.12.0",
    "packages/headless": "2.12.0"
  },
  "@types/react": {
    "_issues": [
      "different-majors",
      "bypasses-catalog"
    ],
    "_catalog": "19.2.17",
    "packages/headless-react": "^18 || ^19"
  },
  "@types/react-dom": {
    "_issues": [
      "different-majors",
      "bypasses-catalog"
    ],
    "_catalog": "19.2.3",
    "packages/headless-react": "^18 || ^19"
  },
  "express": {
    "_issues": [
      "different-minors"
    ],
    "_catalog": null,
    "samples/headless-ssr/commerce-express": "5.2.1",
    "samples/headless-ssr/commerce-nextjs": "^5.0.0"
  },
  "node-fetch": {
    "_issues": [
      "different-majors"
    ],
    "_catalog": null,
    "packages/headless": "3.3.2",
    "packages/coveo-analytics": "2.7.0"
  },
  "react": {
    "_issues": [
      "different-majors",
      "bypasses-catalog"
    ],
    "_catalog": "19.2.7",
    "packages/headless-react": "^18 || ^19",
    "packages/atomic-react": ">=18.0.0"
  },
  "react-dom": {
    "_issues": [
      "different-majors",
      "bypasses-catalog"
    ],
    "_catalog": "19.2.7",
    "packages/headless-react": "^18 || ^19",
    "packages/atomic-react": ">=18.0.0"
  },
  "ts-dedent": {
    "_issues": [
      "different-minors"
    ],
    "_catalog": null,
    "packages/atomic": "2.3.0",
    "packages/relay-playground": "2.2.0"
  },
  "typescript": {
    "_issues": [
      "different-majors",
      "bypasses-catalog"
    ],
    "_catalog": "6.0.3",
    "packages/headless": ">=5.0.0",
    "packages/atomic": ">=5.0.0"
  },
  "vite": {
    "_issues": [
      "different-minors",
      "bypasses-catalog"
    ],
    "_catalog": "8.1.5",
    "packages/atomic-angular": "^8.0.0"
  },
  "vitest": {
    "_issues": [
      "exact-same",
      "bypasses-catalog"
    ],
    "_catalog": "4.1.9",
    "samples/headless/rga-angular": "4.1.9"
  }
}
```
