### PR TITLE
docs(agents): document mise CLI setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This repository uses [`mise.toml`](mise.toml) to manage the CLI toolchain.
 Before using `aws`, `pnpm` or `node`:
 1. If `mise` is not installed, stop and ask the user to install it with `brew install mise`. Do not do it for them.
 2. Run `mise install`
-3. Export all the env vars as given by `mise env`
+3. `export` all the env vars as given by `mise env` in the current shell for the next command invocations. Notably, this will override `PATH`.
 
 Do not use `nvm`, `corepack`, `npx`, or `npm`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,15 @@
 # AGENTS.md
 
-## Prerequisites
+## Prerequisites using `mise`
 
-- **Node.js**: Version pinned in `.nvmrc` (use `nvm use` or the devcontainer)
-- **pnpm**: Pinned in `package.json` `packageManager` field. Run `corepack enable` to activate it
+This repository uses [`mise.toml`](mise.toml) to manage the CLI toolchain.
+
+Before using `aws`, `pnpm` or `node`:
+1. If `mise` is not installed, stop and ask the user to install it with `brew install mise`. Do not do it for them.
+2. Run `mise install`
+3. Export all the env vars as given by `mise env`
+
+Do not use `nvm`, `corepack`, `npx`, or `npm`.
 
 ## Commands
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,8 +2,9 @@ min_version = "2026.7.0"
 
 [tools]
 awscli = "2.36.13"
-node = "24.18.1"
-pnpm = "10.34.5"
+
+[settings]
+idiomatic_version_file_enable_tools = ["node", "pnpm"]
 
 [tasks.install]
 run = "pnpm install"

--- a/mise.toml
+++ b/mise.toml
@@ -7,4 +7,4 @@ awscli = "2.36.13"
 idiomatic_version_file_enable_tools = ["node", "pnpm"]
 
 [tasks.install]
-run = "pnpm install"
+run = "pnpm install --frozen-lockfile"


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6038

## Motivation

Coding agents need a clear, repository-specific way to initialize the managed CLI toolchain. The previous guidance referenced nvm and corepack even though this repository uses mise.

## Changes

- Document `mise.toml` as the source of truth for the CLI toolchain.
- Instruct agents to verify mise is installed and run `mise install` before using repository CLI tools.
- Prevent fallback to nvm, corepack, npx, or npm for the repository toolchain.
- Correct the inline-code formatting for the AWS CLI reference.

## Validation

- [x] `pnpm run lint:fix`
- [x] Pre-commit hooks passed, including cspell for `AGENTS.md`.

## Checklist

- [x] PR title follows Conventional Commits format (`docs(agents): <description>`)
- [x] No changeset required because this is documentation-only and does not affect a public package API.