### PR TITLE
feat(thermidor-demo): replay A2UI v1 surface snapshots

### DIFF
--- a/samples/thermidor/demo-react/src/a2ui/SurfaceRenderer/SurfaceRenderer.tsx
+++ b/samples/thermidor/demo-react/src/a2ui/SurfaceRenderer/SurfaceRenderer.tsx
@@ -5,7 +5,7 @@ import {A2UINextActionsBar} from '../NextActionsBar/NextActionsBar.js';
 import {A2UIComparisonTable} from '../ComparisonTable/ComparisonTable.js';
 import {A2UIComparisonSummary} from '../ComparisonSummary/ComparisonSummary.js';
 import {A2UISkeleton} from '../Skeleton/Skeleton.js';
-import {parseSurfaceSnapshot, type ParsedSurface} from '../types.js';
+import {parseSurfaceSnapshots, type ParsedSurface} from '../types.js';
 import styles from './SurfaceRenderer.module.css';
 
 type A2UISurface = Record<string, unknown>;
@@ -45,11 +45,7 @@ export function SurfaceRenderer({
   pendingSkeletons = [],
 }: SurfaceRendererProps) {
   const allParsed = useMemo(() => {
-    const result: ParsedSurface[] = [];
-    for (const surface of surfaces) {
-      result.push(...parseSurfaceSnapshot(surface));
-    }
-    return result;
+    return parseSurfaceSnapshots(surfaces);
   }, [surfaces]);
 
   const renderItems = useMemo(() => {

--- a/samples/thermidor/demo-react/src/a2ui/types.test.ts
+++ b/samples/thermidor/demo-react/src/a2ui/types.test.ts
@@ -21,7 +21,7 @@ describe('parseSurfaceSnapshots', () => {
                 {
                   id: 'root',
                   component: 'ProductCarousel',
-                  componentProps: {heading: 'Featured'},
+                  heading: 'Featured',
                 },
               ],
               dataModel: {products: ['shoe']},
@@ -55,7 +55,7 @@ describe('parseSurfaceSnapshots', () => {
         message({
           updateComponents: {
             surfaceId: 'actions',
-            components: [{id: 'next-actions', component: 'NextActionsBar'}],
+            components: [{id: 'root', component: 'NextActionsBar'}],
           },
         }),
         message({
@@ -71,7 +71,7 @@ describe('parseSurfaceSnapshots', () => {
     expect(result).toEqual([
       {
         surfaceId: 'actions',
-        rootId: 'next-actions',
+        rootId: 'root',
         componentType: 'NextActionsBar',
         componentProps: {},
         data: {status: 'ready', count: 1},
@@ -104,6 +104,75 @@ describe('parseSurfaceSnapshots', () => {
     expect(result[0].data).toEqual({status: 'replacement'});
   });
 
+  it('applies nested and escaped JSON Pointer updates', () => {
+    const result = parseSurfaceSnapshot(
+      snapshot(
+        message({
+          createSurface: {
+            surfaceId: 'data',
+            dataModel: {query: {'display/name': 'old'}, products: ['first', 'second']},
+          },
+        }),
+        message({updateDataModel: {surfaceId: 'data', path: '/query/display~1name', value: 'new'}}),
+        message({updateDataModel: {surfaceId: 'data', path: '/products/0', value: null}})
+      )
+    );
+
+    expect(result[0].data).toEqual({query: {'display/name': 'new'}, products: ['second']});
+  });
+
+  it('keeps the existing surface when a duplicate createSurface arrives', () => {
+    const result = parseSurfaceSnapshot(
+      snapshot(
+        message({
+          createSurface: {
+            surfaceId: 'products',
+            components: [{id: 'root', component: 'ProductCarousel'}],
+            dataModel: {status: 'original'},
+          },
+        }),
+        message({
+          createSurface: {
+            surfaceId: 'products',
+            components: [{id: 'root', component: 'NextActionsBar'}],
+            dataModel: {status: 'duplicate'},
+          },
+        })
+      )
+    );
+
+    expect(result).toEqual([
+      {
+        surfaceId: 'products',
+        rootId: 'root',
+        componentType: 'ProductCarousel',
+        componentProps: {},
+        data: {status: 'original'},
+      },
+    ]);
+  });
+
+  it('does not replace the rendered root when a non-root component is updated', () => {
+    const result = parseSurfaceSnapshot(
+      snapshot(
+        message({
+          createSurface: {
+            surfaceId: 'products',
+            components: [{id: 'root', component: 'ProductCarousel'}],
+          },
+        }),
+        message({
+          updateComponents: {
+            surfaceId: 'products',
+            components: [{id: 'next-actions', component: 'NextActionsBar'}],
+          },
+        })
+      )
+    );
+
+    expect(result[0].componentType).toBe('ProductCarousel');
+  });
+
   it('removes a surface on deleteSurface', () => {
     expect(
       parseSurfaceSnapshot(
@@ -127,6 +196,15 @@ describe('parseSurfaceSnapshots', () => {
             deleteSurface: {surfaceId: 'invalid'},
           },
           {version: 'v1.0', createSurface: {surfaceId: 42}},
+          {
+            version: 'v1.0',
+            createSurface: {
+              surfaceId: 'nested-props',
+              components: [
+                {id: 'root', component: 'ProductCarousel', componentProps: {heading: 'Invalid'}},
+              ],
+            },
+          },
           message({createSurface: {surfaceId: 'valid', dataModel: {ok: true}}}),
         ],
       })

--- a/samples/thermidor/demo-react/src/a2ui/types.test.ts
+++ b/samples/thermidor/demo-react/src/a2ui/types.test.ts
@@ -1,617 +1,149 @@
 import {describe, expect, it} from 'vitest';
-import {parseSurfaceSnapshot} from './types.js';
-describe('types', () => {
-  describe('#parseSurfaceSnapshot', () => {
-    describe('Feature: remove-legacy-operation-format, Property 1: Unified surface construction and component normalization', () => {
-      it.each([
-        {
-          surfaceId: 'surface-products',
-          initialData: {title: 'Running shoes', count: 2},
-          initialComponent: {
-            id: 'root-products',
-            component: 'ProductCard',
-            componentProps: {sku: 'shoe-1', featured: true},
-          },
-          updatedComponent: {
-            id: 'root-actions',
-            component: 'NextActionsBar',
-          },
-        },
-        {
-          surfaceId: 'surface with spaces',
-          initialData: {enabled: true, details: {category: 'boots'}},
-          initialComponent: {
-            id: 'root-comparison',
-            component: 'ComparisonTable',
-          },
-          updatedComponent: {
-            id: 'root-summary',
-            component: 'ComparisonSummary',
-            componentProps: {expanded: false},
-          },
-        },
-        {
-          surfaceId: 'surface-empty-data',
-          initialData: {},
-          initialComponent: {
-            id: 'root-empty',
-            component: 'Skeleton',
-          },
-          updatedComponent: {
-            id: 'root-carousel',
-            component: 'ProductCarousel',
-          },
-        },
-      ])(
-        'should create and normalize the first component for $surfaceId, then normalize an updateComponents component',
-        ({surfaceId, initialData, initialComponent, updatedComponent}) => {
-          const created = parseSurfaceSnapshot({
-            replace: true,
-            operations: [
-              {
-                createSurface: {
-                  surfaceId,
-                  components: [initialComponent],
-                  dataModel: initialData,
-                },
-              },
-            ],
-          });
-          expect(created).toEqual([
-            {
-              surfaceId,
-              rootId: initialComponent.id,
-              componentType: initialComponent.component,
-              componentProps: initialComponent.componentProps ?? {},
-              data: initialData,
-            },
-          ]);
-          const updated = parseSurfaceSnapshot({
-            operations: [
-              {
-                createSurface: {
-                  surfaceId,
-                  components: [initialComponent],
-                  dataModel: initialData,
-                },
-              },
-              {
-                updateComponents: {
-                  surfaceId,
-                  components: [updatedComponent],
-                },
-              },
-            ],
-          });
-          expect(updated).toEqual([
-            {
-              surfaceId,
-              rootId: updatedComponent.id,
-              componentType: updatedComponent.component,
-              componentProps: updatedComponent.componentProps ?? {},
-              data: initialData,
-            },
-          ]);
-        }
-      );
-    });
-    it('accepts string component identifiers for createSurface and updateComponents', () => {
-      const parsed = parseSurfaceSnapshot({
-        operations: [
-          {
-            createSurface: {
-              surfaceId: 'surface-string-components',
-              components: [{id: 'comp-1', component: 'ProductCard'}],
-            },
-          },
-          {
-            updateComponents: {
-              surfaceId: 'surface-string-components',
-              components: [
-                {
-                  id: 'comp-2',
-                  component: 'NextActionsBar',
-                  componentProps: {actions: ['Show more']},
-                },
-              ],
-            },
-          },
-        ],
-      });
+import {parseSurfaceSnapshot, parseSurfaceSnapshots} from './types.js';
 
-      expect(parsed).toEqual([
-        {
-          surfaceId: 'surface-string-components',
-          rootId: 'comp-2',
-          componentType: 'NextActionsBar',
-          componentProps: {actions: ['Show more']},
-          data: {},
-        },
-      ]);
-    });
-    describe('Feature: remove-legacy-operation-format, Property 2: Data-model updates preserve the addressed semantics', () => {
-      it.each([
-        {
-          path: '/',
-          value: {status: 'replaced', results: ['new-result']},
-          expectedData: {status: 'replaced', results: ['new-result']},
-        },
-        {
-          path: '',
-          value: {status: 'reset', count: 0},
-          expectedData: {status: 'reset', count: 0},
-        },
-        {
-          path: '/status',
-          value: 'updated',
-          expectedData: {
-            status: 'updated',
-            count: 3,
-            nested: {preserved: true},
-          },
-        },
-        {
-          path: 'count',
-          value: 7,
-          expectedData: {
-            status: 'initial',
-            count: 7,
-            nested: {preserved: true},
-          },
-        },
-        {
-          path: '/nested',
-          value: {preserved: false, added: true},
-          expectedData: {
-            status: 'initial',
-            count: 3,
-            nested: {preserved: false, added: true},
-          },
-        },
-      ])(
-        'should apply the $path update according to root or addressed-entry semantics',
-        ({path, value, expectedData}) => {
-          const parsed = parseSurfaceSnapshot({
-            operations: [
-              {
-                createSurface: {
-                  surfaceId: 'surface-data-model',
-                  dataModel: {
-                    status: 'initial',
-                    count: 3,
-                    nested: {preserved: true},
-                  },
-                },
-              },
-              {
-                updateDataModel: {
-                  surfaceId: 'surface-data-model',
-                  path,
-                  value,
-                },
-              },
-            ],
-          });
-          expect(parsed).toEqual([
-            {
-              surfaceId: 'surface-data-model',
-              rootId: 'root',
-              componentType: '',
-              componentProps: {},
-              data: expectedData,
-            },
-          ]);
-        }
-      );
-    });
-    describe('Feature: remove-legacy-operation-format, Property 3: Unknown and ignored operations do not affect unified results', () => {
-      it('should ignore unsupported and malformed operations while preserving unified results', () => {
-        const validOperations = [
-          {
+function snapshot(...messages: Record<string, unknown>[]) {
+  return {messages};
+}
+
+function message(operation: Record<string, unknown>) {
+  return {version: 'v1.0', ...operation};
+}
+
+describe('parseSurfaceSnapshots', () => {
+  it('creates renderable surfaces from versioned createSurface messages', () => {
+    expect(
+      parseSurfaceSnapshot(
+        snapshot(
+          message({
             createSurface: {
-              surfaceId: 'surface-unified',
+              surfaceId: 'products',
               components: [
                 {
-                  id: 'root-products',
-                  component: 'ProductCard',
-                  componentProps: {sku: 'shoe-1'},
+                  id: 'root',
+                  component: 'ProductCarousel',
+                  componentProps: {heading: 'Featured'},
                 },
               ],
-              dataModel: {status: 'initial', count: 1},
+              dataModel: {products: ['shoe']},
             },
-          },
-          {
-            updateComponents: {
-              surfaceId: 'surface-unified',
-              components: [
-                {
-                  id: 'root-actions',
-                  component: 'NextActionsBar',
-                  componentProps: {actions: ['Show more']},
-                },
-              ],
-            },
-          },
-          {
-            updateDataModel: {
-              surfaceId: 'surface-unified',
-              path: '/status',
-              value: 'updated',
-            },
-          },
-        ];
-        const unifiedSnapshot = {
-          replace: true,
-          operations: validOperations,
-        };
-        const mixedSnapshot = {
-          replace: true,
-          operations: [
-            {
-              beginRendering: {
-                surfaceId: 'surface-unified',
-                rootComponent: {id: 'legacy-root'},
-              },
-            },
-            validOperations[0],
-            {
-              surfaceUpdate: {
-                surfaceId: 'surface-unified',
-                components: [{id: 'legacy-root', component: {LegacyCard: {}}}],
-              },
-            },
-            {actionResponse: {actionId: 'ignored-action'}},
-            null,
-            'malformed operation',
-            {unsupportedOperation: {surfaceId: 'surface-unified'}},
-            {
-              updateDataModel: {
-                surfaceId: 'unknown-surface',
-                path: '/',
-                value: {unexpected: true},
-              },
-            },
-            {
-              dataModelUpdate: {
-                surfaceId: 'surface-unified',
-                path: '/status',
-                value: 'legacy',
-              },
-            },
-            {updateDataModel: {surfaceId: 123, value: {invalid: true}}},
-            validOperations[1],
-            validOperations[2],
-          ],
-        };
-        let unifiedResult: ReturnType<typeof parseSurfaceSnapshot> = [];
-        let mixedResult: ReturnType<typeof parseSurfaceSnapshot> = [];
-        expect(() => {
-          unifiedResult = parseSurfaceSnapshot(unifiedSnapshot);
-        }).not.toThrow();
-        expect(() => {
-          mixedResult = parseSurfaceSnapshot(mixedSnapshot);
-        }).not.toThrow();
-        expect(mixedResult).toEqual(unifiedResult);
-      });
-    });
-    describe('Feature: remove-legacy-operation-format, Property 4: Equivalent unified construction paths are observationally equivalent', () => {
-      it.each([
-        {
-          surfaceId: 'surface-products',
-          initialComponent: {
-            id: 'root-products',
-            component: 'ProductCard',
-            componentProps: {sku: 'shoe-1', featured: false},
-          },
-          intermediateComponent: {
-            id: 'root-recommendations',
-            component: 'RecommendationList',
-            componentProps: {count: 2},
-          },
-          finalComponent: {
-            id: 'root-actions',
-            component: 'NextActionsBar',
-            componentProps: {actions: ['Show more']},
-          },
-          initialData: {status: 'initial', count: 1},
-          intermediateData: {status: 'intermediate', count: 2},
-          finalData: {status: 'final', count: 3, ready: true},
-        },
-        {
-          surfaceId: 'surface with spaces',
-          initialComponent: {
-            id: 'root-loading',
-            component: 'Skeleton',
-            componentProps: {size: 'small'},
-          },
-          intermediateComponent: {
-            id: 'root-comparison',
-            component: 'ComparisonTable',
-            componentProps: {columns: 3},
-          },
-          finalComponent: {
-            id: 'root-summary',
-            component: 'ComparisonSummary',
-            componentProps: {expanded: true},
-          },
-          initialData: {category: 'boots', selected: false},
-          intermediateData: {category: 'shoes', selected: false},
-          finalData: {category: 'shoes', selected: true},
-        },
-      ])(
-        'should produce the same final surface when values arrive in createSurface or subsequent updates',
-        ({
-          surfaceId,
-          initialComponent,
-          intermediateComponent,
-          finalComponent,
-          initialData,
-          intermediateData,
-          finalData,
-        }) => {
-          const createdWithFinalValues = parseSurfaceSnapshot({
-            replace: true,
-            operations: [
-              {
-                createSurface: {
-                  surfaceId,
-                  components: [finalComponent],
-                  dataModel: finalData,
-                },
-              },
-            ],
-          });
-          const updatedToFinalValues = parseSurfaceSnapshot({
-            replace: true,
-            operations: [
-              {
-                createSurface: {
-                  surfaceId,
-                  components: [initialComponent],
-                  dataModel: initialData,
-                },
-              },
-              {
-                updateComponents: {
-                  surfaceId,
-                  components: [intermediateComponent],
-                },
-              },
-              {
-                updateDataModel: {
-                  surfaceId,
-                  path: '/',
-                  value: intermediateData,
-                },
-              },
-              {
-                updateComponents: {
-                  surfaceId,
-                  components: [finalComponent],
-                },
-              },
-              {
-                updateDataModel: {
-                  surfaceId,
-                  path: '/',
-                  value: finalData,
-                },
-              },
-            ],
-          });
-          expect(updatedToFinalValues).toEqual(createdWithFinalValues);
-        }
-      );
-    });
-    describe('boundary cases', () => {
-      it('should return no surfaces when operations are missing', () => {
-        expect(parseSurfaceSnapshot({})).toEqual([]);
-      });
-      it('should return no surfaces when operations is not an array', () => {
-        expect(parseSurfaceSnapshot({operations: {invalid: true}})).toEqual([]);
-      });
-      it('should return no surfaces when operations is empty', () => {
-        expect(parseSurfaceSnapshot({operations: []})).toEqual([]);
-      });
-      it('should use component and data defaults when createSurface omits both fields', () => {
-        expect(
-          parseSurfaceSnapshot({
-            replace: true,
-            operations: [{createSurface: {surfaceId: 'surface-defaults'}}],
           })
-        ).toEqual([
-          {
-            surfaceId: 'surface-defaults',
-            rootId: 'root',
-            componentType: '',
-            componentProps: {},
-            data: {},
+        )
+      )
+    ).toEqual([
+      {
+        surfaceId: 'products',
+        rootId: 'root',
+        componentType: 'ProductCarousel',
+        componentProps: {heading: 'Featured'},
+        data: {products: ['shoe']},
+      },
+    ]);
+  });
+
+  it('applies updates from later activities to their previously created surface', () => {
+    const result = parseSurfaceSnapshots([
+      snapshot(
+        message({
+          createSurface: {
+            surfaceId: 'actions',
+            components: [{id: 'root', component: 'ProductCarousel'}],
+            dataModel: {status: 'loading', count: 1},
           },
-        ]);
-      });
-      it('should ignore updates for unknown surfaces', () => {
-        expect(
-          parseSurfaceSnapshot({
-            operations: [
-              {
-                createSurface: {
-                  surfaceId: 'surface-known',
-                  components: [
-                    {id: 'root-known', component: 'KnownCard', componentProps: {value: 'initial'}},
-                  ],
-                  dataModel: {status: 'initial'},
-                },
-              },
-              {
-                updateComponents: {
-                  surfaceId: 'surface-unknown',
-                  components: [{id: 'root-unknown', component: 'UnknownCard'}],
-                },
-              },
-              {
-                updateDataModel: {
-                  surfaceId: 'surface-unknown',
-                  path: '/status',
-                  value: 'unexpected',
-                },
-              },
-            ],
-          })
-        ).toEqual([
-          {
-            surfaceId: 'surface-known',
-            rootId: 'root-known',
-            componentType: 'KnownCard',
-            componentProps: {value: 'initial'},
-            data: {status: 'initial'},
+        })
+      ),
+      snapshot(
+        message({
+          updateComponents: {
+            surfaceId: 'actions',
+            components: [{id: 'next-actions', component: 'NextActionsBar'}],
           },
-        ]);
-      });
-      it('should treat actionResponse as a no-op', () => {
-        expect(
-          parseSurfaceSnapshot({
-            operations: [
-              {
-                createSurface: {
-                  surfaceId: 'surface-actions',
-                  dataModel: {status: 'initial'},
-                },
-              },
-              {actionResponse: {actionId: 'action-1', result: 'ignored'}},
-            ],
-          })
-        ).toEqual([
-          {
-            surfaceId: 'surface-actions',
-            rootId: 'root',
-            componentType: '',
-            componentProps: {},
-            data: {status: 'initial'},
+        }),
+        message({
+          updateDataModel: {
+            surfaceId: 'actions',
+            path: '/status',
+            value: 'ready',
           },
-        ]);
-      });
-      it('should ignore a snapshot containing only legacy operations', () => {
-        expect(
-          parseSurfaceSnapshot({
-            operations: [
-              {beginRendering: {surfaceId: 'legacy-surface', rootComponent: {id: 'legacy-root'}}},
-              {
-                surfaceUpdate: {
-                  surfaceId: 'legacy-surface',
-                  components: [{id: 'legacy-root', component: {LegacyCard: {}}}],
-                },
-              },
-              {
-                dataModelUpdate: {
-                  surfaceId: 'legacy-surface',
-                  path: '/status',
-                  value: 'legacy',
-                },
-              },
-            ],
-          })
-        ).toEqual([]);
-      });
-      it('should ignore an unknown operation', () => {
-        expect(
-          parseSurfaceSnapshot({
-            operations: [{unsupportedOperation: {surfaceId: 'surface-unknown'}}],
-          })
-        ).toEqual([]);
-      });
-      it('should ignore malformed entries while preserving later valid operations', () => {
-        expect(
-          parseSurfaceSnapshot({
-            operations: [
-              null,
-              'malformed operation',
-              {createSurface: {surfaceId: 123}},
-              {updateDataModel: {surfaceId: 'surface-valid'}},
-              {
-                updateComponents: {
-                  surfaceId: 'surface-valid',
-                  components: [{id: 'invalid-component', component: {Invalid: 'not-an-object'}}],
-                },
-              },
-              {
-                createSurface: {
-                  surfaceId: 'surface-valid',
-                  dataModel: {status: 'valid'},
-                },
-              },
-            ],
-          })
-        ).toEqual([
-          {
-            surfaceId: 'surface-valid',
-            rootId: 'root',
-            componentType: '',
-            componentProps: {},
-            data: {status: 'valid'},
+        })
+      ),
+    ]);
+
+    expect(result).toEqual([
+      {
+        surfaceId: 'actions',
+        rootId: 'next-actions',
+        componentType: 'NextActionsBar',
+        componentProps: {},
+        data: {status: 'ready', count: 1},
+      },
+    ]);
+  });
+
+  it('replaces the full data model for an empty path and removes addressed values for null', () => {
+    const result = parseSurfaceSnapshot(
+      snapshot(
+        message({
+          createSurface: {
+            surfaceId: 'data',
+            dataModel: {status: 'initial', stale: true},
           },
-        ]);
-      });
-      it('should preserve valid unified results in a mixed legacy and unified snapshot', () => {
-        expect(
-          parseSurfaceSnapshot({
-            replace: true,
-            operations: [
-              {beginRendering: {surfaceId: 'surface-mixed', rootComponent: {id: 'legacy-root'}}},
-              {
-                createSurface: {
-                  surfaceId: 'surface-mixed',
-                  components: [
-                    {id: 'root-unified', component: 'UnifiedCard', componentProps: {sku: 'shoe-1'}},
-                  ],
-                  dataModel: {status: 'initial'},
-                },
-              },
-              {
-                surfaceUpdate: {
-                  surfaceId: 'surface-mixed',
-                  components: [{id: 'legacy-root', component: {LegacyCard: {}}}],
-                },
-              },
-              {
-                dataModelUpdate: {
-                  surfaceId: 'surface-mixed',
-                  path: '/status',
-                  value: 'legacy',
-                },
-              },
-              {actionResponse: {actionId: 'ignored-action'}},
-              {unsupportedOperation: {surfaceId: 'surface-mixed'}},
-              {
-                updateComponents: {
-                  surfaceId: 'surface-mixed',
-                  components: [
-                    {
-                      id: 'root-updated',
-                      component: 'UpdatedCard',
-                      componentProps: {featured: true},
-                    },
-                  ],
-                },
-              },
-              {
-                updateDataModel: {
-                  surfaceId: 'surface-mixed',
-                  path: '/status',
-                  value: 'updated',
-                },
-              },
-            ],
-          })
-        ).toEqual([
-          {
-            surfaceId: 'surface-mixed',
-            rootId: 'root-updated',
-            componentType: 'UpdatedCard',
-            componentProps: {featured: true},
-            data: {status: 'updated'},
+        }),
+        message({
+          updateDataModel: {
+            surfaceId: 'data',
+            path: '/',
+            value: {status: 'replacement', removable: true},
           },
-        ]);
-      });
-    });
+        }),
+        message({
+          updateDataModel: {surfaceId: 'data', path: '/removable', value: null},
+        })
+      )
+    );
+
+    expect(result[0].data).toEqual({status: 'replacement'});
+  });
+
+  it('removes a surface on deleteSurface', () => {
+    expect(
+      parseSurfaceSnapshot(
+        snapshot(
+          message({createSurface: {surfaceId: 'removable'}}),
+          message({deleteSurface: {surfaceId: 'removable'}})
+        )
+      )
+    ).toEqual([]);
+  });
+
+  it('ignores old, malformed, and unsupported messages while preserving valid siblings', () => {
+    expect(
+      parseSurfaceSnapshot({
+        operations: [{createSurface: {surfaceId: 'legacy'}}],
+        messages: [
+          {version: 'v0.8', createSurface: {surfaceId: 'old'}},
+          {
+            version: 'v1.0',
+            createSurface: {surfaceId: 'invalid'},
+            deleteSurface: {surfaceId: 'invalid'},
+          },
+          {version: 'v1.0', createSurface: {surfaceId: 42}},
+          message({createSurface: {surfaceId: 'valid', dataModel: {ok: true}}}),
+        ],
+      })
+    ).toEqual([
+      {
+        surfaceId: 'valid',
+        rootId: 'root',
+        componentType: '',
+        componentProps: {},
+        data: {ok: true},
+      },
+    ]);
+  });
+
+  it('returns no surfaces for snapshots without versioned messages', () => {
+    expect(parseSurfaceSnapshot({})).toEqual([]);
+    expect(parseSurfaceSnapshot({messages: 'invalid'})).toEqual([]);
+    expect(parseSurfaceSnapshot({messages: []})).toEqual([]);
   });
 });

--- a/samples/thermidor/demo-react/src/a2ui/types.ts
+++ b/samples/thermidor/demo-react/src/a2ui/types.ts
@@ -1,8 +1,7 @@
-interface ComponentDefinition {
+type ComponentDefinition = {
   id: string;
   component: string;
-  componentProps?: Record<string, unknown>;
-}
+} & Record<string, unknown>;
 
 interface CreateSurfaceOp {
   surfaceId: string;
@@ -20,7 +19,7 @@ interface UpdateDataModelOp {
 
 interface UpdateComponentsOp {
   surfaceId: string;
-  components?: ComponentDefinition[];
+  components: ComponentDefinition[];
 }
 
 interface DeleteSurfaceOp {
@@ -32,7 +31,7 @@ type A2UIOperation =
   | {updateDataModel: UpdateDataModelOp}
   | {updateComponents: UpdateComponentsOp}
   | {deleteSurface: DeleteSurfaceOp}
-  | {actionResponse: unknown};
+  | {actionResponse: {actionId: string; response: unknown}};
 
 /**
  * Parsed surface ready for rendering.
@@ -45,17 +44,22 @@ export interface ParsedSurface {
   data: Record<string, unknown>;
 }
 
-type SurfaceState = Omit<ParsedSurface, 'surfaceId'>;
+interface SurfaceState {
+  components: Map<string, ComponentDefinition>;
+  data?: Record<string, unknown>;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function isComponentDefinition(value: unknown): value is ComponentDefinition {
-  if (!isRecord(value) || typeof value.id !== 'string' || typeof value.component !== 'string') {
-    return false;
-  }
-  return value.componentProps === undefined || isRecord(value.componentProps);
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.component === 'string' &&
+    !Object.prototype.hasOwnProperty.call(value, 'componentProps')
+  );
 }
 
 function isComponentDefinitions(value: unknown): value is ComponentDefinition[] {
@@ -64,7 +68,7 @@ function isComponentDefinitions(value: unknown): value is ComponentDefinition[] 
 
 function normalizeComponent(
   component: ComponentDefinition | undefined
-): Omit<SurfaceState, 'data'> {
+): Pick<ParsedSurface, 'rootId' | 'componentType' | 'componentProps'> {
   if (!component) {
     return {
       rootId: 'root',
@@ -72,10 +76,11 @@ function normalizeComponent(
       componentProps: {},
     };
   }
+  const {id, component: componentType, ...componentProps} = component;
   return {
-    rootId: component.id,
-    componentType: component.component,
-    componentProps: component.componentProps ?? {},
+    rootId: id,
+    componentType,
+    componentProps,
   };
 }
 
@@ -105,7 +110,9 @@ function getOperation(message: unknown): A2UIOperation | undefined {
     case 'deleteSurface':
       return getDeleteSurfaceOperation(message);
     case 'actionResponse':
-      return {actionResponse: message.actionResponse};
+      return typeof message.actionId === 'string'
+        ? {actionResponse: {actionId: message.actionId, response: message.actionResponse}}
+        : undefined;
     default:
       return undefined;
   }
@@ -148,10 +155,7 @@ function getUpdateComponentsOperation(value: Record<string, unknown>): A2UIOpera
     return undefined;
   }
   const operation = value.updateComponents;
-  if (
-    typeof operation.surfaceId !== 'string' ||
-    (operation.components !== undefined && !isComponentDefinitions(operation.components))
-  ) {
+  if (typeof operation.surfaceId !== 'string' || !isComponentDefinitions(operation.components)) {
     return undefined;
   }
   return {updateComponents: operation as UpdateComponentsOp};
@@ -189,15 +193,24 @@ export function parseSurfaceSnapshots(
     }
   }
 
-  return Array.from(surfaces.entries()).map(([surfaceId, entry]) => ({surfaceId, ...entry}));
+  return Array.from(surfaces.entries()).map(([surfaceId, entry]) => ({
+    surfaceId,
+    ...normalizeComponent(entry.components.get('root')),
+    data: entry.data ?? {},
+  }));
 }
 
 function applyOperation(surfaces: Map<string, SurfaceState>, operation: A2UIOperation): void {
   if ('createSurface' in operation) {
     const createSurface = operation.createSurface;
+    if (surfaces.has(createSurface.surfaceId)) {
+      return;
+    }
     surfaces.set(createSurface.surfaceId, {
-      ...normalizeComponent(createSurface.components?.[0]),
-      data: createSurface.dataModel ?? {},
+      components: new Map(
+        (createSurface.components ?? []).map((component) => [component.id, component])
+      ),
+      data: createSurface.dataModel,
     });
     return;
   }
@@ -208,26 +221,16 @@ function applyOperation(surfaces: Map<string, SurfaceState>, operation: A2UIOper
     if (!entry) {
       return;
     }
-    if (updateDataModel.path === '/' || !updateDataModel.path) {
-      entry.data = isRecord(updateDataModel.value) ? updateDataModel.value : {};
-      return;
-    }
-
-    const key = updateDataModel.path.startsWith('/')
-      ? updateDataModel.path.slice(1)
-      : updateDataModel.path;
-    if (updateDataModel.value === null) {
-      delete entry.data[key];
-    } else {
-      entry.data[key] = updateDataModel.value;
-    }
+    entry.data = applyDataModelPatch(entry.data, updateDataModel.path, updateDataModel.value);
     return;
   }
 
   if ('updateComponents' in operation) {
     const entry = surfaces.get(operation.updateComponents.surfaceId);
-    if (entry && operation.updateComponents.components?.[0]) {
-      Object.assign(entry, normalizeComponent(operation.updateComponents.components[0]));
+    if (entry) {
+      for (const component of operation.updateComponents.components) {
+        entry.components.set(component.id, component);
+      }
     }
     return;
   }
@@ -235,4 +238,92 @@ function applyOperation(surfaces: Map<string, SurfaceState>, operation: A2UIOper
   if ('deleteSurface' in operation) {
     surfaces.delete(operation.deleteSurface.surfaceId);
   }
+}
+
+function applyDataModelPatch(
+  current: Record<string, unknown> | undefined,
+  path: string | undefined,
+  value: unknown
+): Record<string, unknown> | undefined {
+  if (!path || path === '/') {
+    return isRecord(value) ? value : undefined;
+  }
+  if (!path.startsWith('/')) {
+    return current;
+  }
+
+  const segments = path
+    .slice(1)
+    .split('/')
+    .map((segment) => segment.replace(/~1/g, '/').replace(/~0/g, '~'));
+  const root: Record<string, unknown> = {...(current ?? {})};
+  let target: Record<string, unknown> | unknown[] = root;
+
+  for (let index = 0; index < segments.length - 1; index++) {
+    const segment = segments[index];
+    const nextSegment = segments[index + 1];
+    const existing = getContainerValue(target, segment);
+    const child = isContainer(existing) ? cloneContainer(existing) : createContainer(nextSegment);
+    setContainerValue(target, segment, child);
+    target = child;
+  }
+
+  const leaf = segments.at(-1);
+  if (leaf === undefined) {
+    return root;
+  }
+  if (value === null) {
+    deleteContainerValue(target, leaf);
+  } else {
+    setContainerValue(target, leaf, value);
+  }
+  return root;
+}
+
+function createContainer(nextSegment: string): Record<string, unknown> | unknown[] {
+  return isArrayIndex(nextSegment) || nextSegment === '-' ? [] : {};
+}
+
+function cloneContainer(
+  value: Record<string, unknown> | unknown[]
+): Record<string, unknown> | unknown[] {
+  return Array.isArray(value) ? [...value] : {...value};
+}
+
+function isContainer(value: unknown): value is Record<string, unknown> | unknown[] {
+  return Array.isArray(value) || isRecord(value);
+}
+
+function getContainerValue(container: Record<string, unknown> | unknown[], key: string): unknown {
+  return Array.isArray(container) ? container[Number(key)] : container[key];
+}
+
+function setContainerValue(
+  container: Record<string, unknown> | unknown[],
+  key: string,
+  value: unknown
+): void {
+  if (Array.isArray(container)) {
+    if (key === '-') {
+      container.push(value);
+    } else if (isArrayIndex(key)) {
+      container[Number(key)] = value;
+    }
+    return;
+  }
+  container[key] = value;
+}
+
+function deleteContainerValue(container: Record<string, unknown> | unknown[], key: string): void {
+  if (Array.isArray(container)) {
+    if (isArrayIndex(key)) {
+      container.splice(Number(key), 1);
+    }
+    return;
+  }
+  delete container[key];
+}
+
+function isArrayIndex(value: string): boolean {
+  return /^(0|[1-9]\d*)$/.test(value);
 }

--- a/samples/thermidor/demo-react/src/a2ui/types.ts
+++ b/samples/thermidor/demo-react/src/a2ui/types.ts
@@ -3,32 +3,37 @@ interface ComponentDefinition {
   component: string;
   componentProps?: Record<string, unknown>;
 }
+
 interface CreateSurfaceOp {
   surfaceId: string;
   catalogId?: string;
-  surfaceProperties?: Record<string, unknown>;
   sendDataModel?: boolean;
   components?: ComponentDefinition[];
   dataModel?: Record<string, unknown>;
 }
+
 interface UpdateDataModelOp {
   surfaceId: string;
   path?: string;
   value: unknown;
 }
+
 interface UpdateComponentsOp {
   surfaceId: string;
   components?: ComponentDefinition[];
 }
+
+interface DeleteSurfaceOp {
+  surfaceId: string;
+}
+
 type A2UIOperation =
   | {createSurface: CreateSurfaceOp}
   | {updateDataModel: UpdateDataModelOp}
   | {updateComponents: UpdateComponentsOp}
+  | {deleteSurface: DeleteSurfaceOp}
   | {actionResponse: unknown};
-interface A2UISurfaceData {
-  operations: A2UIOperation[];
-  replace?: boolean;
-}
+
 /**
  * Parsed surface ready for rendering.
  */
@@ -39,19 +44,24 @@ export interface ParsedSurface {
   componentProps: Record<string, unknown>;
   data: Record<string, unknown>;
 }
+
 type SurfaceState = Omit<ParsedSurface, 'surfaceId'>;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
+
 function isComponentDefinition(value: unknown): value is ComponentDefinition {
   if (!isRecord(value) || typeof value.id !== 'string' || typeof value.component !== 'string') {
     return false;
   }
   return value.componentProps === undefined || isRecord(value.componentProps);
 }
+
 function isComponentDefinitions(value: unknown): value is ComponentDefinition[] {
   return Array.isArray(value) && value.every(isComponentDefinition);
 }
+
 function normalizeComponent(
   component: ComponentDefinition | undefined
 ): Omit<SurfaceState, 'data'> {
@@ -68,28 +78,58 @@ function normalizeComponent(
     componentProps: component.componentProps ?? {},
   };
 }
-function getCreateSurfaceOperation(value: unknown): CreateSurfaceOp | undefined {
-  if (!isRecord(value) || !isRecord(value.createSurface)) {
+
+function getOperation(message: unknown): A2UIOperation | undefined {
+  if (!isRecord(message) || message.version !== 'v1.0') {
+    return undefined;
+  }
+
+  const operationKeys = [
+    'createSurface',
+    'updateDataModel',
+    'updateComponents',
+    'deleteSurface',
+    'actionResponse',
+  ].filter((key) => Object.prototype.hasOwnProperty.call(message, key));
+  if (operationKeys.length !== 1) {
+    return undefined;
+  }
+
+  switch (operationKeys[0]) {
+    case 'createSurface':
+      return getCreateSurfaceOperation(message);
+    case 'updateDataModel':
+      return getUpdateDataModelOperation(message);
+    case 'updateComponents':
+      return getUpdateComponentsOperation(message);
+    case 'deleteSurface':
+      return getDeleteSurfaceOperation(message);
+    case 'actionResponse':
+      return {actionResponse: message.actionResponse};
+    default:
+      return undefined;
+  }
+}
+
+function getCreateSurfaceOperation(value: Record<string, unknown>): A2UIOperation | undefined {
+  if (!isRecord(value.createSurface)) {
     return undefined;
   }
   const operation = value.createSurface;
-  if (typeof operation.surfaceId !== 'string') {
-    return undefined;
-  }
-  if (operation.components !== undefined && !isComponentDefinitions(operation.components)) {
-    return undefined;
-  }
   if (
-    operation.dataModel !== undefined &&
-    operation.dataModel !== null &&
-    !isRecord(operation.dataModel)
+    typeof operation.surfaceId !== 'string' ||
+    (operation.catalogId !== undefined && typeof operation.catalogId !== 'string') ||
+    (operation.sendDataModel !== undefined && typeof operation.sendDataModel !== 'boolean') ||
+    (operation.components !== undefined && !isComponentDefinitions(operation.components)) ||
+    (operation.dataModel !== undefined && !isRecord(operation.dataModel))
   ) {
     return undefined;
   }
-  return operation as unknown as CreateSurfaceOp;
+  return {createSurface: operation as CreateSurfaceOp};
 }
-function getUpdateDataModelOperation(value: unknown): UpdateDataModelOp | undefined {
-  if (!isRecord(value) || !isRecord(value.updateDataModel)) {
+
+function getUpdateDataModelOperation(value: Record<string, unknown>): A2UIOperation | undefined {
+  if (!isRecord(value.updateDataModel)) {
     return undefined;
   }
   const operation = value.updateDataModel;
@@ -100,10 +140,11 @@ function getUpdateDataModelOperation(value: unknown): UpdateDataModelOp | undefi
   ) {
     return undefined;
   }
-  return operation as unknown as UpdateDataModelOp;
+  return {updateDataModel: operation as UpdateDataModelOp};
 }
-function getUpdateComponentsOperation(value: unknown): UpdateComponentsOp | undefined {
-  if (!isRecord(value) || !isRecord(value.updateComponents)) {
+
+function getUpdateComponentsOperation(value: Record<string, unknown>): A2UIOperation | undefined {
+  if (!isRecord(value.updateComponents)) {
     return undefined;
   }
   const operation = value.updateComponents;
@@ -113,63 +154,85 @@ function getUpdateComponentsOperation(value: unknown): UpdateComponentsOp | unde
   ) {
     return undefined;
   }
-  return operation as unknown as UpdateComponentsOp;
+  return {updateComponents: operation as UpdateComponentsOp};
 }
+
+function getDeleteSurfaceOperation(value: Record<string, unknown>): A2UIOperation | undefined {
+  if (!isRecord(value.deleteSurface) || typeof value.deleteSurface.surfaceId !== 'string') {
+    return undefined;
+  }
+  return {deleteSurface: value.deleteSurface as DeleteSurfaceOp};
+}
+
 /**
  * Parse an A2UI surface snapshot into a list of renderable surfaces.
  */
 export function parseSurfaceSnapshot(raw: Record<string, unknown>): ParsedSurface[] {
-  const snapshot = isRecord(raw) ? (raw as unknown as A2UISurfaceData) : undefined;
-  if (!snapshot || !Array.isArray(snapshot.operations) || snapshot.operations.length === 0) {
-    return [];
-  }
+  return parseSurfaceSnapshots([raw]);
+}
+
+export function parseSurfaceSnapshots(
+  rawSnapshots: ReadonlyArray<Record<string, unknown>>
+): ParsedSurface[] {
   const surfaces = new Map<string, SurfaceState>();
-  for (const operation of snapshot.operations) {
-    const createSurface = getCreateSurfaceOperation(operation);
-    if (createSurface) {
-      surfaces.set(createSurface.surfaceId, {
-        ...normalizeComponent(createSurface.components?.[0]),
-        data: createSurface.dataModel ?? {},
-      });
+
+  for (const snapshot of rawSnapshots) {
+    if (!Array.isArray(snapshot.messages)) {
       continue;
     }
-    const updateDataModel = getUpdateDataModelOperation(operation);
-    if (updateDataModel) {
-      const entry = surfaces.get(updateDataModel.surfaceId);
-      if (!entry) {
+    for (const message of snapshot.messages) {
+      const operation = getOperation(message);
+      if (!operation) {
         continue;
       }
-      if (updateDataModel.path === '/' || !updateDataModel.path) {
-        if (
-          updateDataModel.value !== null &&
-          updateDataModel.value !== undefined &&
-          !isRecord(updateDataModel.value)
-        ) {
-          continue;
-        }
-        entry.data = isRecord(updateDataModel.value) ? updateDataModel.value : {};
-      } else {
-        const key = updateDataModel.path.startsWith('/')
-          ? updateDataModel.path.slice(1)
-          : updateDataModel.path;
-        entry.data[key] = updateDataModel.value;
-      }
-      continue;
-    }
-    const updateComponents = getUpdateComponentsOperation(operation);
-    if (updateComponents) {
-      const entry = surfaces.get(updateComponents.surfaceId);
-      if (entry && updateComponents.components?.[0]) {
-        Object.assign(entry, normalizeComponent(updateComponents.components[0]));
-      }
-      continue;
-    }
-    if (isRecord(operation) && Object.prototype.hasOwnProperty.call(operation, 'actionResponse')) {
-      continue;
+      applyOperation(surfaces, operation);
     }
   }
-  return Array.from(surfaces.entries()).map(([surfaceId, entry]) => ({
-    surfaceId,
-    ...entry,
-  }));
+
+  return Array.from(surfaces.entries()).map(([surfaceId, entry]) => ({surfaceId, ...entry}));
+}
+
+function applyOperation(surfaces: Map<string, SurfaceState>, operation: A2UIOperation): void {
+  if ('createSurface' in operation) {
+    const createSurface = operation.createSurface;
+    surfaces.set(createSurface.surfaceId, {
+      ...normalizeComponent(createSurface.components?.[0]),
+      data: createSurface.dataModel ?? {},
+    });
+    return;
+  }
+
+  if ('updateDataModel' in operation) {
+    const updateDataModel = operation.updateDataModel;
+    const entry = surfaces.get(updateDataModel.surfaceId);
+    if (!entry) {
+      return;
+    }
+    if (updateDataModel.path === '/' || !updateDataModel.path) {
+      entry.data = isRecord(updateDataModel.value) ? updateDataModel.value : {};
+      return;
+    }
+
+    const key = updateDataModel.path.startsWith('/')
+      ? updateDataModel.path.slice(1)
+      : updateDataModel.path;
+    if (updateDataModel.value === null) {
+      delete entry.data[key];
+    } else {
+      entry.data[key] = updateDataModel.value;
+    }
+    return;
+  }
+
+  if ('updateComponents' in operation) {
+    const entry = surfaces.get(operation.updateComponents.surfaceId);
+    if (entry && operation.updateComponents.components?.[0]) {
+      Object.assign(entry, normalizeComponent(operation.updateComponents.components[0]));
+    }
+    return;
+  }
+
+  if ('deleteSurface' in operation) {
+    surfaces.delete(operation.deleteSurface.surfaceId);
+  }
 }

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.integration.test.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.integration.test.tsx
@@ -182,7 +182,7 @@ describe('ConversationPage integration', () => {
               surfaceId: 'surface-actions',
               components: [
                 {
-                  id: 'comp-1',
+                  id: 'root',
                   component: 'NextActionsBar',
                 },
               ],

--- a/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.integration.test.tsx
+++ b/samples/thermidor/demo-react/src/components/ConversationPage/ConversationPage.integration.test.tsx
@@ -169,13 +169,15 @@ describe('ConversationPage integration', () => {
     it('calls onSubmit with the action text when a next-action button is clicked', () => {
       const onSubmit = vi.fn();
       const nextActionsSurface = {
-        operations: [
+        messages: [
           {
+            version: 'v1.0',
             createSurface: {
               surfaceId: 'surface-actions',
             },
           },
           {
+            version: 'v1.0',
             updateComponents: {
               surfaceId: 'surface-actions',
               components: [
@@ -187,6 +189,7 @@ describe('ConversationPage integration', () => {
             },
           },
           {
+            version: 'v1.0',
             updateDataModel: {
               surfaceId: 'surface-actions',
               path: '/',


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/SMITH-39

## Context

Thermidor's initial A2UI v1 implementation was based on a July 2026 snapshot of the then-candidate specification. The upstream v1.0 contract continued to evolve and be clarified through late July and August—including explicit data-model `null` deletion, removal of `surfaceProperties`, canonical surface/root composition, catalog resolution, and envelope/component validation. This stack aligns Thermidor with the current shared surface contract used by the Gateway and Smith implementations.

The React demo is a consumer of the same A2UI v1 surface stream as Thermidor. A2UI v1 requires replaying the ordered lifecycle: a surface can be created in one activity and updated, patched, or deleted in a later activity.

The previous demo parser treated each activity as an isolated snapshot and selected the first component it received. That diverges from the v1 model and from the Thermidor lifecycle processor, especially as Gateway and Smith adopt direct catalog properties and canonical `id: "root"` components.

## Changes

- Replay all stored `content.messages` activities through persistent per-surface state instead of parsing each snapshot independently.
- Consume canonical direct component properties and normalize them into the demo renderer's existing `ParsedSurface.componentProps` API.
- Render the component whose ID is `root`; non-root component updates no longer replace the displayed surface.
- Merge component definitions by ID, preserve the first valid create for a surface ID, and remove a surface on `deleteSurface`.
- Apply the same JSON Pointer data-model semantics as Thermidor for nested paths, escaped keys, array updates, root replacement, and `null` deletion.
- Update the NextActionsBar integration fixture to use the canonical root ID.
- Keep this as a curated Commerce demo renderer, not a claim of generic A2UI catalog rendering.

## Why this is separate

This layer is deliberately presentation-only. It depends on the protocol normalization in PR #8210 and complements the runtime lifecycle behavior in PR #8211 without adding renderer-side RPC or unsupported catalog capabilities.

## Validation

- `pnpm --filter @samples/thermidor-demo-react test`
- `pnpm --filter @samples/thermidor-demo-react build`
- `pnpm run lint:check`

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] No changeset required because this modifies a private demo.

## Stack

**3 of 3 — review last:** [A2UI v1 format](https://github.com/coveo/ui-kit/pull/8210) → [surface lifecycle](https://github.com/coveo/ui-kit/pull/8211) → [demo replay](https://github.com/coveo/ui-kit/pull/8195).

This PR applies the lower parsing and lifecycle work to the React demo renderer.