### PR TITLE
fix(ci): use affected Turbo tasks for package detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,18 +127,16 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - name: Get affected projects
+      - name: Affected tasks
         id: set
         run: |
-          AFFECTED=$(pnpm exec turbo build --affected --dry-run 2>/dev/null \
-          | awk '/^@(coveo|samples)/ && !/#/ {print $1}' \
-          | tr '\n' ' ')
-          echo "projects=$AFFECTED" >> "$GITHUB_OUTPUT"
-      - name: Log affected projects
-        run: |
-          echo "Affected projects: ${STEPS_SET_OUTPUTS_PROJECTS}"
-        env:
-          STEPS_SET_OUTPUTS_PROJECTS: ${{ steps.set.outputs.projects }}
+          TASKS="$(pnpm exec node scripts/turbo/outdated-tasks.mjs | sort)"
+          echo "Affected tasks:"
+          echo
+          echo "$TASKS"
+
+          echo "tasks=$(echo "$TASKS" | sort -u | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+          echo "projects=$(echo "$TASKS" | sed 's/#.*//' | sort -u | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
   build-cdn:
     name: Build CDN
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,19 +554,15 @@ jobs:
       - name: Get affected samples with e2e
         id: set
         run: |
-          pnpm exec turbo run e2e --affected --dry-run=json > turbo-e2e.json 2>/dev/null || echo '{"tasks":[]}' > turbo-e2e.json
-          SAMPLES=$(node -e "
-            let d;
-            try { d = JSON.parse(require('fs').readFileSync('turbo-e2e.json','utf8')); } catch (e) { d = {}; }
-            const tasks = Array.isArray(d.tasks) ? d.tasks : [];
-            const pkgs = tasks
-              .filter(t => t.taskId && t.taskId.endsWith('#e2e') && t.command && t.command !== '<NONEXISTENT>' && t.package && (t.package.startsWith('@samples') || t.package.startsWith('@coveo/ui-kit-sample')))
-              .map(t => t.package);
-            console.log(JSON.stringify(pkgs));
-          " || echo '[]')
-          echo "samples=$SAMPLES" >> "$GITHUB_OUTPUT"
-      - name: Log affected samples
-        run: echo "Affected samples for e2e:${{ steps.set.outputs.samples }}"
+          SAMPLES="$(pnpm exec node scripts/turbo/outdated-tasks.mjs e2e \
+            | grep -E "^@(samples/[^#]+|coveo/ui-kit-samples)#e2e" \
+            | sed 's/#.*//' \
+            | sort)"
+          echo "Affected samples for e2e:"
+          echo
+          echo "$SAMPLES"
+
+          echo "samples=$(echo "$SAMPLES" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
 
   samples-e2e:
     name: 'E2E: ${{ matrix.sample }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,8 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+        with:
+          build-command: 'pnpm run build' # FIXME: https://coveord.atlassian.net/browse/KIT-6039
       - name: Run knip
         run: pnpm run knip
   cdn-checks:
@@ -320,6 +322,8 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+        with:
+          build-command: 'pnpm run build' # FIXME: https://coveord.atlassian.net/browse/KIT-6040
       - run: pnpm run package-compatibility
   typedoc:
     name: 'Build typedoc'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ permissions:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'main' }}
+  TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   pr-report:
@@ -38,12 +40,6 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
-      - run: git branch ${GITHUB_EVENT_PULL_REQUEST_BASE_REF} origin/${GITHUB_EVENT_PULL_REQUEST_BASE_REF}
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
-      - run: git branch main origin/main
-        if: ${{ github.event_name != 'pull_request' }}
       - uses: ./.github/actions/setup
         with:
           skip-build: 'true'
@@ -130,12 +126,6 @@ jobs:
         with:
           fetch-depth: 0
           filter: blob:none
-      - run: git branch ${GITHUB_EVENT_PULL_REQUEST_BASE_REF} origin/${GITHUB_EVENT_PULL_REQUEST_BASE_REF}
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
-      - run: git branch main origin/main
-        if: ${{ github.event_name != 'pull_request' }}
       - uses: ./.github/actions/setup
       - name: Get affected projects
         id: set
@@ -265,12 +255,6 @@ jobs:
         with:
           fetch-depth: 0
           filter: blob:none
-      - run: git branch ${GITHUB_EVENT_PULL_REQUEST_BASE_REF} origin/${GITHUB_EVENT_PULL_REQUEST_BASE_REF}
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
-      - run: git branch main origin/main
-        if: ${{ github.event_name != 'pull_request' }}
       - uses: ./.github/actions/setup
       - run: pnpm exec turbo test --affected
   relay-tests:
@@ -308,12 +292,6 @@ jobs:
         with:
           fetch-depth: 0
           filter: blob:none
-      - run: git branch ${GITHUB_EVENT_PULL_REQUEST_BASE_REF} origin/${GITHUB_EVENT_PULL_REQUEST_BASE_REF}
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
-      - run: git branch main origin/main
-        if: ${{ github.event_name != 'pull_request' }}
       - uses: ./.github/actions/setup
       - run: pnpm exec turbo test:dts:ci --affected
   package-compatibility:
@@ -574,12 +552,6 @@ jobs:
         with:
           fetch-depth: 0
           filter: blob:none
-      - run: git branch ${GITHUB_EVENT_PULL_REQUEST_BASE_REF} origin/${GITHUB_EVENT_PULL_REQUEST_BASE_REF}
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
-      - run: git branch main origin/main
-        if: ${{ github.event_name != 'pull_request' }}
       - uses: ./.github/actions/setup
       - name: Get affected samples with e2e
         id: set

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: PR Artifacts
     outputs:
-      # When running on changeset-release branches, we don't want to run most downstream jobs, so we set the output to an empty string.
+      # When running on changeset-release branches, we don't want to run most downstream jobs, so we set most outputs to an empty string.
       # Notably, Chromatic will still run on changeset-release branches, but it will run with the `--skip` flag.
       projects: ${{ (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) && steps.set.outputs.projects || '' }}
+      samples: ${{ (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) && steps.set.outputs.samples || '[]' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -134,9 +135,21 @@ jobs:
           echo "Affected tasks:"
           echo
           echo "$TASKS"
+          echo
 
           echo "tasks=$(echo "$TASKS" | sort -u | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
           echo "projects=$(echo "$TASKS" | sed 's/#.*//' | sort -u | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+
+          SAMPLES="$(pnpm exec node scripts/turbo/outdated-tasks.mjs e2e \
+            | sed -nE 's/^(@(samples\/[^#]+|coveo\/ui-kit-samples))#e2e.*/\1/p' \
+            | sort)"
+          echo "Affected samples for e2e:"
+          echo
+          echo "$SAMPLES"
+          echo
+
+          echo "samples=$(echo "$SAMPLES" | jq -Rsc 'split("\n") | map(select(length > 0))')" >> "$GITHUB_OUTPUT"
+
   build-cdn:
     name: Build CDN
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/') }}
@@ -534,40 +547,11 @@ jobs:
       - name: 'Check openacr.yaml is up to date'
         run: node scripts/check-openacr-drift.mjs
         working-directory: packages/atomic-a11y
-  samples-e2e-matrix:
-    name: 'Discover affected sample e2e'
-    needs: build
-    runs-on: ubuntu-latest
-    outputs:
-      samples: ${{ steps.set.outputs.samples }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          fetch-depth: 0
-          filter: blob:none
-      - uses: ./.github/actions/setup
-      - name: Get affected samples with e2e
-        id: set
-        run: |
-          SAMPLES="$(pnpm exec node scripts/turbo/outdated-tasks.mjs e2e \
-            | grep -E "^@(samples/[^#]+|coveo/ui-kit-samples)#e2e" \
-            | sed 's/#.*//' \
-            | sort)"
-          echo "Affected samples for e2e:"
-          echo
-          echo "$SAMPLES"
-
-          echo "samples=$(echo "$SAMPLES" | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
 
   samples-e2e:
     name: 'E2E: ${{ matrix.sample }}'
-    needs: samples-e2e-matrix
-    if: ${{ needs.samples-e2e-matrix.outputs.samples != '[]' }}
+    needs: build
+    if: ${{ needs.build.outputs.samples != '[]' }}
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -575,7 +559,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sample: ${{ fromJson(needs.samples-e2e-matrix.outputs.samples) }}
+        sample: ${{ fromJson(needs.build.outputs.samples) }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -702,7 +686,6 @@ jobs:
       - 'playwright-atomic-hosted-page-test'
       - 'puppeteer-atomic-csp'
       - 'e2e-quantic'
-      - 'samples-e2e-matrix'
       - 'samples-e2e'
       - 'playwright-pkg-new-template-test'
       - 'publish-preview'
@@ -736,7 +719,6 @@ jobs:
       - 'playwright-atomic-theming'
       - 'playwright-atomic-hosted-page-test'
       - 'e2e-quantic'
-      - 'samples-e2e-matrix'
       - 'samples-e2e'
       - 'playwright-pkg-new-template-test'
       - 'changeset-merge-guard'

--- a/scripts/turbo/outdated-tasks.mjs
+++ b/scripts/turbo/outdated-tasks.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import {execFile as execFileCallback} from 'node:child_process';
+import {promisify} from 'node:util';
+
+const turboArgs = [
+  'exec',
+  'turbo',
+  'build',
+  '--affected',
+  '--dry-run=json',
+  '--no-update-notifier',
+];
+const packageManager = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+const execFile = promisify(execFileCallback);
+
+async function runTurbo() {
+  const {stdout} = await execFile(packageManager, turboArgs, {
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+    shell: process.platform === 'win32',
+  });
+
+  return stdout;
+}
+
+function getOutdatedTasks(output) {
+  const {tasks = []} = JSON.parse(output);
+
+  return tasks.filter(({command}) => command !== '<NONEXISTENT>').map(({taskId}) => taskId);
+}
+
+try {
+  const output = await runTurbo();
+  const taskIds = getOutdatedTasks(output);
+
+  if (taskIds.length > 0) {
+    process.stdout.write(`${taskIds.join('\n')}\n`);
+  }
+} catch (error) {
+  const stderr =
+    error instanceof Error && 'stderr' in error && typeof error.stderr === 'string'
+      ? error.stderr.trim()
+      : '';
+  console.error(stderr || (error instanceof Error ? error.message : error));
+  process.exitCode = 1;
+}

--- a/scripts/turbo/outdated-tasks.mjs
+++ b/scripts/turbo/outdated-tasks.mjs
@@ -2,14 +2,8 @@
 import {execFile as execFileCallback} from 'node:child_process';
 import {promisify} from 'node:util';
 
-const turboArgs = [
-  'exec',
-  'turbo',
-  'build',
-  '--affected',
-  '--dry-run=json',
-  '--no-update-notifier',
-];
+const [task = 'build'] = process.argv.slice(2);
+const turboArgs = ['exec', 'turbo', task, '--affected', '--dry-run=json', '--no-update-notifier'];
 const packageManager = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 const execFile = promisify(execFileCallback);
 


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6033

## Motivation

CI used the human-readable `Packages in Scope` output from Turbo to determine affected packages. That section contains every workspace package, causing docs-only or narrowly scoped pull requests to trigger unrelated builds, Playwright tests, Storybook tests, CDN checks, and other downstream jobs.

## Root Cause

The workflow parsed package names from the scope listing instead of the actual tasks selected by `turbo --affected`. It also duplicated Git base-reference setup across jobs and separately discovered affected sample E2E tasks.

## Changes

- Set `TURBO_SCM_BASE` and `TURBO_SCM_HEAD` centrally for GitHub Actions events.
- Add `scripts/turbo/outdated-tasks.mjs` to read Turbo JSON dry-run output and emit only actual task IDs.
- Derive affected projects and sample E2E targets from those task IDs.
- Remove duplicated local branch creation and the separate sample E2E discovery job.

While at it:
- Merge the 2 "affected" calculation blocks to save a step

Some follow ups were split in a separate PR: https://github.com/coveo/ui-kit/pull/8198

## Validation

- `pnpm exec node scripts/turbo/outdated-tasks.mjs`
- `pnpm exec node scripts/turbo/outdated-tasks.mjs e2e`
- `pnpm run lint:fix`
- `pnpm exec oxlint --deny-warnings .`
- `pnpm exec oxfmt --check .`
- Markdown spell check
- Workflow YAML parsing and `git diff --check`

## Checklist

- [x] PR title follows Conventional Commits format (`fix(<scope>): <description>`)
- [x] Changeset not required: this only modifies internal CI and tooling files
