### PR TITLE
fix(quantic): stabilize sort keyboard accessibility E2E test

### DIFF
--- a/packages/quantic/force-app/main/default/lwc/quanticSort/e2e/pageObject.ts
+++ b/packages/quantic/force-app/main/default/lwc/quanticSort/e2e/pageObject.ts
@@ -43,7 +43,13 @@ export class SortObject {
   async selectNextSortOptionUsingKeyboard(
     expectedLabel: string
   ): Promise<void> {
+    const previousDescendant =
+      await this.sortDropDown.getAttribute('aria-activedescendant');
     await this.sortDropDown.press('ArrowDown');
+    await expect(this.sortDropDown).not.toHaveAttribute(
+      'aria-activedescendant',
+      previousDescendant ?? ''
+    );
     await this.sortDropDown.press('Enter');
     await expect(this.sortDropDown).toHaveText(expectedLabel);
   }


### PR DESCRIPTION
[KIT-5978](https://coveord.atlassian.net/browse/KIT-5978)

## Problem

The Quantic Sort E2E test `should be accessible to keyboard` is flaky in CI. The `selectNextSortOptionUsingKeyboard` page object method presses `ArrowDown` then immediately `Enter` on the SLDS combobox, but the combobox does not always process the ArrowDown navigation before Enter is received. This causes the wrong sort option to be selected intermittently.

Evidence from [CI run #16425](https://github.com/coveo/ui-kit/actions/runs/30913026735/job/92006510879):
- First attempt: Expected "Newest" but received "Relevancy" (ArrowDown had no effect)
- Retry `#2`: Expected "Oldest" but received "Newest"

The cause is NOT throttling (confirmed).

## Solution

Wait for `aria-activedescendant` to change after pressing ArrowDown before pressing Enter. This ensures the combobox has fully processed the keyboard navigation and moved focus to the next option before committing the selection.

[KIT-5978]: https://coveord.atlassian.net/browse/KIT-5978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ