### PR TITLE
fix(coveo.analytics): omit cookie domain attribute for IP address hosts

### DIFF
--- a/.changeset/cajs-cookie-ip-host-domain.md
+++ b/.changeset/cajs-cookie-ip-host-domain.md
@@ -1,0 +1,5 @@
+---
+'coveo.analytics': minor
+---
+
+Stop deriving a cookie `domain` attribute from an IP address host. On a host such as `192.168.1.5`, `Cookie.set` previously wrote `;domain=1.5`, which browsers reject, so the visitor ID cookie was silently dropped. IP hosts are now written without a `domain` attribute, matching the behavior already used for hosts without a dot.

--- a/packages/coveo-analytics/src/cookieutils.spec.ts
+++ b/packages/coveo-analytics/src/cookieutils.spec.ts
@@ -1,59 +1,212 @@
-import {vi} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {Cookie} from './cookieutils';
 
 describe('Cookie', () => {
-  const originalLocation = window.location;
+  const mockDocument = {cookie: ''};
+  const mockWindow = {location: {hostname: '', protocol: ''}};
 
-  const captureCookieWrite = (protocol: string, hostname: string) => {
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: {...originalLocation, protocol, hostname},
-    });
-    const writes: string[] = [];
-    vi.spyOn(document, 'cookie', 'set').mockImplementation((value: string) => {
-      writes.push(value);
-    });
-    return writes;
-  };
+  beforeEach(() => {
+    vi.stubGlobal('document', mockDocument);
+    vi.stubGlobal('window', mockWindow);
+    mockWindow.location.hostname = 'example.com';
+    mockWindow.location.protocol = 'http:';
+    mockDocument.cookie = '';
+  });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: originalLocation,
+    vi.unstubAllGlobals();
+  });
+
+  describe('set', () => {
+    it('should set a cookie with name and value on a single domain', () => {
+      mockWindow.location.hostname = 'localhost';
+
+      Cookie.set('testCookie', 'testValue');
+
+      expect(mockDocument.cookie).toBe('testCookie=testValue;path=/;SameSite=Lax');
+    });
+
+    it('should set a cookie with domain for multi-level domain', () => {
+      mockWindow.location.hostname = 'subdomain.example.com';
+
+      Cookie.set('testCookie', 'testValue');
+
+      expect(mockDocument.cookie).toBe(
+        'testCookie=testValue;domain=example.com;path=/;SameSite=Lax'
+      );
+    });
+
+    it('should extract correct domain from multi-level subdomain', () => {
+      mockWindow.location.hostname = 'deep.subdomain.example.com';
+
+      Cookie.set('testCookie', 'testValue');
+
+      expect(mockDocument.cookie).toBe(
+        'testCookie=testValue;domain=example.com;path=/;SameSite=Lax'
+      );
+    });
+
+    it('should keep the last two labels of a multi-part public suffix', () => {
+      mockWindow.location.hostname = 'test.co.uk';
+
+      Cookie.set('testCookie', 'testValue');
+
+      expect(mockDocument.cookie).toBe('testCookie=testValue;domain=co.uk;path=/;SameSite=Lax');
+    });
+
+    it('should set a cookie with expiration date when expire is provided', () => {
+      mockWindow.location.hostname = 'localhost';
+
+      Cookie.set('testCookie', 'testValue', 3600000);
+
+      expect(mockDocument.cookie).toContain('testCookie=testValue');
+      expect(mockDocument.cookie).toContain('expires=');
+      expect(mockDocument.cookie).toContain('path=/;SameSite=Lax');
+    });
+
+    it('should add the Secure attribute when the page is served over https', () => {
+      mockWindow.location.protocol = 'https:';
+      mockWindow.location.hostname = 'localhost';
+
+      Cookie.set('testCookie', 'testValue');
+
+      expect(mockDocument.cookie).toBe('testCookie=testValue;path=/;SameSite=Lax;Secure');
+    });
+
+    it('should omit the Secure attribute when the page is served over http', () => {
+      mockWindow.location.hostname = 'localhost';
+
+      Cookie.set('testCookie', 'testValue');
+
+      expect(mockDocument.cookie).toBe('testCookie=testValue;path=/;SameSite=Lax');
+    });
+
+    it('should keep the domain attribute alongside Secure over https', () => {
+      mockWindow.location.protocol = 'https:';
+      mockWindow.location.hostname = 'subdomain.example.com';
+
+      Cookie.set('testCookie', 'testValue');
+
+      expect(mockDocument.cookie).toBe(
+        'testCookie=testValue;domain=example.com;path=/;SameSite=Lax;Secure'
+      );
+    });
+
+    it('should keep the expiration attribute alongside Secure over https', () => {
+      mockWindow.location.protocol = 'https:';
+      mockWindow.location.hostname = 'localhost';
+
+      Cookie.set('testCookie', 'testValue', 3600000);
+
+      expect(mockDocument.cookie).toContain('expires=');
+      expect(mockDocument.cookie).toContain(';path=/;SameSite=Lax;Secure');
+    });
+
+    it('should omit the domain attribute for an IPv4 host', () => {
+      mockWindow.location.hostname = '192.168.1.1';
+
+      Cookie.set('testCookie', 'testValue');
+
+      expect(mockDocument.cookie).toBe('testCookie=testValue;path=/;SameSite=Lax');
+    });
+
+    it('should omit the domain attribute for a bracketless IPv6 host', () => {
+      mockWindow.location.hostname = 'fe80::1';
+
+      Cookie.set('testCookie', 'testValue');
+
+      expect(mockDocument.cookie).toBe('testCookie=testValue;path=/;SameSite=Lax');
+    });
+
+    it('should omit the domain attribute for a bracketed IPv6 host', () => {
+      mockWindow.location.hostname = '[::1]';
+
+      Cookie.set('testCookie', 'testValue');
+
+      expect(mockDocument.cookie).toBe('testCookie=testValue;path=/;SameSite=Lax');
+    });
+
+    it('should handle hostname with only one dot', () => {
+      mockWindow.location.hostname = 'example.com';
+
+      Cookie.set('testCookie', 'testValue');
+
+      expect(mockDocument.cookie).toBe(
+        'testCookie=testValue;domain=example.com;path=/;SameSite=Lax'
+      );
+    });
+
+    it('should handle empty cookie name gracefully', () => {
+      mockWindow.location.hostname = 'localhost';
+
+      Cookie.set('', 'testValue');
+
+      expect(mockDocument.cookie).toBe('=testValue;path=/;SameSite=Lax');
+    });
+
+    it('should handle special characters in cookie values', () => {
+      mockWindow.location.hostname = 'localhost';
+      const specialValue = 'test=value;with,special|chars';
+
+      Cookie.set('testCookie', specialValue);
+
+      expect(mockDocument.cookie).toBe(`testCookie=${specialValue};path=/;SameSite=Lax`);
     });
   });
 
-  it('adds the Secure attribute when the page is served over https', () => {
-    const writes = captureCookieWrite('https:', 'localhost');
+  describe('get', () => {
+    it('should return the cookie value when cookie exists', () => {
+      mockDocument.cookie = 'testCookie=testValue; otherCookie=otherValue';
 
-    Cookie.set('testCookie', 'testValue');
+      expect(Cookie.get('testCookie')).toBe('testValue');
+    });
 
-    expect(writes[0]).toBe('testCookie=testValue;path=/;SameSite=Lax;Secure');
+    it('should return the cookie value when cookie has spaces', () => {
+      mockDocument.cookie = ' testCookie=testValue ; otherCookie=otherValue';
+
+      expect(Cookie.get('testCookie')).toBe('testValue ');
+    });
+
+    it('should return null when cookie does not exist', () => {
+      mockDocument.cookie = 'otherCookie=otherValue';
+
+      expect(Cookie.get('testCookie')).toBeNull();
+    });
+
+    it('should return null when no cookies exist', () => {
+      mockDocument.cookie = '';
+
+      expect(Cookie.get('testCookie')).toBeNull();
+    });
+
+    it('should handle cookies with empty values', () => {
+      mockDocument.cookie = 'testCookie=; otherCookie=otherValue';
+
+      expect(Cookie.get('testCookie')).toBe('');
+    });
+
+    it('should handle cookies with complex values', () => {
+      const complexValue = 'value with spaces and symbols!@#$%';
+      mockDocument.cookie = `testCookie=${complexValue}; otherCookie=otherValue`;
+
+      expect(Cookie.get('testCookie')).toBe(complexValue);
+    });
+
+    it('should return the first matching cookie when multiple cookies have the same prefix', () => {
+      mockDocument.cookie = 'testCookie=firstValue; testCookieExtended=secondValue';
+
+      expect(Cookie.get('testCookie')).toBe('firstValue');
+    });
   });
 
-  it('omits the Secure attribute when the page is served over http', () => {
-    const writes = captureCookieWrite('http:', 'localhost');
+  describe('erase', () => {
+    it('should call set with empty value and negative expiration', () => {
+      const setSpy = vi.spyOn(Cookie, 'set');
 
-    Cookie.set('testCookie', 'testValue');
+      Cookie.erase('testCookie');
 
-    expect(writes[0]).toBe('testCookie=testValue;path=/;SameSite=Lax');
-  });
-
-  it('keeps the domain attribute alongside Secure over https', () => {
-    const writes = captureCookieWrite('https:', 'subdomain.example.com');
-
-    Cookie.set('testCookie', 'testValue');
-
-    expect(writes[0]).toBe('testCookie=testValue;domain=example.com;path=/;SameSite=Lax;Secure');
-  });
-
-  it('keeps the expiration attribute alongside Secure over https', () => {
-    const writes = captureCookieWrite('https:', 'localhost');
-
-    Cookie.set('testCookie', 'testValue', 3600000);
-
-    expect(writes[0]).toContain('expires=');
-    expect(writes[0]).toContain(';path=/;SameSite=Lax;Secure');
+      expect(setSpy).toHaveBeenCalledWith('testCookie', '', -1);
+    });
   });
 });

--- a/packages/coveo-analytics/src/cookieutils.ts
+++ b/packages/coveo-analytics/src/cookieutils.ts
@@ -14,7 +14,11 @@ export class Cookie {
       expirationDate.setTime(expirationDate.getTime() + expire);
     }
     host = window.location.hostname;
-    if (host.indexOf('.') === -1) {
+    if (isIpAddress(host)) {
+      // Deriving a domain from an IP address yields a value the browser rejects, e.g. `1.5` for
+      // `192.168.1.5`, which silently drops the cookie. IP hosts must be set without a domain.
+      writeCookie(name, value, expirationDate);
+    } else if (host.indexOf('.') === -1) {
       // no "." in a domain - single domain name, it's localhost or something similar
       writeCookie(name, value, expirationDate);
     } else {
@@ -41,6 +45,15 @@ export class Cookie {
   static erase(name: string) {
     Cookie.set(name, '', -1);
   }
+}
+
+const ipv4Pattern = /^(\d{1,3}\.){3}\d{1,3}$/;
+// A bracketless IPv6 host, as exposed by `location.hostname` in non-browser runtimes. Browsers
+// bracket it, and brackets contain no ".", so those already take the domainless path above.
+const ipv6Pattern = /^([0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}$/;
+
+function isIpAddress(host: string) {
+  return ipv4Pattern.test(host) || ipv6Pattern.test(host);
 }
 
 function writeCookie(name: string, value: string, expirationDate?: Date, domain?: string) {


### PR DESCRIPTION
[KIT-5959](https://coveord.atlassian.net/browse/KIT-5959)

## Problem

`Cookie.set` derives the cookie `domain` attribute by taking the last two dot-separated labels of the host. That is wrong for IPv4 hosts: on `192.168.1.5` it computes `domain=1.5`, which is not a suffix of the host, so **the browser rejects the cookie and it is silently dropped**.

This path is not Headless-specific — it is how every browser consumer of `CoveoAnalyticsClient` persists the visitor ID:

```
CoveoAnalyticsClient (client/analytics.ts:240)
  -> new BrowserRuntime(...)
  -> new CookieAndLocalStorage()   (runtimeEnvironment.ts:29)
  -> CookieStorage.setItem         (storage.ts:37)
  -> Cookie.set                    (cookieutils.ts)
```

So anyone served over a bare IP — LAN, dev/staging, appliance deployments — loses visitor ID persistence, via the `coveoua` script and Quantic as much as Headless.

Headless already handles this in its vendored copy of the module (`packages/headless/src/api/analytics/coveo.analytics/cookie.ts`) — and that is the **only** place it has ever been handled.

To be precise about the origin, since it changes how this PR should be read: this logic has never existed in `coveo.analytics` in any form. Verified four ways:

- The upstream repo `coveo/coveo.analytics.js` (now archived) has `src/cookieutils.ts` on `master` with no IP branch, logically identical to this package's current version.
- Code search for `ipv4Regex` in that repo: 0 results.
- Published tarballs `2.30.56` and `2.31.0`: no IPv4 pattern in `dist/library.mjs`.
- Org-wide code search for `ipv4Regex` across `coveo`: exactly one hit, the Headless vendored copy.

It was authored from scratch in [PR #5346](https://github.com/coveo/ui-kit/pull/5346) (*stop bundling ESM headless for NPM*) — the same PR that created the vendored copies — as an undocumented change made while copying the file (branch commit `80d43f02c9`, "ut & tweak cajs copy", squashed into [`7de844f`](https://github.com/coveo/ui-kit/commit/7de844f634)).

So **this PR is not porting a fix back; it is introducing behavior that only ever lived in a private copy.** The bug has been live for every `coveo.analytics` consumer since long before the vendoring, and it was invisible because the only fixed copy was one nobody publishes.

That is also a different failure mode from the `Secure` attribute, which genuinely was later drift ([PR #7462](https://github.com/coveo/ui-kit/pull/7462), ported back in #8156).

## Solution

Treat an IP host like a host with no `.`: write the cookie without a `domain` attribute.

```ts
if (isIpAddress(host)) {
  writeCookie(name, value, expirationDate);
} else if (host.indexOf('.') === -1) {
  ...
```

**Only the IPv4 branch changes behavior.** IPv6 hostnames contain no `.`, so they already took the domainless path; the IPv6 pattern is defensive parity with the Headless copy, and its tests pass before and after. I verified this rather than assuming it — see below.

## Tests

The vendored Headless copy had 18 tests for this module against 4 here, so I ported the missing coverage while I was in the file. `src/cookieutils.spec.ts` goes from 4 to 23 tests, now covering `get`, `erase`, multi-level subdomains, multi-part public suffixes, empty names, special characters, and both IP families.

The existing `Secure` assertions are preserved, restated in the same global-stubbing style as the rest of the file rather than leaving two different mocking approaches in one spec.

Confirmed the new test actually pins the fix — reverting only the source change fails exactly one test, with the real-world symptom:

```
× should omit the domain attribute for an IPv4 host
  AssertionError: expected 'testCookie=testValue;domain=1.1;path=…'
                        to be 'testCookie=testValue;path=/;SameSite=…'
```

## Verification

- 734 tests pass across 18 files (`coveo.analytics#test`), up from 714.
- `coveo.analytics#build` passes; `lint:check` clean.

## Notes for review

- Marked `minor` rather than `patch`. It is a bug fix, but it changes cookie-writing behavior for every consumer of the package, so it seemed worth the more visible bump. #8156 shipped the comparable `Secure` addition as a patch, so say the word if you'd rather align with that precedent.
- This unblocks KIT-5959: Headless cannot delete its vendored copy until this behavior exists here, otherwise the swap is a silent regression.


[KIT-5959]: https://coveord.atlassian.net/browse/KIT-5959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

