### PR TITLE
feat(ci): add run-affected action and migrate CI callers

### DIFF
--- a/.github/actions/build-cdn/action.yml
+++ b/.github/actions/build-cdn/action.yml
@@ -10,10 +10,14 @@ runs:
   using: composite
   steps:
     - uses: ./.github/actions/setup
-      # Samples are not CDN artifacts. Exclude them so the CDN build does not try
-      # to bundle samples that depend on CDN-externalized packages.
-    - run: pnpm exec turbo build --filter='!./samples/**'
-      shell: bash
+    - uses: ./.github/actions/run-affected
+      with:
+        tasks: build
+        # Samples are not CDN artifacts. Exclude them so the CDN build does not try
+        # to bundle samples that depend on CDN-externalized packages.
+        packages: |
+          !@samples/*
+          !@coveo/ui-kit-sample-*
       env:
         DEPLOYMENT_ENVIRONMENT: CDN
         CDN_COMMIT_SHA: ${{ inputs.commit-sha }}

--- a/.github/actions/run-affected/action.yml
+++ b/.github/actions/run-affected/action.yml
@@ -1,0 +1,43 @@
+name: 'Run affected Turbo tasks'
+description: 'Select affected Turbo tasks from the current task graph and run them.'
+inputs:
+  affected-tasks:
+    description: 'Affected Turbo task identifiers as a JSON array. When not specified, run all tasks in the selected graph. When the array is empty, run no tasks.'
+    required: false
+    default: ''
+  tasks:
+    description: 'Turbo target task names, one per line.'
+    required: false
+    default: 'build'
+  packages:
+    description: 'Project package name selectors, one per line. Supports exact names, * wildcards, and ! negation. An empty value defaults to all projects.'
+    required: false
+    default: ''
+  arguments:
+    description: 'Additional arguments passed to Turbo tasks after --, one per line.'
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+    - name: Resolve affected tasks
+      id: resolve
+      shell: bash
+      env:
+        AFFECTED_TASKS: ${{ inputs.affected-tasks }}
+        TASKS: ${{ inputs.tasks }}
+        PACKAGES: ${{ inputs.packages }}
+      run: |
+        tasks="$(node "$GITHUB_ACTION_PATH/resolve-tasks.mjs")"
+        {
+          echo 'tasks<<EOF'
+          echo "$tasks"
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+    - name: Run tasks
+      if: ${{ steps.resolve.outputs.tasks != '' }}
+      shell: bash
+      env:
+        TASKS: ${{ steps.resolve.outputs.tasks }}
+        ARGUMENTS: ${{ inputs.arguments }}
+      run: bash "$GITHUB_ACTION_PATH/run-tasks.sh"

--- a/.github/actions/run-affected/resolve-tasks.mjs
+++ b/.github/actions/run-affected/resolve-tasks.mjs
@@ -77,6 +77,13 @@ const parseInputs = () => {
   const affectedInput = process.env.AFFECTED_TASKS ?? '';
   const affectedTasks = affectedInput == '' ? null : JSON.parse(affectedInput);
 
+  if (
+    affectedInput != '' &&
+    (!Array.isArray(affectedTasks) || affectedTasks.some((task) => typeof task !== 'string'))
+  ) {
+    throw new TypeError('AFFECTED_TASKS must be a JSON array of strings.');
+  }
+
   return {requestedTasks, matchesPackage, affectedTasks};
 };
 

--- a/.github/actions/run-affected/resolve-tasks.mjs
+++ b/.github/actions/run-affected/resolve-tasks.mjs
@@ -1,0 +1,103 @@
+import {existsSync, globSync, readFileSync, statSync} from 'node:fs';
+import {resolve} from 'node:path';
+import {parse} from 'yaml';
+
+const root = resolve(process.env.GITHUB_WORKSPACE ?? process.cwd());
+
+const splitLines = (value = '') =>
+  value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+const escapeRegExp = (value) => value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+
+const globToRegExp = (pattern) => {
+  let source = '';
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index];
+    if (character !== '*') {
+      source += escapeRegExp(character);
+      continue;
+    }
+    source += '[^/]*';
+  }
+  return new RegExp(`^${source}$`);
+};
+
+const matchesPattern = (value, pattern) => globToRegExp(pattern).test(value);
+
+const matchesPackage = (project, packageName) => matchesPattern(project.name, packageName);
+
+const parsePackages = (value) => {
+  const packages = splitLines(value).map((packageName) => {
+    const negative = packageName.startsWith('!');
+    return {
+      negative,
+      pattern: packageName.slice(negative ? 1 : 0),
+    };
+  });
+
+  const positive = packages.filter(({negative}) => !negative);
+  const negative = packages.filter(({negative}) => negative);
+
+  return (project) => {
+    const included =
+      positive.length === 0 || positive.some(({pattern}) => matchesPackage(project, pattern));
+    const excluded = negative.some(({pattern}) => matchesPackage(project, pattern));
+    return included && !excluded;
+  };
+};
+
+const readPackage = (directory) => {
+  const path = resolve(root, directory, 'package.json');
+  const pkg = JSON.parse(readFileSync(path, 'utf8'));
+
+  return {
+    name: pkg.name,
+    scripts: pkg.scripts ?? {},
+  };
+};
+
+const readWorkspacePackages = () => {
+  const workspace = parse(readFileSync(resolve(root, 'pnpm-workspace.yaml'), 'utf8'));
+  const directories = new Set(
+    (workspace.packages ?? []).flatMap((pattern) => globSync(pattern, {cwd: root}))
+  );
+  return [...directories]
+    .filter((directory) => statSync(resolve(root, directory)).isDirectory())
+    .filter((directory) => existsSync(resolve(root, directory, 'package.json')))
+    .map(readPackage);
+};
+
+const parseInputs = () => {
+  const requestedTasks = splitLines(process.env.TASKS || 'build');
+  const matchesPackage = parsePackages(process.env.PACKAGES);
+
+  const affectedInput = process.env.AFFECTED_TASKS ?? '';
+  const affectedTasks = affectedInput == '' ? null : JSON.parse(affectedInput);
+
+  return {requestedTasks, matchesPackage, affectedTasks};
+};
+
+const resolveTasks = () => {
+  const {requestedTasks, matchesPackage, affectedTasks} = parseInputs();
+  const packages = readWorkspacePackages();
+  const projects = matchesPackage ? packages.filter(matchesPackage) : packages;
+  const tasks = projects.flatMap((project) =>
+    Object.keys(project.scripts).map((task) => ({project, task}))
+  );
+
+  return tasks
+    .filter(({task}) => requestedTasks.includes(task))
+    .map(({project, task}) => `${project.name}#${task}`)
+    .filter((task) => affectedTasks === null || affectedTasks.includes(task))
+    .sort();
+};
+
+const tasks = resolveTasks();
+console.error(`tasks:`);
+for (const task of tasks) {
+  console.error(task);
+  console.log(task);
+}

--- a/.github/actions/run-affected/run-tasks.sh
+++ b/.github/actions/run-affected/run-tasks.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+run_command=(pnpm exec turbo run)
+
+while IFS= read -r task; do
+  run_command+=("$task")
+done <<< "${TASKS}"
+run_command+=(--no-update-notifier)
+
+if [[ -n "$ARGUMENTS" ]]; then
+  run_command+=(--)
+  while IFS= read -r argument; do
+    [[ -z "$argument" ]] || run_command+=("$argument")
+  done <<< "$ARGUMENTS"
+fi
+
+echo "${run_command[*]}"
+"${run_command[@]}"

--- a/.github/actions/run-affected/test-resolve-tasks.mjs
+++ b/.github/actions/run-affected/test-resolve-tasks.mjs
@@ -16,6 +16,20 @@ const run = (name, environment, expected) => {
     .trim();
   assert.equal(actual, expected.join('\n'), name);
 };
+const runFailure = (name, environment, expectedError) => {
+  assert.throws(
+    () =>
+      execFileSync(process.execPath, [resolver], {
+        cwd: workspace,
+        env: {...process.env, GITHUB_WORKSPACE: workspace, ...environment},
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+    (error) => {
+      assert.match(error.stderr.toString(), expectedError, name);
+      return true;
+    }
+  );
+};
 run(
   'matches an exact project filter',
   {
@@ -63,6 +77,16 @@ run(
   },
   []
 );
+for (const invalidAffectedTasks of ['null', '{}', '["@coveo/atomic#build", 1]']) {
+  runFailure(
+    `rejects invalid affected tasks: ${invalidAffectedTasks}`,
+    {
+      GITHUB_WORKSPACE: resolve(directory, 'missing-workspace'),
+      AFFECTED_TASKS: invalidAffectedTasks,
+    },
+    /AFFECTED_TASKS must be a JSON array of strings\./
+  );
+}
 run(
   'resolves the selected workspace when affected tasks are not provided',
   {

--- a/.github/actions/run-affected/test-resolve-tasks.mjs
+++ b/.github/actions/run-affected/test-resolve-tasks.mjs
@@ -1,0 +1,75 @@
+// Simple ad-hoc script to help development of resolve-tasks.mjs
+import {execFileSync} from 'node:child_process';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import assert from 'node:assert/strict';
+const directory = dirname(fileURLToPath(import.meta.url));
+const resolver = resolve(directory, 'resolve-tasks.mjs');
+const workspace = resolve(directory, '../../..');
+const run = (name, environment, expected) => {
+  const actual = execFileSync(process.execPath, [resolver], {
+    cwd: workspace,
+    env: {...process.env, GITHUB_WORKSPACE: workspace, ...environment},
+    stdio: ['ignore', 'pipe', 'ignore'],
+  })
+    .toString()
+    .trim();
+  assert.equal(actual, expected.join('\n'), name);
+};
+run(
+  'matches an exact project filter',
+  {
+    TASKS: 'publint',
+    PACKAGES: '@coveo/atomic',
+    AFFECTED_TASKS: '["@coveo/atomic#publint", "@coveo/headless#publint"]',
+  },
+  ['@coveo/atomic#publint']
+);
+run(
+  'matches project-name wildcards',
+  {
+    TASKS: 'publint',
+    PACKAGES: '@coveo/atomic*',
+    AFFECTED_TASKS:
+      '["@coveo/atomic#publint", "@coveo/atomic-react#publint", "@coveo/headless#publint"]',
+  },
+  ['@coveo/atomic#publint', '@coveo/atomic-react#publint']
+);
+run(
+  'subtracts multiple negated project-name filters',
+  {
+    TASKS: 'build\npublint',
+    PACKAGES: '!@samples/*\n!@coveo/ui-kit-sample-*',
+    AFFECTED_TASKS:
+      '["@coveo/atomic#publint", "@coveo/ui-kit-sample-atomic-commerce-react#build", "@samples/atomic-search-commerce-angular#build"]',
+  },
+  ['@coveo/atomic#publint']
+);
+run(
+  'supports multiple task names',
+  {
+    TASKS: 'test\npublint',
+    PACKAGES: '@coveo/atomic',
+    AFFECTED_TASKS: '["@coveo/atomic#test", "@coveo/atomic#publint"]',
+  },
+  ['@coveo/atomic#publint', '@coveo/atomic#test']
+);
+run(
+  'does not resolve an explicit empty affected list',
+  {
+    TASKS: 'build',
+    PACKAGES: '@coveo/atomic',
+    AFFECTED_TASKS: '[]',
+  },
+  []
+);
+run(
+  'resolves the selected workspace when affected tasks are not provided',
+  {
+    TASKS: 'publint',
+    PACKAGES: '@coveo/atomic',
+    AFFECTED_TASKS: '',
+  },
+  ['@coveo/atomic#publint']
+);
+console.log('All resolve-tasks scenarios passed.');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,10 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm run build --affected
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: build
   build-missing:
     name: 'Build & commit missing generated files'
     needs: [affected, build]
@@ -81,7 +84,10 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm run build --affected
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: build
       - name: Check for uncommitted changes
         id: check-changes
         run: |
@@ -120,10 +126,14 @@ jobs:
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: false
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm run build --affected
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: build
 
   build-cdn:
     name: Build CDN
@@ -179,7 +189,13 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo build --filter='!./samples/**'
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: build
+          packages: |
+            !@samples/*
+            !@coveo/ui-kit-sample-*
       - name: 'Run CDN checks'
         uses: ./.github/actions/cdn-checks
   lint-check:
@@ -216,7 +232,11 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo run validate:light-dom-styles --filter=@coveo/atomic --affected
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: validate:light-dom-styles
+          packages: '@coveo/atomic'
   validate-no-new-light-dom:
     name: 'Validate no new Light DOM components'
     needs: affected
@@ -233,10 +253,14 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo run validate:no-new-light-dom --filter=@coveo/atomic --affected
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: validate:no-new-light-dom
+          packages: '@coveo/atomic'
   unit-test:
     name: 'Run unit tests'
-    needs: [affected, build]
+    needs: affected
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -250,10 +274,14 @@ jobs:
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: false
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo test --affected
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: test
   relay-tests:
     name: 'Run Relay functional and playground smoke tests'
     needs: [affected, build]
@@ -269,10 +297,16 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup
-      - name: Run Relay functional tests in Chromium, Firefox, and WebKit
-        run: pnpm exec turbo run functional-test --filter=@coveo/relay --affected
-      - name: Build the playground and run its CJS/ESM Node smoke tests
-        run: pnpm exec turbo run test --filter=@coveo/relay-playground --affected
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: functional-test
+          packages: '@coveo/relay'
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: test
+          packages: '@coveo/relay-playground'
   validate-dts:
     name: 'Validate DTS API surface'
     needs: [affected, build]
@@ -289,7 +323,11 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo test:dts:ci --affected
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: test:dts:ci
+          packages: '@coveo/thermidor'
   package-compatibility:
     name: 'Verify compatibility of packages'
     needs: [affected, build]
@@ -306,7 +344,10 @@ jobs:
           filter: blob:none
       - uses: ./.github/actions/setup
       - run: pnpm exec node ./scripts/ci/validate-publint-tasks.mjs
-      - run: pnpm exec turbo run publint --affected
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: publint
   typedoc:
     name: 'Build typedoc'
     needs: [affected, build]
@@ -323,8 +364,10 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - name: 'Build typedoc'
-        run: pnpm exec turbo run build:typedoc --affected
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: build:typedoc
   puppeteer-atomic-csp:
     name: 'Run e2e tests on Atomic CSP'
     needs: [affected, build]
@@ -410,7 +453,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm run build --affected
+      - run: pnpm exec turbo run build --filter=@coveo/atomic
       - uses: ./.github/actions/playwright-atomic
         with:
           shardIndex: ${{ matrix.shardIndex }}
@@ -484,8 +527,13 @@ jobs:
           filter: blob:none
       - run: git branch main origin/main
       - uses: ./.github/actions/setup
-      - run: pnpm run build --affected
-      - run: pnpm exec turbo run test:storybook --filter=@coveo/atomic --affected -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          packages: '@coveo/atomic'
+          tasks: test:storybook
+          arguments: |
+            --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: 'Upload a11y shard report'
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -558,8 +606,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm run build --affected
-      - run: pnpm exec turbo run "${{ matrix.sample }}"
+      - run: pnpm exec turbo run "${{ matrix.sample }}" # Already filtered by affected
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -630,7 +677,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   publish-preview:
     if: ${{ !cancelled() && github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/') }}
-    needs: build
+    needs: [affected, build]
     name: 'Publish Preview Packages'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6051

## What does this PR do?

Refactors the shared `run-affected` GitHub Action so it resolves affected Turbo task IDs in JavaScript and leaves Turbo responsible only for executing those tasks.

The resolver reads workspace package manifests and scripts, supports exact package names, `*` wildcards, and `!` negation, then intersects the requested tasks with the affected task list. The action now has dedicated resolution and execution steps and skips execution when no tasks resolve.

The selector input is renamed from `filters` to `packages`, and all CI/CD callers—including the CDN build—are updated. The old Turbo dry-run shell script is replaced by a small execution-only script. Development scenarios cover exact, wildcard, multiple-negation, multiple-task, empty affected-list, and unset affected-list behavior.

## How should this be tested?

- [x] `node .github/actions/run-affected/test-resolve-tasks.mjs`
- [x] `node --check .github/actions/run-affected/resolve-tasks.mjs`
- [x] `node --check .github/actions/run-affected/test-resolve-tasks.mjs`
- [x] `zsh -n .github/actions/run-affected/run-tasks.sh`
- [x] `pnpm exec oxlint --no-ignore .github/actions/run-affected/resolve-tasks.mjs .github/actions/run-affected/test-resolve-tasks.mjs`
- [x] `pnpm exec oxfmt --check .github/actions/run-affected/resolve-tasks.mjs .github/actions/run-affected/test-resolve-tasks.mjs`
- [x] GitHub Actions YAML parsing
- [x] `pnpm run lint:fix`

## Checklist

- [x] The PR title follows the Conventional Commits format.
- [x] No changeset is included because this changes internal CI tooling only and does not modify public package source.

Part of stack #8240. Depends on #8237. This is the core of the ADR in #8235.