### PR TITLE
feat(ci): use calculated checkout depth for merge checks

### DIFF
--- a/.github/actions/calculate-affected/action.yml
+++ b/.github/actions/calculate-affected/action.yml
@@ -1,5 +1,5 @@
 name: Calculate affected tasks
-description: Calculate affected Turbo tasks, projects, and samples.
+description: Calculate affected Turbo tasks, projects, samples, and required fetch depth.
 inputs:
   base-sha:
     description: Base commit to compare against.
@@ -8,6 +8,9 @@ inputs:
     description: Head commit to calculate affected tasks for.
     required: true
 outputs:
+  fetch-depth:
+    description: Minimum checkout depth required for the calculated commit range.
+    value: ${{ steps.calculate.outputs.fetch-depth }}
   tasks:
     description: Affected Turbo task identifiers as a single-line JSON array of strings.
     value: ${{ steps.calculate.outputs.tasks }}
@@ -59,6 +62,9 @@ runs:
         GIT_NO_LAZY_FETCH=1 git rev-parse --verify "${TURBO_SCM_BASE}^{commit}"
         GIT_NO_LAZY_FETCH=1 git rev-parse --verify "${TURBO_SCM_HEAD}^{commit}"
 
+        range_count="$(git rev-list --count "${TURBO_SCM_BASE}..${TURBO_SCM_HEAD}")"
+        fetch_depth=$((range_count + 1))
+
         turbo_version="$(node -p "require('./package.json').devDependencies.turbo")"
         affected_tasks="$(
           pnpm dlx "turbo@$turbo_version" query --no-update-notifier "${QUERY}" \
@@ -73,6 +79,8 @@ runs:
           value="$(jq -c "$query" <<< "${affected_tasks}")"
           echo "$name=$value" >> "$GITHUB_OUTPUT"
         }
+
+        echo "fetch-depth=$fetch_depth" >> "$GITHUB_OUTPUT"
 
         jq_output tasks    'map(.fullName)'
         jq_output projects 'map(.package.name) | unique'

--- a/.github/actions/changeset-merge-guard/action.yml
+++ b/.github/actions/changeset-merge-guard/action.yml
@@ -2,7 +2,7 @@ name: 'Changeset merge guard'
 description: >
   Detects stale version PRs in a merge queue group by checking whether
   unprocessed changeset files still exist after the version-packages commit.
-  Requires the repository to be checked out with full history (fetch-depth: 0).
+  Requires enough checkout history to resolve the supplied base-to-head range.
 inputs:
   base-sha:
     description: 'Base SHA of the merge group'
@@ -24,7 +24,7 @@ runs:
         echo "Checking commits in range ${BASE_SHA}..${HEAD_SHA}"
 
         if ! COMMITS=$(git log --format='%s' "${BASE_SHA}..${HEAD_SHA}"); then
-          echo "::error::Failed to resolve commit range. Ensure the repository is checked out with sufficient history (fetch-depth: 0)."
+          echo "::error::Failed to resolve commit range. Ensure the repository is checked out with enough history to include ${BASE_SHA}..${HEAD_SHA}."
           exit 1
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     name: 'Calculate affected tasks'
     runs-on: ubuntu-latest
     outputs:
+      fetch-depth: ${{ steps.publish.outputs.fetch-depth }}
       tasks: ${{ steps.publish.outputs.tasks }}
       projects: ${{ steps.publish.outputs.projects }}
       samples: ${{ steps.publish.outputs.samples }}
@@ -818,7 +819,8 @@ jobs:
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          fetch-depth: 0
+          fetch-depth: ${{ needs.affected.outputs.fetch-depth }}
+          fetch-tags: false
 
       - uses: ./.github/actions/changeset-merge-guard
         with:


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6052

## Motivation

With affectedness computed once, most jobs no longer need Git history. The changeset merge guard still does, but only enough to resolve the merge group's base-to-head range — not a full clone.

## Changes

- `calculate-affected` computes the commit count of the compared range and publishes it as a `fetch-depth` output
- The `affected` job republishes that output for consumers
- The changeset merge guard checks out with the published depth instead of `fetch-depth: 0`
- `changeset-merge-guard` documents the bounded-history requirement, and its error message now names the range it failed to resolve rather than telling the caller to clone everything

## Validation

- [x] `actionlint` and YAML parsing pass on the modified workflow and actions
- [x] Merge-guard range resolution reviewed for both `pull_request` and `merge_group`

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`feat(<scope>): <description>`)
- [x] No changeset needed: CI configuration only, no public package source modified

---

Part of stack #8240. Top of the stack — depends on #8238.
