### PR TITLE
chore(deps): replace exact-same hardcoded versions with catalog:

### DIFF
--- a/packages/atomic-cdn-smoke/package.json
+++ b/packages/atomic-cdn-smoke/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@chromatic-com/playwright": "0.14.11",
     "@coveo/platform-mock-api": "workspace:*",
-    "@msw/playwright": "0.6.7",
+    "@msw/playwright": "catalog:",
     "@playwright/test": "catalog:",
     "chromatic": "catalog:",
     "msw": "catalog:",

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -101,7 +101,7 @@
     "@coveo/bueno": "workspace:*",
     "@coveo/relay": "workspace:*",
     "@coveo/relay-event-types": "catalog:",
-    "@reduxjs/toolkit": "2.12.0",
+    "@reduxjs/toolkit": "catalog:",
     "abortcontroller-polyfill": "catalog:",
     "coveo.analytics": "workspace:*",
     "dayjs": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,7 +589,7 @@ importers:
         specifier: workspace:*
         version: link:../platform-mock-api
       '@msw/playwright':
-        specifier: 0.6.7
+        specifier: 'catalog:'
         version: 0.6.7(msw@2.15.0(@types/node@26.1.0)(typescript@6.0.3))
       '@playwright/test':
         specifier: 'catalog:'
@@ -1021,7 +1021,7 @@ importers:
         specifier: 'catalog:'
         version: 19.22.0
       '@reduxjs/toolkit':
-        specifier: 2.12.0
+        specifier: 'catalog:'
         version: 2.12.0(react@19.2.7)
       abortcontroller-polyfill:
         specifier: 'catalog:'


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-5977

## Motivation

Dependencies that hardcode a version identical to the workspace catalog entry should use `catalog:` instead. This eliminates silent bypasses and keeps the catalog as the single source of truth.

## Changes

Replaced hardcoded dependency versions with `catalog:` references for 2 more exact-match bypass violations:

| Package | Location | Version |
|---------|----------|---------|
| `@msw/playwright` | `packages/atomic-cdn-smoke` | `0.6.7` |
| `@reduxjs/toolkit` | `packages/headless` | `2.12.0` |

Identified using `scripts/report-catalog-candidates.mjs` (see ADR 0003).

## Validation

- Ran `pnpm install --frozen-lockfile` successfully after manually updating lockfile specifiers
- Ran `pnpm exec node scripts/report-catalog-candidates.mjs` — `exact-same` count reduced from 2 to 0
- No new features or bug fixes are included in this PR

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] No changeset needed (internal dependency metadata only, no public source changes)