### PR TITLE
ci: gate Chromatic by Atomic dependencies

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -246,8 +246,6 @@ jobs:
   chromatic-update-main:
     name: 'Update Chromatic baseline on main'
     runs-on: ubuntu-latest
-    env:
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -261,4 +259,11 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           load-cache: 'false'
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --exit-zero-on-changes --auto-accept-changes --branchName=main
+      - name: Update Chromatic baseline
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
+        with:
+          autoAcceptChanges: true
+          branchName: main
+          exitZeroOnChanges: true
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: packages/atomic

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -259,11 +259,19 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           load-cache: 'false'
+      - name: Determine whether to update the Chromatic baseline
+        id: chromatic-gate
+        env:
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: node utils/ci/chromatic-gate.mjs --base "${BASE_SHA}" --head "${HEAD_SHA}"
       - name: Update Chromatic baseline
         uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
+        if: steps.chromatic-gate.outputs.should_run == 'true'
         with:
           autoAcceptChanges: true
           branchName: main
           exitZeroOnChanges: true
+          onlyChanged: ${{ steps.chromatic-gate.outputs.dependency_changed != 'true' }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/atomic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,19 +372,18 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
-      - name: Run Chromatic visual tests
+      - name: Determine whether to run Chromatic
+        id: chromatic-gate
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: node utils/ci/chromatic-gate.mjs --base "${BASE_SHA}" --head "${HEAD_SHA}"
+      - name: Run or skip Chromatic visual tests
         uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
-        id: chromatic-run
-        if: contains(needs.build.outputs.projects, '@coveo/atomic') && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'chromatic')
         with:
+          onlyChanged: ${{ steps.chromatic-gate.outputs.dependency_changed != 'true' }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          workingDir: packages/atomic
-      - name: Skip Chromatic visual tests
-        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
-        if: steps.chromatic-run.outcome == 'skipped'
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          skip: true
+          skip: ${{ steps.chromatic-gate.outputs.should_run != 'true' }}
           workingDir: packages/atomic
   playwright-atomic:
     name: 'Run Playwright tests for Atomic'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,13 +355,6 @@ jobs:
     name: 'Run Chromatic visual tests on Atomic'
     needs: build
     runs-on: ubuntu-latest
-    env:
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-      # Should be fine without because of https://github.com/chromaui/chromatic-cli/blob/56920bf704895dcef6d1106df608d8e0d7886b58/action-src/main.ts#L24-L82
-      # # https://www.chromatic.com/docs/faq/environment-variables/#how-to-set-chromatic-environment-variables-in-popular-ci-providers
-      # CHROMATIC_SHA: ${{ github.event.pull_request.head.sha }}
-      # CHROMATIC_BRANCH: ${{ github.head_ref }}
-      # CHROMATIC_SLUG: ${{ github.repository }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -379,12 +372,20 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic
+      - name: Run Chromatic visual tests
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         id: chromatic-run
         if: contains(needs.build.outputs.projects, '@coveo/atomic') && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'chromatic')
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --skip
-        working-directory: packages/atomic
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: packages/atomic
+      - name: Skip Chromatic visual tests
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         if: steps.chromatic-run.outcome == 'skipped'
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          skip: true
+          workingDir: packages/atomic
   playwright-atomic:
     name: 'Run Playwright tests for Atomic'
     needs: build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2276,6 +2276,9 @@ importers:
       octokit:
         specifier: 5.0.5
         version: 5.0.5
+      yaml:
+        specifier: 'catalog:'
+        version: 2.9.0
 
 packages:
 

--- a/utils/ci/chromatic-gate.mjs
+++ b/utils/ci/chromatic-gate.mjs
@@ -1,0 +1,203 @@
+import {execFileSync} from 'node:child_process';
+import {appendFileSync} from 'node:fs';
+import {pathToFileURL} from 'node:url';
+import {parse as parseYaml} from 'yaml';
+
+const dependencySections = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+];
+const lockDependencySections = ['dependencies', 'devDependencies', 'optionalDependencies'];
+const localProtocolPattern = /^(workspace:|link:|file:|portal:)/;
+const dependencyInputPaths = new Set([
+  'packages/atomic/package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+]);
+
+const stable = (value) => JSON.stringify(value, Object.keys(value ?? {}).sort());
+
+const catalogVersion = (workspace, dependency, specifier) => {
+  if (!specifier.startsWith('catalog:')) {
+    return specifier;
+  }
+
+  const catalogName = specifier.slice('catalog:'.length);
+  const catalog = catalogName ? workspace.catalogs?.[catalogName] : workspace.catalog;
+  const version = catalog?.[dependency];
+
+  if (!version) {
+    throw new Error(`Could not resolve ${dependency} from ${specifier}`);
+  }
+
+  return `catalog:${catalogName}:${version}`;
+};
+
+const directExternalDependencies = (manifest) => {
+  const dependencies = new Map();
+
+  for (const section of dependencySections) {
+    for (const [dependency, specifier] of Object.entries(manifest[section] ?? {})) {
+      if (localProtocolPattern.test(specifier)) {
+        continue;
+      }
+
+      const entry = dependencies.get(dependency) ?? {sections: new Set(), specifiers: []};
+      entry.sections.add(section);
+      entry.specifiers.push({section, specifier});
+      dependencies.set(dependency, entry);
+    }
+  }
+
+  return dependencies;
+};
+
+const lockVersion = (entry) => {
+  if (typeof entry === 'string') {
+    return entry;
+  }
+
+  return entry?.version ?? null;
+};
+
+const dependencyState = ({dependency, directDependency, manifest, workspace, lock}) => {
+  if (!directDependency) {
+    return null;
+  }
+
+  const importer = lock.importers?.['packages/atomic'];
+  if (!importer) {
+    throw new Error('Missing packages/atomic importer in pnpm-lock.yaml');
+  }
+
+  const specifiers = directDependency.specifiers
+    .map(({section, specifier}) => `${section}:${catalogVersion(workspace, dependency, specifier)}`)
+    .sort();
+  const lockVersions = [];
+
+  for (const section of lockDependencySections) {
+    if (!directDependency.sections.has(section)) {
+      continue;
+    }
+
+    const version = lockVersion(importer[section]?.[dependency]);
+    if (!version) {
+      throw new Error(`Missing ${dependency} resolution in ${section}`);
+    }
+    lockVersions.push(`${section}:${version}`);
+  }
+
+  return {specifiers, lockVersions: lockVersions.sort()};
+};
+
+export const evaluateChromaticGate = ({changedFiles, base, head}) => {
+  const atomicChanged = changedFiles.some((file) => file.startsWith('packages/atomic/'));
+  const dependencyInputsChanged = changedFiles.some((file) => dependencyInputPaths.has(file));
+
+  if (!dependencyInputsChanged) {
+    return {
+      shouldRun: atomicChanged,
+      dependencyChanged: false,
+      reasons: atomicChanged ? ['atomic-changed'] : [],
+    };
+  }
+
+  try {
+    const baseDependencies = directExternalDependencies(base.manifest);
+    const headDependencies = directExternalDependencies(head.manifest);
+    const dependencies = new Set([...baseDependencies.keys(), ...headDependencies.keys()]);
+    const changedDependencies = [];
+
+    for (const dependency of dependencies) {
+      const baseState = dependencyState({
+        dependency,
+        directDependency: baseDependencies.get(dependency),
+        manifest: base.manifest,
+        workspace: base.workspace,
+        lock: base.lock,
+      });
+      const headState = dependencyState({
+        dependency,
+        directDependency: headDependencies.get(dependency),
+        manifest: head.manifest,
+        workspace: head.workspace,
+        lock: head.lock,
+      });
+
+      if (stable(baseState) !== stable(headState)) {
+        changedDependencies.push(dependency);
+      }
+    }
+
+    return {
+      shouldRun: atomicChanged || changedDependencies.length > 0,
+      dependencyChanged: changedDependencies.length > 0,
+      reasons: [...(atomicChanged ? ['atomic-changed'] : []), ...changedDependencies],
+    };
+  } catch (error) {
+    return {
+      shouldRun: true,
+      dependencyChanged: true,
+      reasons: [`invalid-dependency-state:${error.message}`],
+    };
+  }
+};
+
+const git = (args) =>
+  execFileSync('git', args, {encoding: 'utf8', maxBuffer: 50 * 1024 * 1024}).trim();
+
+const gitFile = (sha, path) => git(['show', `${sha}:${path}`]);
+
+const readState = (sha) => ({
+  manifest: JSON.parse(gitFile(sha, 'packages/atomic/package.json')),
+  workspace: parseYaml(gitFile(sha, 'pnpm-workspace.yaml')),
+  lock: parseYaml(gitFile(sha, 'pnpm-lock.yaml')),
+});
+
+const writeOutput = (result) => {
+  const output = [
+    `should_run=${result.shouldRun}`,
+    `dependency_changed=${result.dependencyChanged}`,
+    `reasons=${result.reasons.join(',')}`,
+  ].join('\n');
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${output}\n`);
+  } else {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  }
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [baseFlag, base, headFlag, head] = process.argv.slice(2);
+
+  if (baseFlag !== '--base' || headFlag !== '--head') {
+    throw new Error('Usage: node chromatic-gate.mjs --base <sha> --head <sha>');
+  }
+
+  let result;
+  if (!base || !head) {
+    result = {
+      shouldRun: true,
+      dependencyChanged: true,
+      reasons: ['invalid-git-state:missing-base-or-head'],
+    };
+  } else {
+    try {
+      const changedFiles = git(['diff', '--name-only', '--no-renames', `${base}..${head}`])
+        .split('\n')
+        .filter(Boolean);
+      result = evaluateChromaticGate({changedFiles, base: readState(base), head: readState(head)});
+    } catch (error) {
+      result = {
+        shouldRun: true,
+        dependencyChanged: true,
+        reasons: [`invalid-git-state:${error.message}`],
+      };
+    }
+  }
+
+  writeOutput(result);
+}

--- a/utils/ci/chromatic-gate.test.mjs
+++ b/utils/ci/chromatic-gate.test.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {evaluateChromaticGate} from './chromatic-gate.mjs';
+
+const state = ({dependencies = {}, devDependencies = {}, catalog = {}, importer = {}} = {}) => ({
+  manifest: {dependencies, devDependencies},
+  workspace: {catalog},
+  lock: {importers: {'packages/atomic': importer}},
+});
+
+const evaluate = ({changedFiles = [], base, head}) =>
+  evaluateChromaticGate({changedFiles, base, head});
+
+test('runs for Atomic source, Storybook, assets, and configuration changes', () => {
+  const fixture = state();
+
+  for (const file of [
+    'packages/atomic/src/components/common/button.ts',
+    'packages/atomic/.storybook/preview.ts',
+    'packages/atomic/src/assets/lang/en.json',
+    'packages/atomic/chromatic.config.json',
+  ]) {
+    assert.equal(evaluate({changedFiles: [file], base: fixture, head: fixture}).shouldRun, true);
+  }
+});
+
+test('runs when a direct catalog dependency changes', () => {
+  const base = state({
+    devDependencies: {tailwindcss: 'catalog:'},
+    catalog: {tailwindcss: '4.3.2'},
+    importer: {devDependencies: {tailwindcss: {version: '4.3.2'}}},
+  });
+  const head = state({
+    devDependencies: {tailwindcss: 'catalog:'},
+    catalog: {tailwindcss: '4.3.3'},
+    importer: {devDependencies: {tailwindcss: {version: '4.3.3'}}},
+  });
+
+  const result = evaluate({changedFiles: ['pnpm-workspace.yaml', 'pnpm-lock.yaml'], base, head});
+  assert.equal(result.shouldRun, true);
+  assert.equal(result.dependencyChanged, true);
+  assert.deepEqual(result.reasons, ['tailwindcss']);
+});
+
+test('disables TurboSnap when an Atomic direct dependency declaration changes', () => {
+  const base = state({
+    devDependencies: {tailwindcss: '4.3.2'},
+    importer: {devDependencies: {tailwindcss: {version: '4.3.2'}}},
+  });
+  const head = state({
+    devDependencies: {tailwindcss: '4.3.3'},
+    importer: {devDependencies: {tailwindcss: {version: '4.3.3'}}},
+  });
+
+  const result = evaluate({
+    changedFiles: ['packages/atomic/package.json', 'pnpm-lock.yaml'],
+    base,
+    head,
+  });
+  assert.equal(result.shouldRun, true);
+  assert.equal(result.dependencyChanged, true);
+  assert.deepEqual(result.reasons, ['atomic-changed', 'tailwindcss']);
+});
+
+test('runs when a direct dependency lock resolution changes', () => {
+  const base = state({
+    dependencies: {lit: '3.3.3'},
+    importer: {dependencies: {lit: {version: '3.3.3'}}},
+  });
+  const head = state({
+    dependencies: {lit: '3.3.3'},
+    importer: {dependencies: {lit: {version: '3.3.3(peer-a@1.0.0)'}}},
+  });
+
+  const result = evaluate({changedFiles: ['pnpm-lock.yaml'], base, head});
+  assert.equal(result.shouldRun, true);
+  assert.deepEqual(result.reasons, ['lit']);
+});
+
+test('skips unrelated catalog and lockfile changes', () => {
+  const base = state({
+    dependencies: {lit: 'catalog:'},
+    catalog: {lit: '3.3.3', vite: '6.0.0'},
+    importer: {dependencies: {lit: {version: '3.3.3'}}},
+  });
+  const head = state({
+    dependencies: {lit: 'catalog:'},
+    catalog: {lit: '3.3.3', vite: '6.1.0'},
+    importer: {dependencies: {lit: {version: '3.3.3'}}},
+  });
+
+  const result = evaluate({base, head});
+  assert.equal(result.shouldRun, false);
+  assert.equal(result.dependencyChanged, false);
+});
+
+test('skips local workspace dependency source changes', () => {
+  const fixture = state({dependencies: {'@coveo/headless': 'workspace:*'}});
+  const result = evaluate({
+    changedFiles: ['packages/headless/src/app/engine.ts'],
+    base: fixture,
+    head: fixture,
+  });
+
+  assert.equal(result.shouldRun, false);
+});
+
+test('skips unrelated source changes', () => {
+  const fixture = state();
+  const result = evaluate({
+    changedFiles: ['packages/headless/src/app/engine.ts'],
+    base: fixture,
+    head: fixture,
+  });
+
+  assert.equal(result.shouldRun, false);
+  assert.equal(result.dependencyChanged, false);
+});
+
+test('fails closed for missing direct dependency resolutions', () => {
+  const invalid = state({dependencies: {lit: '3.3.3'}});
+  const result = evaluate({changedFiles: ['pnpm-lock.yaml'], base: invalid, head: invalid});
+
+  assert.equal(result.shouldRun, true);
+  assert.equal(result.dependencyChanged, true);
+  assert.match(result.reasons[0], /^invalid-dependency-state:/);
+});

--- a/utils/ci/package.json
+++ b/utils/ci/package.json
@@ -6,12 +6,14 @@
   "type": "module",
   "scripts": {
     "add-generated-files": "node ./add-generated-files.mjs",
+    "test:chromatic-gate": "node --test ./chromatic-gate.test.mjs",
     "if-not-cdn": "node ./if-not-cdn.mjs",
     "if-cdn": "node ./if-cdn.mjs",
     "if-ci": "node ./if-ci.mjs"
   },
   "dependencies": {
     "@coveo/semantic-monorepo-tools": "2.7.1",
-    "octokit": "5.0.5"
+    "octokit": "5.0.5",
+    "yaml": "catalog:"
   }
 }


### PR DESCRIPTION
## Superseded

Superseded by #8188, which implements the retained Renovate skip/allowlist policy on top of the Chromatic action and release-status stack. The dependency-gate approach from this PR is intentionally dropped.

## Stacked on

#8175 — `ci/migrate-chromatic-action`

## Supersedes

#8177, which was closed. This implementation is branch-agnostic and replaces Renovate-specific conditions with a direct Atomic dependency gate.

## Motivation

Turbo's affected-project output is intentionally broad for root workspace and lockfile changes. Chromatic should run only when Atomic itself or an Atomic direct external dependency can affect the Storybook build.

## Changes

- Adds a SHA-based gate that runs real Chromatic for any tracked `packages/atomic/**` change.
- Compares Atomic's direct non-local dependencies across the base and head manifests, pnpm catalog, and Atomic lockfile importer.
- Skips source-only local workspace dependency changes and unrelated catalog/lockfile updates while retaining passing CI status via the Chromatic action's `skip` input.
- Disables TurboSnap for direct external dependency resolution changes to ensure actual visual coverage.
- Applies the same gate to CD; nonmatching `main` pushes do not invoke Chromatic.
- Adds the approved `yaml@catalog:` dependency to private `@coveo/ci` for reliable catalog and lockfile parsing.

## Validation

- `pnpm --filter @coveo/ci test:chromatic-gate` (8 cases)
- `node utils/ci/chromatic-gate.mjs --base 2a49322877^ --head 2a49322877` → run
- `node utils/ci/chromatic-gate.mjs --base origin/main --head HEAD` → skip
- Frozen-lockfile installation validation
- `pnpm run lint:fix`

## Checklist

- [x] PR title follows Conventional Commits 1.0.0 format
- [x] No changeset required; this modifies private CI tooling and workflow configuration only