### PR TITLE
fix(KIT-6043): forward Turbo SCM range to Quantic E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,6 +602,8 @@ jobs:
     uses: ./.github/workflows/e2e-quantic.yml
     with:
       event_name: ${{ github.event_name }}
+      turbo_scm_base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'main' }}
+      turbo_scm_head: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets:
       SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
       SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}

--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -46,6 +46,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/setup-sfdx
       - uses: ./.github/actions/e2e-quantic-setup
@@ -66,6 +68,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/post-scratch-org-links-on-pr
   e2e-quantic-playwright-test:
     name: 'Run Playwright e2e tests on Quantic'
@@ -86,6 +90,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/playwright-quantic
         with:
@@ -105,6 +111,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup
       - name: Merge Playwright reports
         uses: ./.github/actions/merge-playwright-reports
@@ -124,6 +132,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/setup-sfdx
       - name: Delete Quantic scratch orgs

--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -6,6 +6,14 @@ on:
         required: false
         type: string
         default: 'pull_request'
+      turbo_scm_base:
+        description: 'The base commit used by Turborepo to determine affected projects'
+        required: true
+        type: string
+      turbo_scm_head:
+        description: 'The head commit used by Turborepo to determine affected projects'
+        required: true
+        type: string
     secrets:
       SFDX_AUTH_CLIENT_ID:
         required: true
@@ -20,6 +28,8 @@ permissions:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_SCM_BASE: ${{ inputs.turbo_scm_base }}
+  TURBO_SCM_HEAD: ${{ inputs.turbo_scm_head }}
 
 jobs:
   e2e-quantic-setup:


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6043

## Motivation

The Quantic E2E reusable workflow did not receive the `TURBO_SCM_BASE` and `TURBO_SCM_HEAD` values calculated by the root CI workflow, preventing affected builds from using the intended commit range.

## Root Cause

Workflow-level environment variables are not inherited across reusable workflow boundaries, and `with:` cannot reference the caller workflow's `env` context.

## Changes

- Added required `turbo_scm_base` and `turbo_scm_head` inputs to the reusable Quantic E2E workflow.
- Passed the calculated commit SHAs from the CI caller.
- Mapped the inputs to `TURBO_SCM_BASE` and `TURBO_SCM_HEAD` in the reusable workflow environment.

## Validation

- `pnpm run lint:fix`
- YAML parsing for both modified workflows
- Oxfmt check for both modified workflows
- `git diff --check`

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`fix(<scope>): <description>`)
- [x] Changeset not required: this is an internal CI workflow change.