### PR TITLE
ci: migrate Chromatic to GitHub Action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -263,8 +263,6 @@ jobs:
   chromatic-update-main:
     name: 'Update Chromatic baseline on main'
     runs-on: ubuntu-latest
-    env:
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -276,4 +274,13 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --exit-zero-on-changes --auto-accept-changes --branchName=main
+        with:
+          load-cache: 'false'
+      - name: Update Chromatic baseline
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
+        with:
+          autoAcceptChanges: true
+          branchName: main
+          exitZeroOnChanges: true
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: packages/atomic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,13 +350,6 @@ jobs:
     name: 'Run Chromatic visual tests on Atomic'
     needs: build
     runs-on: ubuntu-latest
-    env:
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-      # Should be fine without because of https://github.com/chromaui/chromatic-cli/blob/56920bf704895dcef6d1106df608d8e0d7886b58/action-src/main.ts#L24-L82
-      # # https://www.chromatic.com/docs/faq/environment-variables/#how-to-set-chromatic-environment-variables-in-popular-ci-providers
-      # CHROMATIC_SHA: ${{ github.event.pull_request.head.sha }}
-      # CHROMATIC_BRANCH: ${{ github.head_ref }}
-      # CHROMATIC_SLUG: ${{ github.repository }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -374,12 +367,20 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic
+      - name: Run Chromatic visual tests
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         id: chromatic-run
         if: contains(needs.build.outputs.projects, '@coveo/atomic') && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'chromatic')
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --skip
-        working-directory: packages/atomic
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: packages/atomic
+      - name: Skip Chromatic visual tests
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         if: steps.chromatic-run.outcome == 'skipped'
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          skip: true
+          workingDir: packages/atomic
   playwright-atomic:
     name: 'Run Playwright tests for Atomic'
     needs: build


### PR DESCRIPTION
## Motivation

Chromatic CLI logs recommend using the official GitHub Action. The action provides supported GitHub event metadata handling while preserving Atomic's existing Chromatic configuration.

## Changes

- Replaces raw Chromatic CLI calls in CI with the immutable StepSecurity-style pin `chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719` (`v18.1.0`).
- Runs the action from `packages/atomic`, retaining the package's build command and TurboSnap configuration.
- Preserves CI skip behavior and CD's auto-accept, main-branch, and exit-zero behavior through action inputs.

## Validation

- `pnpm run lint:fix`
- Verified the action metadata supports `workingDir`, `skip`, `autoAcceptChanges`, `branchName`, and `exitZeroOnChanges`.
- PR CI will exercise the action with the repository Chromatic token.

## Checklist

- [x] PR title follows Conventional Commits 1.0.0 format
- [x] No changeset required; this modifies CI configuration only

## Chromatic CI stack

Physical PR order:

1. #8175 — migrate Chromatic to the official GitHub Action
2. #8187 — preserve required Chromatic statuses on release PRs
3. #8188 — skip full Chromatic builds on Renovate PRs by default
