### PR TITLE
test(relay): fix flaky cookie.jsdom.test.ts

### DIFF
--- a/packages/relay/src/environment/browser/storage/cookie.jsdom.test.ts
+++ b/packages/relay/src/environment/browser/storage/cookie.jsdom.test.ts
@@ -9,6 +9,11 @@ describe('CookieManager', () => {
   const key = 'wow';
   const someData = 'something';
 
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2023-08-15T00:00:00.000Z'));
+  });
+
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -25,9 +30,6 @@ describe('CookieManager', () => {
   });
 
   it('honors expiration date', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2023-08-15T00:00:00.000Z'));
-
     cookieManager.setItem(key, someData, 1000);
     vi.advanceTimersByTime(1001);
 


### PR DESCRIPTION
[KIT-5968](https://coveord.atlassian.net/browse/KIT-5968)

## Problem
`cookie.jsdom.test.ts` is flaky in CI:

```
FAIL   jsdom  src/environment/browser/storage/cookie.jsdom.test.ts > CookieManager > setItem writes data to a cookie
AssertionError: expected null to be 'something' // Object.is equality
```

`CookieManager.setItem`/`getItem` compute cookie expiry from the real wall clock (`Date.now()` inside jsdom's tough-cookie cookie jar). Most tests used a short 1000ms/10000ms expiry purely to exercise a set-then-get flow, not to test expiration timing. On a loaded/throttled CI runner, GC pauses or scheduling jitter of just over a second between the `setItem` and `getItem` calls are enough for the cookie to be considered expired, causing `getItem` to return `null`. I confirmed this locally by injecting a synchronous ~1050ms delay between `setItem` and `getItem`, which reproduces the exact failure.

## Solution
Freeze the clock for the whole suite with `vi.useFakeTimers()` + `vi.setSystemTime()` in a `beforeEach`, instead of only in the one test that already used fake timers. This makes every test in the file deterministic: `setItem`'s expiry computation and `getItem`'s expiry check always see the same fixed `Date.now()` unless a test explicitly calls `vi.advanceTimersByTime`, so real-clock jitter (CI slowness, GC pauses, etc.) can no longer affect the outcome. Verified that a simulated ~1050ms scheduling delay no longer breaks the assertion once the clock is frozen.


[KIT-5968]: https://coveord.atlassian.net/browse/KIT-5968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ