### PR TITLE
chore(ci): build only affected packages by default

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,7 +9,7 @@ inputs:
   build-command:
     description: 'Command used to build. Defaults to building every package.'
     required: false
-    default: 'pnpm run build'
+    default: 'pnpm run build --affected'
 #endregion
 runs:
   using: composite


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6035

Identified while working on https://github.com/coveo/ui-kit/pull/8192

## Motivation

Building every package for each CI change performs unnecessary work. The shared setup action should default to Turbo's affected-package build mode while still allowing callers to override the command.

## Changes

Changed the default `build-command` input in `.github/actions/setup/action.yml` from `pnpm run build` to `pnpm run build --affected`.

## Validation

- [x] No public package source or API was modified


## Checklist

- [x] PR title follows Conventional Commits 1.0.0 format (`chore(ci): description`)
- [x] No changeset required because no public package source code was modified
