### PR TITLE
chore(ci): benchmark Bun for Atomic generators

### DIFF
--- a/.github/scripts/benchmark-atomic-runtime.mjs
+++ b/.github/scripts/benchmark-atomic-runtime.mjs
@@ -1,0 +1,192 @@
+import {spawnSync} from 'node:child_process';
+import {createHash} from 'node:crypto';
+import {appendFileSync, existsSync, readdirSync, readFileSync, rmSync, statSync} from 'node:fs';
+import {dirname, relative, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {performance} from 'node:perf_hooks';
+
+const iterations = 30;
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const atomicRoot = resolve(repositoryRoot, 'packages/atomic');
+const bunExecutable = process.env.BUN_BIN;
+
+if (!bunExecutable) {
+  throw new Error('BUN_BIN must point to the Bun executable');
+}
+
+const runtimes = [
+  {name: 'Node', executable: process.execPath},
+  {name: 'Bun', executable: bunExecutable},
+];
+const tasks = [
+  {
+    name: 'build:locales',
+    script: 'scripts/build-locales.mjs',
+    outputs: ['src/assets/lang', 'src/generated', 'dist/lang'],
+  },
+  {
+    name: 'build:assets',
+    script: 'scripts/build-assets.mjs',
+    outputs: ['dist/assets'],
+  },
+  {
+    name: 'build:themes',
+    script: 'scripts/build-themes.mjs',
+    outputs: ['dist/themes'],
+  },
+];
+
+function clean(task) {
+  for (const output of task.outputs) {
+    rmSync(resolve(atomicRoot, output), {recursive: true, force: true});
+  }
+}
+
+function execute(runtime, task) {
+  clean(task);
+  const start = performance.now();
+  const result = spawnSync(runtime.executable, [task.script], {
+    cwd: atomicRoot,
+    encoding: 'utf8',
+  });
+  const duration = performance.now() - start;
+
+  if (result.status !== 0) {
+    throw new Error(
+      `${runtime.name} failed ${task.name}:\n${result.stdout ?? ''}\n${result.stderr ?? ''}`
+    );
+  }
+
+  return duration;
+}
+
+function filesUnder(directory) {
+  if (!existsSync(directory)) {
+    return [];
+  }
+
+  return readdirSync(directory, {withFileTypes: true}).flatMap((entry) => {
+    const path = resolve(directory, entry.name);
+    return entry.isDirectory() ? filesUnder(path) : [path];
+  });
+}
+
+function outputManifest(task) {
+  return Object.fromEntries(
+    task.outputs
+      .flatMap((output) => filesUnder(resolve(atomicRoot, output)))
+      .filter((path) => statSync(path).isFile())
+      .sort()
+      .map((path) => [
+        relative(atomicRoot, path),
+        createHash('sha256').update(readFileSync(path)).digest('hex'),
+      ])
+  );
+}
+
+function runtimeVersion(runtime) {
+  const result = spawnSync(runtime.executable, ['--version'], {encoding: 'utf8'});
+  if (result.status !== 0) {
+    throw new Error(`Could not determine the ${runtime.name} version`);
+  }
+  return result.stdout.trim();
+}
+
+function median(values) {
+  const sorted = values.toSorted((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+}
+
+function percentile(values, percentileValue) {
+  const sorted = values.toSorted((left, right) => left - right);
+  return sorted[Math.ceil(sorted.length * percentileValue) - 1];
+}
+
+function formatMilliseconds(value) {
+  return `${value.toFixed(2)} ms`;
+}
+
+const equivalentOutputs = new Map();
+for (const task of tasks) {
+  execute(runtimes[0], task);
+  const nodeManifest = outputManifest(task);
+  execute(runtimes[1], task);
+  equivalentOutputs.set(
+    task.name,
+    JSON.stringify(nodeManifest) === JSON.stringify(outputManifest(task))
+  );
+}
+
+for (const runtime of runtimes) {
+  for (const task of tasks) {
+    execute(runtime, task);
+  }
+}
+
+const samples = new Map(
+  runtimes.flatMap((runtime) => tasks.map((task) => [`${runtime.name}:${task.name}`, []]))
+);
+
+for (let iteration = 0; iteration < iterations; iteration++) {
+  const orderedRuntimes = iteration % 2 === 0 ? runtimes : runtimes.toReversed();
+  const orderedTasks = [
+    ...tasks.slice(iteration % tasks.length),
+    ...tasks.slice(0, iteration % tasks.length),
+  ];
+
+  for (const task of orderedTasks) {
+    for (const runtime of orderedRuntimes) {
+      samples.get(`${runtime.name}:${task.name}`).push(execute(runtime, task));
+    }
+  }
+}
+
+const rows = tasks.map((task) => {
+  const nodeSamples = samples.get(`Node:${task.name}`);
+  const bunSamples = samples.get(`Bun:${task.name}`);
+  const nodeMedian = median(nodeSamples);
+  const bunMedian = median(bunSamples);
+
+  return {
+    task: task.name,
+    nodeMedian,
+    bunMedian,
+    nodeP95: percentile(nodeSamples, 0.95),
+    bunP95: percentile(bunSamples, 0.95),
+    saved: nodeMedian - bunMedian,
+    speedup: nodeMedian / bunMedian,
+    equivalent: equivalentOutputs.get(task.name),
+  };
+});
+
+const totalNodeMedian = rows.reduce((total, row) => total + row.nodeMedian, 0);
+const totalBunMedian = rows.reduce((total, row) => total + row.bunMedian, 0);
+const summary = [
+  '# Atomic Node vs Bun benchmark',
+  '',
+  `- Runner: \`${process.platform}/${process.arch}\``,
+  `- Node: \`${runtimeVersion(runtimes[0])}\``,
+  `- Bun: \`${runtimeVersion(runtimes[1])}\``,
+  `- Iterations: ${iterations} per runtime and task`,
+  '',
+  '| Task | Node median | Bun median | Node p95 | Bun p95 | Median saved | Speedup | Byte-identical |',
+  '| --- | ---: | ---: | ---: | ---: | ---: | ---: | :---: |',
+  ...rows.map(
+    (row) =>
+      `| \`${row.task}\` | ${formatMilliseconds(row.nodeMedian)} | ${formatMilliseconds(row.bunMedian)} | ${formatMilliseconds(row.nodeP95)} | ${formatMilliseconds(row.bunP95)} | ${formatMilliseconds(row.saved)} | ${row.speedup.toFixed(2)}x | ${row.equivalent ? 'yes' : 'no'} |`
+  ),
+  `| **Sequential total** | **${formatMilliseconds(totalNodeMedian)}** | **${formatMilliseconds(totalBunMedian)}** | | | **${formatMilliseconds(totalNodeMedian - totalBunMedian)}** | **${(totalNodeMedian / totalBunMedian).toFixed(2)}x** | |`,
+  '',
+  '> Turbo can run these tasks concurrently, so the sequential total is an upper bound. The slowest task is a closer approximation of critical-path savings.',
+  '',
+].join('\n');
+
+console.log(summary);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+}
+
+if (rows.some((row) => !row.equivalent)) {
+  process.exitCode = 1;
+}

--- a/.github/workflows/atomic-bun-benchmark.yml
+++ b/.github/workflows/atomic-bun-benchmark.yml
@@ -1,0 +1,35 @@
+name: Atomic Bun benchmark
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/scripts/benchmark-atomic-runtime.mjs'
+      - '.github/workflows/atomic-bun-benchmark.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: Compare Node and Bun on Atomic generators
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - uses: ./.github/actions/setup
+
+      - name: Install Bun for the benchmark
+        run: mise install bun@1.3.14
+
+      - name: Resolve the Bun executable
+        run: echo "BUN_BIN=$(mise exec bun@1.3.14 -- which bun)" >> "$GITHUB_ENV"
+
+      - name: Benchmark Atomic generation scripts
+        run: node .github/scripts/benchmark-atomic-runtime.mjs


### PR DESCRIPTION
https://coveord.atlassian.net/browse/KIT-5536

## Motivation

Measure whether Bun improves Atomic generator performance on the less-performant GitHub-hosted Linux CI runner before changing production package scripts.

## Changes

- add a temporary Node-versus-Bun benchmark for three Atomic generation scripts
- run 30 interleaved clean-output iterations per runtime and report median and p95 timings
- fail if Node and Bun do not produce byte-identical outputs
- install Bun only in the isolated benchmark job

This is a disposable measurement PR and is not intended to merge as-is.

## CI results

Measured on GitHub's `ubuntu-latest` runner with Node 24.18.1 and Bun 1.3.14:

| Task | Node median | Bun median | Saved | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `build:locales` | 55.98 ms | 45.14 ms | 10.84 ms | 1.24x |
| `build:assets` | 182.27 ms | 116.92 ms | 65.35 ms | 1.56x |
| `build:themes` | 34.58 ms | 27.95 ms | 6.63 ms | 1.24x |
| **Sequential total** | **272.83 ms** | **190.01 ms** | **82.82 ms** | **1.44x** |

All generated outputs were byte-identical. Since Turbo runs these tasks concurrently, the practical critical-path saving is approximately 65 ms. The cold Bun installation took approximately 0.92 seconds, so these generators alone do not justify adding Bun to CI; remote-cache hits would reduce the benefit further.

Benchmark job: https://github.com/coveo/ui-kit/actions/runs/32266366080/job/96111736931

## Validation

- [x] Benchmark passes locally with Node 24.18.1 and Bun 1.3.14
- [x] Benchmark passes on GitHub's Linux runner
- [x] All compared outputs are byte-identical locally and in CI
- [x] Formatting and script syntax checks pass
- [x] No new features or bug fixes are included in this PR
- [x] Public API surface is unchanged

## Checklist

- [x] PR title follows Conventional Commits 1.0.0
- [x] No changeset is needed because no public package source code is modified