### PR TITLE
chore(ci): enable Turbo preflight for large remote-cache artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,8 @@ permissions:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # Route large (>6MB) remote-cache artifacts directly to S3 via Turbo preflight.
+  TURBO_PREFLIGHT: true
 
 jobs:
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ permissions:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # Route large (>6MB) remote-cache artifacts directly to S3 via Turbo preflight.
+  TURBO_PREFLIGHT: true
   TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'main' }}
   TURBO_SCM_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -20,6 +20,8 @@ permissions:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # Route large (>6MB) remote-cache artifacts directly to S3 via Turbo preflight.
+  TURBO_PREFLIGHT: true
 
 jobs:
   e2e-quantic-setup:

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -25,6 +25,8 @@ permissions:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  # Route large (>6MB) remote-cache artifacts directly to S3 via Turbo preflight.
+  TURBO_PREFLIGHT: true
 
 jobs:
   build-cdn:


### PR DESCRIPTION
## Summary

Opt ui-kit CI into Turbo's **preflight** protocol so remote-cache artifacts larger than the cache Lambda Function URL's ~6MB body limit upload/download through a presigned S3 URL instead of failing with `413 Request Entity Too Large`.

> [!IMPORTANT]
> **Merge order — this PR must be merged _after_ [coveo-platform/jsadmin-infra#258](https://github.com/coveo-platform/jsadmin-infra/pull/258) is deployed.**
> That PR adds the server-side preflight support to the remote-cache Lambda. If preflight is enabled here first, the Lambda won't yet answer the `OPTIONS` preflight request with a presigned `Location`, which would break remote-cache uploads and downloads. Kept as a **draft** until the infra change is live.

## What it does

- Sets `TURBO_PREFLIGHT: true` in the top-level `env:` block of the `ci`, `cd`, `hotfix`, and `e2e-quantic` workflows — everywhere `TURBO_TOKEN` (remote caching) is configured.
- With preflight on, Turbo sends `OPTIONS /v8/artifacts/:hash`; the Lambda validates the existing `TURBO_TOKEN` and returns a 60s presigned S3 URL, and the artifact streams straight to/from S3 — bypassing the Lambda's ~6MB body cap.
- Same `<team>/<hash>` key and bucket as today, so preflight and normal traffic share the exact same cache objects. Small artifacts still flow through the existing handler, unchanged.
- No effect on fork PRs: they don't receive `TURBO_TOKEN`, so there's no remote cache to negotiate.

## Usage

Automatic in CI once merged. Locally or ad hoc:

```sh
turbo run build --preflight
# or repo-wide:
TURBO_PREFLIGHT=true turbo run build
```