### PR TITLE
chore(ci): merge affected-projects detection into the build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,16 +143,6 @@ jobs:
           | awk '/^@(coveo|samples)/ && !/#/ {print $1}' \
           | tr '\n' ' ')
           echo "projects=$AFFECTED" >> "$GITHUB_OUTPUT"
-      # TEMPORARY (remove before merge): validates that running the build before
-      # the affected dry-run does not dirty tracked files. A real build can emit
-      # tracked generated files (see the build-missing job), and with
-      # futureFlags.affectedUsingTaskInputs those would count as task inputs and
-      # could inflate the affected set. Empty output here confirms it does not.
-      - name: 'VALIDATION: working tree cleanliness after build'
-        run: |
-          echo "--- git status --porcelain (expected: empty) ---"
-          git status --porcelain
-          echo "--- end ---"
       - name: Log affected projects
         run: |
           echo "Affected projects: ${STEPS_SET_OUTPUTS_PROJECTS}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,16 +113,51 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/') }}
     runs-on: ubuntu-latest
     environment: PR Artifacts
+    outputs:
+      projects: ${{ steps.set.outputs.projects }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
+      # Full history is required by `turbo --affected`, which compares the
+      # checkout against the base ref to determine which packages changed.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - run: git branch ${GITHUB_EVENT_PULL_REQUEST_BASE_REF} origin/${GITHUB_EVENT_PULL_REQUEST_BASE_REF}
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
+      - run: git branch main origin/main
+        if: ${{ github.event_name != 'pull_request' }}
       - uses: ./.github/actions/setup
         with:
           save-cache: 'true'
+      - name: Get affected projects
+        id: set
+        run: |
+          AFFECTED=$(pnpm exec turbo build --affected --dry-run 2>/dev/null \
+          | awk '/^@(coveo|samples)/ && !/#/ {print $1}' \
+          | tr '\n' ' ')
+          echo "projects=$AFFECTED" >> "$GITHUB_OUTPUT"
+      # TEMPORARY (remove before merge): validates that running the build before
+      # the affected dry-run does not dirty tracked files. A real build can emit
+      # tracked generated files (see the build-missing job), and with
+      # futureFlags.affectedUsingTaskInputs those would count as task inputs and
+      # could inflate the affected set. Empty output here confirms it does not.
+      - name: 'VALIDATION: working tree cleanliness after build'
+        run: |
+          echo "--- git status --porcelain (expected: empty) ---"
+          git status --porcelain
+          echo "--- end ---"
+      - name: Log affected projects
+        run: |
+          echo "Affected projects: ${STEPS_SET_OUTPUTS_PROJECTS}"
+        env:
+          STEPS_SET_OUTPUTS_PROJECTS: ${{ steps.set.outputs.projects }}
   build-cdn:
     name: Build CDN
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/') }}
@@ -136,41 +171,6 @@ jobs:
       - uses: ./.github/actions/build-cdn
         with:
           commit-sha: ${{ github.sha }}
-  affected:
-    name: 'Determine affected projects'
-    runs-on: ubuntu-latest
-    needs: build
-    outputs:
-      projects: ${{ steps.set.outputs.projects }}
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          fetch-depth: 0
-          filter: blob:none
-      - run: git branch ${GITHUB_EVENT_PULL_REQUEST_BASE_REF} origin/${GITHUB_EVENT_PULL_REQUEST_BASE_REF}
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
-      - run: git branch main origin/main
-        if: ${{ github.event_name != 'pull_request' }}
-      - uses: ./.github/actions/setup
-      - name: Get affected projects
-        id: set
-        run: |
-          AFFECTED=$(pnpm exec turbo build --affected --dry-run 2>/dev/null \
-          | awk '/^@(coveo|samples)/ && !/#/ {print $1}' \
-          | tr '\n' ' ')
-          echo "projects=$AFFECTED" >> "$GITHUB_OUTPUT"
-      - name: Log affected projects
-        run: |
-          echo "Affected projects: ${STEPS_SET_OUTPUTS_PROJECTS}"
-        env:
-          STEPS_SET_OUTPUTS_PROJECTS: ${{ steps.set.outputs.projects }}
   knip:
     name: 'Look for unused code or dependencies'
     runs-on: ubuntu-latest
@@ -186,8 +186,8 @@ jobs:
         run: pnpm run knip
   cdn-checks:
     name: 'CDN Checks'
-    needs: [affected, build-cdn]
-    if: contains(needs.affected.outputs.projects, '@coveo/atomic') || contains(needs.affected.outputs.projects, '@coveo/atomic-hosted-page')
+    needs: [build, build-cdn]
+    if: contains(needs.build.outputs.projects, '@coveo/atomic') || contains(needs.build.outputs.projects, '@coveo/atomic-hosted-page')
     env:
       DEPLOYMENT_ENVIRONMENT: CDN
     runs-on: ubuntu-latest
@@ -273,8 +273,8 @@ jobs:
       - run: pnpm exec turbo test --affected
   relay-tests:
     name: 'Run Relay functional and playground smoke tests'
-    needs: affected
-    if: contains(needs.affected.outputs.projects, '@coveo/relay') || contains(needs.affected.outputs.projects, '@coveo/relay-playground')
+    needs: build
+    if: contains(needs.build.outputs.projects, '@coveo/relay') || contains(needs.build.outputs.projects, '@coveo/relay-playground')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -329,8 +329,8 @@ jobs:
       - run: pnpm run package-compatibility
   typedoc:
     name: 'Build typedoc'
-    needs: affected
-    if: contains(needs.affected.outputs.projects, '@coveo/headless') || contains(needs.affected.outputs.projects, '@coveo/headless-react')
+    needs: build
+    if: contains(needs.build.outputs.projects, '@coveo/headless') || contains(needs.build.outputs.projects, '@coveo/headless-react')
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -348,8 +348,8 @@ jobs:
         working-directory: packages/headless-react
   puppeteer-atomic-csp:
     name: 'Run e2e tests on Atomic CSP'
-    needs: affected
-    if: contains(needs.affected.outputs.projects, '@coveo/atomic')
+    needs: build
+    if: contains(needs.build.outputs.projects, '@coveo/atomic')
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -363,7 +363,7 @@ jobs:
 
   chromatic:
     name: 'Run Chromatic visual tests on Atomic'
-    needs: affected
+    needs: build
     runs-on: ubuntu-latest
     env:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
@@ -391,14 +391,14 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm exec turbo chromatic --filter=@coveo/atomic
         id: chromatic-run
-        if: contains(needs.affected.outputs.projects, '@coveo/atomic') && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'chromatic')
+        if: contains(needs.build.outputs.projects, '@coveo/atomic') && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'chromatic')
       - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --skip
         working-directory: packages/atomic
         if: steps.chromatic-run.outcome == 'skipped'
   playwright-atomic:
     name: 'Run Playwright tests for Atomic'
-    needs: affected
-    if: contains(needs.affected.outputs.projects, '@coveo/atomic')
+    needs: build
+    if: contains(needs.build.outputs.projects, '@coveo/atomic')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -443,8 +443,8 @@ jobs:
 
   playwright-atomic-theming:
     name: 'Run theming smoke tests for Atomic'
-    needs: affected
-    if: contains(needs.affected.outputs.projects, '@coveo/atomic')
+    needs: build
+    if: contains(needs.build.outputs.projects, '@coveo/atomic')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -460,8 +460,8 @@ jobs:
       - uses: ./.github/actions/playwright-atomic-theming
   storybook-atomic:
     name: 'Run Storybook tests'
-    needs: affected
-    if: contains(needs.affected.outputs.projects, '@coveo/atomic')
+    needs: build
+    if: contains(needs.build.outputs.projects, '@coveo/atomic')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -495,8 +495,8 @@ jobs:
           if-no-files-found: warn
   merge-storybook-a11y-reports:
     name: 'Merge Storybook a11y reports and validate OpenACR'
-    needs: [affected, storybook-atomic]
-    if: always() && contains(needs.affected.outputs.projects, '@coveo/atomic')
+    needs: [build, storybook-atomic]
+    if: always() && contains(needs.build.outputs.projects, '@coveo/atomic')
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -602,8 +602,8 @@ jobs:
           if-no-files-found: ignore
   playwright-pkg-new-template-test:
     name: 'Run smoke tests on pkg-new-template'
-    needs: affected
-    if: contains(needs.affected.outputs.projects, '@coveo/pkg-new-template')
+    needs: build
+    if: contains(needs.build.outputs.projects, '@coveo/pkg-new-template')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -619,8 +619,8 @@ jobs:
       - uses: ./.github/actions/playwright-pkg-new-template
   playwright-atomic-hosted-page-test:
     name: 'Run e2e tests for Atomic Hosted Page'
-    needs: affected
-    if: contains(needs.affected.outputs.projects, '@coveo/atomic-hosted-page')
+    needs: build
+    if: contains(needs.build.outputs.projects, '@coveo/atomic-hosted-page')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -636,8 +636,8 @@ jobs:
       - uses: ./.github/actions/playwright-atomic-hosted-pages
   e2e-quantic:
     name: 'Run Quantic E2E tests'
-    needs: affected
-    if: contains(needs.affected.outputs.projects, '@coveo/quantic') && !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-quantic'))
+    needs: build
+    if: contains(needs.build.outputs.projects, '@coveo/quantic') && !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-quantic'))
     permissions:
       contents: read
       pull-requests: write

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -1,3 +1,1 @@
 export * from './saml/saml-client';
-
-// temp: validate affected detection

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -1,1 +1,3 @@
 export * from './saml/saml-client';
+
+// temp: validate affected detection


### PR DESCRIPTION
## Problem

The `affected` job existed only to run `turbo build --affected --dry-run` and expose the result as an output, but it was structured so it could never overlap with `build`:

- It declared `needs: build`.
- Its `./.github/actions/setup` call passed no `skip-build`, so it defaulted to `skip-build: 'false'` and ran a **full `pnpm run build`** (a cache hit off `build`'s artifact) before doing its dry-run.

Measured on [run 30619643623](https://github.com/coveo/ui-kit/actions/runs/30619643623): `Build` ran 09:21:41→09:25:43 (242s), then `Determine affected projects` started 3s later and took a further 62s.

Because the 12 affected-gated jobs also need `build`'s Turbo cache artifact, simply decoupling `affected` from `build` was **not** viable — those jobs would start before the artifact existed and their `download-artifact` step (no `continue-on-error`, no `if-no-files-found`) would fail hard. The ~60s was not reorderable, only removable.

Nearly all of that 60s was duplicated setup rather than computation: a second checkout, a second `pnpm install`, a ~7s Turbo artifact download, and a redundant cache-hit build pass. The dry-run itself takes ~1s.

Found during a broader CI audit (`.kiro/specs/mega-ci-analysis/`, not part of this PR).

## Solution

Merge the affected-projects dry-run into the `build` job and delete the standalone `affected` job.

- `build` gains `outputs.projects`, the `fetch-depth: 0` / `filter: blob:none` checkout and base-ref `git branch` steps that `--affected` needs, and the `Get affected projects` step.
- The dry-run runs against the `.turbo` directory `build` just produced, so there is no artifact download at all.
- 10× `needs: affected` → `needs: build`; `[affected, build-cdn]` → `[build, build-cdn]`; `[affected, storybook-atomic]` → `[build, storybook-atomic]`.
- 15× `needs.affected.outputs.projects` → `needs.build.outputs.projects`.

Job count drops 33 → 32. `is-valid-pr` / `is-valid-merge-queue` already listed `build` and never listed `affected`, so their `needs` lists are unchanged.

## Measured result

On this branch, `Build` ran 17:15:00→17:19:09 (**249s**) and the first downstream job started at 17:19:12.

| | before | after |
|---|---|---|
| Time until affected-gated jobs can start | ~310s (242s build + 3s + 62s affected + 3s) | ~252s |
| `Build` job duration | 242s (baseline range 209-255s) | 249s |

**~58s off the critical path of every PR and merge-queue run**, plus one fewer runner, checkout, install and redundant build pass. Adding the full-history checkout and dry-run to `build` cost ~4s, well inside its normal variance.

On a ~16 min run that is ~5% — real and universal, but modest. Nothing here is a dramatic lever: the Playwright matrix already runs at ~80% parallel efficiency (9.66x on 12 shards, measured across 61 runs), so shard rebalancing was ruled out as low-value.

**Tradeoff:** the 9 jobs that `needs: build` now wait a few extra seconds for the full-history checkout and dry-run. Small regression for them, ~58s win for the 12 affected-gated ones.

## Validation

Why the parsed output is unchanged by construction: the command string is byte-identical, and the `awk` filter reads the unindented **"Packages in Scope"** table, which `--affected` derives from the git diff. Cache state appears only in the indented `Cached (Local)` fields, which `awk` never matches.

Both risks were then confirmed empirically on [run 30836369768](https://github.com/coveo/ui-kit/actions/runs/30836369768) (full run: **success**), using a temporary commit touching `packages/auth/src/auth.ts` (a package with no dependents) plus a temporary diagnostic step — both since reverted, leaving `ci.yml` as the only change:

1. **Working tree clean after the build.** `git status --porcelain` printed nothing. This mattered because the dry-run now runs after a *real* build rather than a cache hit, and a real build can emit tracked generated files (what `build-missing` exists to catch); with `futureFlags.affectedUsingTaskInputs: true` and `build` inputs of `$TURBO_DEFAULT$`, those would count as task inputs and could inflate the affected set. Confirmed a non-issue, so the dry-run does not need to move before the build.
2. **Correct affected output.** `Affected projects: @coveo/auth` — exactly right, nothing spurious.
3. **Correct downstream gating.** All 13 Atomic/Quantic/Relay/typedoc/CDN/pkg-new-template gated jobs skipped as expected, `Chromatic` correctly still ran (its gate is step-level, not job-level), and `Confirm build is valid (PR)` + `Confirm build is valid` both passed.

### BEFORE
<img width="984" height="567" alt="image" src="https://github.com/user-attachments/assets/d4cdd0b5-fa5d-4b39-bd5b-07fde532b66e" />

### AFTER
<img width="898" height="590" alt="image" src="https://github.com/user-attachments/assets/2a55bf4f-012d-4d25-af8b-547ed5e61c2a" />
