### PR TITLE
chore(ci): ignore generated Angular rxjs dependency in Knip

### DIFF
--- a/knip.js
+++ b/knip.js
@@ -33,6 +33,7 @@ export default {
       ignoreDependencies: [
         // Can be removed once we bump our package to use more recent Angular versions that support Vite 7+.
         'vite',
+        'rxjs',
       ],
     },
     'packages/atomic-angular/projects/atomic-angular': {

--- a/knip.js
+++ b/knip.js
@@ -33,7 +33,7 @@ export default {
       ignoreDependencies: [
         // Can be removed once we bump our package to use more recent Angular versions that support Vite 7+.
         'vite',
-        'rxjs',
+        'rxjs', // Used by generated Angular wrapper; Knip can't trace it.
       ],
     },
     'packages/atomic-angular/projects/atomic-angular': {


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6037

## Motivation

Knip reports `rxjs` as an unused dependency in the private Angular builder workspace, although the generated Angular wrapper uses `fromEvent` from `rxjs`. This creates a false-positive dependency warning.

## Changes

- Add `rxjs` to the `ignoreDependencies` list for `packages/atomic-angular` in `knip.js`.
- Leave the actual dependency and generated Angular wrapper unchanged.
- No public API or published package behavior changes.

## Validation

- Before the change, scoped Knip reported `rxjs  packages/atomic-angular/package.json:15:6` and exited with code 1.
- After the change, the same scoped Knip check exited with code 0.
- `pnpm run lint:fix` passed.
- No new features or bug fixes are included in this PR

## Checklist

- [x] PR title follows Conventional Commits format
- [x] No changeset required: this is an internal tooling change