### PR TITLE
fix(ci): avoid Chromatic merge-queue baselines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,7 +394,7 @@ jobs:
         if: contains(needs.affected.outputs.projects, '@coveo/atomic') && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'chromatic')
       - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --skip
         working-directory: packages/atomic
-        if: steps.chromatic-run.outcome == 'skipped'
+        if: github.event_name == 'pull_request' && steps.chromatic-run.outcome == 'skipped'
   playwright-atomic:
     name: 'Run Playwright tests for Atomic'
     needs: affected


### PR DESCRIPTION
## Motivation

TurboSnap repeatedly performs full Storybook rebuilds after falling back across merge-queue commits that no longer exist in Git history.

## Root Cause

The Chromatic fallback step invoked `chromatic --skip` for `merge_group` runs. Although it skipped visual tests, it still recorded an ephemeral merge-queue SHA as a Chromatic build. Subsequent builds could not resolve that SHA and fell back to a baseline predating a Storybook configuration change, causing `changedStorybookFiles` bailouts.

## Changes

Run the fallback `chromatic --skip` command only for pull-request events. Merge-queue checks remain successful without recording an ephemeral Chromatic build.

## Validation

- `pnpm run lint:fix`

## Checklist

- [x] PR title follows Conventional Commits 1.0.0 format
- [x] No changeset required; this modifies CI configuration only