### PR TITLE
fix(coveo.analytics): restore first-party sources in CDN source maps

### DIFF
--- a/.changeset/cajs-sourcemap-inline-sources.md
+++ b/.changeset/cajs-sourcemap-inline-sources.md
@@ -1,0 +1,5 @@
+---
+'coveo.analytics': patch
+---
+
+Restore first-party sources in the CDN bundles' source maps. Since the migration to `@rollup/plugin-typescript`, `coveoua.js.map`, `coveoua.browser.js.map` and `coveoua.debug.js.map` shipped with `sourcesContent: null` for all 38 `src/*.ts` entries, so debuggers could resolve a stack frame to a file and line but could not display any coveo.analytics source. Enabling `inlineSources` in `tsconfig.json` populates them again. The emitted JavaScript is unchanged.

--- a/packages/coveo-analytics/rollup.config.mjs
+++ b/packages/coveo-analytics/rollup.config.mjs
@@ -28,6 +28,13 @@ const browserFetch = () =>
     ],
   });
 
+/**
+ * `@rollup/plugin-typescript` forwards TypeScript's own source maps to Rollup rather
+ * than letting Rollup build them from the original sources, and `tsc` only fills
+ * `sourcesContent` when `inlineSources` is enabled. That option therefore has to stay
+ * on in `tsconfig.json`, or the published `coveoua*.js.map` files resolve stack frames
+ * to `src/*.ts` without carrying any of that source for a debugger to display.
+ */
 const tsPlugin = () =>
   typescript({
     tsconfig: './tsconfig.json',

--- a/packages/coveo-analytics/tsconfig.json
+++ b/packages/coveo-analytics/tsconfig.json
@@ -10,6 +10,7 @@
     "noImplicitAny": true,
     "removeComments": true,
     "sourceMap": true,
+    "inlineSources": true,
     "skipLibCheck": true,
     "strict": true,
     "lib": ["es5", "dom", "scripthost", "es6"],


### PR DESCRIPTION
## Problem

The `coveo.analytics` CDN source maps ship with no first-party source content. `sourcesContent` is `null` for all 38 `src/*.ts` entries — only the 11 bundled `node_modules` dependencies carry content — so a debugger can resolve a stack frame to a file and line but cannot display any coveo.analytics source.

Found while smoke-testing the first successful `coveo.analytics` upload to the dev CDN. Comparing the new payload against what is currently published:

| map | sources | null `sourcesContent` | size |
|---|---|---|---|
| `static.cloud.coveo.com/coveo.analytics.js/2/coveoua.js.map` | 49 | 0 | 343508 |
| `staticdev.cloud.coveo.com/coveo.analytics.js/2.32.0/coveoua.js.map` | 49 | **38** | 152850 |

A fresh local build at the deployed commit (`f0016dd7fd`, node 24.18.0) reproduces the deployed bytes exactly — identical sha256 on all six files — so this is a build defect, not a deployment one.

### Cause

#8111 replaced `rollup-plugin-typescript2` with `@rollup/plugin-typescript`. The old plugin populated `sourcesContent` itself. The new one forwards TypeScript's own map to Rollup instead of letting Rollup build one from the original sources, and `tsc` only fills `sourcesContent` when `inlineSources` is enabled — which this package's `tsconfig.json` does not set. The content has been missing from every build since then.

(`relay` uses the same plugin but is unaffected: its tsconfig never sets `sourceMap`, so Rollup generates the map from the source it read and includes the content by default. Its published map checks out at `sources=22, nullContent=0`.)

## Solution

Enable `inlineSources` in `packages/coveo-analytics/tsconfig.json`, and document the coupling next to `tsPlugin` in `rollup.config.mjs` so the option is not dropped as redundant later.

## Testing

Rebuilt on node 24.18.0 at the deployed commit:

- `nullContent` goes `38 -> 0` in all three of `coveoua.js.map`, `coveoua.browser.js.map`, `coveoua.debug.js.map`
- the three JS bundles stay **byte-identical** (sha256) to what is deployed, so this changes maps only
- resolved bundle positions back through the map with `@jridgewell/trace-mapping` and got real source text, e.g. `coveoua.debug.js 116:4 -> ../src/events.ts:4:2` showing `search = 'search',`
- `sourcesContent` for `src/version.ts` matches the on-disk file exactly
- maps return to roughly their pre-regression size (`coveoua.js.map` 152850 -> 362519, vs 343508 for the published major-2 map)
- `pnpm --filter coveo.analytics test`: 715 tests in 18 files pass
- previously verified the deployed bundles are functional in headless Chromium (`window.coveoua` defined, `init` + `send pageview` produce a well-formed `POST /rest/v15/analytics/collect`, no console or page errors); unchanged here since the JS is identical