### PR TITLE
chore(ci): separate dependency setup from task execution

### DIFF
--- a/.github/actions/build-cdn/action.yml
+++ b/.github/actions/build-cdn/action.yml
@@ -10,9 +10,10 @@ runs:
   using: composite
   steps:
     - uses: ./.github/actions/setup
-    - run: pnpm exec turbo build --filter='!./samples/**'
       # Samples are not CDN artifacts. Exclude them so the CDN build does not try
       # to bundle samples that depend on CDN-externalized packages.
+    - run: pnpm exec turbo build --filter='!./samples/**'
+      shell: bash
       env:
         DEPLOYMENT_ENVIRONMENT: CDN
         CDN_COMMIT_SHA: ${{ inputs.commit-sha }}

--- a/.github/actions/build-cdn/action.yml
+++ b/.github/actions/build-cdn/action.yml
@@ -10,10 +10,9 @@ runs:
   using: composite
   steps:
     - uses: ./.github/actions/setup
-      with:
-        # Samples are not CDN artifacts. Exclude them so the CDN build does not try
-        # to bundle samples that depend on CDN-externalized packages.
-        build-command: "pnpm exec turbo build --filter='!./samples/**'"
+    - run: pnpm exec turbo build --filter='!./samples/**'
+      # Samples are not CDN artifacts. Exclude them so the CDN build does not try
+      # to bundle samples that depend on CDN-externalized packages.
       env:
         DEPLOYMENT_ENVIRONMENT: CDN
         CDN_COMMIT_SHA: ${{ inputs.commit-sha }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,15 +1,6 @@
 #region Metadata
-name: 'Setup & build'
-description: 'Setup node, install dependencies & build'
-inputs:
-  skip-build:
-    description: 'Skip the build step'
-    required: false
-    default: 'false'
-  build-command:
-    description: 'Command used to build. Defaults to building every package.'
-    required: false
-    default: 'pnpm run build --affected'
+name: 'Setup'
+description: 'Setup node and install dependencies'
 #endregion
 runs:
   using: composite
@@ -32,11 +23,5 @@ runs:
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
     - run: pnpm install --frozen-lockfile --prefer-offline
-      shell: bash
-    #endregion
-    #region Build
-    # Turbo build outputs come from Turborepo remote caching (turbo.json remoteCache + TURBO_TOKEN).
-    - run: ${{ inputs.build-command }}
-      if: inputs.skip-build != 'true'
       shell: bash
     #endregion

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -134,8 +134,6 @@ jobs:
 
       - name: Set up and build the project
         uses: ./.github/actions/setup
-        with:
-          skip-build: 'true' # defer build to only build what's necessary
 
       - name: Build typedoc site
         run: pnpm exec turbo run build:typedoc --filter=@coveo/headless
@@ -176,8 +174,6 @@ jobs:
 
       - name: Set up and build the project
         uses: ./.github/actions/setup
-        with:
-          skip-build: 'true' # defer build to only build what's necessary
 
       - name: Build typedoc site
         run: pnpm exec turbo run build:typedoc --filter=@coveo/headless-react
@@ -254,8 +250,6 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup
-        with:
-          skip-build: 'true'
       - name: Trigger commit artifact upload on ui-kit-cd
         run: node ./scripts/deploy/trigger-commit-upload.mjs
         env:
@@ -278,8 +272,6 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup
-        with:
-          load-cache: 'false'
       - name: Update Chromatic baseline
         uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,7 +457,6 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm run build --affected
       - uses: ./.github/actions/playwright-atomic-theming
   storybook-atomic:
     name: 'Run Storybook tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+      - run: pnpm run build --affected
   build-missing:
     name: 'Build & commit missing generated files'
     needs: [affected, build]
@@ -80,6 +81,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+      - run: pnpm run build --affected
       - name: Check for uncommitted changes
         id: check-changes
         run: |
@@ -116,13 +118,12 @@ jobs:
         with:
           egress-policy: audit
 
-      # Full history is required by `turbo --affected`, which compares the
-      # checkout against the base ref to determine which packages changed.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+      - run: pnpm run build --affected
 
   build-cdn:
     name: Build CDN
@@ -178,8 +179,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup
-        with:
-          build-command: "pnpm exec turbo build --filter='!./samples/**'"
+      - run: pnpm exec turbo build --filter='!./samples/**'
       - name: 'Run CDN checks'
         uses: ./.github/actions/cdn-checks
   lint-check:
@@ -198,8 +198,6 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-        with:
-          skip-build: 'true'
       - run: pnpm run lint:check
   validate-light-dom-styles:
     name: 'Validate Light DOM styles'
@@ -217,8 +215,6 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-        with:
-          skip-build: 'true'
       - run: pnpm --filter @coveo/atomic run validate:light-dom-styles
   validate-no-new-light-dom:
     name: 'Validate no new Light DOM components'
@@ -236,8 +232,6 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-        with:
-          skip-build: 'true'
       - run: pnpm --filter @coveo/atomic run validate:no-new-light-dom
   unit-test:
     name: 'Run unit tests'
@@ -274,8 +268,6 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup
-        with:
-          skip-build: 'true'
       - name: Run Relay functional tests in Chromium, Firefox, and WebKit
         run: pnpm exec turbo functional-test --filter=@coveo/relay
       - name: Build the playground and run its CJS/ESM Node smoke tests
@@ -296,8 +288,6 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-        with:
-          skip-build: 'true' # Defer to test:dts:ci building what it needs
       - run: pnpm exec turbo test:dts:ci --affected
   package-compatibility:
     name: 'Verify compatibility of packages'
@@ -332,8 +322,6 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-        with:
-          skip-build: 'true' # defer build to only build what's necessary
       - name: 'Build typedoc'
         run: pnpm exec turbo run build:typedoc --affected
   puppeteer-atomic-csp:
@@ -375,8 +363,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
-        with:
-          skip-build: 'true' # Defer build after determining if we run the tests
       - name: Run Chromatic visual tests
         uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         id: chromatic-run
@@ -423,6 +409,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+      - run: pnpm run build --affected
       - uses: ./.github/actions/playwright-atomic
         with:
           shardIndex: ${{ matrix.shardIndex }}
@@ -470,8 +457,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-        with:
-          skip-build: 'true'
+      - run: pnpm run build --affected
       - uses: ./.github/actions/playwright-atomic-theming
   storybook-atomic:
     name: 'Run Storybook tests'
@@ -498,6 +484,7 @@ jobs:
           filter: blob:none
       - run: git branch main origin/main
       - uses: ./.github/actions/setup
+      - run: pnpm run build --affected
       - run: npm run test:storybook -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         working-directory: packages/atomic
       - name: 'Upload a11y shard report'
@@ -528,8 +515,6 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-        with:
-          skip-build: 'true'
       - name: 'Download a11y shard reports'
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -574,6 +559,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+      - run: pnpm run build --affected
       - run: pnpm exec turbo run "${{ matrix.sample }}"
       - name: Upload Playwright report
         if: failure()
@@ -602,6 +588,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+      - run: pnpm exec turbo run build --filter=@coveo/pkg-new-template
       - uses: ./.github/actions/playwright-pkg-new-template
   playwright-atomic-hosted-page-test:
     name: 'Run e2e tests for Atomic Hosted Page'
@@ -622,6 +609,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+      - run: pnpm exec turbo run build --filter=@coveo/atomic-hosted-page
       - uses: ./.github/actions/playwright-atomic-hosted-pages
   e2e-quantic:
     name: 'Run Quantic E2E tests'
@@ -658,6 +646,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+      - run: pnpm exec turbo run build --filter='!./samples/**'
       - name: Resolve catalog references in pkg.pr.new templates
         run: node packages/pkg-new-template/scripts/flatten-catalog.mjs
       - name: Publish to pkg.pr.new

--- a/.github/workflows/create-quantic-package.yml
+++ b/.github/workflows/create-quantic-package.yml
@@ -49,6 +49,8 @@ jobs:
             })
       - name: Setup
         uses: ./.github/actions/setup
+      - name: Build Quantic
+        run: pnpm exec turbo run build --filter=@coveo/quantic
       - name: Setup SFDX
         uses: ./.github/actions/setup-sfdx
       - name: Create package version

--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
+      - run: pnpm exec turbo run build --filter=@coveo/quantic
       - uses: ./.github/actions/setup-sfdx
       - uses: ./.github/actions/e2e-quantic-setup
         with:
@@ -93,6 +94,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
+      - run: pnpm exec turbo run build --filter=@coveo/quantic
       - uses: ./.github/actions/playwright-quantic
         with:
           shardIndex: ${{ matrix.shardIndex }}

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -53,8 +53,6 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup
-        with:
-          skip-build: 'true'
       - name: Trigger commit artifact upload and hotfix pointer update
         run: node ./scripts/deploy/trigger-commit-upload.mjs
         env:

--- a/.github/workflows/setup-quantic-examples-community.yml
+++ b/.github/workflows/setup-quantic-examples-community.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Project setup
         uses: ./.github/actions/setup
 
+      - name: Build Quantic
+        run: pnpm exec turbo run build --filter=@coveo/quantic
+
       - name: Setup Salesforce CLI
         uses: ./.github/actions/setup-sfdx
 


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6049

## Motivation

The shared `setup` action both installed dependencies and ran a build, driven by `skip-build` and `build-command` inputs. That let callers smuggle arbitrary build commands through the setup boundary and made "install" and "decide what to build" the same step, which blocks putting task selection under Turbo.

## Changes

- Removes `skip-build` and `build-command` from `.github/actions/setup/action.yml`; it now only installs tooling and dependencies
- Renames the action from `Setup & build` to `Setup`
- Drops the now-invalid inputs from every caller in `ci.yml`, `cd.yml`, and `hotfix.yml`
- Adds an explicit build where a workflow genuinely needs artifacts: Quantic (E2E, package creation, examples community), pkg-new-template, Atomic Hosted Page, and preview publishing
- Moves the CDN build out of the setup input and into its own step in `build-cdn`

Behavior is intentionally preserved: every job that previously got an implicit build still gets one, just explicitly.

## Validation

- [x] All existing tests pass without modification
- [x] No new features or bug fixes are included in this PR
- [x] Public API surface is unchanged

`actionlint` (with pre-existing `SC2086` findings ignored) and YAML parsing pass on every modified workflow and action.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`chore(<scope>): <description>`)
- [x] No changeset needed: CI configuration only, no public package source modified

---

Part of stack #8240. Depends on #8235.
