### PR TITLE
feat(thermidor): parse A2UI v1 surface messages

### DIFF
--- a/packages/thermidor/src/internal/api/generative/generative-runtime.ts
+++ b/packages/thermidor/src/internal/api/generative/generative-runtime.ts
@@ -20,6 +20,7 @@ export interface GenerativeStatePort {
   setActiveTurnId(id: string): void;
   replaceTurnId(oldId: string, newId: string): void;
   setRoutedInterface(turnId: string, hydrationResult: HydrationResult): void;
+  clearRoutedInterface(turnId: string, surfaceId: string): void;
   initAgentResponse(turnId: string): void;
   startMessage(turnId: string, role: string): void;
   appendMessageDelta(turnId: string, delta: string): void;

--- a/packages/thermidor/src/internal/api/protocol/stream-types.ts
+++ b/packages/thermidor/src/internal/api/protocol/stream-types.ts
@@ -66,38 +66,42 @@ export type SearchApiResponseEvent = {
 
 export type A2UIOperation =
   | {
-      beginRendering: {
+      createSurface: {
         surfaceId: string;
-        root: string;
         catalogId?: string;
+        components?: Array<{
+          id: string;
+          component: string;
+          componentProps?: Record<string, unknown>;
+        }>;
+        dataModel?: Record<string, unknown>;
       };
     }
   | {
-      surfaceUpdate: {
+      updateComponents: {
         surfaceId: string;
         components: Array<{
           id: string;
-          component: Record<string, unknown>;
+          component: string;
+          componentProps?: Record<string, unknown>;
         }>;
       };
     }
   | {
-      dataModelUpdate: {
+      updateDataModel: {
         surfaceId: string;
-        contents: Array<{
-          key: string;
-          valueString?: string;
-          valueNumber?: number;
-          valueBoolean?: boolean;
-          valueMap?: Array<unknown>;
-        }>;
+        path?: string;
+        value: unknown;
       };
     }
   | {
       deleteSurface: {
         surfaceId: string;
       };
-    };
+    }
+  | {actionResponse: unknown};
+
+export type A2UIMessage = {version: 'v1.0'} & A2UIOperation;
 
 // ============================================================================
 // Unknown fallback (events not recognized by AG-UI or Coveo extensions)

--- a/packages/thermidor/src/internal/api/protocol/stream-types.ts
+++ b/packages/thermidor/src/internal/api/protocol/stream-types.ts
@@ -64,27 +64,24 @@ export type SearchApiResponseEvent = {
 // Structured snapshot events (A2UI — Coveo-specific payload shape)
 // ============================================================================
 
+export type A2UIComponent = {
+  id: string;
+  component: string;
+} & Record<string, unknown>;
+
 export type A2UIOperation =
   | {
       createSurface: {
         surfaceId: string;
         catalogId?: string;
-        components?: Array<{
-          id: string;
-          component: string;
-          componentProps?: Record<string, unknown>;
-        }>;
+        components?: A2UIComponent[];
         dataModel?: Record<string, unknown>;
       };
     }
   | {
       updateComponents: {
         surfaceId: string;
-        components: Array<{
-          id: string;
-          component: string;
-          componentProps?: Record<string, unknown>;
-        }>;
+        components: A2UIComponent[];
       };
     }
   | {
@@ -99,9 +96,11 @@ export type A2UIOperation =
         surfaceId: string;
       };
     }
-  | {actionResponse: unknown};
+  | {actionResponse: {actionId: string; response: unknown}};
 
-export type A2UIMessage = {version: 'v1.0'} & A2UIOperation;
+export type A2UIMessage =
+  | ({version: 'v1.0'} & Exclude<A2UIOperation, {actionResponse: unknown}>)
+  | {version: 'v1.0'; actionId: string; actionResponse: unknown};
 
 // ============================================================================
 // Unknown fallback (events not recognized by AG-UI or Coveo extensions)

--- a/packages/thermidor/src/internal/api/unified/unified-runtime.test.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-runtime.test.ts
@@ -70,6 +70,7 @@ function createMockStatePort(): GenerativeStatePort {
     setActiveTurnId: vi.fn(),
     replaceTurnId: vi.fn(),
     setRoutedInterface: vi.fn(),
+    clearRoutedInterface: vi.fn(),
     initAgentResponse: vi.fn(),
     startMessage: vi.fn(),
     appendMessageDelta: vi.fn(),
@@ -1155,6 +1156,49 @@ describe('UnifiedRuntime', () => {
         query: undefined,
         surfaceId: 's1',
       });
+    });
+
+    it('disposes and clears a routed interface when its surface is deleted', async () => {
+      const config = createMockConfig();
+      const engine = createMockEngine();
+      const mockIface = createMockInterface();
+      const creationContent = {
+        operations: [{createSurface: {surfaceId: 's1', dataModel: {products: []}}}],
+      };
+      const deletionContent = {
+        operations: [{deleteSurface: {surfaceId: 's1'}}],
+      };
+
+      mockExtractA2uiOperations
+        .mockReturnValueOnce(creationContent.operations)
+        .mockReturnValueOnce(deletionContent.operations);
+      mockHydrateFromCreateSurface.mockReturnValue({
+        surfaceId: 's1',
+        useCase: 'commerceSearch',
+        interface: mockIface,
+        snapshot: {products: []},
+        query: undefined,
+      });
+
+      setupSuccessfulStream([
+        {
+          type: 'ACTIVITY_SNAPSHOT',
+          activityType: 'a2ui-surface',
+          content: creationContent,
+        } as unknown as NormalizedStreamEvent,
+        {
+          type: 'ACTIVITY_SNAPSHOT',
+          activityType: 'a2ui-surface',
+          content: deletionContent,
+        } as unknown as NormalizedStreamEvent,
+        {type: 'turn_complete'} as NormalizedStreamEvent,
+      ]);
+
+      const runtime = UnifiedRuntime.getInstance(engine, 'a2ui-delete', config);
+      await runtime.submit('Hello');
+
+      expect(mockIface.dispose).toHaveBeenCalledOnce();
+      expect(config.statePort.clearRoutedInterface).toHaveBeenCalledWith('generated-id-1', 's1');
     });
 
     it('updateDataModel with path `/` calls applyDataModelUpdate with root path', async () => {

--- a/packages/thermidor/src/internal/api/unified/unified-stream-extractor.test.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-stream-extractor.test.ts
@@ -48,9 +48,15 @@ describe('extractUpdateDataModelOperationsFromStream', () => {
         type: 'ACTIVITY_SNAPSHOT',
         activityType: 'a2ui-surface',
         content: {
-          operations: [
-            {updateDataModel: {path: '/products', value: [{id: '1'}]}},
-            {updateDataModel: {path: '/pagination', value: {page: 2}}},
+          messages: [
+            {
+              version: 'v1.0',
+              updateDataModel: {surfaceId: 's1', path: '/products', value: [{id: '1'}]},
+            },
+            {
+              version: 'v1.0',
+              updateDataModel: {surfaceId: 's1', path: '/pagination', value: {page: 2}},
+            },
           ],
         },
       });
@@ -73,7 +79,12 @@ describe('extractUpdateDataModelOperationsFromStream', () => {
         type: 'ACTIVITY_SNAPSHOT',
         activityType: 'some-other-activity',
         content: {
-          operations: [{updateDataModel: {path: '/ignored', value: 'data'}}],
+          messages: [
+            {
+              version: 'v1.0',
+              updateDataModel: {surfaceId: 's1', path: '/ignored', value: 'data'},
+            },
+          ],
         },
       });
       onDone?.();
@@ -92,16 +103,27 @@ describe('extractUpdateDataModelOperationsFromStream', () => {
         type: 'ACTIVITY_SNAPSHOT',
         activityType: 'a2ui-surface',
         content: {
-          operations: [{updateDataModel: {path: '/first', value: 1}}],
+          messages: [
+            {
+              version: 'v1.0',
+              updateDataModel: {surfaceId: 's1', path: '/first', value: 1},
+            },
+          ],
         },
       });
       onEvent({
         type: 'ACTIVITY_SNAPSHOT',
         activityType: 'a2ui-surface',
         content: {
-          operations: [
-            {updateDataModel: {path: '/second', value: 2}},
-            {updateDataModel: {path: '/third', value: 3}},
+          messages: [
+            {
+              version: 'v1.0',
+              updateDataModel: {surfaceId: 's1', path: '/second', value: 2},
+            },
+            {
+              version: 'v1.0',
+              updateDataModel: {surfaceId: 's1', path: '/third', value: 3},
+            },
           ],
         },
       });

--- a/packages/thermidor/src/internal/api/unified/unified-surface-hydration.test.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-surface-hydration.test.ts
@@ -56,6 +56,8 @@ const validDataModel = {
   triggers: [],
 };
 
+const statefulRoot = [{id: 'root', component: 'ProductSearchSurface'}];
+
 describe('unified-surface-hydration', () => {
   describe('hydrateFromCreateSurface', () => {
     it('returns null when dataModel is undefined', () => {
@@ -89,6 +91,23 @@ describe('unified-surface-hydration', () => {
       expect(result).toBeNull();
     });
 
+    it('returns null for display-only A2UI surfaces', () => {
+      const fullEngine = createTestEngine();
+
+      const result = hydrateFromCreateSurface(
+        fullEngine,
+        {
+          surfaceId: 'test',
+          components: [{id: 'root', component: 'ProductCarousel'}],
+          dataModel: validDataModel,
+        },
+        mockGenerativeInterface,
+        mockCartInterface
+      );
+
+      expect(result).toBeNull();
+    });
+
     it('returns non-null result with correct state for empty arrays', () => {
       const fullEngine = createTestEngine();
 
@@ -96,7 +115,7 @@ describe('unified-surface-hydration', () => {
         fullEngine,
         {
           surfaceId: 'test',
-          surfaceProperties: {placement: 'main'},
+          components: statefulRoot,
           dataModel: validDataModel,
         },
         mockGenerativeInterface,
@@ -135,7 +154,7 @@ describe('unified-surface-hydration', () => {
         fullEngine,
         {
           surfaceId: 'test',
-          surfaceProperties: {placement: 'main'},
+          components: statefulRoot,
           dataModel: validDataModel,
         },
         mockGenerativeInterface,
@@ -161,7 +180,7 @@ describe('unified-surface-hydration', () => {
         fullEngine,
         {
           surfaceId: 'test',
-          surfaceProperties: {placement: 'main'},
+          components: statefulRoot,
           dataModel: validDataModel,
         },
         mockGenerativeInterface,
@@ -181,7 +200,7 @@ describe('unified-surface-hydration', () => {
         fullEngine,
         {
           surfaceId: 'test',
-          surfaceProperties: {placement: 'main'},
+          components: statefulRoot,
           dataModel: validDataModel,
         },
         mockGenerativeInterface,
@@ -217,7 +236,7 @@ describe('unified-surface-hydration', () => {
         fullEngine,
         {
           surfaceId: 'test',
-          surfaceProperties: {placement: 'main'},
+          components: statefulRoot,
           dataModel: validDataModel,
         },
         mockGenerativeInterface,
@@ -239,7 +258,7 @@ describe('unified-surface-hydration', () => {
         fullEngine,
         {
           surfaceId: 'test',
-          surfaceProperties: {placement: 'main'},
+          components: statefulRoot,
           dataModel: validDataModel,
         },
         mockGenerativeInterface,
@@ -296,16 +315,69 @@ describe('unified-surface-hydration', () => {
       expect(extractA2uiOperations({})).toEqual([]);
     });
 
-    it('returns empty array when operations is not an array', () => {
-      expect(extractA2uiOperations({operations: 'not-an-array'})).toEqual([]);
+    it('returns empty array when messages is not an array', () => {
+      expect(extractA2uiOperations({messages: 'not-an-array'})).toEqual([]);
     });
 
-    it('returns the operations array when valid', () => {
-      const ops = [
+    it('unwraps valid versioned messages', () => {
+      const messages = [
+        {version: 'v1.0', createSurface: {surfaceId: 's1'}},
+        {version: 'v1.0', updateDataModel: {surfaceId: 's1', path: '/', value: {}}},
+      ];
+      expect(extractA2uiOperations({messages})).toEqual([
         {createSurface: {surfaceId: 's1'}},
         {updateDataModel: {surfaceId: 's1', path: '/', value: {}}},
-      ];
-      expect(extractA2uiOperations({operations: ops})).toEqual(ops);
+      ]);
+    });
+
+    it('unwraps a valid updateComponents message', () => {
+      expect(
+        extractA2uiOperations({
+          messages: [
+            {
+              version: 'v1.0',
+              updateComponents: {
+                surfaceId: 's1',
+                components: [{id: 'root', component: 'ProductSearchSurface'}],
+              },
+            },
+          ],
+        })
+      ).toEqual([
+        {
+          updateComponents: {
+            surfaceId: 's1',
+            components: [{id: 'root', component: 'ProductSearchSurface'}],
+          },
+        },
+      ]);
+    });
+
+    it('ignores malformed updateComponents messages', () => {
+      expect(
+        extractA2uiOperations({
+          messages: [
+            {version: 'v1.0', updateComponents: {surfaceId: 's1'}},
+            {version: 'v1.0', updateComponents: {surfaceId: 1, components: []}},
+          ],
+        })
+      ).toEqual([]);
+    });
+
+    it('ignores malformed messages while preserving valid siblings', () => {
+      expect(
+        extractA2uiOperations({
+          messages: [
+            {version: 'v0.8', createSurface: {surfaceId: 'old'}},
+            {
+              version: 'v1.0',
+              createSurface: {surfaceId: 'invalid'},
+              deleteSurface: {surfaceId: 'invalid'},
+            },
+            {version: 'v1.0', deleteSurface: {surfaceId: 's1'}},
+          ],
+        })
+      ).toEqual([{deleteSurface: {surfaceId: 's1'}}]);
     });
   });
 
@@ -317,7 +389,7 @@ describe('unified-surface-hydration', () => {
         fullEngine,
         {
           surfaceId: 'test',
-          surfaceProperties: {placement: 'main'},
+          components: statefulRoot,
           dataModel: validDataModel,
         },
         mockGenerativeInterface,

--- a/packages/thermidor/src/internal/api/unified/unified-surface-hydration.test.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-surface-hydration.test.ts
@@ -353,15 +353,71 @@ describe('unified-surface-hydration', () => {
       ]);
     });
 
+    it('preserves direct catalog properties on component nodes', () => {
+      expect(
+        extractA2uiOperations({
+          messages: [
+            {
+              version: 'v1.0',
+              updateComponents: {
+                surfaceId: 's1',
+                components: [
+                  {
+                    id: 'root',
+                    component: 'ProductSearchSurface',
+                    accessibility: {label: 'Product search results'},
+                  },
+                ],
+              },
+            },
+          ],
+        })
+      ).toEqual([
+        {
+          updateComponents: {
+            surfaceId: 's1',
+            components: [
+              {
+                id: 'root',
+                component: 'ProductSearchSurface',
+                accessibility: {label: 'Product search results'},
+              },
+            ],
+          },
+        },
+      ]);
+    });
+
     it('ignores malformed updateComponents messages', () => {
       expect(
         extractA2uiOperations({
           messages: [
             {version: 'v1.0', updateComponents: {surfaceId: 's1'}},
             {version: 'v1.0', updateComponents: {surfaceId: 1, components: []}},
+            {
+              version: 'v1.0',
+              updateComponents: {
+                surfaceId: 's1',
+                components: [
+                  {
+                    id: 'root',
+                    component: 'ProductSearchSurface',
+                    componentProps: {label: 'Non-canonical'},
+                  },
+                ],
+              },
+            },
           ],
         })
       ).toEqual([]);
+    });
+
+    it('preserves the top-level action identifier on action responses', () => {
+      expect(
+        extractA2uiOperations({
+          messages: [{version: 'v1.0', actionId: 'action-1', actionResponse: {value: null}}],
+        })
+      ).toEqual([{actionResponse: {actionId: 'action-1', response: {value: null}}}]);
     });
 
     it('ignores malformed messages while preserving valid siblings', () => {

--- a/packages/thermidor/src/internal/api/unified/unified-surface-hydration.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-surface-hydration.ts
@@ -20,28 +20,50 @@ import {getOrCreateTriggersActions} from '@/src/internal/features/triggers/index
 import {getOrCreateQueryCorrectionActions} from '@/src/internal/features/query-correction/index.js';
 
 export interface A2uiSurfaceContent {
-  operations: A2uiOperation[];
+  messages: A2uiMessage[];
 }
+
+export type A2uiMessage =
+  | {version: 'v1.0'; createSurface: CreateSurfacePayload}
+  | {version: 'v1.0'; updateDataModel: UpdateDataModelPayload}
+  | {version: 'v1.0'; updateComponents: UpdateComponentsPayload}
+  | {version: 'v1.0'; deleteSurface: DeleteSurfacePayload}
+  | {version: 'v1.0'; actionResponse: unknown};
 
 export type A2uiOperation =
   | {createSurface: CreateSurfacePayload}
   | {updateDataModel: UpdateDataModelPayload}
-  | {updateComponents: unknown}
+  | {updateComponents: UpdateComponentsPayload}
+  | {deleteSurface: DeleteSurfacePayload}
   | {actionResponse: unknown};
 
 export interface CreateSurfacePayload {
   surfaceId: string;
   catalogId?: string;
-  surfaceProperties?: Record<string, unknown>;
   sendDataModel?: boolean;
-  components?: unknown[];
+  components?: ComponentNode[];
   dataModel?: Record<string, unknown>;
+}
+
+export interface ComponentNode {
+  id: string;
+  component: string;
+  componentProps?: Record<string, unknown>;
 }
 
 export interface UpdateDataModelPayload {
   surfaceId: string;
   path?: string;
   value: unknown;
+}
+
+export interface UpdateComponentsPayload {
+  surfaceId: string;
+  components: ComponentNode[];
+}
+
+export interface DeleteSurfacePayload {
+  surfaceId: string;
 }
 
 export interface UnifiedHydrationResult {
@@ -64,7 +86,7 @@ export function hydrateFromCreateSurface(
     return null;
   }
 
-  if (payload.surfaceProperties?.placement !== 'main') {
+  if (!hasStatefulCommerceRootComponent(payload.components)) {
     return null;
   }
 
@@ -160,8 +182,106 @@ export function applyDataModelUpdate(
 }
 
 export function extractA2uiOperations(content: Record<string, unknown>): A2uiOperation[] {
-  if (content && Array.isArray(content.operations)) {
-    return content.operations as A2uiOperation[];
+  if (!Array.isArray(content.messages)) {
+    return [];
   }
-  return [];
+
+  return content.messages.flatMap(parseA2uiMessage);
+}
+
+function parseA2uiMessage(message: unknown): A2uiOperation[] {
+  if (!isRecord(message) || message.version !== 'v1.0') {
+    return [];
+  }
+
+  const operationKeys = [
+    'createSurface',
+    'updateDataModel',
+    'updateComponents',
+    'deleteSurface',
+    'actionResponse',
+  ].filter((key) => Object.prototype.hasOwnProperty.call(message, key));
+  if (operationKeys.length !== 1) {
+    return [];
+  }
+
+  switch (operationKeys[0]) {
+    case 'createSurface':
+      return isCreateSurfacePayload(message.createSurface)
+        ? [{createSurface: message.createSurface}]
+        : [];
+    case 'updateDataModel':
+      return isUpdateDataModelPayload(message.updateDataModel)
+        ? [{updateDataModel: message.updateDataModel}]
+        : [];
+    case 'updateComponents':
+      return isUpdateComponentsPayload(message.updateComponents)
+        ? [{updateComponents: message.updateComponents}]
+        : [];
+    case 'deleteSurface':
+      return isDeleteSurfacePayload(message.deleteSurface)
+        ? [{deleteSurface: message.deleteSurface}]
+        : [];
+    case 'actionResponse':
+      return [{actionResponse: message.actionResponse}];
+    default:
+      return [];
+  }
+}
+
+function hasStatefulCommerceRootComponent(components: ComponentNode[] | undefined): boolean {
+  const root = components?.find((component) => component.id === 'root');
+  return root?.component === 'ProductSearchSurface' || root?.component === 'ProductListingSurface';
+}
+
+function isCreateSurfacePayload(value: unknown): value is CreateSurfacePayload {
+  if (!isRecord(value) || typeof value.surfaceId !== 'string') {
+    return false;
+  }
+  if (value.catalogId !== undefined && typeof value.catalogId !== 'string') {
+    return false;
+  }
+  if (value.sendDataModel !== undefined && typeof value.sendDataModel !== 'boolean') {
+    return false;
+  }
+  if (value.components !== undefined && !isComponentNodes(value.components)) {
+    return false;
+  }
+  return value.dataModel === undefined || isRecord(value.dataModel);
+}
+
+function isUpdateDataModelPayload(value: unknown): value is UpdateDataModelPayload {
+  return (
+    isRecord(value) &&
+    typeof value.surfaceId === 'string' &&
+    Object.prototype.hasOwnProperty.call(value, 'value') &&
+    (value.path === undefined || typeof value.path === 'string')
+  );
+}
+
+function isUpdateComponentsPayload(value: unknown): value is UpdateComponentsPayload {
+  return (
+    isRecord(value) && typeof value.surfaceId === 'string' && isComponentNodes(value.components)
+  );
+}
+
+function isDeleteSurfacePayload(value: unknown): value is DeleteSurfacePayload {
+  return isRecord(value) && typeof value.surfaceId === 'string';
+}
+
+function isComponentNodes(value: unknown): value is ComponentNode[] {
+  return Array.isArray(value) && value.every(isComponentNode);
+}
+
+function isComponentNode(value: unknown): value is ComponentNode {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.component === 'string' &&
+    (value.componentProps === undefined || isRecord(value.componentProps))
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/thermidor/src/internal/api/unified/unified-surface-hydration.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-surface-hydration.ts
@@ -28,14 +28,14 @@ export type A2uiMessage =
   | {version: 'v1.0'; updateDataModel: UpdateDataModelPayload}
   | {version: 'v1.0'; updateComponents: UpdateComponentsPayload}
   | {version: 'v1.0'; deleteSurface: DeleteSurfacePayload}
-  | {version: 'v1.0'; actionResponse: unknown};
+  | {version: 'v1.0'; actionId: string; actionResponse: unknown};
 
 export type A2uiOperation =
   | {createSurface: CreateSurfacePayload}
   | {updateDataModel: UpdateDataModelPayload}
   | {updateComponents: UpdateComponentsPayload}
   | {deleteSurface: DeleteSurfacePayload}
-  | {actionResponse: unknown};
+  | {actionResponse: {actionId: string; response: unknown}};
 
 export interface CreateSurfacePayload {
   surfaceId: string;
@@ -45,11 +45,10 @@ export interface CreateSurfacePayload {
   dataModel?: Record<string, unknown>;
 }
 
-export interface ComponentNode {
+export type ComponentNode = {
   id: string;
   component: string;
-  componentProps?: Record<string, unknown>;
-}
+} & Record<string, unknown>;
 
 export interface UpdateDataModelPayload {
   surfaceId: string;
@@ -223,7 +222,9 @@ function parseA2uiMessage(message: unknown): A2uiOperation[] {
         ? [{deleteSurface: message.deleteSurface}]
         : [];
     case 'actionResponse':
-      return [{actionResponse: message.actionResponse}];
+      return typeof message.actionId === 'string'
+        ? [{actionResponse: {actionId: message.actionId, response: message.actionResponse}}]
+        : [];
     default:
       return [];
   }
@@ -278,7 +279,7 @@ function isComponentNode(value: unknown): value is ComponentNode {
     isRecord(value) &&
     typeof value.id === 'string' &&
     typeof value.component === 'string' &&
-    (value.componentProps === undefined || isRecord(value.componentProps))
+    !Object.prototype.hasOwnProperty.call(value, 'componentProps')
   );
 }
 

--- a/packages/thermidor/src/internal/api/unified/unified-surface-processor.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-surface-processor.ts
@@ -62,6 +62,13 @@ function processOperations(
       if (iface) {
         applyDataModelUpdate(deps.engine, iface, op.updateDataModel.path, op.updateDataModel.value);
       }
+    } else if ('deleteSurface' in op) {
+      const iface = surfaceMap.get(op.deleteSurface.surfaceId);
+      if (iface) {
+        iface.dispose();
+        surfaceMap.delete(op.deleteSurface.surfaceId);
+        deps.statePort.clearRoutedInterface(turnId, op.deleteSurface.surfaceId);
+      }
     }
   }
 }

--- a/packages/thermidor/src/internal/features/generative/generative-actions.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-actions.ts
@@ -21,6 +21,7 @@ export function createGenerativeActions(interfaceId: string) {
       turnId: string;
       useCase: RoutedUseCase;
     }>(`${prefix}/setRoutedInterface`),
+    clearRoutedInterface: createAction<{turnId: string}>(`${prefix}/clearRoutedInterface`),
     initAgentResponse: createAction<{turnId: string}>(`${prefix}/initAgentResponse`),
     startMessage: createAction<{turnId: string; role: string}>(`${prefix}/startMessage`),
     appendMessageDelta: createAction<{turnId: string; delta: string}>(

--- a/packages/thermidor/src/internal/features/generative/generative-slice.test.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-slice.test.ts
@@ -39,4 +39,26 @@ describe('generative slice', () => {
 
     expect(state.turns[0].status).toBe('complete');
   });
+
+  it('clears a routed interface without removing the agent response', () => {
+    let state = reducer(
+      undefined,
+      actions.createTurn({id: 'turn-1', prompt: 'find shoes', status: 'streaming'})
+    );
+    state = reducer(
+      state,
+      actions.setRoutedInterface({turnId: 'turn-1', useCase: 'commerceSearch'})
+    );
+    state = reducer(state, actions.initAgentResponse({turnId: 'turn-1'}));
+
+    state = reducer(state, actions.clearRoutedInterface({turnId: 'turn-1'}));
+
+    expect(state.turns[0]).toEqual(
+      expect.objectContaining({
+        agentResponse: {messages: [], surfaces: [], reasoningSteps: []},
+        status: 'streaming',
+      })
+    );
+    expect(state.turns[0].routedInterface).toBeUndefined();
+  });
 });

--- a/packages/thermidor/src/internal/features/generative/generative-slice.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-slice.ts
@@ -57,6 +57,12 @@ export function createGenerativeSlice(
             turn.routedInterface = {useCase: payload.useCase};
           }
         })
+        .addCase(actions.clearRoutedInterface, (state, {payload}) => {
+          const turn = state.turns.find((t) => t.id === payload.turnId);
+          if (turn) {
+            delete turn.routedInterface;
+          }
+        })
         .addCase(actions.initAgentResponse, (state, {payload}) => {
           const turn = state.turns.find((t) => t.id === payload.turnId);
           if (turn) {

--- a/packages/thermidor/src/public/controllers/converse/converse-controller.test.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller.test.ts
@@ -551,4 +551,30 @@ describe('buildConverseController', () => {
       });
     });
   });
+
+  describe('state port: setRoutedInterface', () => {
+    it('stores surfaceId in registry entries', async () => {
+      buildController();
+      const registry = getOrCreateRoutedInterfaceRegistry(generativeInterface);
+
+      const {GenerativeRuntime} = vi.mocked(await import('@/src/internal/api/generative/index.js'));
+      const getInstanceMock = GenerativeRuntime.getInstance as ReturnType<typeof vi.fn>;
+      const config = getInstanceMock.mock.calls[0][2];
+
+      config.statePort.setRoutedInterface('turn-1', {
+        useCase: 'commerceSearch',
+        interface: {} as never,
+        snapshot: {products: []},
+        query: 'shoes',
+        surfaceId: 'surface-abc',
+      });
+
+      const entry = registry.get('turn-1');
+      expect(entry).toBeDefined();
+      expect(entry!.surfaceId).toBe('surface-abc');
+      expect(entry!.useCase).toBe('commerceSearch');
+      expect(entry!.snapshot).toEqual({products: []});
+      expect(entry!.query).toBe('shoes');
+    });
+  });
 });

--- a/packages/thermidor/src/public/controllers/converse/converse-controller.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller.ts
@@ -76,6 +76,13 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
             this.#actions.setRoutedInterface({turnId, useCase: hydrationResult.useCase})
           );
         },
+        clearRoutedInterface: (turnId, surfaceId) => {
+          const registry = getOrCreateRoutedInterfaceRegistry(options.interface);
+          if (registry.get(turnId)?.surfaceId === surfaceId) {
+            registry.remove(turnId);
+            this.engine.mutate(this.#actions.clearRoutedInterface({turnId}));
+          }
+        },
         initAgentResponse: (turnId) => {
           this.engine.mutate(this.#actions.initAgentResponse({turnId}));
         },
@@ -85,11 +92,11 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
         appendMessageDelta: (turnId, delta) => {
           this.engine.mutate(this.#actions.appendMessageDelta({turnId, delta}));
         },
-        appendSurface: (turnId, surface) => {
-          this.engine.mutate(this.#actions.appendSurface({turnId, surface}));
-          const ops = (surface as {operations?: unknown[]}).operations;
-          if (Array.isArray(ops)) {
-            options.onSurfaceOperation?.(ops);
+        appendSurface: (turnId, surface, activity) => {
+          this.engine.mutate(this.#actions.appendSurface({turnId, surface, activity}));
+          const messages = (surface as {messages?: unknown[]}).messages;
+          if (Array.isArray(messages)) {
+            options.onSurfaceOperation?.(messages);
           }
         },
         startToolCall: (turnId, toolCallId, toolName) => {

--- a/packages/thermidor/src/public/controllers/converse/converse-controller.ts
+++ b/packages/thermidor/src/public/controllers/converse/converse-controller.ts
@@ -71,6 +71,7 @@ class ConverseControllerImpl extends BaseController<ConverseControllerState> {
             interface: hydrationResult.interface,
             snapshot: hydrationResult.snapshot,
             query: hydrationResult.query,
+            surfaceId: hydrationResult.surfaceId,
           });
           this.engine.mutate(
             this.#actions.setRoutedInterface({turnId, useCase: hydrationResult.useCase})

--- a/packages/thermidor/src/public/controllers/unified-converse/unified-converse-controller.test.ts
+++ b/packages/thermidor/src/public/controllers/unified-converse/unified-converse-controller.test.ts
@@ -501,7 +501,7 @@ describe('buildUnifiedConverseController', () => {
   });
 
   describe('state port: appendSurface', () => {
-    it('invokes onSurfaceOperation callback when operations are present', async () => {
+    it('invokes onSurfaceOperation callback when messages are present', async () => {
       const onSurfaceOperation = vi.fn();
       buildController({onSurfaceOperation});
 
@@ -509,13 +509,13 @@ describe('buildUnifiedConverseController', () => {
       const getInstanceMock = UnifiedRuntime.getInstance as ReturnType<typeof vi.fn>;
       const config = getInstanceMock.mock.calls[0][2];
 
-      const ops = [{createSurface: {surfaceId: 's1'}}];
-      config.statePort.appendSurface('turn-1', {operations: ops});
+      const messages = [{version: 'v1.0', createSurface: {surfaceId: 's1'}}];
+      config.statePort.appendSurface('turn-1', {messages});
 
-      expect(onSurfaceOperation).toHaveBeenCalledWith(ops);
+      expect(onSurfaceOperation).toHaveBeenCalledWith(messages);
     });
 
-    it('does not invoke onSurfaceOperation when no operations field', async () => {
+    it('does not invoke onSurfaceOperation when no messages field', async () => {
       const onSurfaceOperation = vi.fn();
       buildController({onSurfaceOperation});
 

--- a/packages/thermidor/src/public/controllers/unified-converse/unified-converse-controller.test.ts
+++ b/packages/thermidor/src/public/controllers/unified-converse/unified-converse-controller.test.ts
@@ -498,6 +498,33 @@ describe('buildUnifiedConverseController', () => {
       expect(entry!.snapshot).toEqual({products: []});
       expect(entry!.query).toBe('shoes');
     });
+
+    it('clears the registry and turn when the deleted surface matches', async () => {
+      const controller = buildController();
+      const actions = getOrCreateGenerativeActions(generativeInterface);
+      const registry = getOrCreateRoutedInterfaceRegistry(generativeInterface);
+      fullEngine.mutate(actions.createTurn({id: 'turn-1', prompt: 'hello', status: 'complete'}));
+
+      const {UnifiedRuntime} = vi.mocked(await import('@/src/internal/api/unified/index.js'));
+      const getInstanceMock = UnifiedRuntime.getInstance as ReturnType<typeof vi.fn>;
+      const config = getInstanceMock.mock.calls[0][2];
+
+      config.statePort.setRoutedInterface('turn-1', {
+        useCase: 'commerceSearch',
+        interface: {} as never,
+        snapshot: {products: []},
+        query: undefined,
+        surfaceId: 'surface-abc',
+      });
+
+      config.statePort.clearRoutedInterface('turn-1', 'other-surface');
+      expect(registry.get('turn-1')).toBeDefined();
+      expect(controller.state.turns[0].routedInterface).toBeDefined();
+
+      config.statePort.clearRoutedInterface('turn-1', 'surface-abc');
+      expect(registry.get('turn-1')).toBeUndefined();
+      expect(controller.state.turns[0].routedInterface).toBeUndefined();
+    });
   });
 
   describe('state port: appendSurface', () => {

--- a/packages/thermidor/src/public/controllers/unified-converse/unified-converse-controller.ts
+++ b/packages/thermidor/src/public/controllers/unified-converse/unified-converse-controller.ts
@@ -79,6 +79,13 @@ class UnifiedConverseControllerImpl extends BaseController<UnifiedConverseContro
             this.#actions.setRoutedInterface({turnId, useCase: hydrationResult.useCase})
           );
         },
+        clearRoutedInterface: (turnId, surfaceId) => {
+          const registry = getOrCreateRoutedInterfaceRegistry(options.interface);
+          if (registry.get(turnId)?.surfaceId === surfaceId) {
+            registry.remove(turnId);
+            this.engine.mutate(this.#actions.clearRoutedInterface({turnId}));
+          }
+        },
         initAgentResponse: (turnId) => {
           this.engine.mutate(this.#actions.initAgentResponse({turnId}));
         },
@@ -88,11 +95,11 @@ class UnifiedConverseControllerImpl extends BaseController<UnifiedConverseContro
         appendMessageDelta: (turnId, delta) => {
           this.engine.mutate(this.#actions.appendMessageDelta({turnId, delta}));
         },
-        appendSurface: (turnId, surface) => {
-          this.engine.mutate(this.#actions.appendSurface({turnId, surface}));
-          const ops = (surface as {operations?: unknown[]}).operations;
-          if (Array.isArray(ops)) {
-            options.onSurfaceOperation?.(ops);
+        appendSurface: (turnId, surface, activity) => {
+          this.engine.mutate(this.#actions.appendSurface({turnId, surface, activity}));
+          const messages = (surface as {messages?: unknown[]}).messages;
+          if (Array.isArray(messages)) {
+            options.onSurfaceOperation?.(messages);
           }
         },
         startToolCall: (turnId, toolCallId, toolName) => {

--- a/packages/thermidor/src/public/controllers/unified-converse/unified-converse-integration.test.ts
+++ b/packages/thermidor/src/public/controllers/unified-converse/unified-converse-integration.test.ts
@@ -91,13 +91,16 @@ const surfaceCreationEvents: SSEEvent[] = [
     event: 'message',
     data: JSON.stringify({
       type: 'ACTIVITY_SNAPSHOT',
+      messageId: 'surface-1-activity',
+      replace: true,
       activityType: 'a2ui-surface',
       content: {
-        operations: [
+        messages: [
           {
+            version: 'v1.0',
             createSurface: {
               surfaceId: 'surface-1',
-              surfaceProperties: {placement: 'main'},
+              components: [{id: 'root', component: 'ProductSearchSurface'}],
               dataModel: {
                 responseId: 'resp-1',
                 products: [
@@ -136,10 +139,13 @@ const actionResponseEvents: SSEEvent[] = [
     event: 'message',
     data: JSON.stringify({
       type: 'ACTIVITY_SNAPSHOT',
+      messageId: 'surface-1-activity',
+      replace: true,
       activityType: 'a2ui-surface',
       content: {
-        operations: [
+        messages: [
           {
+            version: 'v1.0',
             updateDataModel: {
               surfaceId: 'surface-1',
               path: '/pagination',
@@ -147,6 +153,7 @@ const actionResponseEvents: SSEEvent[] = [
             },
           },
           {
+            version: 'v1.0',
             updateDataModel: {
               surfaceId: 'surface-1',
               path: '/products',
@@ -165,6 +172,23 @@ const actionResponseEvents: SSEEvent[] = [
     event: 'turn_complete',
     data: JSON.stringify({conversationSessionId: 'session-1', conversationToken: 'token-1'}),
   },
+];
+
+const surfaceDeletionEvents: SSEEvent[] = [
+  ...surfaceCreationEvents.slice(0, -2),
+  {
+    event: 'message',
+    data: JSON.stringify({
+      type: 'ACTIVITY_SNAPSHOT',
+      messageId: 'surface-1-activity',
+      replace: true,
+      activityType: 'a2ui-surface',
+      content: {
+        messages: [{version: 'v1.0', deleteSurface: {surfaceId: 'surface-1'}}],
+      },
+    }),
+  },
+  ...surfaceCreationEvents.slice(-2),
 ];
 
 const errorEvents: SSEEvent[] = [
@@ -301,6 +325,23 @@ describe('UnifiedConverseController integration', () => {
 
       expect(paginationController.state.totalCount).toBe(100);
       expect(paginationController.state.pageSize).toBe(20);
+    });
+  });
+
+  describe('surface lifecycle', () => {
+    it('removes a routed interface when its A2UI surface is deleted', async () => {
+      mockClient.call.mockReturnValue({
+        success: true,
+        data: {stream: createSSEStream(surfaceDeletionEvents)},
+      });
+
+      controller.submit({prompt: 'Show me boots'});
+
+      await vi.waitFor(() => {
+        expect(controller.state.turns[0]?.status).toBe('complete');
+      });
+
+      expect(controller.state.turns[0].routedInterface).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/SMITH-39

## Context

Thermidor's initial A2UI v1 implementation was based on a July 2026 snapshot of the then-candidate specification. The upstream v1.0 contract continued to evolve and be clarified through late July and August—including explicit data-model `null` deletion, removal of `surfaceProperties`, canonical surface/root composition, catalog resolution, and envelope/component validation. This stack aligns Thermidor with the current shared surface contract used by the Gateway and Smith implementations.

A2UI v1.0 remains a candidate specification. Its surface protocol differs materially from the legacy A2UI shapes Thermidor previously consumed:

- agent-to-renderer updates are versioned `v1.0` envelopes carried in `content.messages`;
- each envelope contains one surface operation;
- components are flat catalog objects with direct properties beside `id` and `component`;
- surface lifecycle messages use `createSurface`, `updateComponents`, `updateDataModel`, and `deleteSurface`;
- `actionResponse` correlates with a top-level `actionId`.

Agent Gateway and Agent Smith are moving their commerce surfaces to this shape. This bottom stack layer establishes the shared parsing boundary so later layers can process the lifecycle rather than support producer-specific legacy payloads.

## Changes

- Parse only versioned A2UI v1 messages from `content.messages`; malformed, legacy, and multi-operation envelopes are ignored without discarding valid siblings.
- Define the v1 surface lifecycle payloads used by Thermidor unified conversations.
- Model component nodes as canonical `{id, component, ...catalogProperties}` objects and reject the former UI Kit-only nested `componentProps` wire shape.
- Preserve the top-level `actionId` when parsing `actionResponse`; handling a response remains outside this stack's required scope.
- Keep non-stateful or unsupported catalog components as raw A2UI data rather than hydrating them as Commerce interfaces.

## Why this is separate

This PR owns protocol normalization only. It intentionally does not decide when a surface is renderable, mutate a data model, manage interfaces, or render demo components; those responsibilities are introduced in the next two stack layers.

## Validation

- `pnpm --filter @coveo/thermidor exec vitest run src/internal/api/unified/unified-surface-hydration.test.ts`
- `pnpm run lint:check`

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] No changeset required because `@coveo/thermidor` is experimental and private.

## Stack

**1 of 3 — review first:** [A2UI v1 format](https://github.com/coveo/ui-kit/pull/8210) → [surface lifecycle](https://github.com/coveo/ui-kit/pull/8211) → [demo replay](https://github.com/coveo/ui-kit/pull/8195).

This PR establishes the protocol boundary consumed by the two layers above it.