### PR TITLE
fix(thermidor): preserve unified turn contracts

### DIFF
--- a/.changeset/bright-rivers-converse.md
+++ b/.changeset/bright-rivers-converse.md
@@ -1,0 +1,5 @@
+---
+'@coveo/thermidor': patch
+---
+
+Keep unified turns streaming until their terminal event, distinguish unified generative interfaces from legacy ones, and translate incremental commerce sort updates.

--- a/packages/thermidor/src/internal/api/generative/generative-runtime.test.ts
+++ b/packages/thermidor/src/internal/api/generative/generative-runtime.test.ts
@@ -508,6 +508,7 @@ describe('GenerativeRuntime', () => {
         'generated-id-1',
         routedInterface
       );
+      expect(config.statePort.completeTurn).toHaveBeenCalledWith('generated-id-1');
     });
 
     it('does not set routed interface when hydration returns null', async () => {

--- a/packages/thermidor/src/internal/api/generative/generative-runtime.ts
+++ b/packages/thermidor/src/internal/api/generative/generative-runtime.ts
@@ -265,6 +265,7 @@ export class GenerativeRuntime {
 
         if (hydrationResult) {
           this.statePort.setRoutedInterface(turnId, hydrationResult);
+          this.statePort.completeTurn(turnId);
           return {turnId, isTerminal: true};
         }
 

--- a/packages/thermidor/src/internal/api/unified/unified-endpoint-client.test.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-endpoint-client.test.ts
@@ -83,7 +83,7 @@ describe('UnifiedEndpointClient', () => {
       {
         method: 'POST',
         signal: undefined,
-        body: JSON.stringify(request.agentInput),
+        body: JSON.stringify(request),
         headers: {
           'Content-Type': 'application/json',
           Accept: 'text/event-stream',

--- a/packages/thermidor/src/internal/api/unified/unified-surface-hydration.test.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-surface-hydration.test.ts
@@ -175,6 +175,63 @@ describe('unified-surface-hydration', () => {
       }).not.toThrow();
     });
 
+    it('translates incremental sort updates to controller criteria', () => {
+      const fullEngine = createTestEngine();
+      const result = hydrateFromCreateSurface(
+        fullEngine,
+        {
+          surfaceId: 'test',
+          surfaceProperties: {placement: 'main'},
+          dataModel: validDataModel,
+        },
+        mockGenerativeInterface,
+        mockCartInterface
+      );
+      const iface = result!.interface;
+      adoptAllSlices(fullEngine, iface);
+
+      applyDataModelUpdate(fullEngine, iface, '/sort', {
+        appliedSort: {
+          sortCriteria: 'fields',
+          fields: [{field: 'price', direction: 'desc', displayName: 'Price'}],
+        },
+        availableSorts: [{sortCriteria: 'relevance'}],
+      });
+
+      const sortSelectors = getOrCreateSortSelectors(iface);
+      expect(fullEngine.read(sortSelectors.getAppliedSort)).toEqual({
+        by: 'field',
+        field: 'price',
+        direction: 'descending',
+        displayName: 'Price',
+      });
+      expect(fullEngine.read(sortSelectors.getAvailableSorts)).toEqual([{by: 'relevance'}]);
+    });
+
+    it.each([
+      {availableSorts: [{sortCriteria: 'relevance'}]},
+      {appliedSort: {sortCriteria: 'relevance'}},
+    ])('ignores incomplete incremental sort update %#', (sortUpdate) => {
+      const fullEngine = createTestEngine();
+      const result = hydrateFromCreateSurface(
+        fullEngine,
+        {
+          surfaceId: 'test',
+          surfaceProperties: {placement: 'main'},
+          dataModel: validDataModel,
+        },
+        mockGenerativeInterface,
+        mockCartInterface
+      );
+      const iface = result!.interface;
+      adoptAllSlices(fullEngine, iface);
+      const sortSelectors = getOrCreateSortSelectors(iface);
+
+      expect(() => applyDataModelUpdate(fullEngine, iface, '/sort', sortUpdate)).not.toThrow();
+      expect(fullEngine.read(sortSelectors.getAppliedSort)).toEqual({by: 'relevance'});
+      expect(fullEngine.read(sortSelectors.getAvailableSorts)).toEqual([]);
+    });
+
     it('runs full response handler when path is /', () => {
       const fullEngine = createTestEngine();
 

--- a/packages/thermidor/src/internal/api/unified/unified-surface-hydration.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-surface-hydration.ts
@@ -11,7 +11,11 @@ import type {CoveoFacetResponse} from '@/src/internal/api/search/index.js';
 import {getOrCreateProductListActions} from '@/src/internal/features/product-list/index.js';
 import {getOrCreatePaginationActions} from '@/src/internal/features/pagination/index.js';
 import {getOrCreateFacetsActions} from '@/src/internal/features/facets/index.js';
-import {getOrCreateSortActions} from '@/src/internal/features/sort/index.js';
+import {
+  fromCommerceApiSort,
+  getOrCreateSortActions,
+  type CommerceApiSortPayload,
+} from '@/src/internal/features/sort/index.js';
 import {getOrCreateTriggersActions} from '@/src/internal/features/triggers/index.js';
 import {getOrCreateQueryCorrectionActions} from '@/src/internal/features/query-correction/index.js';
 
@@ -125,7 +129,19 @@ export function applyDataModelUpdate(
     }
     case '/sort': {
       const sortActions = getOrCreateSortActions(iface);
-      engine.mutate(sortActions.updateFromResponse(value as never));
+      const sort = value as {
+        appliedSort?: CommerceApiSortPayload;
+        availableSorts?: CommerceApiSortPayload[];
+      };
+      if (!sort.appliedSort || !Array.isArray(sort.availableSorts)) {
+        break;
+      }
+      engine.mutate(
+        sortActions.updateFromResponse({
+          appliedSort: fromCommerceApiSort(sort.appliedSort),
+          availableSorts: sort.availableSorts.map(fromCommerceApiSort),
+        })
+      );
       break;
     }
     case '/triggers': {

--- a/packages/thermidor/src/internal/features/generative/generative-slice.test.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-slice.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from 'vitest';
+import {createGenerativeActions} from './generative-actions.js';
+import {createGenerativeSlice} from './generative-slice.js';
+
+describe('generative slice', () => {
+  const actions = createGenerativeActions('test');
+  const reducer = createGenerativeSlice('test', actions).reducer;
+
+  it('keeps a turn streaming when attaching a routed interface', () => {
+    let state = reducer(
+      undefined,
+      actions.createTurn({id: 'turn-1', prompt: 'find shoes', status: 'streaming'})
+    );
+
+    state = reducer(
+      state,
+      actions.setRoutedInterface({turnId: 'turn-1', useCase: 'commerceSearch'})
+    );
+
+    expect(state.turns[0]).toEqual(
+      expect.objectContaining({
+        status: 'streaming',
+        routedInterface: {useCase: 'commerceSearch'},
+      })
+    );
+  });
+
+  it('completes a routed turn only from the completion action', () => {
+    let state = reducer(
+      undefined,
+      actions.createTurn({id: 'turn-1', prompt: 'find shoes', status: 'streaming'})
+    );
+    state = reducer(
+      state,
+      actions.setRoutedInterface({turnId: 'turn-1', useCase: 'commerceSearch'})
+    );
+
+    state = reducer(state, actions.completeTurn({turnId: 'turn-1'}));
+
+    expect(state.turns[0].status).toBe('complete');
+  });
+});

--- a/packages/thermidor/src/internal/features/generative/generative-slice.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-slice.ts
@@ -55,7 +55,6 @@ export function createGenerativeSlice(
           const turn = state.turns.find((t) => t.id === payload.turnId);
           if (turn) {
             turn.routedInterface = {useCase: payload.useCase};
-            turn.status = 'complete';
           }
         })
         .addCase(actions.initAgentResponse, (state, {payload}) => {

--- a/packages/thermidor/src/internal/interfaces/generative-unified.test.ts
+++ b/packages/thermidor/src/internal/interfaces/generative-unified.test.ts
@@ -1,7 +1,8 @@
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect, expectTypeOf, vi} from 'vitest';
 import {GenerativeUnifiedInterfaceImpl} from './generative-unified.js';
 import {getInterfaceInternals} from '@/src/internal/utils/index.js';
 import type {FullEngine} from '@/src/internal/engine/index.js';
+import type {GenerativeInterface, GenerativeUnifiedInterface} from '@/src/internal/utils/index.js';
 
 function createMockEngine(): FullEngine {
   return {
@@ -17,6 +18,11 @@ function createMockEngine(): FullEngine {
 }
 
 describe('GenerativeUnifiedInterfaceImpl', () => {
+  it('is nominally distinct from the legacy generative interface', () => {
+    expectTypeOf<GenerativeUnifiedInterface>().not.toMatchTypeOf<GenerativeInterface>();
+    expectTypeOf<GenerativeInterface>().not.toMatchTypeOf<GenerativeUnifiedInterface>();
+  });
+
   it('calls engine.adoptSlice with the generative slice on construction', () => {
     const engine = createMockEngine();
 

--- a/packages/thermidor/src/internal/utils/interface-types.ts
+++ b/packages/thermidor/src/internal/utils/interface-types.ts
@@ -80,8 +80,12 @@ export interface CommerceInterface extends Supports<Facades['commerce']> {
   readonly [InterfaceTypeBrand]: 'commerce';
 }
 
-export interface GenerativeInterface extends Supports<Facades['generative']> {}
+export interface GenerativeInterface extends Supports<Facades['generative']> {
+  readonly [InterfaceTypeBrand]: 'generative';
+}
 
-export interface GenerativeUnifiedInterface extends Supports<Facades['generativeUnified']> {}
+export interface GenerativeUnifiedInterface extends Supports<Facades['generativeUnified']> {
+  readonly [InterfaceTypeBrand]: 'generativeUnified';
+}
 
 export interface ComposedInterface<T extends InterfaceType> extends Supports<Facades[T]> {}


### PR DESCRIPTION
## Problem

Unified routed-interface attachment marks turns complete before the unified stream ends, incremental commerce sort patches bypass API-to-controller translation, legacy and unified generative interfaces are structurally interchangeable, and the required endpoint-client test asserts the wrong serialized request body. These defects are present in the feature work from https://github.com/coveo/ui-kit/pull/8182.

## Why it matters

Consumers can observe prematurely terminal turns, malformed sort controller state after streamed updates, and compile-time acceptance of the wrong generative interface flavor. The incorrect body assertion also makes this layer's required unit-test job fail.

## Fix (symptoms → root cause → change)

Keep routed-interface attachment non-terminal and explicitly complete successful legacy turns in the legacy runtime. Translate valid incremental `/sort` payloads with `fromCommerceApiSort`, ignoring incomplete payloads instead of crashing. Add nominal interface brands so legacy and unified generative interfaces cannot be substituted. Correct request-body coverage to assert direct serialization of the supplied commerce request model. Include a Thermidor patch changeset.

## Tests

- Added reducer coverage proving routed-interface attachment remains streaming until `completeTurn`.
- Updated legacy runtime tests to preserve terminal behavior.
- Added valid and malformed incremental `/sort` hydration coverage.
- Added compile-time assertions that the generative interface types are distinct.
- Corrected unified endpoint request-body coverage.
- Unified endpoint client: 10 tests passed.
- Full Thermidor suite: 696 tests passed.
- Thermidor build: passed.
- Repository `pnpm run lint:fix`: passed.

## Manual verification

N/A — focused reducer/runtime/hydration/transport coverage plus the full package test and build gates exercise the changed contracts.

## Screenshots

N/A — no user-visible UI change.