### PR TITLE
fix(atomic-angular): serialize asset builds

### DIFF
--- a/packages/atomic-angular/turbo.json
+++ b/packages/atomic-angular/turbo.json
@@ -10,7 +10,7 @@
       "outputs": ["projects/atomic-angular/src/lib/generated/**/*"]
     },
     "build:assets": {
-      "dependsOn": ["@coveo/atomic#build:locales", "@coveo/atomic#build:assets"],
+      "dependsOn": ["build:bundles", "@coveo/atomic#build:locales", "@coveo/atomic#build:assets"],
       "outputs": ["projects/atomic-angular/dist/assets/**", "projects/atomic-angular/dist/lang/**"]
     },
     "build:bundles": {


### PR DESCRIPTION
## Issue

Atomic Angular could copy runtime assets before ng-packagr cleared the shared `dist` directory. On a cold Turbo build, Angular sample e2e servers then failed to start because `dist/assets` and `dist/lang` were missing.

## Solution

Make `build:assets` depend on `build:bundles`, so runtime assets and locales are copied only after the Angular bundle build completes.