### PR TITLE
feat(thermidor-demo): add local Agent Gateway routing

### DIFF
--- a/samples/thermidor/demo-react/.env.example
+++ b/samples/thermidor/demo-react/.env.example
@@ -7,3 +7,6 @@ VITE_COVEO_CURRENCY=USD
 VITE_COVEO_PLATFORM_ENVIRONMENT=dev
 VITE_COVEO_ENDPOINT=
 VITE_COVEO_USE_VITE_PROXY=true
+# Optional AgentCore runtime routing. Configure a qualifier only when the selected runtime exposes one.
+VITE_COVEO_AGENT_RUNTIME_NAME=
+VITE_COVEO_AGENT_RUNTIME_QUALIFIER=

--- a/samples/thermidor/demo-react/package.json
+++ b/samples/thermidor/demo-react/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:agent-gateway": "VITE_COVEO_ENDPOINT=http://localhost:8980 VITE_COVEO_USE_VITE_PROXY=true vite",
     "dev:mock": "VITE_COVEO_ENDPOINT=http://localhost:3456 vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/samples/thermidor/demo-react/vite.config.test.ts
+++ b/samples/thermidor/demo-react/vite.config.test.ts
@@ -1,9 +1,13 @@
 import {describe, expect, it} from 'vitest';
-import {resolveProxyTargets} from './vite.config.js';
+import {resolveAgentRuntimeHeaders, resolveProxyTargets} from './vite.config.js';
 
 describe('resolveProxyTargets', () => {
   it('does not configure a proxy without an organization ID', () => {
     expect(resolveProxyTargets(undefined, 'http://localhost:8980', 'dev')).toBeUndefined();
+  });
+
+  it('does not configure a proxy with a blank organization ID', () => {
+    expect(resolveProxyTargets('  ', 'http://localhost:8980', 'dev')).toBeUndefined();
   });
 
   it('uses the organization platform endpoint by default', () => {
@@ -21,9 +25,28 @@ describe('resolveProxyTargets', () => {
   });
 
   it('uses the platform endpoint when the override is blank', () => {
-    expect(resolveProxyTargets('my-org', '', 'dev')).toEqual({
+    expect(resolveProxyTargets(' my-org ', '  ', 'dev')).toEqual({
       agentGateway: 'https://my-org.orgdev.coveo.com',
       platform: 'https://my-org.orgdev.coveo.com',
+    });
+  });
+});
+
+describe('resolveAgentRuntimeHeaders', () => {
+  it('returns undefined without a runtime name', () => {
+    expect(resolveAgentRuntimeHeaders('  ', 'qualifier')).toBeUndefined();
+  });
+
+  it('returns the runtime name header', () => {
+    expect(resolveAgentRuntimeHeaders(' runtime ', undefined)).toEqual({
+      'x-coveo-agent-runtime-name': 'runtime',
+    });
+  });
+
+  it('returns runtime name and qualifier headers', () => {
+    expect(resolveAgentRuntimeHeaders('runtime', ' qualifier ')).toEqual({
+      'x-coveo-agent-runtime-name': 'runtime',
+      'x-coveo-agent-runtime-qualifier': 'qualifier',
     });
   });
 });

--- a/samples/thermidor/demo-react/vite.config.test.ts
+++ b/samples/thermidor/demo-react/vite.config.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from 'vitest';
+import {resolveProxyTargets} from './vite.config.js';
+
+describe('resolveProxyTargets', () => {
+  it('does not configure a proxy without an organization ID', () => {
+    expect(resolveProxyTargets(undefined, 'http://localhost:8980', 'dev')).toBeUndefined();
+  });
+
+  it('uses the organization platform endpoint by default', () => {
+    expect(resolveProxyTargets('my-org', undefined, 'dev')).toEqual({
+      agentGateway: 'https://my-org.orgdev.coveo.com',
+      platform: 'https://my-org.orgdev.coveo.com',
+    });
+  });
+
+  it('routes AG-UI requests to an explicit Agent Gateway endpoint', () => {
+    expect(resolveProxyTargets('my-org', 'http://localhost:8980', 'dev')).toEqual({
+      agentGateway: 'http://localhost:8980',
+      platform: 'https://my-org.orgdev.coveo.com',
+    });
+  });
+
+  it('uses the platform endpoint when the override is blank', () => {
+    expect(resolveProxyTargets('my-org', '', 'dev')).toEqual({
+      agentGateway: 'https://my-org.orgdev.coveo.com',
+      platform: 'https://my-org.orgdev.coveo.com',
+    });
+  });
+});

--- a/samples/thermidor/demo-react/vite.config.ts
+++ b/samples/thermidor/demo-react/vite.config.ts
@@ -41,14 +41,17 @@ export function resolveProxyTargets(
   endpointOverride: string | undefined,
   environment: PlatformEnvironment
 ) {
-  if (!organizationId) {
+  const normalizedOrganizationId = organizationId?.trim();
+  const normalizedEndpointOverride = endpointOverride?.trim();
+
+  if (!normalizedOrganizationId) {
     return undefined;
   }
 
-  const platform = getOrganizationPlatformEndpoint(organizationId, environment);
+  const platform = getOrganizationPlatformEndpoint(normalizedOrganizationId, environment);
 
   return {
-    agentGateway: endpointOverride || platform,
+    agentGateway: normalizedEndpointOverride || platform,
     platform,
   };
 }
@@ -70,12 +73,10 @@ export function resolveAgentRuntimeHeaders(
   };
 }
 
-function getProxyTargets(mode: string) {
-  const env = loadEnv(mode, process.cwd(), '');
-
+function getProxyTargets(env: Record<string, string>) {
   return resolveProxyTargets(
-    env.VITE_COVEO_ORGANIZATION_ID?.trim(),
-    env.VITE_COVEO_ENDPOINT?.trim(),
+    env.VITE_COVEO_ORGANIZATION_ID,
+    env.VITE_COVEO_ENDPOINT,
     resolveEnvironment(env.VITE_COVEO_PLATFORM_ENVIRONMENT)
   );
 }
@@ -83,7 +84,7 @@ function getProxyTargets(mode: string) {
 export default defineConfig(({mode}) => {
   const env = loadEnv(mode, process.cwd(), '');
   const useProxy = parseBoolean(env.VITE_COVEO_USE_VITE_PROXY) ?? true;
-  const targets = getProxyTargets(mode);
+  const targets = getProxyTargets(env);
   const orgId = env.VITE_COVEO_ORGANIZATION_ID?.trim();
   const agentRuntimeHeaders = resolveAgentRuntimeHeaders(
     env.VITE_COVEO_AGENT_RUNTIME_NAME,

--- a/samples/thermidor/demo-react/vite.config.ts
+++ b/samples/thermidor/demo-react/vite.config.ts
@@ -53,6 +53,23 @@ export function resolveProxyTargets(
   };
 }
 
+export function resolveAgentRuntimeHeaders(
+  runtimeName: string | undefined,
+  runtimeQualifier: string | undefined
+) {
+  const name = runtimeName?.trim();
+  const qualifier = runtimeQualifier?.trim();
+
+  if (!name) {
+    return undefined;
+  }
+
+  return {
+    'x-coveo-agent-runtime-name': name,
+    ...(qualifier ? {'x-coveo-agent-runtime-qualifier': qualifier} : {}),
+  };
+}
+
 function getProxyTargets(mode: string) {
   const env = loadEnv(mode, process.cwd(), '');
 
@@ -68,6 +85,10 @@ export default defineConfig(({mode}) => {
   const useProxy = parseBoolean(env.VITE_COVEO_USE_VITE_PROXY) ?? true;
   const targets = getProxyTargets(mode);
   const orgId = env.VITE_COVEO_ORGANIZATION_ID?.trim();
+  const agentRuntimeHeaders = resolveAgentRuntimeHeaders(
+    env.VITE_COVEO_AGENT_RUNTIME_NAME,
+    env.VITE_COVEO_AGENT_RUNTIME_QUALIFIER
+  );
 
   return {
     plugins: [react()],
@@ -80,6 +101,7 @@ export default defineConfig(({mode}) => {
                 target: targets.agentGateway,
                 changeOrigin: true,
                 secure: true,
+                ...(agentRuntimeHeaders ? {headers: agentRuntimeHeaders} : {}),
               },
               '/rest': {
                 target: targets.platform,

--- a/samples/thermidor/demo-react/vite.config.ts
+++ b/samples/thermidor/demo-react/vite.config.ts
@@ -28,14 +28,6 @@ function resolveEnvironment(value: string | undefined): PlatformEnvironment {
   return 'dev';
 }
 
-function getOrganizationAdminEndpoint(
-  organizationId: string,
-  environment: PlatformEnvironment
-): string {
-  const environmentSuffix = environment === 'prod' ? '' : environment;
-  return `https://${organizationId}.admin.org${environmentSuffix}.coveo.com`;
-}
-
 function getOrganizationPlatformEndpoint(
   organizationId: string,
   environment: PlatformEnvironment
@@ -44,22 +36,31 @@ function getOrganizationPlatformEndpoint(
   return `https://${organizationId}.org${environmentSuffix}.coveo.com`;
 }
 
-function getProxyTargets(mode: string) {
-  const env = loadEnv(mode, process.cwd(), '');
-  const organizationId = env.VITE_COVEO_ORGANIZATION_ID?.trim();
-  const endpointOverride = env.VITE_COVEO_ENDPOINT?.trim();
-  const environment = resolveEnvironment(env.VITE_COVEO_PLATFORM_ENVIRONMENT);
-
+export function resolveProxyTargets(
+  organizationId: string | undefined,
+  endpointOverride: string | undefined,
+  environment: PlatformEnvironment
+) {
   if (!organizationId) {
     return undefined;
   }
 
   const platform = getOrganizationPlatformEndpoint(organizationId, environment);
-  const admin = endpointOverride
-    ? endpointOverride
-    : getOrganizationAdminEndpoint(organizationId, environment);
 
-  return {admin, platform};
+  return {
+    agentGateway: endpointOverride || platform,
+    platform,
+  };
+}
+
+function getProxyTargets(mode: string) {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return resolveProxyTargets(
+    env.VITE_COVEO_ORGANIZATION_ID?.trim(),
+    env.VITE_COVEO_ENDPOINT?.trim(),
+    resolveEnvironment(env.VITE_COVEO_PLATFORM_ENVIRONMENT)
+  );
 }
 
 export default defineConfig(({mode}) => {
@@ -76,7 +77,7 @@ export default defineConfig(({mode}) => {
         ? {
             proxy: {
               [`/api/preview/organizations/${orgId}/agents/commerce/agui`]: {
-                target: targets.platform,
+                target: targets.agentGateway,
                 changeOrigin: true,
                 secure: true,
               },


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/SMITH-39

## Motivation

Allow the Thermidor React demo to target a local Agent Gateway while continuing to proxy platform requests to the organization endpoint. Support selecting an optional AgentCore runtime for AG-UI requests.

## Changes

- Adds a `dev:agent-gateway` command that routes AG-UI traffic to `http://localhost:8980`.
- Routes AG-UI requests through `VITE_COVEO_ENDPOINT` while keeping `/rest` requests on the organization platform endpoint.
- Adds optional AgentCore runtime name and qualifier environment variables, forwarded as AG-UI proxy headers.
- Adds coverage for Agent Gateway proxy target resolution.

## Validation

- Added focused Vitest coverage for proxy target resolution.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`feat(<scope>): <description>`)
- [x] No changeset required because this changes a private sample.