### PR TITLE
chore: add areas file for coveo.analytics

### DIFF
--- a/.areas/coveo-analytics.yml
+++ b/.areas/coveo-analytics.yml
@@ -1,0 +1,5 @@
+description: Coveo analytics library (coveo.analytics)
+file_patterns:
+  - packages/coveo-analytics/**
+reviewers:
+  dxui: ~


### PR DESCRIPTION
## Problem

`packages/coveo-analytics/` had no entry in `.areas/`, so changes to the recently-imported `coveo.analytics` package (#8057) had no area-based reviewer assignment.

`root.yml` matches `packages/*` (non-recursive, intended to catch newly added packages), so files deeper inside `packages/coveo-analytics/` were not covered by any area.

## Solution

Add `.areas/coveo-analytics.yml` assigning `dxui` as reviewer, following the same shape as the existing `relay.yml` / `bueno.yml` areas.

`relay` already has an area file (`.areas/relay.yml`, covering `packages/relay/**` and `packages/relay-playground/**` with `dxui`), so no change was needed there.
