### PR TITLE
feat(thermidor): align Controller.subscribe signature with existing pattern in @coveo/headless

### DIFF
--- a/packages/thermidor/src/internal/utils/base-controller.test.ts
+++ b/packages/thermidor/src/internal/utils/base-controller.test.ts
@@ -1,7 +1,7 @@
 import {describe, it, expect, vi} from 'vitest';
 import {BaseController} from './base-controller.js';
 import type {FullEngine} from '@/src/internal/engine/index.js';
-import type {StateSelector, Unsubscribe} from '@/src/internal/engine/index.js';
+import type {StateSelector} from '@/src/internal/engine/index.js';
 
 interface TestState {
   value: number;
@@ -55,23 +55,40 @@ describe('BaseController', () => {
   });
 
   describe('subscribe', () => {
-    it('delegates to engine.subscribe with the selector and callback', () => {
+    it('delegates to engine.subscribe with the selector', () => {
       const mockEngine = createMockEngine();
       const unsubscribeFn = vi.fn();
       vi.mocked(mockEngine.subscribe).mockReturnValue(unsubscribeFn);
 
       const selector: StateSelector<TestState> = (state) => state as unknown as TestState;
       const controller = new TestController(mockEngine, selector);
-      const callback = vi.fn();
+      const listener = vi.fn();
 
-      controller.subscribe(callback);
+      controller.subscribe(listener);
 
-      expect(mockEngine.subscribe).toHaveBeenCalledWith(selector, callback);
+      expect(mockEngine.subscribe).toHaveBeenCalledWith(selector, expect.any(Function));
+    });
+
+    it('calls the listener without arguments when engine notifies', () => {
+      const mockEngine = createMockEngine();
+      vi.mocked(mockEngine.subscribe).mockImplementation((_selector, callback) => {
+        callback({value: 99, label: 'new'});
+        return vi.fn();
+      });
+
+      const selector: StateSelector<TestState> = (state) => state as unknown as TestState;
+      const controller = new TestController(mockEngine, selector);
+      const listener = vi.fn();
+
+      controller.subscribe(listener);
+
+      expect(listener).toHaveBeenCalledWith();
+      expect(listener).toHaveBeenCalledTimes(1);
     });
 
     it('returns the unsubscribe function from engine', () => {
       const mockEngine = createMockEngine();
-      const unsubscribeFn: Unsubscribe = vi.fn();
+      const unsubscribeFn = vi.fn();
       vi.mocked(mockEngine.subscribe).mockReturnValue(unsubscribeFn);
 
       const selector: StateSelector<TestState> = (state) => state as unknown as TestState;

--- a/packages/thermidor/src/internal/utils/base-controller.ts
+++ b/packages/thermidor/src/internal/utils/base-controller.ts
@@ -1,5 +1,5 @@
 import type {FullEngine} from '@/src/internal/engine/index.js';
-import type {StateSelector, Unsubscribe} from '@/src/internal/engine/index.js';
+import type {StateSelector} from '@/src/internal/engine/index.js';
 import type {Controller} from './controller-types.js';
 
 export abstract class BaseController<TState> implements Controller<TState> {
@@ -16,7 +16,7 @@ export abstract class BaseController<TState> implements Controller<TState> {
     this.#stateSelector = stateSelector;
   }
 
-  subscribe(callback: (state: TState) => void): Unsubscribe {
-    return this.engine.subscribe(this.#stateSelector, callback);
+  subscribe(listener: () => void): () => void {
+    return this.engine.subscribe(this.#stateSelector, () => listener());
   }
 }

--- a/packages/thermidor/src/internal/utils/base-controller.ts
+++ b/packages/thermidor/src/internal/utils/base-controller.ts
@@ -1,5 +1,5 @@
 import type {FullEngine} from '@/src/internal/engine/index.js';
-import type {StateSelector} from '@/src/internal/engine/index.js';
+import type {StateSelector, Unsubscribe} from '@/src/internal/engine/index.js';
 import type {Controller} from './controller-types.js';
 
 export abstract class BaseController<TState> implements Controller<TState> {
@@ -16,7 +16,7 @@ export abstract class BaseController<TState> implements Controller<TState> {
     this.#stateSelector = stateSelector;
   }
 
-  subscribe(listener: () => void): () => void {
+  subscribe(listener: () => void): Unsubscribe {
     return this.engine.subscribe(this.#stateSelector, () => listener());
   }
 }

--- a/packages/thermidor/src/internal/utils/controller-types.ts
+++ b/packages/thermidor/src/internal/utils/controller-types.ts
@@ -1,5 +1,3 @@
-import {Unsubscribe} from '@/src/internal/engine/index.js';
-
 export interface Controller<T = unknown> {
   /**
    * The current state of the controller.
@@ -9,8 +7,8 @@ export interface Controller<T = unknown> {
   /**
    * Subscribes to controller state changes.
    *
-   * @param callback - Invoked with the new state when the controller state changes.
+   * @param listener - Invoked when the controller state changes.
    * @returns A function that unsubscribes the listener.
    */
-  subscribe(callback: (state: T) => void): Unsubscribe;
+  subscribe(listener: () => void): () => void;
 }

--- a/packages/thermidor/src/internal/utils/controller-types.ts
+++ b/packages/thermidor/src/internal/utils/controller-types.ts
@@ -1,3 +1,5 @@
+import type {Unsubscribe} from '@/src/internal/engine/index.js';
+
 export interface Controller<T = unknown> {
   /**
    * The current state of the controller.
@@ -10,5 +12,5 @@ export interface Controller<T = unknown> {
    * @param listener - Invoked when the controller state changes.
    * @returns A function that unsubscribes the listener.
    */
-  subscribe(listener: () => void): () => void;
+  subscribe(listener: () => void): Unsubscribe;
 }

--- a/samples/thermidor/commerce-react/src/hooks/use-build-controller.ts
+++ b/samples/thermidor/commerce-react/src/hooks/use-build-controller.ts
@@ -6,7 +6,6 @@ type StateOf<T> = T extends Controller<infer TState> ? TState : never;
 /**
  * Instantiates a controller once (via `useRef`) and subscribes to its state.
  * The subscription is automatically cleaned up by `useSyncExternalStore` on unmount.
- * The controller becomes eligible for garbage collection when the component unmounts.
  *
  * Returns the controller instance, and its reactive state.
  */
@@ -19,7 +18,7 @@ export function useBuildController<TController extends Controller<any>>(
   const controller = controllerRef.current;
 
   const subscribe = useCallback(
-    (onStoreChange: () => void) => controller.subscribe(onStoreChange),
+    (listener: () => void) => controller.subscribe(listener),
     [controller]
   );
 

--- a/samples/thermidor/demo-react/src/hooks/use-build-controller.ts
+++ b/samples/thermidor/demo-react/src/hooks/use-build-controller.ts
@@ -12,7 +12,7 @@ export function useBuildController<TController extends Controller<any>>(
   const controller = controllerRef.current;
 
   const subscribe = useCallback(
-    (onStoreChange: () => void) => controller.subscribe(onStoreChange),
+    (listener: () => void) => controller.subscribe(listener),
     [controller]
   );
 

--- a/samples/thermidor/generative-angular/src/app/services/conversation.service.ts
+++ b/samples/thermidor/generative-angular/src/app/services/conversation.service.ts
@@ -36,8 +36,8 @@ export class ConversationService {
     });
 
     this.applyState(this.controller.state);
-    this.controller.subscribe((state) => {
-      this.applyState(state);
+    this.controller.subscribe(() => {
+      this.applyState(this.controller.state);
       this.persistState();
     });
   }

--- a/samples/thermidor/generative-react/src/hooks/use-build-controller.ts
+++ b/samples/thermidor/generative-react/src/hooks/use-build-controller.ts
@@ -6,7 +6,6 @@ type StateOf<T> = T extends Controller<infer TState> ? TState : never;
 /**
  * Instantiates a controller once (via `useRef`) and subscribes to its state.
  * The subscription is automatically cleaned up by `useSyncExternalStore` on unmount.
- * The controller becomes eligible for garbage collection when the component unmounts.
  *
  * Returns the controller instance, and its reactive state.
  */
@@ -19,7 +18,7 @@ export function useBuildController<TController extends Controller<any>>(
   const controller = controllerRef.current;
 
   const subscribe = useCallback(
-    (onStoreChange: () => void) => controller.subscribe(onStoreChange),
+    (listener: () => void) => controller.subscribe(listener),
     [controller]
   );
 

--- a/samples/thermidor/search-react/src/hooks/use-build-controller.ts
+++ b/samples/thermidor/search-react/src/hooks/use-build-controller.ts
@@ -6,7 +6,6 @@ type StateOf<T> = T extends Controller<infer TState> ? TState : never;
 /**
  * Instantiates a controller once (via `useRef`) and subscribes to its state.
  * The subscription is automatically cleaned up by `useSyncExternalStore` on unmount.
- * The controller becomes eligible for garbage collection when the component unmounts.
  *
  * Returns the controller instance, and its reactive state.
  */
@@ -19,7 +18,7 @@ export function useBuildController<TController extends Controller<any>>(
   const controller = controllerRef.current;
 
   const subscribe = useCallback(
-    (onStoreChange: () => void) => controller.subscribe(onStoreChange),
+    (listener: () => void) => controller.subscribe(listener),
     [controller]
   );
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5951

The listener callback no longer receives the derived state as an argument. Consumers read `.state` on demand instead, aligning with the existing pattern in @coveo/headless (and also matching how React's `useSyncExternalStore` expects subscribe to work).

## Changes

- `controller-types.ts`: `subscribe(callback: (state: T) => void): Unsubscribe` → `subscribe(listener: () => void): Unsubscribe`
- `base-controller.ts`: wraps the engine callback so state isn't forwarded to the listener
- `base-controller.test.ts`: updated to assert the listener receives no arguments
- `useBuildController` hooks in Thermidor samples: renamed param from `onStoreChange` to `listener` for clarity