### PR TITLE
chore: keep react wide range

### DIFF
--- a/.changeset/align-react-peer-dependency-ranges.md
+++ b/.changeset/align-react-peer-dependency-ranges.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic-react': patch
+---
+
+Aligned the `react` and `react-dom` peer dependency ranges to `^18 || ^19` and declared `@types/react` and `@types/react-dom` as optional peer dependencies. React 18 and 19 both remain supported; there is no consumer-facing behavior change.

--- a/docs/adr/0004-react-peer-dependency-ranges.md
+++ b/docs/adr/0004-react-peer-dependency-ranges.md
@@ -1,0 +1,67 @@
+---
+status: Proposed
+date: 2026-08-12
+related:
+  - https://coveord.atlassian.net/browse/KIT-5994
+  - packages/atomic-react/package.json
+  - packages/headless-react/package.json
+  - scripts/report-catalog-candidates.mjs
+  - docs/adr/0003-catalog-first-dependency-management-with-automated-reporting.md
+---
+
+# React peer dependency ranges stay wide and bypass the catalog intentionally
+
+## Context and Problem Statement
+
+The pnpm catalog pins `react`, `react-dom`, `@types/react`, and `@types/react-dom` to a single 19.x version for the monorepo's own tooling. The published React wrapper packages (`atomic-react`, `headless-react`) instead declare wide peer ranges (`^18 || ^19`), which the catalog-candidates report flags as bypassing the catalog.
+
+We must decide whether to align these peers with the catalog or keep them wide.
+
+## Decision Drivers
+
+- The catalog should remain the single source of truth for the monorepo's internal tooling versions.
+- Peer dependency ranges serve a fundamentally different purpose: they declare compatibility for external consumers.
+- Any change should be justified by a concrete gain in code, maintenance, or correctness.
+
+## Considered Options
+
+### Option A: Pin peer ranges to `catalog:`
+
+- **Summary:** Replace wide ranges with `catalog:`, publishing an exact 19.x peer.
+- **Pros:** Eliminates the catalog-bypass report noise.
+- **Cons:** `catalog:` publishes as an exact version (verified against published `@coveo/headless`). This forces consumers into lockstep with our patch upgrades, causes `ERESOLVE` errors for anyone not on that exact version, and risks duplicate React installs at runtime. The monorepo already pins React internally via `pnpm.overrides`, so `catalog:` on the peer brings zero additional consistency for us — only pain for consumers.
+
+### Option B: Drop React 18 (`^19` only)
+
+- **Summary:** Narrow the peer ranges to React 19+.
+- **Pros:** Fewer supported majors to document.
+- **Cons:** Neither package uses any React-19-only API. The entire surface (`useEffect`, `useRef`, `useState`, `createContext`, `createRoot`, `flushSync`, etc.) is identical across 18 and 19 — there is no code or maintenance benefit to dropping 18. React 18 is still security-supported with no announced end of life. Narrowing would force a full 18→19 migration on consumers for zero functional gain.
+
+### Option C: Keep wide ranges, standardize to `^18 || ^19`, allowlist the bypass
+
+- **Summary:** Align both packages to `^18 || ^19`, declare `@types/react(-dom)` as optional peers on `atomic-react`, and add an intentional-bypass allowlist to the report script.
+- **Pros:** Accurate compatibility contract; no unnecessary churn for consumers; report stays meaningful by distinguishing intentional bypasses from real drift.
+- **Cons:** Four dependencies remain a maintained exception to the catalog-first rule.
+
+## Decision Outcome
+
+Chosen option: **Option C — keep wide ranges, standardize, and allowlist the bypass.**
+
+### Rationale
+
+There is no gain in pinning or narrowing:
+
+- Pinning to `catalog:` solves no real problem — internal consistency is already handled by `pnpm.overrides` — and introduces install failures for consumers.
+- Dropping React 18 removes no code, enables no new API usage, and eliminates no maintenance burden. It only imposes cost on consumers who are on a still-supported React version.
+- The wide range accurately reflects the actual compatibility of these packages and is the correct contract for a published library.
+
+## Consequences
+
+- **Positive:** The report distinguishes intentional bypasses from real drift; both packages declare consistent, explicit ranges that match their actual compatibility.
+- **Negative:** Four dependencies are a maintained exception to the catalog-first rule.
+- **Neutral:** When a real trigger arises (usage of a React-19-only API, or React 18 end of life), revisit the ranges and this ADR.
+
+## Implementation
+
+- `atomic-react` peers standardized to `^18 || ^19`; `@types/react` and `@types/react-dom` added as optional peers to match `headless-react`.
+- `scripts/report-catalog-candidates.mjs` gained an `INTENTIONAL_CATALOG_BYPASSES` allowlist that reclassifies these four peers as `intentional-bypass` instead of `bypasses-catalog`.

--- a/docs/adr/0004-react-peer-dependency-ranges.md
+++ b/docs/adr/0004-react-peer-dependency-ranges.md
@@ -1,67 +1,74 @@
 ---
 status: Proposed
-date: 2026-08-12
+date: 2026-08-13
 related:
   - https://coveord.atlassian.net/browse/KIT-5994
   - packages/atomic-react/package.json
   - packages/headless-react/package.json
-  - scripts/report-catalog-candidates.mjs
+  - pnpm-workspace.yaml
   - docs/adr/0003-catalog-first-dependency-management-with-automated-reporting.md
 ---
 
-# React peer dependency ranges stay wide and bypass the catalog intentionally
+# Use a named catalog for React peer dependency ranges
 
 ## Context and Problem Statement
 
-The pnpm catalog pins `react`, `react-dom`, `@types/react`, and `@types/react-dom` to a single 19.x version for the monorepo's own tooling. The published React wrapper packages (`atomic-react`, `headless-react`) instead declare wide peer ranges (`^18 || ^19`), which the catalog-candidates report flags as bypassing the catalog.
+The default pnpm catalog pins `react`, `react-dom`, `@types/react`, and `@types/react-dom` to a single 19.x version for the monorepo's own tooling. The published React wrapper packages (`atomic-react`, `headless-react`) must declare wide peer ranges (`^18 || ^19`) because they support both React 18 and 19 consumers.
 
-We must decide whether to align these peers with the catalog or keep them wide.
+We must decide how to manage these peer ranges without breaking consumers or undermining the catalog-first policy.
 
 ## Decision Drivers
 
-- The catalog should remain the single source of truth for the monorepo's internal tooling versions.
+- The catalog should remain the single source of truth for dependency version specifiers across the monorepo.
 - Peer dependency ranges serve a fundamentally different purpose: they declare compatibility for external consumers.
 - Any change should be justified by a concrete gain in code, maintenance, or correctness.
+- The solution should not require special-case tooling (allowlists, report modifications).
 
 ## Considered Options
 
-### Option A: Pin peer ranges to `catalog:`
+### Option A: Pin peer ranges to the default `catalog:`
 
-- **Summary:** Replace wide ranges with `catalog:`, publishing an exact 19.x peer.
-- **Pros:** Eliminates the catalog-bypass report noise.
-- **Cons:** `catalog:` publishes as an exact version (verified against published `@coveo/headless`). This forces consumers into lockstep with our patch upgrades, causes `ERESOLVE` errors for anyone not on that exact version, and risks duplicate React installs at runtime. The monorepo already pins React internally via `pnpm.overrides`, so `catalog:` on the peer brings zero additional consistency for us — only pain for consumers.
+- **Summary:** Replace wide ranges with `catalog:`, publishing the default catalog's exact 19.x peer.
+- **Pros:** Eliminates catalog-bypass report noise.
+- **Cons:** The default catalog holds an exact version (`react: 19.2.7`). Publishing that as a peer dependency forces consumers into lockstep with our patch upgrades, causes `ERESOLVE` errors for anyone not on that exact version, and risks duplicate React installs at runtime.
 
 ### Option B: Drop React 18 (`^19` only)
 
 - **Summary:** Narrow the peer ranges to React 19+.
 - **Pros:** Fewer supported majors to document.
-- **Cons:** Neither package uses any React-19-only API. The entire surface (`useEffect`, `useRef`, `useState`, `createContext`, `createRoot`, `flushSync`, etc.) is identical across 18 and 19 — there is no code or maintenance benefit to dropping 18. React 18 is still security-supported with no announced end of life. Narrowing would force a full 18→19 migration on consumers for zero functional gain.
+- **Cons:** Neither package uses any React-19-only API. The entire surface (`useEffect`, `useRef`, `useState`, `createContext`, `createRoot`, `flushSync`, etc.) is identical across 18 and 19. React 18 is still security-supported with no announced end of life. Narrowing would force a full 18→19 migration on consumers for zero functional gain.
 
-### Option C: Keep wide ranges, standardize to `^18 || ^19`, allowlist the bypass
+### Option C: Keep wide ranges hardcoded, allowlist the bypass
 
-- **Summary:** Align both packages to `^18 || ^19`, declare `@types/react(-dom)` as optional peers on `atomic-react`, and add an intentional-bypass allowlist to the report script.
-- **Pros:** Accurate compatibility contract; no unnecessary churn for consumers; report stays meaningful by distinguishing intentional bypasses from real drift.
-- **Cons:** Four dependencies remain a maintained exception to the catalog-first rule.
+- **Summary:** Hardcode `^18 || ^19` in both packages and add an intentional-bypass allowlist to `scripts/report-catalog-candidates.mjs`.
+- **Pros:** Accurate compatibility contract; report stays meaningful.
+- **Cons:** Four dependencies remain a maintained exception. Requires custom tooling (allowlist + `isIntentionalBypass` function) that must stay in sync with any future React-consuming package. The hardcoded ranges can drift between packages.
+
+### Option D: Named catalog (`catalogs.react-compatibility`)
+
+- **Summary:** Define a named catalog `react-compatibility` in `pnpm-workspace.yaml` holding `^18 || ^19` for `react`, `react-dom`, `@types/react`, and `@types/react-dom`. Reference it as `catalog:react-compatibility` in both packages' `peerDependencies`.
+- **Pros:** Single source of truth for the compatibility range. On publish, pnpm replaces `catalog:react-compatibility` with the stored specifier (`^18 || ^19`) — consumers see exactly the range we intend. No report-script changes needed (the report already skips `catalog:` specifiers). No allowlist to maintain.
+- **Cons:** Slight indirection — readers must look up the named catalog in `pnpm-workspace.yaml` to see the actual range. Standard catalog tradeoff, already accepted repo-wide.
 
 ## Decision Outcome
 
-Chosen option: **Option C — keep wide ranges, standardize, and allowlist the bypass.**
+Chosen option: **Option D — named catalog (`catalogs.react-compatibility`).**
 
 ### Rationale
 
-There is no gain in pinning or narrowing:
-
-- Pinning to `catalog:` solves no real problem — internal consistency is already handled by `pnpm.overrides` — and introduces install failures for consumers.
-- Dropping React 18 removes no code, enables no new API usage, and eliminates no maintenance burden. It only imposes cost on consumers who are on a still-supported React version.
-- The wide range accurately reflects the actual compatibility of these packages and is the correct contract for a published library.
+- A named catalog preserves the wide range contract (`^18 || ^19`) for consumers while staying within the catalog-first policy (ADR-0003).
+- `pnpm publish` replaces `catalog:react-compatibility` with the catalog's specifier verbatim, so the published `package.json` contains `^18 || ^19` — identical behavior to hardcoding, with centralized management.
+- No custom tooling or allowlists required; `report-catalog-candidates.mjs` naturally skips `catalog:` specifiers.
+- Future range changes (e.g., adding React 20, or eventually dropping React 18) require editing only one line in `pnpm-workspace.yaml`.
 
 ## Consequences
 
-- **Positive:** The report distinguishes intentional bypasses from real drift; both packages declare consistent, explicit ranges that match their actual compatibility.
-- **Negative:** Four dependencies are a maintained exception to the catalog-first rule.
-- **Neutral:** When a real trigger arises (usage of a React-19-only API, or React 18 end of life), revisit the ranges and this ADR.
+- **Positive:** Both packages declare consistent ranges from a single source; the catalog-candidates report stays clean without modifications; no maintained exceptions to the catalog-first rule.
+- **Negative:** None significant. The named catalog is a minor addition to `pnpm-workspace.yaml`.
+- **Neutral:** When a real trigger arises (usage of a React-19-only API, or React 18 end of life), update the named catalog entry and this ADR.
 
 ## Implementation
 
-- `atomic-react` peers standardized to `^18 || ^19`; `@types/react` and `@types/react-dom` added as optional peers to match `headless-react`.
-- `scripts/report-catalog-candidates.mjs` gained an `INTENTIONAL_CATALOG_BYPASSES` allowlist that reclassifies these four peers as `intentional-bypass` instead of `bypasses-catalog`.
+- `pnpm-workspace.yaml` gains a `catalogs.react-compatibility` section with all four deps at `^18 || ^19`.
+- `atomic-react` and `headless-react` peer dependencies reference `catalog:react-compatibility`.
+- `scripts/report-catalog-candidates.mjs` requires no changes (reverted to its pre-PR state).

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -61,10 +61,10 @@
   },
   "peerDependencies": {
     "@coveo/headless": "workspace:^",
-    "@types/react": "^18 || ^19",
-    "@types/react-dom": "^18 || ^19",
-    "react": "^18 || ^19",
-    "react-dom": "^18 || ^19"
+    "@types/react": "catalog:react-compatibility",
+    "@types/react-dom": "catalog:react-compatibility",
+    "react": "catalog:react-compatibility",
+    "react-dom": "catalog:react-compatibility"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/atomic-react/package.json
+++ b/packages/atomic-react/package.json
@@ -61,8 +61,18 @@
   },
   "peerDependencies": {
     "@coveo/headless": "workspace:^",
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "@types/react": "^18 || ^19",
+    "@types/react-dom": "^18 || ^19",
+    "react": "^18 || ^19",
+    "react-dom": "^18 || ^19"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "^20.9.0 || ^22.11.0 || ^24.11.0"

--- a/packages/headless-react/package.json
+++ b/packages/headless-react/package.json
@@ -51,10 +51,10 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "@types/react": "^18 || ^19",
-    "@types/react-dom": "^18 || ^19",
-    "react": "^18 || ^19",
-    "react-dom": "^18 || ^19"
+    "@types/react": "catalog:react-compatibility",
+    "@types/react-dom": "catalog:react-compatibility",
+    "react": "catalog:react-compatibility",
+    "react-dom": "catalog:react-compatibility"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,13 @@ catalogs:
     zone.js:
       specifier: 0.15.1
       version: 0.15.1
+  react-compatibility:
+    '@types/react':
+      specifier: ^18 || ^19
+      version: 19.2.18
+    '@types/react-dom':
+      specifier: ^18 || ^19
+      version: 19.2.4
 
 overrides:
   braces: 3.0.3
@@ -547,7 +554,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 'catalog:'
-        version: 21.2.19(c4cd55c9d1bc75b6dbc1e1789386423e)
+        version: 21.2.19(215fcea745dbe4e520255ebe13b6079a)
       '@angular/cli':
         specifier: 'catalog:'
         version: 21.2.19(@types/node@24.13.3)(chokidar@5.0.0)
@@ -1152,10 +1159,10 @@ importers:
         specifier: workspace:*
         version: link:../headless
       '@types/react':
-        specifier: ^18 || ^19
+        specifier: catalog:react-compatibility
         version: 19.2.18
       '@types/react-dom':
-        specifier: ^18 || ^19
+        specifier: catalog:react-compatibility
         version: 19.2.4(@types/react@19.2.18)
       react:
         specifier: 19.2.7
@@ -1283,10 +1290,10 @@ importers:
         version: 1.60.0
       '@salesforce/eslint-config-lwc':
         specifier: 3.7.2
-        version: 3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.16.0(eslint@8.57.1)(jest@30.3.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)
+        version: 3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.16.0(eslint@8.57.1)(jest@30.3.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)
       '@salesforce/sfdx-lwc-jest':
         specifier: 6.0.0
-        version: 6.0.0(@types/node@24.13.3)(eslint@8.57.1)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)
+        version: 6.0.0(@types/node@26.1.2)(eslint@8.57.1)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))(typescript@6.0.3)
       '@types/wait-on':
         specifier: 5.3.4
         version: 5.3.4
@@ -1307,7 +1314,7 @@ importers:
         version: 3.1.3
       jest:
         specifier: 'catalog:'
-        version: 30.3.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+        version: 30.3.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
       jest-junit:
         specifier: 16.0.0
         version: 16.0.0
@@ -1325,7 +1332,7 @@ importers:
         version: 2.2.6(prettier@3.9.6)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@24.13.3)(typescript@6.0.3)
+        version: 10.9.2(@types/node@26.1.2)(typescript@6.0.3)
       wait-on:
         specifier: 9.1.0
         version: 9.1.0
@@ -17097,13 +17104,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@21.2.19(c4cd55c9d1bc75b6dbc1e1789386423e)':
+  '@angular-devkit/build-angular@21.2.19(215fcea745dbe4e520255ebe13b6079a)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.19(chokidar@5.0.0)
       '@angular-devkit/build-webpack': 0.2102.19(chokidar@5.0.0)(webpack-dev-server@5.2.5(tslib@2.8.1)(webpack@5.105.2(esbuild@0.28.1)(postcss@8.5.12)))(webpack@5.105.2(esbuild@0.28.1)(postcss@8.5.12))
       '@angular-devkit/core': 21.2.19(chokidar@5.0.0)
-      '@angular/build': 21.2.19(b6916b4148e106175487802e478d25c6)
+      '@angular/build': 21.2.19(23402e11a3800cc144ad1cc97917c14b)
       '@angular/compiler-cli': 21.2.18(@angular/compiler@21.2.18)(typescript@6.0.3)
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.1
@@ -17287,7 +17294,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.2.19(b6916b4148e106175487802e478d25c6)':
+  '@angular/build@21.2.19(23402e11a3800cc144ad1cc97917c14b)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.19(chokidar@5.0.0)
@@ -17310,7 +17317,7 @@ snapshots:
       parse5-html-rewriting-stream: 8.0.0
       picomatch: 4.0.4
       piscina: 5.2.0
-      rolldown: 1.0.0-rc.4(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      rolldown: 1.0.0-rc.4(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
       sass: 1.97.3
       semver: 7.7.4
       source-map-support: 0.5.21
@@ -19950,7 +19957,7 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -19964,7 +19971,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -20019,6 +20026,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))':
     dependencies:
@@ -20601,33 +20609,33 @@ snapshots:
       globals: 13.24.0
       minimatch: 9.0.9
 
-  '@lwc/jest-preset@16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))':
+  '@lwc/jest-preset@16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))':
     dependencies:
       '@lwc/compiler': 7.1.2
       '@lwc/engine-dom': 7.1.2
       '@lwc/engine-server': 7.1.2
-      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))
-      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))
-      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))
+      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))
+      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))
+      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))
       '@lwc/synthetic-shadow': 7.1.2
-      jest: 29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
     transitivePeerDependencies:
       - supports-color
 
-  '@lwc/jest-resolver@16.0.0(jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))':
+  '@lwc/jest-resolver@16.0.0(jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))':
     dependencies:
       '@lwc/jest-shared': 16.0.0
-      jest: 29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
 
-  '@lwc/jest-serializer@16.0.0(jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))':
+  '@lwc/jest-serializer@16.0.0(jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))':
     dependencies:
       '@lwc/jest-shared': 16.0.0
-      jest: 29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
       pretty-format: 29.7.0
 
   '@lwc/jest-shared@16.0.0': {}
 
-  '@lwc/jest-transformer@16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))':
+  '@lwc/jest-transformer@16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.29.7)
@@ -20638,7 +20646,7 @@ snapshots:
       '@lwc/compiler': 7.1.2
       '@lwc/jest-shared': 16.0.0
       babel-preset-jest: 29.6.3(@babel/core@7.29.7)
-      jest: 29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
       magic-string: 0.30.21
       semver: 7.8.5
     transitivePeerDependencies:
@@ -22049,6 +22057,14 @@ snapshots:
   '@rolldown/binding-openharmony-arm64@1.2.1':
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.4(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.4(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     dependencies:
       '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
@@ -22414,7 +22430,7 @@ snapshots:
     dependencies:
       postcss: 8.5.24
 
-  '@salesforce/eslint-config-lwc@3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.16.0(eslint@8.57.1)(jest@30.3.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)':
+  '@salesforce/eslint-config-lwc@3.7.2(@lwc/eslint-plugin-lwc@2.2.0(@babel/eslint-parser@7.24.8(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1))(@salesforce/eslint-plugin-lightning@1.0.1(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint-plugin-jest@29.16.0(eslint@8.57.1)(jest@30.3.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))(typescript@6.0.3))(eslint@8.57.1)':
     dependencies:
       '@babel/core': 7.24.9
       '@babel/eslint-parser': 7.24.8(@babel/core@7.24.9)(eslint@8.57.1)
@@ -22422,7 +22438,7 @@ snapshots:
       '@salesforce/eslint-plugin-lightning': 1.0.1(eslint@8.57.1)
       eslint: 8.57.1
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)
-      eslint-plugin-jest: 29.16.0(eslint@8.57.1)(jest@30.3.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))(typescript@6.0.3)
+      eslint-plugin-jest: 29.16.0(eslint@8.57.1)(jest@30.3.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))(typescript@6.0.3)
       eslint-restricted-globals: 0.2.0
       semver: 7.8.5
     transitivePeerDependencies:
@@ -22432,21 +22448,21 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  '@salesforce/sfdx-lwc-jest@6.0.0(@types/node@24.13.3)(eslint@8.57.1)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@salesforce/sfdx-lwc-jest@6.0.0(@types/node@26.1.2)(eslint@8.57.1)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@lwc/compiler': 7.1.2
       '@lwc/engine-dom': 7.1.2
       '@lwc/engine-server': 7.1.2
-      '@lwc/jest-preset': 16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))
-      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))
-      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))
-      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))
+      '@lwc/jest-preset': 16.0.0(@lwc/compiler@7.1.2)(@lwc/engine-dom@7.1.2)(@lwc/engine-server@7.1.2)(@lwc/synthetic-shadow@7.1.2)(jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))
+      '@lwc/jest-resolver': 16.0.0(jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))
+      '@lwc/jest-serializer': 16.0.0(jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))
+      '@lwc/jest-transformer': 16.0.0(@lwc/compiler@7.1.2)(jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))
       '@lwc/module-resolver': 7.1.2
       '@lwc/synthetic-shadow': 7.1.2
       '@lwc/wire-service': 7.1.2
       '@salesforce/wire-service-jest-util': 4.1.4(@lwc/engine-dom@7.1.2)(eslint@8.57.1)(typescript@6.0.3)
       fast-glob: 3.3.3
-      jest: 29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
       jest-environment-jsdom: 29.7.0(patch_hash=b419a992476c3323e67ee6c86f3f9ecf6f4f073127cb572aa9af3b9c6550751d)
       yargs: 17.7.3
     transitivePeerDependencies:
@@ -23628,34 +23644,6 @@ snapshots:
       vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0)
       vue: 3.5.39(typescript@6.0.3)
 
-  '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.60.0)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1)(lightningcss@1.33.0)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
-    dependencies:
-      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1)(lightningcss@1.33.0)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1)(lightningcss@1.33.0)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))
-      playwright: 1.60.0
-      tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1)(lightningcss@1.33.0)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
-  '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.60.0)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
-    dependencies:
-      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))
-      playwright: 1.60.0
-      tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.60.0)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
@@ -23669,6 +23657,34 @@ snapshots:
       - utf-8-validate
       - vite
 
+  '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.62.0-alpha-1783623505000)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1)(lightningcss@1.33.0)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1)(lightningcss@1.33.0)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1)(lightningcss@1.33.0)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))
+      playwright: 1.62.0-alpha-1783623505000
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1)(lightningcss@1.33.0)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.62.0-alpha-1783623505000)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))
+      playwright: 1.62.0-alpha-1783623505000
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
@@ -23681,6 +23697,20 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+
+  '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.0-alpha-1783623505000)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
+      playwright: 1.62.0-alpha-1783623505000
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(jsdom@28.1.0)(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
 
   '@vitest/browser@4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1)(lightningcss@1.33.0)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
@@ -25254,13 +25284,13 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  create-jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)):
+  create-jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -26089,12 +26119,12 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest@29.16.0(eslint@8.57.1)(jest@30.3.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)))(typescript@6.0.3):
+  eslint-plugin-jest@29.16.0(eslint@8.57.1)(jest@30.3.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/utils': 8.65.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
     optionalDependencies:
-      jest: 30.3.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      jest: 30.3.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -27795,16 +27825,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)):
+  jest-cli@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      create-jest: 29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.3
@@ -27832,6 +27862,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   jest-cli@30.3.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)):
     dependencies:
@@ -27852,38 +27883,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.7)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 24.13.3
-      ts-node: 10.9.2(@types/node@24.13.3)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)):
+  jest-config@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 29.7.0
@@ -27909,7 +27909,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 26.1.2
-      ts-node: 10.9.2(@types/node@24.13.3)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@26.1.2)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -27945,6 +27945,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+    optional: true
 
   jest-config@30.3.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)):
     dependencies:
@@ -27977,6 +27978,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+    optional: true
 
   jest-config@30.3.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)):
     dependencies:
@@ -28512,12 +28514,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3)):
+  jest@29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.13.3)(ts-node@10.9.2(@types/node@24.13.3)(typescript@6.0.3))
+      jest-cli: 29.7.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -28536,6 +28538,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   jest@30.3.0(@types/node@26.1.2)(ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3)):
     dependencies:
@@ -31899,6 +31902,28 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown@1.0.0-rc.4(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2):
+    dependencies:
+      '@oxc-project/types': 0.113.0
+      '@rolldown/pluginutils': 1.0.0-rc.4
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.4
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.4
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.4
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.4
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.4
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.4
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.4
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.4
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.4
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.4(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.4
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.4
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   rolldown@1.0.0-rc.4(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3):
     dependencies:
       '@oxc-project/types': 0.113.0
@@ -33089,6 +33114,7 @@ snapshots:
       typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optional: true
 
   ts-node@10.9.2(@types/node@26.1.2)(typescript@6.0.3):
     dependencies:
@@ -33107,7 +33133,6 @@ snapshots:
       typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optional: true
 
   ts-simple-type@2.0.0-next.0: {}
 
@@ -33663,7 +33688,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.13.3
-      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.60.0)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1)(lightningcss@1.33.0)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.62.0-alpha-1783623505000)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(less@4.8.1)(lightningcss@1.33.0)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw
@@ -33694,7 +33719,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.13.3
-      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.60.0)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(playwright@1.62.0-alpha-1783623505000)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw
@@ -33755,7 +33780,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.1.2
-      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.60.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.0-alpha-1783623505000)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.1)(sass@1.102.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.10)
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -122,6 +122,13 @@ catalog:
   yaml: 2.9.0
   zone.js: 0.15.1
 
+catalogs:
+  react-compatibility:
+    '@types/react': '^18 || ^19'
+    '@types/react-dom': '^18 || ^19'
+    react: '^18 || ^19'
+    react-dom: '^18 || ^19'
+
 minimumReleaseAge: 10080
 
 minimumReleaseAgeExclude:

--- a/scripts/report-catalog-candidates.mjs
+++ b/scripts/report-catalog-candidates.mjs
@@ -19,42 +19,6 @@ import {parse as parseYaml} from 'yaml';
 const DEP_TYPES = ['dependencies', 'devDependencies', 'peerDependencies'];
 
 /**
- * Dependencies intentionally kept as wide, hardcoded peer ranges instead of
- * `catalog:` to preserve backward compatibility for external consumers.
- *
- * The React wrapper packages keep `react`/`react-dom` (and their `@types/*`) at
- * `^18 || ^19` so consumers on React 18 or 19 can install them, even though the
- * catalog pins a single 19.x version for the monorepo's own tooling.
- *
- * See docs/adr/0004-react-peer-dependency-ranges.md (KIT-5994).
- *
- * @type {Record<string, string[]>} Dependency name -> workspace-relative package
- *   paths where bypassing the catalog is intentional.
- */
-const INTENTIONAL_CATALOG_BYPASSES = {
-  react: ['packages/headless-react', 'packages/atomic-react'],
-  'react-dom': ['packages/headless-react', 'packages/atomic-react'],
-  '@types/react': ['packages/headless-react', 'packages/atomic-react'],
-  '@types/react-dom': ['packages/headless-react', 'packages/atomic-react'],
-};
-
-/**
- * Returns `true` when every occurrence of a catalog-bypassing dependency is
- * covered by the intentional-bypass allowlist.
- *
- * @param {string} name
- * @param {DepOccurrence[]} occurrences
- * @returns {boolean}
- */
-function isIntentionalBypass(name, occurrences) {
-  const allowed = INTENTIONAL_CATALOG_BYPASSES[name];
-  if (!allowed) {
-    return false;
-  }
-  return occurrences.every((occurrence) => allowed.includes(occurrence.package));
-}
-
-/**
  * @typedef DepOccurrence
  * @property {string} package - Relative path from workspace root (e.g., `packages/atomic`, `samples/headless/search`, `.`).
  * @property {string} version - Raw version string from the manifest.
@@ -219,7 +183,6 @@ function main() {
     'different-patches': 0,
     'exact-same': 0,
     'bypasses-catalog': 0,
-    'intentional-bypass': 0,
   };
 
   /** @type {Record<string, object>} */
@@ -240,9 +203,7 @@ function main() {
 
     const issues = [divergence];
     if (name in catalog) {
-      issues.push(
-        isIntentionalBypass(name, occurrences) ? 'intentional-bypass' : 'bypasses-catalog'
-      );
+      issues.push('bypasses-catalog');
     }
 
     const entry = {
@@ -259,9 +220,6 @@ function main() {
     counts[divergence]++;
     if (issues.includes('bypasses-catalog')) {
       counts['bypasses-catalog']++;
-    }
-    if (issues.includes('intentional-bypass')) {
-      counts['intentional-bypass']++;
     }
   }
 

--- a/scripts/report-catalog-candidates.mjs
+++ b/scripts/report-catalog-candidates.mjs
@@ -19,6 +19,42 @@ import {parse as parseYaml} from 'yaml';
 const DEP_TYPES = ['dependencies', 'devDependencies', 'peerDependencies'];
 
 /**
+ * Dependencies intentionally kept as wide, hardcoded peer ranges instead of
+ * `catalog:` to preserve backward compatibility for external consumers.
+ *
+ * The React wrapper packages keep `react`/`react-dom` (and their `@types/*`) at
+ * `^18 || ^19` so consumers on React 18 or 19 can install them, even though the
+ * catalog pins a single 19.x version for the monorepo's own tooling.
+ *
+ * See docs/adr/0004-react-peer-dependency-ranges.md (KIT-5994).
+ *
+ * @type {Record<string, string[]>} Dependency name -> workspace-relative package
+ *   paths where bypassing the catalog is intentional.
+ */
+const INTENTIONAL_CATALOG_BYPASSES = {
+  react: ['packages/headless-react', 'packages/atomic-react'],
+  'react-dom': ['packages/headless-react', 'packages/atomic-react'],
+  '@types/react': ['packages/headless-react', 'packages/atomic-react'],
+  '@types/react-dom': ['packages/headless-react', 'packages/atomic-react'],
+};
+
+/**
+ * Returns `true` when every occurrence of a catalog-bypassing dependency is
+ * covered by the intentional-bypass allowlist.
+ *
+ * @param {string} name
+ * @param {DepOccurrence[]} occurrences
+ * @returns {boolean}
+ */
+function isIntentionalBypass(name, occurrences) {
+  const allowed = INTENTIONAL_CATALOG_BYPASSES[name];
+  if (!allowed) {
+    return false;
+  }
+  return occurrences.every((occurrence) => allowed.includes(occurrence.package));
+}
+
+/**
  * @typedef DepOccurrence
  * @property {string} package - Relative path from workspace root (e.g., `packages/atomic`, `samples/headless/search`, `.`).
  * @property {string} version - Raw version string from the manifest.
@@ -183,6 +219,7 @@ function main() {
     'different-patches': 0,
     'exact-same': 0,
     'bypasses-catalog': 0,
+    'intentional-bypass': 0,
   };
 
   /** @type {Record<string, object>} */
@@ -203,7 +240,9 @@ function main() {
 
     const issues = [divergence];
     if (name in catalog) {
-      issues.push('bypasses-catalog');
+      issues.push(
+        isIntentionalBypass(name, occurrences) ? 'intentional-bypass' : 'bypasses-catalog'
+      );
     }
 
     const entry = {
@@ -220,6 +259,9 @@ function main() {
     counts[divergence]++;
     if (issues.includes('bypasses-catalog')) {
       counts['bypasses-catalog']++;
+    }
+    if (issues.includes('intentional-bypass')) {
+      counts['intentional-bypass']++;
     }
   }
 


### PR DESCRIPTION
## KIT-5994 — Align React peer dependency ranges with catalog

**Decision:** keep wide `^18 || ^19` peer ranges; do not pin to `catalog:` or drop React 18.

### Why

- `catalog:` publishes as an exact version (e.g. `react: "19.2.7"`), which would break consumers not on that exact patch and force lockstep upgrades. Internal consistency is already handled by `pnpm.overrides`.
- Neither package uses any React-19-only API, and React 18 is still security-supported with no announced EOL. Dropping 18 brings zero code or maintenance benefit.

### Changes

- **`atomic-react`**: `react`/`react-dom` peers `>=18.0.0` → `^18 || ^19`; added optional `@types/react(-dom)` peers (consistent with `headless-react`).
- **`headless-react`**: unchanged (already `^18 || ^19`).
- **Report script**: added intentional-bypass allowlist so these peers no longer report as catalog violations.
- **ADR-0004**: documents the rationale and revisit triggers.

### Verification

- semver delta confirms `>=18.0.0` and `^18 || ^19` accept the same set for every existing React (18.0–19.2.8).
- No `pnpm-lock.yaml` churn; linting clean.
