### PR TITLE
ci: fix create-ui version quoting and harden CDN preview deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,7 +61,6 @@ jobs:
       - name: Read create-ui version
         id: create-ui-version
         if: ${{ steps.changesets.outputs.published == 'true' && contains(steps.changesets.outputs.publishedPackages, '@coveo/create-ui') }}
-        # Best-effort: source-map bookkeeping must never fail the release or block the CDN deploy.
         continue-on-error: true
         working-directory: packages/create-ui
         run: echo "version=$(jq -r '.version' package.json)" >> "$GITHUB_OUTPUT"
@@ -243,9 +242,6 @@ jobs:
   commit-artifact-upload:
     name: Upload commit artifacts to S3
     needs: [build-cdn, release]
-    # Deploy whenever the CDN build succeeded and the run wasn't cancelled, even if the
-    # release job failed on a non-critical step (e.g. best-effort Sentry/source-map upload).
-    # The private vs. private,preview channel choice still keys off release's `published` output.
     if: ${{ !cancelled() && needs.build-cdn.result == 'success' }}
     runs-on: ubuntu-latest
     # TODO(KIT-5712): Rename to 'CDN Deploy' once token vending machine is available

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -242,7 +242,6 @@ jobs:
   commit-artifact-upload:
     name: Upload commit artifacts to S3
     needs: [build-cdn, release]
-    if: ${{ !cancelled() && needs.build-cdn.result == 'success' }}
     runs-on: ubuntu-latest
     # TODO(KIT-5712): Rename to 'CDN Deploy' once token vending machine is available
     environment: 'Prerelease (CDN)'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,10 +61,13 @@ jobs:
       - name: Read create-ui version
         id: create-ui-version
         if: ${{ steps.changesets.outputs.published == 'true' && contains(steps.changesets.outputs.publishedPackages, '@coveo/create-ui') }}
+        # Best-effort: source-map bookkeeping must never fail the release or block the CDN deploy.
+        continue-on-error: true
         working-directory: packages/create-ui
-        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(jq -r '.version' package.json)" >> "$GITHUB_OUTPUT"
       - name: Upload create-ui source maps to Sentry
-        if: ${{ steps.changesets.outputs.published == 'true' && contains(steps.changesets.outputs.publishedPackages, '@coveo/create-ui') }}
+        if: ${{ steps.changesets.outputs.published == 'true' && contains(steps.changesets.outputs.publishedPackages, '@coveo/create-ui') && steps.create-ui-version.outputs.version != '' }}
+        continue-on-error: true
         uses: step-security/getsentry-action-release@4530160f6bc962e1dd67e2703064a7a5cfd401fb # v3.7.0
         with:
           release: create-ui@${{ steps.create-ui-version.outputs.version }}
@@ -240,6 +243,10 @@ jobs:
   commit-artifact-upload:
     name: Upload commit artifacts to S3
     needs: [build-cdn, release]
+    # Deploy whenever the CDN build succeeded and the run wasn't cancelled, even if the
+    # release job failed on a non-critical step (e.g. best-effort Sentry/source-map upload).
+    # The private vs. private,preview channel choice still keys off release's `published` output.
+    if: ${{ !cancelled() && needs.build-cdn.result == 'success' }}
     runs-on: ubuntu-latest
     # TODO(KIT-5712): Rename to 'CDN Deploy' once token vending machine is available
     environment: 'Prerelease (CDN)'


### PR DESCRIPTION
**Jira:** [KIT-5841](https://coveord.atlassian.net/browse/KIT-5841)

## Issue

Merging the "Version Packages" PR (#8171) published `@coveo/atomic` 3.60.5 (and the rest) to npm, but the **preview CDN channel never updated**.

The `release` job's **Read create-ui version** step escaped its inner quotes inside a `run:` block:

```sh
echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
```

bash rejected that as `syntax error near unexpected token '('` (exit 2). The step had no `continue-on-error`, so it failed the entire `release` job **after** npm publish had already succeeded. Since `commit-artifact-upload` — the job that dispatches the `private,preview` channel update to `ui-kit-cd` — declares `needs: [build-cdn, release]`, it was skipped, and the preview pointer never moved. See run [31519447241](https://github.com/coveo/ui-kit/actions/runs/31519447241).

The step was introduced in #8098 and ran for the first time in this release because `@coveo/create-ui` 0.3.0 was in the published set.

## Solution

- Read the version with `jq` (consistent with the existing typedoc jobs).
- Mark the create-ui version read and the Sentry source-map upload as `continue-on-error` — best-effort observability must never fail a release — and skip the Sentry upload when the version couldn't be read.

[KIT-5841]: https://coveord.atlassian.net/browse/KIT-5841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ