### PR TITLE
chore(ci): express remaining CI steps as Turbo tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm run lint:check
+      - run: pnpm exec turbo run lint:check --affected
   validate-light-dom-styles:
     name: 'Validate Light DOM styles'
     needs: affected
@@ -215,7 +215,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm --filter @coveo/atomic run validate:light-dom-styles
+      - run: pnpm exec turbo run validate:light-dom-styles --filter=@coveo/atomic --affected
   validate-no-new-light-dom:
     name: 'Validate no new Light DOM components'
     needs: affected
@@ -232,7 +232,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm --filter @coveo/atomic run validate:no-new-light-dom
+      - run: pnpm exec turbo run validate:no-new-light-dom --filter=@coveo/atomic --affected
   unit-test:
     name: 'Run unit tests'
     needs: [affected, build]
@@ -269,9 +269,9 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup
       - name: Run Relay functional tests in Chromium, Firefox, and WebKit
-        run: pnpm exec turbo functional-test --filter=@coveo/relay
+        run: pnpm exec turbo run functional-test --filter=@coveo/relay --affected
       - name: Build the playground and run its CJS/ESM Node smoke tests
-        run: pnpm exec turbo test --filter=@coveo/relay-playground
+        run: pnpm exec turbo run test --filter=@coveo/relay-playground --affected
   validate-dts:
     name: 'Validate DTS API surface'
     needs: [affected, build]
@@ -305,7 +305,7 @@ jobs:
           filter: blob:none
       - uses: ./.github/actions/setup
       - run: pnpm exec node ./scripts/ci/validate-publint-tasks.mjs
-      - run: pnpm turbo run publint --affected
+      - run: pnpm exec turbo run publint --affected
   typedoc:
     name: 'Build typedoc'
     needs: [affected, build]
@@ -484,8 +484,7 @@ jobs:
       - run: git branch main origin/main
       - uses: ./.github/actions/setup
       - run: pnpm run build --affected
-      - run: npm run test:storybook -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
-        working-directory: packages/atomic
+      - run: pnpm exec turbo run test:storybook --filter=@coveo/atomic --affected -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: 'Upload a11y shard report'
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -624,8 +623,6 @@ jobs:
     uses: ./.github/workflows/e2e-quantic.yml
     with:
       event_name: ${{ github.event_name }}
-      turbo_scm_base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-      turbo_scm_head: ${{ github.sha }}
     secrets:
       SFDX_AUTH_CLIENT_ID: ${{ secrets.SFDX_AUTH_CLIENT_ID }}
       SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,8 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo run lint:check --affected
+      # TODO: Convert to turbo tasks: https://coveord.atlassian.net/browse/KIT-6074
+      - run: pnpm run lint:check
   validate-light-dom-styles:
     name: 'Validate Light DOM styles'
     needs: affected

--- a/.github/workflows/e2e-quantic.yml
+++ b/.github/workflows/e2e-quantic.yml
@@ -6,14 +6,6 @@ on:
         required: false
         type: string
         default: 'pull_request'
-      turbo_scm_base:
-        description: 'The base commit used by Turborepo to determine affected projects'
-        required: true
-        type: string
-      turbo_scm_head:
-        description: 'The head commit used by Turborepo to determine affected projects'
-        required: true
-        type: string
     secrets:
       SFDX_AUTH_CLIENT_ID:
         required: true
@@ -28,8 +20,6 @@ permissions:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_SCM_BASE: ${{ inputs.turbo_scm_base }}
-  TURBO_SCM_HEAD: ${{ inputs.turbo_scm_head }}
 
 jobs:
   e2e-quantic-setup:

--- a/docs/adr/0006-turbo-governed-ci-with-a-single-affected-calculation.md
+++ b/docs/adr/0006-turbo-governed-ci-with-a-single-affected-calculation.md
@@ -77,7 +77,7 @@ The design has four parts:
 - `tasks` — affected task identifiers such as `@coveo/atomic#build` as a single-line JSON array;
 - `projects` — affected package names, used for coarse job-level `if:` guards;
 - `samples` — affected sample E2E task identifiers, used as the dynamic E2E matrix source.
-- `fetch-depth` — the commit count of the compared range. 
+- `fetch-depth` — the commit count of the compared range.
 
 The action verifies both commits before querying and writes a Markdown table of package, task, reason, and description to the job summary. The query requests [reason variants](https://turborepo.dev/docs/reference/query#understanding-affected-package-reasons) such as `TaskFileChanged` and `TaskDependencyTaskChanged`, so each run explains why tasks were selected.
 

--- a/packages/atomic/turbo.json
+++ b/packages/atomic/turbo.json
@@ -126,6 +126,12 @@
     "e2e:theming": {
       "dependsOn": ["build:cdn"],
       "outputs": ["playwright-report/**"]
+    },
+    "validate:light-dom-styles": {
+      "outputs": []
+    },
+    "validate:no-new-light-dom": {
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6050

## Motivation

Several CI steps still invoked package scripts directly, so that work was invisible to the Turbo task graph: not cacheable, not orderable, and not selectable by affectedness.

## Changes

- Converts the remaining raw invocations in `ci.yml` to `turbo run …`: the two Atomic Light DOM validations, Relay functional and playground tests, publint, and the Atomic Storybook shard
- Registers `validate:light-dom-styles` and `validate:no-new-light-dom` in `packages/atomic/turbo.json`, since those checks had no task to convert to
- Removes the `turbo_scm_base` and `turbo_scm_head` inputs from the Quantic reusable workflow, along with the `TURBO_SCM_*` environment variables and the caller arguments, now that the workflow no longer derives its own comparison range
- The `link:check` is excluded because it will require more extensive refactoring.

## Validation

- [x] All existing tests pass without modification
- [x] No new features or bug fixes are included in this PR
- [x] Public API surface is unchanged

`actionlint` and YAML parsing pass on the modified workflows. Each converted step resolves to a declared Turbo task.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`chore(<scope>): <description>`)
- [x] No changeset needed: CI and task configuration only, no public package source modified

---

Part of stack #8240. Depends on #8236.
