### PR TITLE
chore(KIT-6078): build affected packages before Knip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,10 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
+      - uses: ./.github/actions/run-affected
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: build
       - name: Run selected Knip workspaces
         env:
           PROJECTS: ${{ needs.affected.outputs.projects }}

--- a/knip.js
+++ b/knip.js
@@ -5,6 +5,7 @@ export default {
   ignoreDependencies: ['semver'],
   ignore: [
     '.agents/skills/**',
+    '.github/actions/run-affected/test-resolve-tasks.mjs',
     'packages/quantic/**',
     'samples/headless/rga-react/src/components/Quickstart.tsx',
     'samples/headless/rga-react/src/components/Citation.tsx',


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6078

## Motivation

Ensure affected packages are built before Knip analyzes selected workspaces in CI.

See error at https://github.com/coveo/ui-kit/actions/runs/32286147273/job/96177533400

## Changes

Added the affected `build` task to the Knip CI job using the calculated affected task set.

## Validation

- [x] `pnpm run lint:fix`
- [x] `pnpm run lint:check`
- [x] `git diff --check`
- [x] All existing tests pass without modification
- [x] No new features or bug fixes are included in this PR
- [x] Public API surface is unchanged

## Checklist

- [x] PR title follows Conventional Commits 1.0.0 format (`chore(<scope>): <description>`)
- [x] No changeset required: this changes CI configuration only.