### PR TITLE
ci: use step-security mirror for Sentry release action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,7 @@ jobs:
         run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
       - name: Upload create-ui source maps to Sentry
         if: ${{ steps.changesets.outputs.published == 'true' && contains(steps.changesets.outputs.publishedPackages, '@coveo/create-ui') }}
-        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3
+        uses: step-security/getsentry-action-release@4530160f6bc962e1dd67e2703064a7a5cfd401fb # v3.7.0
         with:
           release: create-ui@${{ steps.create-ui-version.outputs.version }}
           sourcemaps: packages/create-ui/dist


### PR DESCRIPTION
**Jira:** [KIT-5841](https://coveord.atlassian.net/browse/KIT-5841)

## Issue

The `Create release` workflow (`cd.yml`) has failed at **startup** on every push to `main` since #8098, which added `getsentry/action-release`. That action isn't on the org's allowed-actions list, so GitHub blocks the whole run before any job starts (0 jobs, "workflow file issue"). While it's broken, no release can publish — merging the Changesets version PR (#8171) would bump versions in git without publishing to npm or dispatching the CDN deploy.

## Solution

Swap it for the allow-listed `step-security/getsentry-action-release` mirror, SHA-pinned to the same version (`v3.7.0`). The mirror exposes identical inputs, so the `with:`/`env:` blocks are unchanged and the create-ui source-map upload behaves exactly as intended.

[KIT-5841]: https://coveord.atlassian.net/browse/KIT-5841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ