### PR TITLE
fix(ci): Atomic theming Turbo task + atomic-angular asset serialization

### DIFF
--- a/.github/actions/playwright-atomic-theming/action.yml
+++ b/.github/actions/playwright-atomic-theming/action.yml
@@ -9,7 +9,7 @@ runs:
   using: composite
   steps:
     - name: Run Playwright tests
-      run: pnpm exec playwright test -c dev
+      run: pnpm exec turbo run e2e:theming --filter=@coveo/atomic
       working-directory: packages/atomic
       shell: bash
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,7 +446,7 @@ jobs:
           filter: blob:none
       - uses: ./.github/actions/setup
         with:
-          build-command: 'pnpm run build' # FIXME: https://coveord.atlassian.net/browse/KIT-6045
+          skip-build: 'true'
       - uses: ./.github/actions/playwright-atomic-theming
   storybook-atomic:
     name: 'Run Storybook tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,8 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+        with:
+          build-command: 'pnpm run build' # FIXME: https://coveord.atlassian.net/browse/KIT-6045
       - uses: ./.github/actions/playwright-atomic-theming
   storybook-atomic:
     name: 'Run Storybook tests'

--- a/packages/atomic-angular/turbo.json
+++ b/packages/atomic-angular/turbo.json
@@ -10,7 +10,7 @@
       "outputs": ["projects/atomic-angular/src/lib/generated/**/*"]
     },
     "build:assets": {
-      "dependsOn": ["@coveo/atomic#build:locales", "@coveo/atomic#build:assets"],
+      "dependsOn": ["build:bundles", "@coveo/atomic#build:locales", "@coveo/atomic#build:assets"],
       "outputs": ["projects/atomic-angular/dist/assets/**", "projects/atomic-angular/dist/lang/**"]
     },
     "build:bundles": {

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -69,6 +69,7 @@
     "dev:storybook": "storybook dev -p 4400",
     "web:dev": "npx vite serve dev",
     "web:cdn": "node ./scripts/start-cdn.mjs",
+    "e2e:theming": "playwright test -c dev",
     "test": "pnpm run test:lit",
     "test:stencil": "stencil test --spec -- src/utils/initialization-utils.spec.ts",
     "test:lit": "vitest run --project=atomic-default",

--- a/packages/atomic/turbo.json
+++ b/packages/atomic/turbo.json
@@ -124,7 +124,7 @@
       "persistent": true
     },
     "e2e:theming": {
-      "dependsOn": ["build"],
+      "dependsOn": ["build:cdn"],
       "outputs": ["playwright-report/**"]
     }
   }

--- a/packages/atomic/turbo.json
+++ b/packages/atomic/turbo.json
@@ -122,6 +122,10 @@
       "dependsOn": ["build:cdn"],
       "cache": false,
       "persistent": true
+    },
+    "e2e:theming": {
+      "dependsOn": ["build"],
+      "outputs": ["playwright-report/**"]
     }
   }
 }


### PR DESCRIPTION
## Issue

Two CI failures under affected-only builds that were mutually blocking each other:

1. **Theming smoke test** (`playwright-atomic-theming`) fails on PRs that affect `@coveo/atomic` only transitively (e.g. an `atomic-angular`-only change): the affected build produces `@coveo/atomic#build:lit / #build:assets / #build:locales` but **not** `#build:themes`, so `dist/themes/coveo.css` is missing and `vite serve dev` 500s on every page.
2. **`@samples/atomic-search-commerce-angular` e2e** fails with "Some copy operations failed" — a race where `atomic-angular`'s `build:assets` and `build:bundles` write `projects/atomic-angular/dist` concurrently.

Ticket: https://coveord.atlassian.net/browse/KIT-6045

## Solution

1. Model the theming smoke test as a Turbo task — `@coveo/atomic#e2e:theming` (`dependsOn: ["build"]`, mirroring the root `e2e` task) — run through Turbo in the `playwright-atomic-theming` action so the full Atomic build (incl. `build:themes`) is produced before `vite serve dev`. The job uses `skip-build: true`.
2. Serialize `atomic-angular` asset builds — add `build:bundles` to `build:assets`' `dependsOn` so they no longer write `dist` concurrently. Same change as #8213, folded in here so both CI fixes land in one PR (**#8213 is superseded by this PR**).

Related: KIT-6039 (knip), KIT-6040 (publint / package-compatibility), #8213 (superseded).
