### PR TITLE
chore(thermidor-schema): split build configuration

### DIFF
--- a/packages/thermidor-schema/package.json
+++ b/packages/thermidor-schema/package.json
@@ -33,7 +33,7 @@
     "validate:freshness:src": "node --experimental-strip-types scripts/check-freshness.ts src",
     "validate:freshness:dist": "node --experimental-strip-types scripts/check-freshness.ts dist",
     "publint": "publint",
-    "build": "tsc --project tsconfig.json",
+    "build": "tsc --project tsconfig.build.json",
     "test": "vitest run",
     "clean": "rm -rf dist"
   },

--- a/packages/thermidor-schema/tsconfig.build.json
+++ b/packages/thermidor-schema/tsconfig.build.json
@@ -2,15 +2,16 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "rootDir": "src/",
+    "outDir": "dist/",
     "moduleResolution": "NodeNext",
-    "noEmit": true,
-    "allowImportingTsExtensions": true,
     "module": "NodeNext",
     "target": "ES2022",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "types": ["node"]
+    "types": ["node"],
+    "composite": true
   },
-  "include": ["src/**/*.ts", "scripts/**/*.ts"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Motivation

Thermidor Schema's editor and generator scripts need TypeScript settings that differ from its emitting package build. Keeping both concerns in one configuration prevents script imports from being type-checked naturally while preserving declaration output.

## Changes

- Add `tsconfig.build.json` as the emitting package configuration.
- Keep `tsconfig.json` as a no-emit editor/script configuration with TypeScript-extension imports enabled.
- Point the package build script at the build-only configuration.

## Validation

- `pnpm --filter @coveo/thermidor-schema generate:check`
- `pnpm --filter @coveo/thermidor-schema build`
- `pnpm --filter @coveo/thermidor-schema test`
- `pnpm --filter @coveo/thermidor-schema publint`
- `git diff --check`

## Checklist

- [x] PR title follows Conventional Commits 1.0.0 format
- [x] The PR contains only the three-file build-configuration split
- [x] No changeset is required because runtime and public API output are unchanged