### PR TITLE
chore(quantic): retry community creation on transient error

### DIFF
--- a/packages/quantic/scripts/build/deploy-community.ts
+++ b/packages/quantic/scripts/build/deploy-community.ts
@@ -200,7 +200,7 @@ async function ensureScratchOrgExists(log: StepLogger, options: Options) {
   }
 }
 
-// Occasionally, community creation fails with an unknown error on the Salesforce side. 
+// Occasionally, community creation fails with an unknown error on the Salesforce side.
 // Retrying after a short delay often resolves it.
 const TRANSIENT_COMMUNITY_CREATE_ERROR =
   'Error: Unable to create a new experience.';

--- a/packages/quantic/scripts/build/deploy-community.ts
+++ b/packages/quantic/scripts/build/deploy-community.ts
@@ -200,16 +200,39 @@ async function ensureScratchOrgExists(log: StepLogger, options: Options) {
   }
 }
 
+// Occasionally, community creation fails with an unknown error on the Salesforce side. 
+// Retrying after a short delay often resolves it.
+const TRANSIENT_COMMUNITY_CREATE_ERROR =
+  'Error: Unable to create a new experience.';
+
 async function ensureCommunityExists(
   log: StepLogger,
   options: Options
 ): Promise<void> {
   log(`Searching for '${options.community.name}' community`);
   try {
-    await sfdx.createCommunity({
-      alias: options.scratchOrg.alias,
-      community: options.community,
-    });
+    await backOff(
+      async () => {
+        await sfdx.createCommunity({
+          alias: options.scratchOrg.alias,
+          community: options.community,
+        });
+      },
+      {
+        numOfAttempts: 5,
+        startingDelay: 30000,
+        retry: (error) => {
+          const isTransient =
+            (error as Error).message === TRANSIENT_COMMUNITY_CREATE_ERROR;
+          if (isTransient) {
+            log(
+              'Community creation failed because the org domain is not ready yet. Retrying...'
+            );
+          }
+          return isTransient;
+        },
+      }
+    );
     log('Community created successfully.');
   } catch (error) {
     if ((error as Error).message === 'Enter a different name. That one already exists.') {


### PR DESCRIPTION
[SFINT-6885](https://coveord.atlassian.net/browse/SFINT-6885)

## Summary
`ensureCommunityExists` in `deploy-community.ts` occasionally fails in CI with a transient `UNKNOWN_EXCEPTION: Error: Unable to create a new experience.`, likely because the scratch org's domain hasn't finished deploying yet. Added a scoped retry with exponential backoff for this specific error so the flow no longer fails flakily; other errors (e.g. "already exists") still fail fast as before.

## Testing
- The CI run will tell us.

[SFINT-6885]: https://coveord.atlassian.net/browse/SFINT-6885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ