### PR TITLE
fix(ci): always run Chromatic status checks

### DIFF
--- a/packages/atomic/turbo.json
+++ b/packages/atomic/turbo.json
@@ -28,6 +28,7 @@
       "env": ["STORYBOOK_INVOKED_BY"]
     },
     "chromatic": {
+      "cache": false,
       "dependsOn": [],
       "outputs": [],
       "env": ["CHROMATIC_PROJECT_TOKEN", "CHROMATIC_SHA", "CHROMATIC_BRANCH", "CHROMATIC_SLUG"]


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-5985

## Motivation

Turbo caching can skip the Chromatic task, preventing its required pull-request status check from being reported reliably.

## Root Cause

Turbo caches task results by default. A cache hit for the `chromatic` task restores the task result instead of invoking Chromatic, so no fresh status check is sent to the pull request.

## Changes

- Disable Turbo caching for Atomic’s `chromatic` task so Chromatic runs on every pull request.

## Validation

- Reviewed the task configuration: `cache: false` prevents Turbo from restoring the `chromatic` task from cache.
- Unit tests were not run because this is a CI task-configuration change; the next PR workflow run will exercise the fix.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`fix(ci): <description>`)