### PR TITLE
fix(coveo.analytics): add secure cookie attribute for HTTPS session

### DIFF
--- a/.changeset/cajs-secure-cookie-https.md
+++ b/.changeset/cajs-secure-cookie-https.md
@@ -1,0 +1,5 @@
+---
+'coveo.analytics': patch
+---
+
+Add `Secure` attribute on cookie when using HTTPS session

--- a/packages/coveo-analytics/src/cookieutils.spec.ts
+++ b/packages/coveo-analytics/src/cookieutils.spec.ts
@@ -1,0 +1,58 @@
+import {Cookie} from './cookieutils';
+
+describe('Cookie', () => {
+  const originalLocation = window.location;
+
+  const captureCookieWrite = (protocol: string, hostname: string) => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {...originalLocation, protocol, hostname},
+    });
+    const writes: string[] = [];
+    vi.spyOn(document, 'cookie', 'set').mockImplementation((value: string) => {
+      writes.push(value);
+    });
+    return writes;
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('adds the Secure attribute when the page is served over https', () => {
+    const writes = captureCookieWrite('https:', 'localhost');
+
+    Cookie.set('testCookie', 'testValue');
+
+    expect(writes[0]).toBe('testCookie=testValue;path=/;SameSite=Lax;Secure');
+  });
+
+  it('omits the Secure attribute when the page is served over http', () => {
+    const writes = captureCookieWrite('http:', 'localhost');
+
+    Cookie.set('testCookie', 'testValue');
+
+    expect(writes[0]).toBe('testCookie=testValue;path=/;SameSite=Lax');
+  });
+
+  it('keeps the domain attribute alongside Secure over https', () => {
+    const writes = captureCookieWrite('https:', 'subdomain.example.com');
+
+    Cookie.set('testCookie', 'testValue');
+
+    expect(writes[0]).toBe('testCookie=testValue;domain=example.com;path=/;SameSite=Lax;Secure');
+  });
+
+  it('keeps the expiration attribute alongside Secure over https', () => {
+    const writes = captureCookieWrite('https:', 'localhost');
+
+    Cookie.set('testCookie', 'testValue', 3600000);
+
+    expect(writes[0]).toContain('expires=');
+    expect(writes[0]).toContain(';path=/;SameSite=Lax;Secure');
+  });
+});

--- a/packages/coveo-analytics/src/cookieutils.spec.ts
+++ b/packages/coveo-analytics/src/cookieutils.spec.ts
@@ -1,3 +1,4 @@
+import {vi} from 'vitest';
 import {Cookie} from './cookieutils';
 
 describe('Cookie', () => {

--- a/packages/coveo-analytics/src/cookieutils.ts
+++ b/packages/coveo-analytics/src/cookieutils.ts
@@ -48,5 +48,6 @@ function writeCookie(name: string, value: string, expirationDate?: Date, domain?
     `${name}=${value}` +
     (expirationDate ? `;expires=${expirationDate.toUTCString()}` : '') +
     (domain ? `;domain=${domain}` : '') +
-    ';path=/;SameSite=Lax';
+    ';path=/;SameSite=Lax' +
+    (window.location.protocol === 'https:' ? ';Secure' : '');
 }


### PR DESCRIPTION
[KIT-5636](https://coveord.atlassian.net/browse/KIT-5636)

## Problem

[PR #7462](https://github.com/coveo/ui-kit/pull/7462) (`fix(headless): add secure cookie attribute for HTTPS session j:KIT-5636`) added the `Secure` cookie attribute for HTTPS sessions — but only to Headless's **vendored copy** of the coveo.analytics cookie module (`packages/headless/src/api/analytics/coveo.analytics/cookie.ts`).

`packages/coveo-analytics/src/cookieutils.ts` never received the fix. As a result, the `Cookie.set` path used by `CoveoAnalyticsClient`, `CookieStorage`, and the `coveoua` browser script still writes cookies **without** `Secure`, even over HTTPS — affecting every consumer of `coveo.analytics`, not just Headless.

Both copies exist because Headless vendored these modules in [PR #5346](https://github.com/coveo/ui-kit/pull/5346) to keep its ESM output treeshakeable, since coveo.analytics ships only bundled artifacts. That duplication is what [KIT-5959](https://coveord.atlassian.net/browse/KIT-5959) tracks; this PR closes the security-relevant divergence first, independently.

## Solution

Port the exact same conditional from the Headless copy into `packages/coveo-analytics/src/cookieutils.ts`:

```ts
(window.location.protocol === 'https:' ? ';Secure' : '')
```

- `Secure` is added only over HTTPS, so plain-HTTP pages are unaffected.
- Adds `src/cookieutils.spec.ts` covering the https/http cases plus interaction with the `domain` and `expires` attributes (coverage the package had none of before).
- Matches the versioning precedent of #7462, which shipped this same change as a `patch`.

All 714 existing coveo.analytics tests pass.


[KIT-5636]: https://coveord.atlassian.net/browse/KIT-5636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIT-5959]: https://coveord.atlassian.net/browse/KIT-5959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ