### PR TITLE
chore(ci): convert typedoc builds to Turbo

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -134,10 +134,11 @@ jobs:
 
       - name: Set up and build the project
         uses: ./.github/actions/setup
+        with:
+          skip-build: 'true' # defer build to only build what's necessary
 
       - name: Build typedoc site
-        run: pnpm run build:typedoc
-        working-directory: packages/headless
+        run: pnpm exec turbo run build:typedoc --filter=@coveo/headless
         shell: bash
 
       - name: Read version from package.json
@@ -175,10 +176,11 @@ jobs:
 
       - name: Set up and build the project
         uses: ./.github/actions/setup
+        with:
+          skip-build: 'true' # defer build to only build what's necessary
 
       - name: Build typedoc site
-        run: pnpm run build:typedoc
-        working-directory: packages/headless-react
+        run: pnpm exec turbo run build:typedoc --filter=@coveo/headless-react
         shell: bash
 
       - name: Read version from package.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,12 +332,10 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - name: 'Build headless typedoc'
-        run: pnpm run build:typedoc
-        working-directory: packages/headless
-      - name: 'Build headless-react typedoc'
-        run: pnpm run build:typedoc
-        working-directory: packages/headless-react
+        with:
+          skip-build: 'true' # defer build to only build what's necessary
+      - name: 'Build typedoc'
+        run: pnpm exec turbo run build:typedoc --affected
   puppeteer-atomic-csp:
     name: 'Run e2e tests on Atomic CSP'
     needs: [affected, build]

--- a/turbo.json
+++ b/turbo.json
@@ -32,6 +32,10 @@
         "**/*.tsbuildinfo"
       ]
     },
+    "build:typedoc": {
+      "dependsOn": ["^build"],
+      "outputs": ["docs/**", "!docs/adr/**"]
+    },
     "publint": {
       "dependsOn": ["build"],
       "outputs": []


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6044

## Motivation

Route typedoc generation through Turbo so CI and CD use the repository task orchestration consistently and CI can run only affected typedoc builds.

## Changes

- Added the `build:typedoc` task to `turbo.json` with its build dependency and `docs/**` outputs.
- Updated CI to run `pnpm turbo build:typedoc --affected`.
- Updated CD to run the typedoc task through Turbo for Headless and Headless React.

## Validation

- `pnpm run lint:fix`
- `pnpm turbo build:typedoc --affected` — 29 tasks successful
- `git diff --check`

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`chore(<scope>): <description>`)
- [x] No public package source code was modified; no changeset is required