### PR TITLE
fix(ci): preserve Chromatic status on release PRs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -263,8 +263,6 @@ jobs:
   chromatic-update-main:
     name: 'Update Chromatic baseline on main'
     runs-on: ubuntu-latest
-    env:
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -276,4 +274,13 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --exit-zero-on-changes --auto-accept-changes --branchName=main
+        with:
+          load-cache: 'false'
+      - name: Update Chromatic baseline
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
+        with:
+          autoAcceptChanges: true
+          branchName: main
+          exitZeroOnChanges: true
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: packages/atomic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,11 +108,12 @@ jobs:
           DEBUG: '*'
   build:
     name: 'Build'
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/') }}
     runs-on: ubuntu-latest
     environment: PR Artifacts
     outputs:
-      projects: ${{ steps.set.outputs.projects }}
+      # When running on changeset-release branches, we don't want to run most downstream jobs, so we set the output to an empty string.
+      # Notably, Chromatic will still run on changeset-release branches, but it will run with the `--skip` flag.
+      projects: ${{ (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) && steps.set.outputs.projects || '' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,13 +350,6 @@ jobs:
     name: 'Run Chromatic visual tests on Atomic'
     needs: build
     runs-on: ubuntu-latest
-    env:
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-      # Should be fine without because of https://github.com/chromaui/chromatic-cli/blob/56920bf704895dcef6d1106df608d8e0d7886b58/action-src/main.ts#L24-L82
-      # # https://www.chromatic.com/docs/faq/environment-variables/#how-to-set-chromatic-environment-variables-in-popular-ci-providers
-      # CHROMATIC_SHA: ${{ github.event.pull_request.head.sha }}
-      # CHROMATIC_BRANCH: ${{ github.head_ref }}
-      # CHROMATIC_SLUG: ${{ github.repository }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -374,12 +367,20 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic
+      - name: Run Chromatic visual tests
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         id: chromatic-run
         if: contains(needs.build.outputs.projects, '@coveo/atomic') && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'chromatic')
-      - run: pnpm exec turbo chromatic --filter=@coveo/atomic -- --skip
-        working-directory: packages/atomic
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: packages/atomic
+      - name: Skip Chromatic visual tests
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         if: steps.chromatic-run.outcome == 'skipped'
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          skip: true
+          workingDir: packages/atomic
   playwright-atomic:
     name: 'Run Playwright tests for Atomic'
     needs: build


### PR DESCRIPTION
## Problem

Generated `changeset-release/*` pull requests skipped the `build` job. Because Chromatic depends on Build, GitHub skipped Chromatic before its existing `--skip` fallback could publish the required status.

## Why it matters

Release PRs can be blocked by a missing Chromatic status even though they intentionally do not need visual snapshots. Build should remain the prerequisite: if Build fails, Chromatic may remain blocked.

## Fix

Run Build for generated release PRs, but expose an empty `projects` output for `changeset-release/*`. This keeps affected-project downstream jobs disabled while allowing the Chromatic job to start after a successful Build. Its full visual-test step sees no affected Atomic project, so the existing fallback runs Chromatic with `--skip`.

Running Build on release PRs is acceptable because CI uses Turbo remote caching, so unchanged build work is restored rather than recomputed.

## Tests

- Reviewed the GitHub Actions condition paths for normal PRs and `changeset-release/*` PRs
- Confirmed the workflow output is empty only for generated release PRs
- Confirmed Chromatic remains gated on Build success and selects its existing `--skip` fallback
- CI validates the workflow on this PR

## Manual verification

Confirmed a `changeset-release/*` PR with a successful Build exposes no affected projects: project-gated jobs remain skipped and Chromatic runs with `--skip`.

## Changeset

Not required: CI-only change with no public package source modification.

## Chromatic CI stack

Physical PR order:

1. #8175 — migrate Chromatic to the official GitHub Action
2. #8187 — preserve required Chromatic statuses on release PRs
3. #8188 — skip full Chromatic builds on Renovate PRs by default
