### PR TITLE
ci: skip Chromatic builds on Renovate PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,13 @@ jobs:
       - name: Run Chromatic visual tests
         uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         id: chromatic-run
-        if: contains(needs.build.outputs.projects, '@coveo/atomic') && github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'chromatic')
+        # Set the CHROMATIC_RENOVATE_ALLOWLIST repository variable to a JSON array of exact branch names.
+        # Example: `["renovate/playwright", "renovate/chromatic"]`
+        if: >-
+          contains(needs.build.outputs.projects, '@coveo/atomic') &&
+          github.event_name == 'pull_request' &&
+          (!startsWith(github.head_ref, 'renovate/') ||
+          contains(fromJSON(vars.CHROMATIC_RENOVATE_ALLOWLIST || '[]'), github.head_ref))
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/atomic


### PR DESCRIPTION
## Problem
Renovate pull requests that affect Atomic currently run a full Chromatic build unless they carry a manual override label. This consumes visual-testing capacity for routine dependency updates.

## Why it matters
Running snapshots for every Renovate update increases Chromatic usage and cost without providing proportional review value. Some sensitive dependency updates still need an explicit path to full visual validation.

## Fix (symptoms → root cause → change)
The full Chromatic step considers affected projects and the pull-request event but does not distinguish automated Renovate branches. The condition now sends every `renovate/*` branch through the existing `skip: true` fallback by default and permits exact branch exceptions through the `CHROMATIC_RENOVATE_ALLOWLIST` repository variable, expressed as a JSON array. The former label override is removed so this branch policy is the single control point.

This change now sits directly on `main`; its two foundations have merged:

- #8175 migrated Chromatic to the official GitHub Action.
- #8187 preserved required Chromatic statuses when downstream work is skipped.

## Tests
- `git diff --check origin/main...HEAD`
- Parsed `.github/workflows/ci.yml` as YAML.
- Verified formatting with `pnpm exec oxfmt --check .github/workflows/ci.yml`.
- Exercised non-Renovate, blocked Renovate, allowlisted Renovate, and exact-match behavior with four passing cases.
- Completed a read-only review with no Critical/High findings.

## Manual verification
Inspected the GitHub Actions expression against the four intended execution paths and confirmed that non-allowlisted Renovate branches fall through to the existing `skip: true` step while non-Renovate behavior is unchanged.