### PR TITLE
fix(atomic): resolve Turbo in Chromatic builds

### DIFF
--- a/packages/atomic/chromatic.config.json
+++ b/packages/atomic/chromatic.config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://www.chromatic.com/config-file.schema.json",
-  "buildCommand": "turbo run build:storybook --filter=@coveo/atomic --",
+  "buildCommand": "pnpm --workspace-root exec turbo run build:storybook --filter=@coveo/atomic --",
   "outputDir": "dist-storybook",
   "exitOnceUploaded": true,
   "untraced": ["package.json", "pnpm-lock.yaml", "/virtual:*", "packages/coveo-analytics/**/*"],


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6036

## Motivation

The Atomic Chromatic CI job fails while building Storybook because the Chromatic action cannot resolve the workspace-local `turbo` executable, causing `spawn turbo ENOENT`.

https://github.com/coveo/ui-kit/actions/runs/31387335957/job/93451188400

```
12:23:00.776 The CLI tried to run your turbo run build:storybook --filter=@coveo/atomic -- script, but the command failed. This indicates a problem with your Storybook. Here's what to do:
             
             - Check the Storybook build log printed below.
             - Run turbo run build:storybook --filter=@coveo/atomic -- yourself and make sure it outputs a valid Storybook by opening the generated index.html in your browser.
             - Review the build-storybook CLI options at https://storybook.js.org/docs/api/cli-options#build
             
             Command failed with ENOENT: turbo run 'build:storybook' '--filter=@coveo/atomic' -- '--webpack-stats-json=dist-storybook'
             spawn turbo ENOENT
             
             ℹ Build command:
             turbo run build:storybook --filter=@coveo/atomic -- --webpack-stats-json=dist-storybook
             
             ℹ Runtime metadata:
             {
               "nodePlatform": "linux",
               "nodeVersion": "24.18.0",
               "packageManager": "pnpm",
               "packageManagerVersion": "10.34.5"
             }
             
             ℹ Storybook build output:
             /home/runner/work/ui-kit/ui-kit/packages/atomic/build-storybook.log
```

## Root Cause

`packages/atomic/chromatic.config.json` invokes `turbo` directly. The Chromatic action does not add the workspace `node_modules/.bin` directory to `PATH`, so the pinned workspace binary cannot be found.

## Changes

Invoke Turbo through pnpm with `--workspace-root`, ensuring the repository-local Turbo version is resolved from the workspace.

## Validation

- Atomic Storybook build completed successfully with 13 Turbo tasks.
- `pnpm run lint:fix` passed.
- `pnpm run lint:check` passed.
- JSON parsing and Turbo dry-run validation passed.
- No changeset added because this changes CI configuration only, not public package source code.

Fixes the issue: https://github.com/coveo/ui-kit/actions/runs/31391432333/job/93464683294?pr=8193

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`fix(<scope>): <description>`)
- [x] Changeset not required (CI configuration only)