### PR TITLE
feat(thermidor): manage A2UI surface lifecycle

### DIFF
--- a/packages/thermidor/src/internal/api/generative/generative-runtime.test.ts
+++ b/packages/thermidor/src/internal/api/generative/generative-runtime.test.ts
@@ -41,6 +41,7 @@ function createMockStatePort(): GenerativeStatePort {
     setActiveTurnId: vi.fn(),
     replaceTurnId: vi.fn(),
     setRoutedInterface: vi.fn(),
+    clearRoutedInterface: vi.fn(),
     initAgentResponse: vi.fn(),
     startMessage: vi.fn(),
     appendMessageDelta: vi.fn(),
@@ -471,7 +472,9 @@ describe('GenerativeRuntime', () => {
       const runtime = GenerativeRuntime.getInstance(engine, 'activity', config);
       await runtime.submit('Hello');
 
-      expect(config.statePort.appendSurface).toHaveBeenCalledWith('generated-id-1', surface);
+      expect(config.statePort.appendSurface).toHaveBeenCalledWith('generated-id-1', surface, {
+        id: 'm1',
+      });
     });
 
     it('handles commerce_search_api_response by routing when hydration succeeds', async () => {

--- a/packages/thermidor/src/internal/api/generative/generative-runtime.ts
+++ b/packages/thermidor/src/internal/api/generative/generative-runtime.ts
@@ -3,6 +3,7 @@ import {
   type ConversationStreamEvent,
   createConversationEndpointClient,
 } from '@/src/internal/api/conversation/index.js';
+import {getActivityMetadata} from '@/src/internal/api/protocol/activity-metadata.js';
 import type {FullEngine} from '@/src/internal/engine/index.js';
 import type {InterfaceHandle} from '@/src/internal/utils/index.js';
 import {createConversationEndpointRequestSelector} from '@/src/internal/api/conversation/index.js';
@@ -314,18 +315,6 @@ export class GenerativeRuntime {
       this.agentResponseInitialized.add(turnId);
     }
   }
-}
-
-function getActivityMetadata(event: unknown): {id?: string; replace?: boolean} {
-  if (typeof event !== 'object' || event === null) {
-    return {};
-  }
-
-  const activity = event as {messageId?: unknown; replace?: unknown};
-  return {
-    ...(typeof activity.messageId === 'string' ? {id: activity.messageId} : {}),
-    ...(activity.replace === true ? {replace: true} : {}),
-  };
 }
 
 function getErrorMessage(error: unknown): string {

--- a/packages/thermidor/src/internal/api/generative/generative-runtime.ts
+++ b/packages/thermidor/src/internal/api/generative/generative-runtime.ts
@@ -24,7 +24,11 @@ export interface GenerativeStatePort {
   initAgentResponse(turnId: string): void;
   startMessage(turnId: string, role: string): void;
   appendMessageDelta(turnId: string, delta: string): void;
-  appendSurface(turnId: string, surface: A2UISurface): void;
+  appendSurface(
+    turnId: string,
+    surface: A2UISurface,
+    activity?: {id?: string; replace?: boolean}
+  ): void;
   startToolCall(turnId: string, toolCallId: string, toolName: string): void;
   appendToolCallArgs(turnId: string, toolCallId: string, delta: string): void;
   completeToolCall(turnId: string, toolCallId: string, result: string): void;
@@ -255,7 +259,12 @@ export class GenerativeRuntime {
 
       case 'ACTIVITY_SNAPSHOT': {
         this.ensureAgentResponse(turnId);
-        this.statePort.appendSurface(turnId, event.content as Record<string, unknown>);
+        const activity = getActivityMetadata(event);
+        if (activity.id || activity.replace) {
+          this.statePort.appendSurface(turnId, event.content as Record<string, unknown>, activity);
+        } else {
+          this.statePort.appendSurface(turnId, event.content as Record<string, unknown>);
+        }
         return {turnId, isTerminal: false};
       }
 
@@ -305,6 +314,18 @@ export class GenerativeRuntime {
       this.agentResponseInitialized.add(turnId);
     }
   }
+}
+
+function getActivityMetadata(event: unknown): {id?: string; replace?: boolean} {
+  if (typeof event !== 'object' || event === null) {
+    return {};
+  }
+
+  const activity = event as {messageId?: unknown; replace?: unknown};
+  return {
+    ...(typeof activity.messageId === 'string' ? {id: activity.messageId} : {}),
+    ...(activity.replace === true ? {replace: true} : {}),
+  };
 }
 
 function getErrorMessage(error: unknown): string {

--- a/packages/thermidor/src/internal/api/protocol/activity-metadata.ts
+++ b/packages/thermidor/src/internal/api/protocol/activity-metadata.ts
@@ -1,0 +1,11 @@
+export function getActivityMetadata(event: unknown): {id?: string; replace?: boolean} {
+  if (typeof event !== 'object' || event === null) {
+    return {};
+  }
+
+  const activity = event as {messageId?: unknown; replace?: unknown};
+  return {
+    ...(typeof activity.messageId === 'string' ? {id: activity.messageId} : {}),
+    ...(activity.replace === true ? {replace: true} : {}),
+  };
+}

--- a/packages/thermidor/src/internal/api/unified/unified-event-dispatcher.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-event-dispatcher.ts
@@ -81,7 +81,12 @@ export function dispatchStreamEvent(
     case 'ACTIVITY_SNAPSHOT': {
       deps.ensureAgentResponse(turnId);
       const content = event.content as Record<string, unknown>;
-      deps.statePort.appendSurface(turnId, content);
+      const activity = getActivityMetadata(event);
+      if (activity.id || activity.replace) {
+        deps.statePort.appendSurface(turnId, content, activity);
+      } else {
+        deps.statePort.appendSurface(turnId, content);
+      }
 
       if (event.activityType === 'a2ui-surface') {
         deps.onA2uiSurface(turnId, content);
@@ -113,6 +118,18 @@ export function dispatchStreamEvent(
     default:
       return handleUnknownEvent(turnId, event, deps);
   }
+}
+
+function getActivityMetadata(event: unknown): {id?: string; replace?: boolean} {
+  if (typeof event !== 'object' || event === null) {
+    return {};
+  }
+
+  const activity = event as {messageId?: unknown; replace?: unknown};
+  return {
+    ...(typeof activity.messageId === 'string' ? {id: activity.messageId} : {}),
+    ...(activity.replace === true ? {replace: true} : {}),
+  };
 }
 
 function handleUnknownEvent(

--- a/packages/thermidor/src/internal/api/unified/unified-event-dispatcher.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-event-dispatcher.ts
@@ -1,4 +1,5 @@
 import type {NormalizedStreamEvent} from '@/src/internal/api/protocol/stream-types.js';
+import {getActivityMetadata} from '@/src/internal/api/protocol/activity-metadata.js';
 import type {GenerativeStatePort} from '@/src/internal/api/generative/index.js';
 
 export interface DispatchResult {
@@ -118,18 +119,6 @@ export function dispatchStreamEvent(
     default:
       return handleUnknownEvent(turnId, event, deps);
   }
-}
-
-function getActivityMetadata(event: unknown): {id?: string; replace?: boolean} {
-  if (typeof event !== 'object' || event === null) {
-    return {};
-  }
-
-  const activity = event as {messageId?: unknown; replace?: unknown};
-  return {
-    ...(typeof activity.messageId === 'string' ? {id: activity.messageId} : {}),
-    ...(activity.replace === true ? {replace: true} : {}),
-  };
 }
 
 function handleUnknownEvent(

--- a/packages/thermidor/src/internal/api/unified/unified-runtime.test.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-runtime.test.ts
@@ -522,7 +522,9 @@ describe('UnifiedRuntime', () => {
       const runtime = UnifiedRuntime.getInstance(engine, 'activity', config);
       await runtime.submit('Hello');
 
-      expect(config.statePort.appendSurface).toHaveBeenCalledWith('generated-id-1', surface);
+      expect(config.statePort.appendSurface).toHaveBeenCalledWith('generated-id-1', surface, {
+        id: 'm1',
+      });
     });
 
     it('handles RUN_ERROR by failing the turn with the error message', async () => {

--- a/packages/thermidor/src/internal/api/unified/unified-runtime.test.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-runtime.test.ts
@@ -1262,7 +1262,15 @@ describe('UnifiedRuntime', () => {
       const engine = createMockEngine();
       const mockIface = createMockInterface();
       const creationContent = {
-        operations: [{createSurface: {surfaceId: 's1', dataModel: {products: []}}}],
+        operations: [
+          {
+            createSurface: {
+              surfaceId: 's1',
+              components: statefulComponents,
+              dataModel: {products: []},
+            },
+          },
+        ],
       };
       const deletionContent = {
         operations: [{deleteSurface: {surfaceId: 's1'}}],

--- a/packages/thermidor/src/internal/api/unified/unified-runtime.test.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-runtime.test.ts
@@ -937,6 +937,8 @@ describe('UnifiedRuntime', () => {
       return {disposed: false, dispose: vi.fn()} as InterfaceHandle;
     }
 
+    const statefulComponents = [{id: 'root', component: 'ProductSearchSurface'}];
+
     it('non-a2ui-surface ACTIVITY_SNAPSHOT only calls appendSurface', async () => {
       const config = createMockConfig();
       const engine = createMockEngine();
@@ -965,7 +967,15 @@ describe('UnifiedRuntime', () => {
       const engine = createMockEngine();
       const mockIface = createMockInterface();
       const content = {
-        operations: [{createSurface: {surfaceId: 's1', dataModel: {products: []}}}],
+        operations: [
+          {
+            createSurface: {
+              surfaceId: 's1',
+              components: statefulComponents,
+              dataModel: {products: []},
+            },
+          },
+        ],
       };
 
       mockExtractA2uiOperations.mockReturnValue(content.operations);
@@ -992,7 +1002,7 @@ describe('UnifiedRuntime', () => {
       expect(config.statePort.appendSurface).toHaveBeenCalledWith('generated-id-1', content);
       expect(mockHydrateFromCreateSurface).toHaveBeenCalledWith(
         engine,
-        {surfaceId: 's1', dataModel: {products: []}},
+        {surfaceId: 's1', components: statefulComponents, dataModel: {products: []}},
         config.generativeInterface,
         config.cartInterface
       );
@@ -1012,8 +1022,20 @@ describe('UnifiedRuntime', () => {
       const mockIface2 = createMockInterface();
       const content = {
         operations: [
-          {createSurface: {surfaceId: 's1', dataModel: {products: ['a']}}},
-          {createSurface: {surfaceId: 's2', dataModel: {products: ['b']}}},
+          {
+            createSurface: {
+              surfaceId: 's1',
+              components: statefulComponents,
+              dataModel: {products: ['a']},
+            },
+          },
+          {
+            createSurface: {
+              surfaceId: 's2',
+              components: statefulComponents,
+              dataModel: {products: ['b']},
+            },
+          },
         ],
       };
 
@@ -1070,7 +1092,13 @@ describe('UnifiedRuntime', () => {
       const mockIface = createMockInterface();
       const content = {
         operations: [
-          {createSurface: {surfaceId: 's1', dataModel: {products: []}}},
+          {
+            createSurface: {
+              surfaceId: 's1',
+              components: statefulComponents,
+              dataModel: {products: []},
+            },
+          },
           {updateDataModel: {surfaceId: 's1', path: '/products', value: ['new-product']}},
         ],
       };
@@ -1101,37 +1129,99 @@ describe('UnifiedRuntime', () => {
       ]);
     });
 
-    it('createSurface with already-existing surfaceId disposes old interface and registers new one', async () => {
+    it('hydrates a model-only createSurface when components arrive in a later snapshot', async () => {
+      const config = createMockConfig();
+      const engine = createMockEngine();
+      const mockIface = createMockInterface();
+      const createOperations = [{createSurface: {surfaceId: 's1', dataModel: {products: []}}}];
+      const componentOperations = [
+        {
+          updateComponents: {
+            surfaceId: 's1',
+            components: [{id: 'root', component: 'ProductSearchSurface'}],
+          },
+        },
+      ];
+
+      mockExtractA2uiOperations
+        .mockReturnValueOnce(createOperations)
+        .mockReturnValueOnce(componentOperations);
+      mockHydrateFromCreateSurface.mockReturnValue({
+        surfaceId: 's1',
+        useCase: 'commerceSearch',
+        interface: mockIface,
+        snapshot: {products: []},
+        query: undefined,
+      });
+
+      setupSuccessfulStream([
+        {
+          type: 'ACTIVITY_SNAPSHOT',
+          activityType: 'a2ui-surface',
+          content: {operations: createOperations},
+        } as unknown as NormalizedStreamEvent,
+        {
+          type: 'ACTIVITY_SNAPSHOT',
+          activityType: 'a2ui-surface',
+          content: {operations: componentOperations},
+        } as unknown as NormalizedStreamEvent,
+        {type: 'turn_complete'} as NormalizedStreamEvent,
+      ]);
+
+      const runtime = UnifiedRuntime.getInstance(engine, 'a2ui-split-hydration', config);
+      await runtime.submit('Hello');
+
+      expect(mockHydrateFromCreateSurface).toHaveBeenCalledWith(
+        engine,
+        expect.objectContaining({
+          surfaceId: 's1',
+          components: [{id: 'root', component: 'ProductSearchSurface'}],
+          dataModel: {products: []},
+        }),
+        config.generativeInterface,
+        config.cartInterface
+      );
+    });
+
+    it('ignores duplicate createSurface without replacing the existing interface', async () => {
       const config = createMockConfig();
       const engine = createMockEngine();
       const oldIface = createMockInterface();
-      const newIface = createMockInterface();
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
       const content1 = {
-        operations: [{createSurface: {surfaceId: 's1', dataModel: {products: ['old']}}}],
+        operations: [
+          {
+            createSurface: {
+              surfaceId: 's1',
+              components: statefulComponents,
+              dataModel: {products: ['old']},
+            },
+          },
+        ],
       };
       const content2 = {
-        operations: [{createSurface: {surfaceId: 's1', dataModel: {products: ['new']}}}],
+        operations: [
+          {
+            createSurface: {
+              surfaceId: 's1',
+              components: statefulComponents,
+              dataModel: {products: ['new']},
+            },
+          },
+        ],
       };
 
       mockExtractA2uiOperations
         .mockReturnValueOnce(content1.operations)
         .mockReturnValueOnce(content2.operations);
-      mockHydrateFromCreateSurface
-        .mockReturnValueOnce({
-          surfaceId: 's1',
-          useCase: 'commerceSearch',
-          interface: oldIface,
-          snapshot: {products: ['old']},
-          query: undefined,
-        })
-        .mockReturnValueOnce({
-          surfaceId: 's1',
-          useCase: 'commerceSearch',
-          interface: newIface,
-          snapshot: {products: ['new']},
-          query: undefined,
-        });
+      mockHydrateFromCreateSurface.mockReturnValue({
+        surfaceId: 's1',
+        useCase: 'commerceSearch',
+        interface: oldIface,
+        snapshot: {products: ['old']},
+        query: undefined,
+      });
 
       setupSuccessfulStream([
         {
@@ -1150,14 +1240,21 @@ describe('UnifiedRuntime', () => {
       const runtime = UnifiedRuntime.getInstance(engine, 'a2ui-recreate', config);
       await runtime.submit('Hello');
 
-      expect(oldIface.dispose).toHaveBeenCalled();
-      expect(config.statePort.setRoutedInterface).toHaveBeenLastCalledWith('generated-id-1', {
+      expect(oldIface.dispose).not.toHaveBeenCalled();
+      expect(mockHydrateFromCreateSurface).toHaveBeenCalledTimes(1);
+      expect(config.statePort.setRoutedInterface).toHaveBeenCalledOnce();
+      expect(config.statePort.setRoutedInterface).toHaveBeenCalledWith('generated-id-1', {
         useCase: 'commerceSearch',
-        interface: newIface,
-        snapshot: {products: ['new']},
+        interface: oldIface,
+        snapshot: {products: ['old']},
         query: undefined,
         surfaceId: 's1',
       });
+      expect(config.statePort.failTurn).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        'Ignoring duplicate A2UI createSurface for existing surfaceId "s1".'
+      );
+      warn.mockRestore();
     });
 
     it('disposes and clears a routed interface when its surface is deleted', async () => {
@@ -1210,7 +1307,13 @@ describe('UnifiedRuntime', () => {
       const fullModel = {products: [], facets: [], pagination: {}};
       const content = {
         operations: [
-          {createSurface: {surfaceId: 's1', dataModel: {products: []}}},
+          {
+            createSurface: {
+              surfaceId: 's1',
+              components: statefulComponents,
+              dataModel: {products: []},
+            },
+          },
           {updateDataModel: {surfaceId: 's1', path: '/', value: fullModel}},
         ],
       };
@@ -1245,7 +1348,13 @@ describe('UnifiedRuntime', () => {
       const mockIface = createMockInterface();
       const content = {
         operations: [
-          {createSurface: {surfaceId: 's1', dataModel: {products: []}}},
+          {
+            createSurface: {
+              surfaceId: 's1',
+              components: statefulComponents,
+              dataModel: {products: []},
+            },
+          },
           {updateDataModel: {surfaceId: 's1', path: '/responseId', value: 'resp-123'}},
         ],
       };

--- a/packages/thermidor/src/internal/api/unified/unified-surface-processor.test.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-surface-processor.test.ts
@@ -282,4 +282,25 @@ describe('applyDataModelPatch', () => {
     expect(deleted).toEqual({query: {text: 'new', locale: 'en'}, products: ['p2']});
     expect(initial).toEqual({query: {text: 'old', locale: 'en'}, products: ['p1', 'p2']});
   });
+
+  it('decodes escaped JSON Pointer segments', () => {
+    const updated = applyDataModelPatch({metadata: {'a/b~c': 'old'}}, '/metadata/a~1b~0c', 'new');
+
+    expect(updated).toEqual({metadata: {'a/b~c': 'new'}});
+  });
+
+  it('replaces array entries and appends with the JSON Pointer append segment', () => {
+    const replaced = applyDataModelPatch({products: ['p1', 'p2']}, '/products/1', 'updated');
+    const appended = applyDataModelPatch(replaced, '/products/-', 'p3');
+
+    expect(appended).toEqual({products: ['p1', 'updated', 'p3']});
+  });
+
+  it('replaces and clears the entire data model at the root path', () => {
+    const replaced = applyDataModelPatch({products: ['p1']}, '/', {products: ['p2']});
+    const cleared = applyDataModelPatch(replaced, '/', null);
+
+    expect(replaced).toEqual({products: ['p2']});
+    expect(cleared).toBeUndefined();
+  });
 });

--- a/packages/thermidor/src/internal/api/unified/unified-surface-processor.test.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-surface-processor.test.ts
@@ -1,0 +1,285 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import type {FullEngine} from '@/src/internal/engine/index.js';
+import type {GenerativeStatePort} from '@/src/internal/api/generative/index.js';
+import type {InterfaceHandle} from '@/src/internal/utils/index.js';
+
+const {mockHydrateFromCreateSurface, mockApplyDataModelUpdate} = vi.hoisted(() => ({
+  mockHydrateFromCreateSurface: vi.fn(),
+  mockApplyDataModelUpdate: vi.fn(),
+}));
+
+vi.mock('./unified-surface-hydration.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./unified-surface-hydration.js')>();
+  return {
+    ...actual,
+    hydrateFromCreateSurface: mockHydrateFromCreateSurface,
+    applyDataModelUpdate: mockApplyDataModelUpdate,
+  };
+});
+
+import {applyDataModelPatch, createSurfaceProcessor} from './unified-surface-processor.js';
+
+function createMockInterface(): InterfaceHandle {
+  return {disposed: false, dispose: vi.fn()} as InterfaceHandle;
+}
+
+function createDeps() {
+  const statePort = {
+    setRoutedInterface: vi.fn(),
+    clearRoutedInterface: vi.fn(),
+  } as unknown as GenerativeStatePort;
+  return {
+    deps: {
+      engine: {} as FullEngine,
+      statePort,
+      generativeInterface: createMockInterface(),
+      cartInterface: createMockInterface(),
+    },
+    statePort,
+  };
+}
+
+function snapshot(messages: unknown[]) {
+  return {messages};
+}
+
+const searchRoot = [{id: 'root', component: 'ProductSearchSurface'}];
+const listingRoot = [{id: 'root', component: 'ProductListingSurface'}];
+
+describe('createSurfaceProcessor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hydrates when updateComponents completes a model-only createSurface', () => {
+    const {deps, statePort} = createDeps();
+    const iface = createMockInterface();
+    mockHydrateFromCreateSurface.mockReturnValue({
+      surfaceId: 's1',
+      useCase: 'commerceSearch',
+      interface: iface,
+      snapshot: {products: []},
+      query: undefined,
+    });
+    const processor = createSurfaceProcessor(deps);
+
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([{version: 'v1.0', createSurface: {surfaceId: 's1', dataModel: {products: []}}}])
+    );
+    expect(mockHydrateFromCreateSurface).not.toHaveBeenCalled();
+
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([{version: 'v1.0', updateComponents: {surfaceId: 's1', components: searchRoot}}])
+    );
+
+    expect(mockHydrateFromCreateSurface).toHaveBeenCalledWith(
+      deps.engine,
+      expect.objectContaining({surfaceId: 's1', components: searchRoot, dataModel: {products: []}}),
+      deps.generativeInterface,
+      deps.cartInterface
+    );
+    expect(statePort.setRoutedInterface).toHaveBeenCalledOnce();
+  });
+
+  it('hydrates when updateDataModel completes a component-only createSurface', () => {
+    const {deps} = createDeps();
+    mockHydrateFromCreateSurface.mockReturnValue({
+      surfaceId: 's1',
+      useCase: 'commerceSearch',
+      interface: createMockInterface(),
+      snapshot: {products: ['p1']},
+      query: undefined,
+    });
+    const processor = createSurfaceProcessor(deps);
+
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([{version: 'v1.0', createSurface: {surfaceId: 's1', components: searchRoot}}])
+    );
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([
+        {
+          version: 'v1.0',
+          updateDataModel: {surfaceId: 's1', path: '/', value: {products: ['p1']}},
+        },
+      ])
+    );
+
+    expect(mockHydrateFromCreateSurface).toHaveBeenCalledWith(
+      deps.engine,
+      expect.objectContaining({dataModel: {products: ['p1']}, components: searchRoot}),
+      deps.generativeInterface,
+      deps.cartInterface
+    );
+  });
+
+  it('ignores updates for surfaces that have not been created', () => {
+    const {deps} = createDeps();
+    const processor = createSurfaceProcessor(deps);
+
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([
+        {
+          version: 'v1.0',
+          updateDataModel: {surfaceId: 's1', path: '/', value: {products: ['stale']}},
+        },
+        {version: 'v1.0', updateComponents: {surfaceId: 's1', components: searchRoot}},
+      ])
+    );
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([{version: 'v1.0', createSurface: {surfaceId: 's1', components: searchRoot}}])
+    );
+
+    expect(mockHydrateFromCreateSurface).not.toHaveBeenCalled();
+  });
+
+  it('warns and preserves pending state for a duplicate createSurface', () => {
+    const {deps} = createDeps();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockHydrateFromCreateSurface.mockReturnValue({
+      surfaceId: 's1',
+      useCase: 'commerceSearch',
+      interface: createMockInterface(),
+      snapshot: {products: ['fresh']},
+      query: undefined,
+    });
+    const processor = createSurfaceProcessor(deps);
+
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([{version: 'v1.0', createSurface: {surfaceId: 's1', components: searchRoot}}])
+    );
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([
+        {
+          version: 'v1.0',
+          createSurface: {
+            surfaceId: 's1',
+            components: listingRoot,
+            dataModel: {products: ['stale']},
+          },
+        },
+      ])
+    );
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([
+        {
+          version: 'v1.0',
+          updateDataModel: {surfaceId: 's1', path: '/', value: {products: ['fresh']}},
+        },
+      ])
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      'Ignoring duplicate A2UI createSurface for existing surfaceId "s1".'
+    );
+    expect(mockHydrateFromCreateSurface).toHaveBeenCalledWith(
+      deps.engine,
+      expect.objectContaining({components: searchRoot, dataModel: {products: ['fresh']}}),
+      deps.generativeInterface,
+      deps.cartInterface
+    );
+    warn.mockRestore();
+  });
+
+  it('recreates a live interface when updateComponents changes the stateful root', () => {
+    const {deps, statePort} = createDeps();
+    const searchInterface = createMockInterface();
+    const listingInterface = createMockInterface();
+    mockHydrateFromCreateSurface
+      .mockReturnValueOnce({
+        surfaceId: 's1',
+        useCase: 'commerceSearch',
+        interface: searchInterface,
+        snapshot: {products: []},
+        query: undefined,
+      })
+      .mockReturnValueOnce({
+        surfaceId: 's1',
+        useCase: 'commerceSearch',
+        interface: listingInterface,
+        snapshot: {products: []},
+        query: undefined,
+      });
+    const processor = createSurfaceProcessor(deps);
+
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([
+        {
+          version: 'v1.0',
+          createSurface: {surfaceId: 's1', components: searchRoot, dataModel: {products: []}},
+        },
+      ])
+    );
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([{version: 'v1.0', updateComponents: {surfaceId: 's1', components: listingRoot}}])
+    );
+
+    expect(searchInterface.dispose).toHaveBeenCalledOnce();
+    expect(statePort.clearRoutedInterface).toHaveBeenCalledWith('turn-1', 's1');
+    expect(mockHydrateFromCreateSurface).toHaveBeenCalledTimes(2);
+  });
+
+  it('deletes pending state so a later createSurface starts fresh', () => {
+    const {deps} = createDeps();
+    mockHydrateFromCreateSurface.mockReturnValue({
+      surfaceId: 's1',
+      useCase: 'commerceSearch',
+      interface: createMockInterface(),
+      snapshot: {products: ['fresh']},
+      query: undefined,
+    });
+    const processor = createSurfaceProcessor(deps);
+
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([{version: 'v1.0', createSurface: {surfaceId: 's1', components: searchRoot}}])
+    );
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([{version: 'v1.0', deleteSurface: {surfaceId: 's1'}}])
+    );
+    processor.processSnapshot(
+      'turn-1',
+      snapshot([
+        {
+          version: 'v1.0',
+          createSurface: {
+            surfaceId: 's1',
+            components: searchRoot,
+            dataModel: {products: ['fresh']},
+          },
+        },
+      ])
+    );
+
+    expect(mockHydrateFromCreateSurface).toHaveBeenCalledOnce();
+    expect(mockHydrateFromCreateSurface).toHaveBeenCalledWith(
+      deps.engine,
+      expect.objectContaining({dataModel: {products: ['fresh']}}),
+      deps.generativeInterface,
+      deps.cartInterface
+    );
+  });
+});
+
+describe('applyDataModelPatch', () => {
+  it('applies nested JSON Pointer updates and explicit null deletions immutably', () => {
+    const initial = {query: {text: 'old', locale: 'en'}, products: ['p1', 'p2']};
+    const updated = applyDataModelPatch(initial, '/query/text', 'new');
+    const deleted = applyDataModelPatch(updated, '/products/0', null);
+
+    expect(updated).toEqual({query: {text: 'new', locale: 'en'}, products: ['p1', 'p2']});
+    expect(deleted).toEqual({query: {text: 'new', locale: 'en'}, products: ['p2']});
+    expect(initial).toEqual({query: {text: 'old', locale: 'en'}, products: ['p1', 'p2']});
+  });
+});

--- a/packages/thermidor/src/internal/api/unified/unified-surface-processor.ts
+++ b/packages/thermidor/src/internal/api/unified/unified-surface-processor.ts
@@ -5,6 +5,8 @@ import {
   hydrateFromCreateSurface,
   applyDataModelUpdate,
   extractA2uiOperations,
+  type ComponentNode,
+  type CreateSurfacePayload,
   type A2uiOperation,
 } from './unified-surface-hydration.js';
 
@@ -15,14 +17,22 @@ export interface SurfaceProcessorDeps {
   cartInterface: InterfaceHandle;
 }
 
+interface SurfaceLifecycleState {
+  createSurface: CreateSurfacePayload;
+  components?: ComponentNode[];
+  dataModel?: Record<string, unknown>;
+  interface?: InterfaceHandle;
+  rootKind?: string;
+}
+
 export function createSurfaceProcessor(deps: SurfaceProcessorDeps) {
-  const surfaceMap = new Map<string, InterfaceHandle>();
+  const surfaces = new Map<string, SurfaceLifecycleState>();
 
   return {
     processSnapshot(turnId: string, content: Record<string, unknown>): void {
       const operations = extractA2uiOperations(content);
       if (operations.length > 0) {
-        processOperations(turnId, operations, surfaceMap, deps);
+        processOperations(turnId, operations, surfaces, deps);
       }
     },
   };
@@ -31,44 +41,205 @@ export function createSurfaceProcessor(deps: SurfaceProcessorDeps) {
 function processOperations(
   turnId: string,
   operations: A2uiOperation[],
-  surfaceMap: Map<string, InterfaceHandle>,
+  surfaces: Map<string, SurfaceLifecycleState>,
   deps: SurfaceProcessorDeps
 ): void {
   for (const op of operations) {
     if ('createSurface' in op) {
-      const existingIface = surfaceMap.get(op.createSurface.surfaceId);
-      if (existingIface) {
-        existingIface.dispose();
+      const {surfaceId} = op.createSurface;
+      if (surfaces.has(surfaceId)) {
+        console.warn(
+          `Ignoring duplicate A2UI createSurface for existing surfaceId "${surfaceId}".`
+        );
+        continue;
       }
 
-      const result = hydrateFromCreateSurface(
-        deps.engine,
-        op.createSurface,
-        deps.generativeInterface,
-        deps.cartInterface
-      );
-      if (result) {
-        surfaceMap.set(result.surfaceId, result.interface);
-        deps.statePort.setRoutedInterface(turnId, {
-          useCase: result.useCase,
-          interface: result.interface,
-          snapshot: result.snapshot,
-          query: result.query,
-          surfaceId: result.surfaceId,
-        });
+      const state: SurfaceLifecycleState = {
+        createSurface: op.createSurface,
+        components: op.createSurface.components,
+        dataModel: op.createSurface.dataModel,
+      };
+      surfaces.set(surfaceId, state);
+      maybeHydrate(turnId, surfaceId, state, deps);
+    } else if ('updateComponents' in op) {
+      const state = surfaces.get(op.updateComponents.surfaceId);
+      if (!state) {
+        continue;
       }
+
+      state.components = op.updateComponents.components;
+      const nextRootKind = getStatefulCommerceRootKind(state.components);
+      if (state.interface && nextRootKind !== state.rootKind) {
+        state.interface.dispose();
+        state.interface = undefined;
+        state.rootKind = undefined;
+        deps.statePort.clearRoutedInterface(turnId, op.updateComponents.surfaceId);
+      }
+      maybeHydrate(turnId, op.updateComponents.surfaceId, state, deps);
     } else if ('updateDataModel' in op) {
-      const iface = surfaceMap.get(op.updateDataModel.surfaceId);
-      if (iface) {
-        applyDataModelUpdate(deps.engine, iface, op.updateDataModel.path, op.updateDataModel.value);
+      const state = surfaces.get(op.updateDataModel.surfaceId);
+      if (!state) {
+        continue;
       }
+
+      state.dataModel = applyDataModelPatch(
+        state.dataModel,
+        op.updateDataModel.path,
+        op.updateDataModel.value
+      );
+      if (!state.dataModel && state.interface) {
+        state.interface.dispose();
+        state.interface = undefined;
+        state.rootKind = undefined;
+        deps.statePort.clearRoutedInterface(turnId, op.updateDataModel.surfaceId);
+      } else if (state.interface) {
+        applyDataModelUpdate(
+          deps.engine,
+          state.interface,
+          op.updateDataModel.path,
+          op.updateDataModel.value
+        );
+      }
+      maybeHydrate(turnId, op.updateDataModel.surfaceId, state, deps);
     } else if ('deleteSurface' in op) {
-      const iface = surfaceMap.get(op.deleteSurface.surfaceId);
-      if (iface) {
-        iface.dispose();
-        surfaceMap.delete(op.deleteSurface.surfaceId);
+      const state = surfaces.get(op.deleteSurface.surfaceId);
+      if (state?.interface) {
+        state.interface.dispose();
         deps.statePort.clearRoutedInterface(turnId, op.deleteSurface.surfaceId);
       }
+      surfaces.delete(op.deleteSurface.surfaceId);
     }
   }
+}
+
+function maybeHydrate(
+  turnId: string,
+  surfaceId: string,
+  state: SurfaceLifecycleState,
+  deps: SurfaceProcessorDeps
+): void {
+  if (state.interface || !state.components || !state.dataModel) {
+    return;
+  }
+
+  const result = hydrateFromCreateSurface(
+    deps.engine,
+    {
+      ...state.createSurface,
+      components: state.components,
+      dataModel: state.dataModel,
+    },
+    deps.generativeInterface,
+    deps.cartInterface
+  );
+  if (!result) {
+    return;
+  }
+
+  state.interface = result.interface;
+  state.rootKind = getStatefulCommerceRootKind(state.components);
+  deps.statePort.setRoutedInterface(turnId, {
+    useCase: result.useCase,
+    interface: result.interface,
+    snapshot: result.snapshot,
+    query: result.query,
+    surfaceId,
+  });
+}
+
+function getStatefulCommerceRootKind(components: ComponentNode[] | undefined): string | undefined {
+  const kind = components?.find((component) => component.id === 'root')?.component;
+  return kind === 'ProductSearchSurface' || kind === 'ProductListingSurface' ? kind : undefined;
+}
+
+export function applyDataModelPatch(
+  current: Record<string, unknown> | undefined,
+  path: string | undefined,
+  value: unknown
+): Record<string, unknown> | undefined {
+  if (!path || path === '/') {
+    return isRecord(value) ? value : undefined;
+  }
+  if (!path.startsWith('/')) {
+    return current;
+  }
+
+  const segments = path
+    .slice(1)
+    .split('/')
+    .map((segment) => segment.replace(/~1/g, '/').replace(/~0/g, '~'));
+  const root: Record<string, unknown> = {...(current ?? {})};
+  let target: Record<string, unknown> | unknown[] = root;
+
+  for (let index = 0; index < segments.length - 1; index++) {
+    const segment = segments[index];
+    const nextSegment = segments[index + 1];
+    const existing = getContainerValue(target, segment);
+    const child = isContainer(existing) ? cloneContainer(existing) : createContainer(nextSegment);
+    setContainerValue(target, segment, child);
+    target = child;
+  }
+
+  const leaf = segments.at(-1);
+  if (leaf === undefined) {
+    return root;
+  }
+  if (value === null) {
+    deleteContainerValue(target, leaf);
+  } else {
+    setContainerValue(target, leaf, value);
+  }
+  return root;
+}
+
+function createContainer(nextSegment: string): Record<string, unknown> | unknown[] {
+  return isArrayIndex(nextSegment) || nextSegment === '-' ? [] : {};
+}
+
+function cloneContainer(
+  value: Record<string, unknown> | unknown[]
+): Record<string, unknown> | unknown[] {
+  return Array.isArray(value) ? [...value] : {...value};
+}
+
+function isContainer(value: unknown): value is Record<string, unknown> | unknown[] {
+  return Array.isArray(value) || isRecord(value);
+}
+
+function getContainerValue(container: Record<string, unknown> | unknown[], key: string): unknown {
+  return Array.isArray(container) ? container[Number(key)] : container[key];
+}
+
+function setContainerValue(
+  container: Record<string, unknown> | unknown[],
+  key: string,
+  value: unknown
+): void {
+  if (Array.isArray(container)) {
+    if (key === '-') {
+      container.push(value);
+    } else if (isArrayIndex(key)) {
+      container[Number(key)] = value;
+    }
+    return;
+  }
+  container[key] = value;
+}
+
+function deleteContainerValue(container: Record<string, unknown> | unknown[], key: string): void {
+  if (Array.isArray(container)) {
+    if (isArrayIndex(key)) {
+      container.splice(Number(key), 1);
+    }
+    return;
+  }
+  delete container[key];
+}
+
+function isArrayIndex(value: string): boolean {
+  return /^(0|[1-9]\d*)$/.test(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/thermidor/src/internal/features/generative/generative-actions.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-actions.ts
@@ -27,7 +27,11 @@ export function createGenerativeActions(interfaceId: string) {
     appendMessageDelta: createAction<{turnId: string; delta: string}>(
       `${prefix}/appendMessageDelta`
     ),
-    appendSurface: createAction<{turnId: string; surface: A2UISurface}>(`${prefix}/appendSurface`),
+    appendSurface: createAction<{
+      turnId: string;
+      surface: A2UISurface;
+      activity?: {id?: string; replace?: boolean};
+    }>(`${prefix}/appendSurface`),
     startToolCall: createAction<{
       turnId: string;
       toolCallId: string;

--- a/packages/thermidor/src/internal/features/generative/generative-slice.test.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-slice.test.ts
@@ -40,6 +40,51 @@ describe('generative slice', () => {
     expect(state.turns[0].status).toBe('complete');
   });
 
+  it('reconciles replacement activities by identity while retaining their A2UI messages', () => {
+    let state = reducer(
+      undefined,
+      actions.createTurn({id: 'turn-1', prompt: 'find shoes', status: 'streaming'})
+    );
+    state = reducer(state, actions.initAgentResponse({turnId: 'turn-1'}));
+    state = reducer(
+      state,
+      actions.appendSurface({
+        turnId: 'turn-1',
+        surface: {messages: [{version: 'v1.0', createSurface: {surfaceId: 'surface-1'}}]},
+        activity: {id: 'activity-1', replace: true},
+      })
+    );
+    state = reducer(
+      state,
+      actions.appendSurface({
+        turnId: 'turn-1',
+        surface: {
+          messages: [
+            {
+              version: 'v1.0',
+              updateDataModel: {surfaceId: 'surface-1', path: '/', value: {products: []}},
+            },
+          ],
+        },
+        activity: {id: 'activity-1', replace: true},
+      })
+    );
+
+    expect(state.turns[0].agentResponse?.surfaces).toEqual([
+      {
+        __thermidorActivityId: 'activity-1',
+        messages: [
+          {version: 'v1.0', createSurface: {surfaceId: 'surface-1'}},
+          {
+            version: 'v1.0',
+            updateDataModel: {surfaceId: 'surface-1', path: '/', value: {products: []}},
+          },
+        ],
+      },
+    ]);
+  });
+});
+
   it('clears a routed interface without removing the agent response', () => {
     let state = reducer(
       undefined,

--- a/packages/thermidor/src/internal/features/generative/generative-slice.test.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-slice.test.ts
@@ -40,7 +40,7 @@ describe('generative slice', () => {
     expect(state.turns[0].status).toBe('complete');
   });
 
-  it('reconciles replacement activities by identity while retaining their A2UI messages', () => {
+  it('replaces activities by identity when their A2UI snapshot is replaced', () => {
     let state = reducer(
       undefined,
       actions.createTurn({id: 'turn-1', prompt: 'find shoes', status: 'streaming'})
@@ -74,7 +74,6 @@ describe('generative slice', () => {
       {
         __thermidorActivityId: 'activity-1',
         messages: [
-          {version: 'v1.0', createSurface: {surfaceId: 'surface-1'}},
           {
             version: 'v1.0',
             updateDataModel: {surfaceId: 'surface-1', path: '/', value: {products: []}},

--- a/packages/thermidor/src/internal/features/generative/generative-slice.test.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-slice.test.ts
@@ -83,7 +83,6 @@ describe('generative slice', () => {
       },
     ]);
   });
-});
 
   it('clears a routed interface without removing the agent response', () => {
     let state = reducer(

--- a/packages/thermidor/src/internal/features/generative/generative-slice.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-slice.ts
@@ -94,20 +94,14 @@ export function createGenerativeSlice(
               const existingIndex = turn.agentResponse.surfaces.findIndex(
                 (surface) => surface.__thermidorActivityId === activityId
               );
-              const existingSurface = turn.agentResponse.surfaces[existingIndex];
-              const existingMessages = existingSurface?.messages;
-              const replacementMessages = payload.surface.messages;
-              const reconciledSurface = {
+              const replacementSurface = {
                 ...payload.surface,
-                ...(Array.isArray(existingMessages) && Array.isArray(replacementMessages)
-                  ? {messages: [...existingMessages, ...replacementMessages]}
-                  : {}),
                 __thermidorActivityId: activityId,
               };
               if (existingIndex >= 0) {
-                turn.agentResponse.surfaces[existingIndex] = reconciledSurface;
+                turn.agentResponse.surfaces[existingIndex] = replacementSurface;
               } else {
-                turn.agentResponse.surfaces.push(reconciledSurface);
+                turn.agentResponse.surfaces.push(replacementSurface);
               }
             } else {
               turn.agentResponse.surfaces.push(payload.surface);

--- a/packages/thermidor/src/internal/features/generative/generative-slice.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-slice.ts
@@ -89,7 +89,29 @@ export function createGenerativeSlice(
         .addCase(actions.appendSurface, (state, {payload}) => {
           const turn = state.turns.find((t) => t.id === payload.turnId);
           if (turn?.agentResponse) {
-            turn.agentResponse.surfaces.push(payload.surface);
+            const activityId = payload.activity?.id;
+            if (activityId && payload.activity?.replace) {
+              const existingIndex = turn.agentResponse.surfaces.findIndex(
+                (surface) => surface.__thermidorActivityId === activityId
+              );
+              const existingSurface = turn.agentResponse.surfaces[existingIndex];
+              const existingMessages = existingSurface?.messages;
+              const replacementMessages = payload.surface.messages;
+              const reconciledSurface = {
+                ...payload.surface,
+                ...(Array.isArray(existingMessages) && Array.isArray(replacementMessages)
+                  ? {messages: [...existingMessages, ...replacementMessages]}
+                  : {}),
+                __thermidorActivityId: activityId,
+              };
+              if (existingIndex >= 0) {
+                turn.agentResponse.surfaces[existingIndex] = reconciledSurface;
+              } else {
+                turn.agentResponse.surfaces.push(reconciledSurface);
+              }
+            } else {
+              turn.agentResponse.surfaces.push(payload.surface);
+            }
           }
         })
         .addCase(actions.startToolCall, (state, {payload}) => {

--- a/packages/thermidor/src/internal/features/generative/generative-types.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-types.ts
@@ -191,7 +191,9 @@ export interface AgentMessage {
 /**
  * Opaque surface data passed through from `/converse` without interpretation.
  */
-export type A2UISurface = Record<string, unknown>;
+export type A2UISurface = Record<string, unknown> & {
+  __thermidorActivityId?: string;
+};
 
 export interface GenerativeState {
   /**

--- a/packages/thermidor/src/internal/features/generative/generative-types.ts
+++ b/packages/thermidor/src/internal/features/generative/generative-types.ts
@@ -189,7 +189,8 @@ export interface AgentMessage {
 }
 
 /**
- * Opaque surface data passed through from `/converse` without interpretation.
+ * Opaque surface data passed through from `/converse`, augmented with an
+ * internal activity identifier for lifecycle tracking.
  */
 export type A2UISurface = Record<string, unknown> & {
   __thermidorActivityId?: string;


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/SMITH-39

## Context

Thermidor's initial A2UI v1 implementation was based on a July 2026 snapshot of the then-candidate specification. The upstream v1.0 contract continued to evolve and be clarified through late July and August—including explicit data-model `null` deletion, removal of `surfaceProperties`, canonical surface/root composition, catalog resolution, and envelope/component validation. This stack aligns Thermidor with the current shared surface contract used by the Gateway and Smith implementations.

A2UI v1 surfaces are stateful streams, not self-contained snapshots. A `createSurface` can arrive without its component tree or data model; later messages may update either in any order, replace values through JSON Pointer paths, or delete the surface entirely.

After PR #8210 normalizes the moving v1 wire format, Thermidor needs a persistent lifecycle processor so Gateway/Smith-style streams can progressively materialize a routed Commerce interface without relying on legacy placement metadata or snapshot-local assumptions.

## Changes

- Maintain per-surface lifecycle state across `createSurface`, `updateComponents`, `updateDataModel`, and `deleteSurface`.
- Buffer incomplete surfaces until both a recognized Commerce root and data model are available, regardless of message ordering.
- Derive stateful Commerce hydration from the canonical `id: "root"` component rather than the removed legacy placement metadata.
- Apply immutable JSON Pointer data-model updates, including nested paths, escaped segments, array updates, root replacement, and `null` deletion.
- Dispose and clear routed interfaces when a stateful root changes, data is cleared, or a surface is deleted; a deleted ID may subsequently be recreated.
- Preserve and reconcile AG-UI activity replacement snapshots so incremental A2UI messages remain replayable.
- Ignore duplicate `createSurface` messages for an existing surface, as required by the v1 surface uniqueness rule.

## Why this is separate

This layer consumes the normalized protocol from PR #8210 and owns runtime state/interface lifecycle. It does not render generic A2UI catalogs; it recognizes only the Commerce root kinds that Thermidor can currently hydrate.

## Validation

- Focused lifecycle, snapshot-replacement, and generative-state coverage is included in this PR.
- The lower protocol parser and top demo replay layers have dedicated targeted validation.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] No changeset required because `@coveo/thermidor` is experimental and private.

## Stack

**2 of 3 — review after [A2UI v1 format](https://github.com/coveo/ui-kit/pull/8210):** [A2UI v1 format](https://github.com/coveo/ui-kit/pull/8210) → [surface lifecycle](https://github.com/coveo/ui-kit/pull/8211) → [demo replay](https://github.com/coveo/ui-kit/pull/8195).

This PR builds the runtime lifecycle on the parsing boundary and is consumed by the demo layer above it.