### PR TITLE
ci: restore intra-run .turbo cache fan-out to cut CI compute

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,6 +10,22 @@ inputs:
     description: 'Command used to build. Defaults to building every package.'
     required: false
     default: 'pnpm run build'
+  load-cache:
+    description: 'Download the per-run .turbo cache artifact produced by the build job (intra-run fan-out). Best-effort; falls back to the Turbo remote cache on a miss.'
+    required: false
+    default: 'true'
+  save-cache:
+    description: 'Upload the .turbo cache as a per-run artifact for other jobs to reuse. Set on the producer build job.'
+    required: false
+    default: 'false'
+  cache-prefix:
+    description: 'Prefix for the .turbo artifact name, to isolate environments (e.g. cdn).'
+    required: false
+    default: 'default'
+  cache-retention-days:
+    description: 'Retention (in days) for the .turbo cache artifact.'
+    required: false
+    default: '1'
 #endregion
 runs:
   using: composite
@@ -34,9 +50,33 @@ runs:
     - run: pnpm install --frozen-lockfile --prefer-offline
       shell: bash
     #endregion
+    #region Turbo cache (intra-run fan-out)
+    # Reuse the .turbo cache the build job produced once, so consumer jobs get
+    # LOCAL cache hits instead of each re-fetching the whole graph from the
+    # Turborepo remote cache. Best-effort: on a miss, turbo falls back to the
+    # remote cache (turbo.json remoteCache + TURBO_TOKEN).
+    - name: Download turbo cache
+      if: inputs.save-cache != 'true' && inputs.load-cache == 'true'
+      continue-on-error: true
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: ${{ runner.os }}-${{ inputs.cache-prefix }}-turbo
+        path: .turbo
+    #endregion
     #region Build
-    # Turbo build outputs come from Turborepo remote caching (turbo.json remoteCache + TURBO_TOKEN).
+    # Build outputs come from the local .turbo cache above (intra-run fan-out)
+    # or the Turborepo remote cache.
     - run: ${{ inputs.build-command }}
       if: inputs.skip-build != 'true'
       shell: bash
+    # Publish the .turbo cache once (producer build job) for consumers to reuse.
+    - name: Upload turbo cache
+      if: inputs.save-cache == 'true'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: ${{ runner.os }}-${{ inputs.cache-prefix }}-turbo
+        path: .turbo
+        include-hidden-files: true
+        retention-days: ${{ inputs.cache-retention-days }}
+        if-no-files-found: error
     #endregion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           skip-build: 'true'
+          load-cache: 'false'
       - run: pnpm run pr:report
         env:
           GITHUB_CREDENTIALS: ${{ steps.generate-token.outputs.token }}
@@ -66,6 +67,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - uses: ./.github/actions/setup
+        with:
+          load-cache: 'false'
   build-missing:
     name: 'Build & commit missing generated files'
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/') }}
@@ -83,6 +86,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
       - uses: ./.github/actions/setup
+        with:
+          load-cache: 'false'
       - name: Check for uncommitted changes
         id: check-changes
         run: |
@@ -132,6 +137,8 @@ jobs:
       - run: git branch main origin/main
         if: ${{ github.event_name != 'pull_request' }}
       - uses: ./.github/actions/setup
+        with:
+          save-cache: 'true'
       - name: Get affected projects
         id: set
         run: |


### PR DESCRIPTION
## Summary

Restores the intra-run `.turbo` cache fan-out (build once → share as one artifact) that #8146 removed, layered on top of Turbo remote caching, to cut CI compute. Spike — draft until measured and reviewed.

## What it does

- After #8146, every CI job re-ran `turbo build` in `setup` and restored the whole graph from the **remote** cache (~60s/job; the `Run unit tests` job showed `57 cached / 62 tasks` in ~61s). With ~70 jobs that added roughly **+57 job-min per full `merge_group` run** (total ~248 → ~291 job-min), and CI got marginally slower rather than faster.
- The `build` job now publishes its `.turbo` **once** as a per-run artifact (`save-cache: 'true'`), and `needs: build` consumers restore it (default `load-cache: 'true'`) for **local** cache hits instead of each re-fetching ~57 task outputs from the remote cache.
- Restore is best-effort (`continue-on-error`): on a miss, turbo falls back to the remote cache. `turbo.json` `remoteCache` + `TURBO_TOKEN` are unchanged, so cross-run / cross-branch / local-dev reuse is preserved.
- `pr-report`, `build-windows` (different runner OS → different artifact), and `build-missing` opt out via `load-cache: 'false'`.

## How to evaluate

Compare median **total job-minutes** of `merge_group` runs against the current baseline (~291 job-min), targeting a return to ≲250. Also spot-check a consumer job's `setup` step duration (was 119s on `Run unit tests`, ~60s of it remote turbo restore).
