### PR TITLE
test(pkg-new-template): stabilize flaky smoke tests

### DIFF
--- a/packages/pkg-new-template/playwright.config.ts
+++ b/packages/pkg-new-template/playwright.config.ts
@@ -7,9 +7,6 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
-  // The pages initialize a live Atomic interface against a sample org while Vite
-  // transforms the Atomic ESM graph on demand, so the default 5s expect timeout
-  // is not enough on a cold, single-worker CI runner.
   timeout: 90_000,
   expect: {
     timeout: 30_000,

--- a/packages/pkg-new-template/playwright.config.ts
+++ b/packages/pkg-new-template/playwright.config.ts
@@ -7,6 +7,13 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
+  // The pages initialize a live Atomic interface against a sample org while Vite
+  // transforms the Atomic ESM graph on demand, so the default 5s expect timeout
+  // is not enough on a cold, single-worker CI runner.
+  timeout: 90_000,
+  expect: {
+    timeout: 30_000,
+  },
   use: {
     trace: 'on-first-retry',
   },

--- a/packages/pkg-new-template/tests/smoke.spec.ts
+++ b/packages/pkg-new-template/tests/smoke.spec.ts
@@ -1,9 +1,5 @@
 import {expect, type Page, test} from '@playwright/test';
 
-// Atomic layouts are `display: none` until the interface finishes initializing
-// and injects its generated layout styles. Waiting for the layout to become
-// visible first means the component assertions below only measure hydrated
-// elements instead of racing the interface bootstrap.
 async function gotoPage(page: Page, path: string, layout: string) {
   await page.goto(`http://localhost:3000/${path}`);
   await expect(page.locator(layout)).toBeVisible();

--- a/packages/pkg-new-template/tests/smoke.spec.ts
+++ b/packages/pkg-new-template/tests/smoke.spec.ts
@@ -1,10 +1,19 @@
-import {expect, test} from '@playwright/test';
+import {expect, type Page, test} from '@playwright/test';
+
+// Atomic layouts are `display: none` until the interface finishes initializing
+// and injects its generated layout styles. Waiting for the layout to become
+// visible first means the component assertions below only measure hydrated
+// elements instead of racing the interface bootstrap.
+async function gotoPage(page: Page, path: string, layout: string) {
+  await page.goto(`http://localhost:3000/${path}`);
+  await expect(page.locator(layout)).toBeVisible();
+}
 
 test.describe('smoke test', () => {
   test.use({viewport: {width: 2000, height: 2000}});
 
   test('Search Page', async ({page}) => {
-    await page.goto('http://localhost:3000/search.html');
+    await gotoPage(page, 'search.html', 'atomic-search-layout');
 
     await expect(page.locator('atomic-search-box')).toBeVisible();
     await expect(page.locator('atomic-result-list')).toBeVisible();
@@ -12,7 +21,7 @@ test.describe('smoke test', () => {
   });
 
   test('Commerce Search Page', async ({page}) => {
-    await page.goto('http://localhost:3000/commerce.html');
+    await gotoPage(page, 'commerce.html', 'atomic-commerce-layout');
 
     await expect(page.locator('atomic-commerce-search-box')).toBeVisible();
     await expect(page.locator('atomic-commerce-product-list')).toBeVisible();
@@ -20,7 +29,7 @@ test.describe('smoke test', () => {
   });
 
   test('Insight Page', async ({page}) => {
-    await page.goto('http://localhost:3000/insight.html');
+    await gotoPage(page, 'insight.html', 'atomic-insight-layout');
 
     await expect(page.locator('atomic-insight-search-box')).toBeVisible();
     await expect(page.locator('atomic-insight-result-list')).toBeVisible();


### PR DESCRIPTION
[KIT-6073](https://coveord.atlassian.net/browse/KIT-6073)

## Problem

The `@coveo/pkg-new-template` smoke test `Search Page` fails intermittently in CI, exhausting all retries with `expect(locator('atomic-search-box')).toBeVisible()` receiving `hidden` ([example run](https://github.com/coveo/ui-kit/actions/runs/32135350559/job/95706599016?pr=8244)).

`atomic-search-layout` is `display: none` until the search interface finishes initializing and injects its generated layout styles, so every descendant has a zero-size box and Playwright reports it as hidden. The test relied on the default 5s `expect` timeout, which is not enough for a cold Vite dev-server transform of the whole Atomic ESM graph plus a live request to the `searchuisamples` org on a single-worker CI runner. The retry log confirms this: the element eventually hydrated (`clear-filters`, `number-of-queries` present) but was still measured as hidden when the timeout expired. `Search Page` runs first, so it absorbs the cold-start cost, which is why the Commerce and Insight tests pass.

## Solution

- Each test now waits for its layout element (`atomic-search-layout`, `atomic-commerce-layout`, `atomic-insight-layout`) to become visible before asserting on individual components, so the component assertions only measure a hydrated interface instead of racing the bootstrap. A failure now points at interface initialization rather than at an arbitrary component.
- Raised the `expect` timeout to 30s and the per-test timeout to 90s in `playwright.config.ts` to cover cold-start plus live API latency.

Verified locally with `CI=1 pnpm --filter @coveo/pkg-new-template test`: 3 passed.

[KIT-6073]: https://coveord.atlassian.net/browse/KIT-6073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ