### PR TITLE
chore(KIT-6046): move publint to consuming packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "oxfmt": "0.61.0",
     "oxlint": "1.76.0",
     "playwright": "catalog:",
-    "publint": "0.3.22",
     "semver": "7.8.5",
     "turbo": "2.10.7",
     "typescript": "catalog:",

--- a/packages/atomic-angular/projects/atomic-angular/package.json
+++ b/packages/atomic-angular/projects/atomic-angular/package.json
@@ -15,6 +15,9 @@
   "dependencies": {
     "@coveo/atomic": "workspace:*"
   },
+  "devDependencies": {
+    "publint": "catalog:"
+  },
   "peerDependencies": {
     "@angular/common": "14 - 21",
     "@angular/core": "14 - 21",

--- a/packages/atomic-hosted-page/package.json
+++ b/packages/atomic-hosted-page/package.json
@@ -46,6 +46,7 @@
     "@playwright/test": "catalog:",
     "local-web-server": "catalog:",
     "msw": "catalog:",
+    "publint": "catalog:",
     "vite": "catalog:"
   },
   "engines": {

--- a/packages/atomic-legacy/package.json
+++ b/packages/atomic-legacy/package.json
@@ -27,6 +27,7 @@
     "@stencil/core": "catalog:"
   },
   "devDependencies": {
-    "i18next": "catalog:"
+    "i18next": "catalog:",
+    "publint": "catalog:"
   }
 }

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -53,6 +53,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "publint": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "rollup": "catalog:",

--- a/packages/atomic/package.json
+++ b/packages/atomic/package.json
@@ -133,6 +133,7 @@
     "postcss": "8.5.24",
     "postcss-load-config": "6.0.1",
     "prettier": "catalog:",
+    "publint": "catalog:",
     "puppeteer": "catalog:",
     "react": "catalog:",
     "remark-gfm": "4.0.1",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -42,6 +42,7 @@
     "e2e:saml": "vite manual-e2e/saml/"
   },
   "devDependencies": {
+    "publint": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/bueno/package.json
+++ b/packages/bueno/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "esbuild-plugin-umd-wrapper": "catalog:",
+    "publint": "catalog:",
     "vitest": "catalog:"
   },
   "engines": {

--- a/packages/coveo-analytics/package.json
+++ b/packages/coveo-analytics/package.json
@@ -51,6 +51,7 @@
     "fetch-mock": "9.11.0",
     "jsdom": "catalog:",
     "node-fetch": "2.7.0",
+    "publint": "catalog:",
     "react-native-get-random-values": "1.11.0",
     "rollup": "catalog:",
     "rollup-plugin-copy": "3.5.0",

--- a/packages/create-atomic-component-project/package.json
+++ b/packages/create-atomic-component-project/package.json
@@ -33,6 +33,9 @@
   "scripts": {
     "publint": "publint"
   },
+  "devDependencies": {
+    "publint": "catalog:"
+  },
   "engines": {
     "node": "^20.9.0 || ^22.11.0 || ^24.11.0"
   }

--- a/packages/create-atomic-component/package.json
+++ b/packages/create-atomic-component/package.json
@@ -35,6 +35,9 @@
   "dependencies": {
     "@coveo/create-atomic-component-project": "workspace:*"
   },
+  "devDependencies": {
+    "publint": "catalog:"
+  },
   "engines": {
     "node": "^20.9.0 || ^22.11.0 || ^24.11.0"
   }

--- a/packages/create-atomic-result-component/package.json
+++ b/packages/create-atomic-result-component/package.json
@@ -35,6 +35,9 @@
   "dependencies": {
     "@coveo/create-atomic-component-project": "workspace:*"
   },
+  "devDependencies": {
+    "publint": "catalog:"
+  },
   "engines": {
     "node": "^20.9.0 || ^22.11.0 || ^24.11.0"
   }

--- a/packages/create-atomic-rollup-plugin/package.json
+++ b/packages/create-atomic-rollup-plugin/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:"
   },
   "engines": {

--- a/packages/create-atomic/package.json
+++ b/packages/create-atomic/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:",
     "yaml": "catalog:"
   },

--- a/packages/create-ui/package.json
+++ b/packages/create-ui/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@types/pacote": "11.1.8",
+    "publint": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/headless-react/package.json
+++ b/packages/headless-react/package.json
@@ -45,6 +45,7 @@
     "@coveo/documentation": "workspace:*",
     "@testing-library/react": "catalog:",
     "live-server": "catalog:",
+    "publint": "catalog:",
     "typedoc": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -121,6 +121,7 @@
     "jsdom": "catalog:",
     "live-server": "catalog:",
     "node-fetch": "3.3.2",
+    "publint": "catalog:",
     "typedoc": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -55,6 +55,7 @@
     "@vitest/browser-playwright": "catalog:",
     "jsdom": "catalog:",
     "playwright": "catalog:",
+    "publint": "catalog:",
     "rollup": "catalog:",
     "typedoc": "catalog:",
     "vitest": "catalog:"

--- a/packages/shopify/package.json
+++ b/packages/shopify/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "publint": "catalog:",
     "vitest": "catalog:"
   },
   "engines": {

--- a/packages/thermidor/package.json
+++ b/packages/thermidor/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "7.58.12",
+    "publint": "catalog:",
     "tsdown": "0.22.14",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ catalogs:
     prettier:
       specifier: 3.9.6
       version: 3.9.6
+    publint:
+      specifier: 0.3.22
+      version: 0.3.22
     puppeteer:
       specifier: 24.43.1
       version: 24.43.1
@@ -302,9 +305,6 @@ importers:
       playwright:
         specifier: 'catalog:'
         version: 1.60.0
-      publint:
-        specifier: 0.3.22
-        version: 0.3.22
       semver:
         specifier: 7.8.5
         version: 7.8.5
@@ -462,6 +462,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.9.6
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       puppeteer:
         specifier: 'catalog:'
         version: 24.43.1(typescript@6.0.3)
@@ -575,6 +578,10 @@ importers:
       '@coveo/headless':
         specifier: workspace:^
         version: link:../../../headless
+    devDependencies:
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
     publishDirectory: dist
 
   packages/atomic-cdn-smoke:
@@ -628,6 +635,9 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       vite:
         specifier: 'catalog:'
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)
@@ -644,6 +654,9 @@ importers:
       i18next:
         specifier: 'catalog:'
         version: 25.10.10(typescript@6.0.3)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
 
   packages/atomic-react:
     dependencies:
@@ -678,6 +691,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -693,6 +709,9 @@ importers:
 
   packages/auth:
     devDependencies:
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       vite:
         specifier: 'catalog:'
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)
@@ -705,6 +724,9 @@ importers:
       esbuild-plugin-umd-wrapper:
         specifier: 'catalog:'
         version: 3.0.0
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0)(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
@@ -751,6 +773,9 @@ importers:
       node-fetch:
         specifier: 2.7.0
         version: 2.7.0(encoding@0.1.13)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       react-native-get-random-values:
         specifier: 1.11.0
         version: 1.11.0(react-native@0.86.2(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.7))
@@ -800,6 +825,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -812,8 +840,16 @@ importers:
       '@coveo/create-atomic-component-project':
         specifier: workspace:*
         version: link:../create-atomic-component-project
+    devDependencies:
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
 
-  packages/create-atomic-component-project: {}
+  packages/create-atomic-component-project:
+    devDependencies:
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
 
   packages/create-atomic-component-project/template:
     dependencies:
@@ -888,6 +924,10 @@ importers:
       '@coveo/create-atomic-component-project':
         specifier: workspace:*
         version: link:../create-atomic-component-project
+    devDependencies:
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
 
   packages/create-atomic-result-component/template/src/components/sample-result-component:
     dependencies:
@@ -928,6 +968,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -990,6 +1033,9 @@ importers:
       '@types/pacote':
         specifier: 11.1.8
         version: 11.1.8
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1081,6 +1127,9 @@ importers:
       node-fetch:
         specifier: 3.3.2
         version: 3.3.2
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       typedoc:
         specifier: 'catalog:'
         version: 0.28.20(typescript@6.0.3)
@@ -1115,6 +1164,9 @@ importers:
       live-server:
         specifier: 'catalog:'
         version: 1.2.2
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       typedoc:
         specifier: 'catalog:'
         version: 0.28.20(typescript@6.0.3)
@@ -1302,6 +1354,9 @@ importers:
       playwright:
         specifier: 'catalog:'
         version: 1.60.0
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       rollup:
         specifier: 'catalog:'
         version: 4.62.4
@@ -1361,6 +1416,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       vitest:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
@@ -1377,6 +1435,9 @@ importers:
       '@microsoft/api-extractor':
         specifier: 7.58.12
         version: 7.58.12(@types/node@26.1.2)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       tsdown:
         specifier: 0.22.14
         version: 0.22.14(oxc-resolver@11.24.2)(publint@0.3.22)(typescript@6.0.3)
@@ -1423,6 +1484,9 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1452,6 +1516,9 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       vite:
         specifier: 'catalog:'
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)
@@ -1619,6 +1686,9 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1648,6 +1718,9 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       vite:
         specifier: 'catalog:'
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)
@@ -1705,6 +1778,9 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.15.0(@types/node@24.13.3)(typescript@6.0.3)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1749,6 +1825,9 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.15.0(@types/node@24.13.3)(typescript@6.0.3)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1895,6 +1974,9 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       vite:
         specifier: 'catalog:'
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)
@@ -1921,6 +2003,9 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       vite:
         specifier: 'catalog:'
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)
@@ -2032,6 +2117,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.5(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -2061,6 +2149,9 @@ importers:
       msw:
         specifier: 'catalog:'
         version: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.22
       vite:
         specifier: 'catalog:'
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -101,6 +101,7 @@ catalog:
   natural-orderby: 5.0.0
   next: 16.2.12
   prettier: 3.9.6
+  publint: 0.3.22
   puppeteer: 24.43.1
   playwright: 1.60.0
   rxjs: 7.8.2

--- a/samples/atomic/commerce-react/package.json
+++ b/samples/atomic/commerce-react/package.json
@@ -34,6 +34,7 @@
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "msw": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:"
   }

--- a/samples/atomic/commerce-vite/package.json
+++ b/samples/atomic/commerce-vite/package.json
@@ -29,6 +29,7 @@
     "@msw/playwright": "catalog:",
     "@playwright/test": "catalog:",
     "msw": "catalog:",
+    "publint": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/samples/atomic/search-react/package.json
+++ b/samples/atomic/search-react/package.json
@@ -34,6 +34,7 @@
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "msw": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:"
   }

--- a/samples/atomic/search-vite/package.json
+++ b/samples/atomic/search-vite/package.json
@@ -29,6 +29,7 @@
     "@msw/playwright": "catalog:",
     "@playwright/test": "catalog:",
     "msw": "catalog:",
+    "publint": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/samples/headless-ssr/commerce-express/package.json
+++ b/samples/headless-ssr/commerce-express/package.json
@@ -38,6 +38,7 @@
     "@types/node": "catalog:",
     "esbuild": "catalog:",
     "msw": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/samples/headless-ssr/commerce-nextjs/package.json
+++ b/samples/headless-ssr/commerce-nextjs/package.json
@@ -36,6 +36,7 @@
     "@types/react-dom": "catalog:",
     "express": "^5.0.0",
     "msw": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/samples/headless/commerce-react/package.json
+++ b/samples/headless/commerce-react/package.json
@@ -31,6 +31,7 @@
     "@playwright/test": "catalog:",
     "@vitejs/plugin-react": "catalog:",
     "msw": "catalog:",
+    "publint": "catalog:",
     "vite": "catalog:"
   },
   "browserslist": {

--- a/samples/headless/commerce-vite/package.json
+++ b/samples/headless/commerce-vite/package.json
@@ -29,6 +29,7 @@
     "@msw/playwright": "catalog:",
     "@playwright/test": "catalog:",
     "msw": "catalog:",
+    "publint": "catalog:",
     "vite": "catalog:"
   }
 }

--- a/samples/headless/search-react/package.json
+++ b/samples/headless/search-react/package.json
@@ -32,6 +32,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "publint": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:"
   },

--- a/samples/headless/search-vite/package.json
+++ b/samples/headless/search-vite/package.json
@@ -29,6 +29,7 @@
     "@msw/playwright": "catalog:",
     "@playwright/test": "catalog:",
     "msw": "catalog:",
+    "publint": "catalog:",
     "vite": "catalog:"
   }
 }


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6046

## Motivation

KIT-6040 moved publint execution from the root package to individual package-level Turbo tasks. The root package no longer invokes publint, so each package that runs the task must declare the dependency locally.

## Changes

- Added publint 0.3.22 to the workspace catalog.
- Removed publint from the root development dependencies.
- Added the catalog-based publint development dependency to all 29 packages and samples that invoke publint.
- Updated the lockfile with the package-level importer declarations.

## Validation

- `pnpm install --lockfile-only --ignore-scripts --frozen-lockfile`
- `pnpm exec node scripts/ci/validate-publint-tasks.mjs`
- `pnpm run lint:check`
- `pnpm run lint:fix`
- Pre-commit hooks and lint-staged checks
- Public API surface is unchanged.

## Checklist

- [x] PR title follows Conventional Commits 1.0.0 format (`chore(<scope>): <description>`)
- [x] No changeset added; this change only updates dependency metadata and tooling configuration.