### PR TITLE
chore(coveo-analytics, atomic-legacy): declare supported node versions

### DIFF
--- a/.changeset/declare-node-engines-analytics-legacy.md
+++ b/.changeset/declare-node-engines-analytics-legacy.md
@@ -1,0 +1,6 @@
+---
+'coveo.analytics': minor
+'@coveo/atomic-legacy': minor
+---
+
+Declared the supported Node.js versions through the `engines` field: `^22.11.0 || ^24.11.0`.

--- a/packages/atomic-legacy/package.json
+++ b/packages/atomic-legacy/package.json
@@ -29,5 +29,8 @@
   "devDependencies": {
     "i18next": "catalog:",
     "publint": "catalog:"
+  },
+  "engines": {
+    "node": "^22.11.0 || ^24.11.0"
   }
 }

--- a/packages/coveo-analytics/package.json
+++ b/packages/coveo-analytics/package.json
@@ -59,5 +59,8 @@
     "tslib": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "engines": {
+    "node": "^22.11.0 || ^24.11.0"
   }
 }


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-5688

## Motivation

`coveo.analytics` and `@coveo/atomic-legacy` were the only two public packages published without an `engines` field, so npm allowed installing them on any Node version, including releases that are past end-of-life and never exercised in CI.

## Changes

Added `"engines": {"node": "^22.11.0 || ^24.11.0"}` to both packages, matching the range already declared by `@coveo/thermidor`.

Note that this narrows the advertised support for `coveo.analytics`: consumers installing it on Node 18 or 20 will now get an engine warning, or a hard failure if they run with `engine-strict`. Flagging it in case you would rather ship this as a major.

## Validation

- [x] No source code changed; manifests and changeset only
- [x] All existing tests pass without modification
- [x] No new features or bug fixes are included in this PR
- [x] Public API surface is unchanged

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`chore(<scope>): <description>`)
- [x] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code
