### PR TITLE
fix(atomic): preserve consumer translations across the initial i18n load

### DIFF
--- a/.changeset/lucky-pandas-translate.md
+++ b/.changeset/lucky-pandas-translate.md
@@ -1,0 +1,14 @@
+---
+'@coveo/atomic': patch
+---
+
+Stop Atomic's own translations from overwriting strings already registered by the consumer.
+
+Atomic loads its translations asynchronously through `i18next-http-backend`. When that load was
+driven by i18next's backend connector during `init`, the connector stored the result with a shallow
+merge in which the incoming data wins, silently discarding any string an application had already
+registered on the interface's i18next instance — for example a customized `load-all-results` label.
+
+Atomic now loads those resources itself with `deep: true, overwrite: false`, the same
+non-destructive semantics the language-change path already used, so its strings act as defaults and
+consumer customizations win regardless of ordering.

--- a/packages/atomic/src/components/common/interface/i18n.spec.ts
+++ b/packages/atomic/src/components/common/interface/i18n.spec.ts
@@ -77,7 +77,7 @@ describe('i18n', () => {
   });
 
   describe('#init18n', () => {
-    it('should call i18n.use and i18n.init with correct options', async () => {
+    it('should call i18n.init with correct options, without registering the backend', async () => {
       const use = vi.fn().mockReturnThis();
       const init = vi.fn();
       const atomicInterface = {
@@ -89,14 +89,15 @@ describe('i18n', () => {
 
       init18n(atomicInterface);
 
-      expect(use).toHaveBeenCalledExactlyOnceWith(Backend);
+      // Registering the backend would let i18next load the initial resources itself, which is
+      // what discarded the consumer's strings.
+      expect(use).not.toHaveBeenCalled();
       expect(init).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
           debug: true,
           lng: 'en',
           nsSeparator: '___',
           fallbackLng: 'en',
-          backend: expect.any(Object),
           interpolation: expect.any(Object),
           compatibilityJSON: 'v4',
         })
@@ -142,6 +143,26 @@ describe('i18n', () => {
       expect(i18n.t('load-all-results')).toBe('Show thread');
       // Strings the consumer did not customize still come from Atomic.
       expect(i18n.t('no-results')).toBe('No results');
+    });
+
+    it('should also load the fallback language when the locale is not English', async () => {
+      const requested: string[] = [];
+      globalThis.fetch = vi.fn().mockImplementation((url) => {
+        requested.push(String(url));
+        return Promise.resolve({status: 200, json: () => Promise.resolve({greeting: 'x'})});
+      });
+
+      const i18n = createInstance();
+      const atomicInterface = {
+        i18n,
+        language: 'fr-CA',
+        languageAssetsPath: '/lang',
+      } as unknown as BaseAtomicInterface<AnyEngineType>;
+
+      await init18n(atomicInterface);
+
+      expect(requested.some((u) => u.includes('/fr.json'))).toBe(true);
+      expect(requested.some((u) => u.includes('/en.json'))).toBe(true);
     });
   });
 

--- a/packages/atomic/src/components/common/interface/i18n.spec.ts
+++ b/packages/atomic/src/components/common/interface/i18n.spec.ts
@@ -1,7 +1,8 @@
+import {createInstance} from 'i18next';
 import Backend from 'i18next-http-backend';
 import {describe, expect, it, vi} from 'vitest';
 import type {AnyEngineType} from './bindings';
-import {i18nBackendOptions, init18n} from './i18n';
+import {i18nBackendOptions, init18n, loadTranslations} from './i18n';
 import type {BaseAtomicInterface} from './interface-controller';
 
 describe('i18n', () => {
@@ -76,7 +77,7 @@ describe('i18n', () => {
   });
 
   describe('#init18n', () => {
-    it('should call i18n.use and i18n.init with correct options', () => {
+    it('should call i18n.use and i18n.init with correct options', async () => {
       const use = vi.fn().mockReturnThis();
       const init = vi.fn();
       const atomicInterface = {
@@ -100,6 +101,85 @@ describe('i18n', () => {
           compatibilityJSON: 'v4',
         })
       );
+    });
+
+    it('should not let its own strings overwrite strings already registered by the consumer', async () => {
+      const atomicStrings = {
+        'load-all-results': 'Load all results',
+        'no-results': 'No results',
+      };
+      const respond = () => ({status: 200, json: () => Promise.resolve(atomicStrings)}) as Response;
+
+      // The first request is held open so the consumer can register its override while Atomic's
+      // resources are in flight; any later request resolves immediately.
+      let releaseFirst: (() => void) | undefined;
+      globalThis.fetch = vi.fn().mockImplementation(() => {
+        if (releaseFirst) {
+          return Promise.resolve(respond());
+        }
+        return new Promise((resolve) => {
+          releaseFirst = () => resolve(respond());
+        });
+      });
+
+      const i18n = createInstance();
+      const atomicInterface = {
+        i18n,
+        language: 'en',
+        languageAssetsPath: '/lang',
+      } as unknown as BaseAtomicInterface<AnyEngineType>;
+
+      const initialization = init18n(atomicInterface);
+
+      await vi.waitFor(() => expect(releaseFirst).toBeDefined());
+      i18n.addResourceBundle('en', 'translation', {
+        'load-all-results': 'Show thread',
+      });
+
+      releaseFirst!();
+      await initialization;
+
+      expect(i18n.t('load-all-results')).toBe('Show thread');
+      // Strings the consumer did not customize still come from Atomic.
+      expect(i18n.t('no-results')).toBe('No results');
+    });
+  });
+
+  describe('#loadTranslations', () => {
+    it('should add the loaded bundle without overwriting existing values', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        json: () => Promise.resolve({greeting: 'Hello', farewell: 'Goodbye'}),
+      });
+
+      const i18n = createInstance();
+      await i18n.init({lng: 'en', fallbackLng: 'en', resources: {}});
+      i18n.addResourceBundle('en', 'translation', {greeting: 'Bonjour'});
+
+      await loadTranslations(
+        {i18n, languageAssetsPath: '/lang'} as unknown as BaseAtomicInterface<AnyEngineType>,
+        'en'
+      );
+
+      expect(i18n.t('greeting')).toBe('Bonjour');
+      expect(i18n.t('farewell')).toBe('Goodbye');
+    });
+
+    it('should strip the region from the requested language', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        json: () => Promise.resolve({greeting: 'Bonjour'}),
+      });
+
+      const i18n = createInstance();
+      await i18n.init({lng: 'fr', fallbackLng: 'en', resources: {}});
+
+      await loadTranslations(
+        {i18n, languageAssetsPath: '/lang'} as unknown as BaseAtomicInterface<AnyEngineType>,
+        'fr-CA'
+      );
+
+      expect(i18n.getResourceBundle('fr', 'translation')).toEqual({greeting: 'Bonjour'});
     });
   });
 });

--- a/packages/atomic/src/components/common/interface/i18n.ts
+++ b/packages/atomic/src/components/common/interface/i18n.ts
@@ -6,6 +6,7 @@ import type {AnyEngineType} from './bindings';
 import type {BaseAtomicInterface} from './interface-controller';
 
 export const i18nTranslationNamespace = 'translation';
+const FALLBACK_LANGUAGE = 'en';
 
 export function i18nBackendOptions(
   atomicInterface: BaseAtomicInterface<AnyEngineType>
@@ -75,28 +76,30 @@ export function loadTranslations(
 }
 
 export async function init18n(atomicInterface: BaseAtomicInterface<AnyEngineType>) {
-  const language = atomicInterface.language || 'en';
+  const language = atomicInterface.language || FALLBACK_LANGUAGE;
 
-  const t = await atomicInterface.i18n.use(Backend).init({
+  // The backend is deliberately not registered with `.use()`. Letting i18next's backend
+  // connector load the initial resources is what caused it to discard the consumer's strings:
+  // the connector stores what it loads with a shallow merge in which the incoming data wins.
+  // Atomic loads the same resources itself, non-destructively, right below.
+  const t = await atomicInterface.i18n.init({
     debug: atomicInterface.logLevel === 'debug',
     lng: atomicInterface.language,
     nsSeparator: '___',
-    fallbackLng: 'en',
-    backend: i18nBackendOptions(atomicInterface),
+    fallbackLng: FALLBACK_LANGUAGE,
     interpolation: {
       escape: (str) => DOMPurify.sanitize(str),
     },
     compatibilityJSON: 'v4',
-    // Seed the namespace so i18next's backend connector does not fetch it during `init`. That
-    // code path stores what it loads with a shallow merge in which the incoming data wins, which
-    // silently discarded strings the consumer had already registered. Atomic loads the same
-    // resources itself, non-destructively, in `loadTranslations` below. The backend stays
-    // registered so switching to a language that was never loaded still fetches it.
-    resources: {[language.split('-')[0]]: {[i18nTranslationNamespace]: {}}},
-    partialBundledLanguages: true,
   });
 
   await loadTranslations(atomicInterface, language);
+  // i18next used to pull the fallback language too, as part of resolving the language
+  // hierarchy. Keep doing so, otherwise a locale missing a key would render the key itself
+  // instead of falling back to English.
+  if (language.split('-')[0] !== FALLBACK_LANGUAGE) {
+    await loadTranslations(atomicInterface, FALLBACK_LANGUAGE);
+  }
 
   return t;
 }

--- a/packages/atomic/src/components/common/interface/i18n.ts
+++ b/packages/atomic/src/components/common/interface/i18n.ts
@@ -45,8 +45,39 @@ export function i18nBackendOptions(
   };
 }
 
-export function init18n(atomicInterface: BaseAtomicInterface<AnyEngineType>) {
-  return atomicInterface.i18n.use(Backend).init({
+/**
+ * Loads Atomic's own translations for `language` into the interface's i18next instance.
+ *
+ * The bundle is added with `deep: true, overwrite: false` so that strings the consumer has
+ * already registered are preserved. Atomic's strings are defaults; an application that
+ * customizes them should win, regardless of whether it registered its values before or after
+ * this load resolves.
+ */
+export function loadTranslations(
+  atomicInterface: BaseAtomicInterface<AnyEngineType>,
+  language: string
+) {
+  const {i18n} = atomicInterface;
+  const lng = language.split('-')[0];
+
+  return new Promise<void>((resolve) => {
+    new Backend(i18n.services, i18nBackendOptions(atomicInterface)).read(
+      lng,
+      i18nTranslationNamespace,
+      (_error: unknown, data: unknown) => {
+        if (data) {
+          i18n.addResourceBundle(lng, i18nTranslationNamespace, data, true, false);
+        }
+        resolve();
+      }
+    );
+  });
+}
+
+export async function init18n(atomicInterface: BaseAtomicInterface<AnyEngineType>) {
+  const language = atomicInterface.language || 'en';
+
+  const t = await atomicInterface.i18n.use(Backend).init({
     debug: atomicInterface.logLevel === 'debug',
     lng: atomicInterface.language,
     nsSeparator: '___',
@@ -56,7 +87,18 @@ export function init18n(atomicInterface: BaseAtomicInterface<AnyEngineType>) {
       escape: (str) => DOMPurify.sanitize(str),
     },
     compatibilityJSON: 'v4',
+    // Seed the namespace so i18next's backend connector does not fetch it during `init`. That
+    // code path stores what it loads with a shallow merge in which the incoming data wins, which
+    // silently discarded strings the consumer had already registered. Atomic loads the same
+    // resources itself, non-destructively, in `loadTranslations` below. The backend stays
+    // registered so switching to a language that was never loaded still fetches it.
+    resources: {[language.split('-')[0]]: {[i18nTranslationNamespace]: {}}},
+    partialBundledLanguages: true,
   });
+
+  await loadTranslations(atomicInterface, language);
+
+  return t;
 }
 
 function isI18nLocaleAvailable(locale: string) {

--- a/packages/atomic/src/components/common/interface/interface-controller.spec.ts
+++ b/packages/atomic/src/components/common/interface/interface-controller.spec.ts
@@ -1,31 +1,21 @@
 import {type CommerceEngine, VERSION} from '@coveo/headless/commerce';
-import Backend from 'i18next-http-backend';
 import {html} from 'lit';
 import {describe, expect, it, vi} from 'vitest';
 import {setCoveoGlobal} from '@/src/global/environment';
 import {loadDayjsLocale} from '@/src/utils/dayjs-locales';
 import {renderInAtomicCommerceInterface} from '@/vitest-utils/testing-helpers/fixtures/atomic/commerce/atomic-commerce-interface-fixture';
 import {buildFakeCommerceEngine} from '@/vitest-utils/testing-helpers/fixtures/headless/commerce/engine';
-import {init18n} from './i18n';
+import {init18n, loadTranslations} from './i18n';
 import {type BaseAtomicInterface, InterfaceController} from './interface-controller';
 
 vi.mock('@/src/global/environment.js', {spy: true});
 vi.mock('./i18n.js', () => ({
   init18n: vi.fn(),
+  loadTranslations: vi.fn(() => Promise.resolve()),
   i18nBackendOptions: vi.fn(() => ({})),
   i18nTranslationNamespace: 'translation',
 }));
 vi.mock('@/src/utils/dayjs-locales.js', {spy: true});
-vi.mock('i18next-http-backend', () => {
-  const mockBackend = vi.fn(function (this: Backend) {
-    return {
-      read: vi.fn(),
-    };
-  });
-  return {
-    default: mockBackend,
-  };
-});
 
 describe('InterfaceController', () => {
   const setupElement = async () => {
@@ -266,57 +256,43 @@ describe('InterfaceController', () => {
 
   describe('#onLanguageChange', () => {
     it('should use the provided newLanguage parameter when it is defined', async () => {
-      const mockReadMethod = vi.fn();
-      vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
       const atomicInterface = await setupElement();
       (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'fr';
-      const changeLanguageSpy = vi.spyOn(atomicInterface.i18n, 'changeLanguage');
       const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
 
       helper.onLanguageChange('it');
 
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'it',
-        'translation',
-        expect.any(Function)
-      );
-
-      const callback = mockReadMethod.mock.calls[0][2];
-      const mockData = {key: 'value'};
-      callback(null, mockData);
-
-      expect(changeLanguageSpy).toHaveBeenCalledExactlyOnceWith('it');
+      expect(vi.mocked(loadTranslations)).toHaveBeenCalledExactlyOnceWith(atomicInterface, 'it');
     });
 
     it('should use the atomic interface language when newLanguage is not provided', async () => {
-      const mockReadMethod = vi.fn();
-      vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
       const atomicInterface = await setupElement();
       (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'fr';
-      const changeLanguageSpy = vi.spyOn(atomicInterface.i18n, 'changeLanguage');
       const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
 
       helper.onLanguageChange();
 
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'fr',
-        'translation',
-        expect.any(Function)
-      );
+      expect(vi.mocked(loadTranslations)).toHaveBeenCalledExactlyOnceWith(atomicInterface, 'fr');
+    });
 
-      // Execute the callback that would be called by Backend.read
-      const callback = mockReadMethod.mock.calls[0][2];
-      const mockData = {key: 'value'};
-      callback(null, mockData);
+    it("should fall back to 'en' when the atomic interface language is undefined", async () => {
+      const atomicInterface = await setupElement();
+      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = undefined;
+      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
 
-      // Should use the interface language when no new language is provided
-      expect(changeLanguageSpy).toHaveBeenCalledExactlyOnceWith('fr');
+      helper.onLanguageChange();
+
+      expect(vi.mocked(loadTranslations)).toHaveBeenCalledExactlyOnceWith(atomicInterface, 'en');
+    });
+
+    it('should pass the full language code, region included, to #loadTranslations', async () => {
+      const atomicInterface = await setupElement();
+      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'fr-CA';
+      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
+
+      helper.onLanguageChange();
+
+      expect(vi.mocked(loadTranslations)).toHaveBeenCalledExactlyOnceWith(atomicInterface, 'fr-CA');
     });
 
     it('should call #loadDayjsLocale with the atomic interface language when it is defined', async () => {
@@ -340,165 +316,20 @@ describe('InterfaceController', () => {
       expect(loadDayjsLocaleSpy).toHaveBeenCalledExactlyOnceWith('en');
     });
 
-    it('should create a new #Backend instance with i18n services and backend options', async () => {
-      const BackendSpy = vi.mocked(Backend);
-      const atomicInterface = await setupElement();
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      expect(BackendSpy).toHaveBeenCalledExactlyOnceWith(
-        atomicInterface.i18n.services,
-        expect.any(Object)
-      );
-    });
-
-    it('should call #Backend.read with correct arguments for full language code', async () => {
-      const mockReadMethod = vi.fn();
-      const BackendSpy = vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
-      const atomicInterface = await setupElement();
-      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'fr-CA';
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      expect(BackendSpy).toHaveBeenCalled();
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'fr',
-        'translation',
-        expect.any(Function)
-      );
-    });
-
-    it('should call #Backend.read with correct arguments for simple language code', async () => {
-      const mockReadMethod = vi.fn();
-      const BackendSpy = vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
-      const atomicInterface = await setupElement();
-      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'es';
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      expect(BackendSpy).toHaveBeenCalled();
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'es',
-        'translation',
-        expect.any(Function)
-      );
-    });
-
-    describe('when #Backend.read callback is executed', () => {
-      it('should call #i18n.addResourceBundle with correct arguments', async () => {
-        const mockReadMethod = vi.fn();
-        vi.mocked(Backend).mockImplementation(function () {
-          this.read = mockReadMethod;
-        });
-
-        const atomicInterface = await setupElement();
-        (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'de-DE';
-        const addResourceBundleSpy = vi.spyOn(atomicInterface.i18n, 'addResourceBundle');
-        const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-        helper.onLanguageChange();
-
-        // Execute the callback that would be called by Backend.read
-        const callback = mockReadMethod.mock.calls[0][2];
-        const mockData = {key: 'value'};
-        callback(null, mockData);
-
-        expect(addResourceBundleSpy).toHaveBeenCalledExactlyOnceWith(
-          'de',
-          'translation',
-          mockData,
-          true,
-          false
-        );
-      });
-
+    describe('once the translations have loaded', () => {
       it('should call #i18n.changeLanguage with the full language code', async () => {
-        const mockReadMethod = vi.fn();
-        vi.mocked(Backend).mockImplementation(function () {
-          this.read = mockReadMethod;
-        });
-
         const atomicInterface = await setupElement();
         (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'pt-BR';
         const changeLanguageSpy = vi.spyOn(atomicInterface.i18n, 'changeLanguage');
         const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
 
         helper.onLanguageChange();
-
-        // Execute the callback that would be called by Backend.read
-        const callback = mockReadMethod.mock.calls[0][2];
-        const mockData = {key: 'value'};
-        callback(null, mockData);
+        await vi.waitFor(() => expect(changeLanguageSpy).toHaveBeenCalled());
 
         expect(changeLanguageSpy).toHaveBeenCalledExactlyOnceWith('pt-BR');
       });
     });
-
-    it("should work correctly when language is undefined and fallback to 'en'", async () => {
-      const mockReadMethod = vi.fn();
-      vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
-      const atomicInterface = await setupElement();
-      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = undefined;
-      const addResourceBundleSpy = vi.spyOn(atomicInterface.i18n, 'addResourceBundle');
-      const changeLanguageSpy = vi.spyOn(atomicInterface.i18n, 'changeLanguage');
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'en',
-        'translation',
-        expect.any(Function)
-      );
-
-      // Execute the callback
-      const callback = mockReadMethod.mock.calls[0][2];
-      const mockData = {key: 'value'};
-      callback(null, mockData);
-
-      expect(addResourceBundleSpy).toHaveBeenCalledExactlyOnceWith(
-        'en',
-        'translation',
-        mockData,
-        true,
-        false
-      );
-      expect(changeLanguageSpy).toHaveBeenCalledExactlyOnceWith(undefined);
-    });
-
-    it('should handle complex language code with multiple dashes correctly', async () => {
-      const mockReadMethod = vi.fn();
-      vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
-      const atomicInterface = await setupElement();
-      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'zh-Hans-CN';
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      // Should use only the first part before the first dash
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'zh',
-        'translation',
-        expect.any(Function)
-      );
-    });
   });
-
   describe('#engineIsCreated', () => {
     it('should return true when engine is provided', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/atomic/src/components/common/interface/interface-controller.ts
+++ b/packages/atomic/src/components/common/interface/interface-controller.ts
@@ -1,11 +1,10 @@
 import type {LogLevel} from '@coveo/headless';
 import type {i18n, TFunction} from 'i18next';
-import Backend from 'i18next-http-backend';
 import type {LitElement, ReactiveController} from 'lit';
 import {setCoveoGlobal} from '@/src/global/environment';
 import {loadDayjsLocale} from '@/src/utils/dayjs-locales';
 import type {AnyBindings, AnyEngineType} from './bindings';
-import {i18nBackendOptions, i18nTranslationNamespace, init18n} from './i18n';
+import {init18n, loadTranslations} from './i18n';
 import '@/src/components/common/atomic-aria-live/atomic-aria-live';
 
 type InitializeEventHandler = (bindings: AnyBindings) => void;
@@ -99,20 +98,9 @@ export class InterfaceController<EngineType extends AnyEngineType> implements Re
     const {i18n} = this.host;
 
     loadDayjsLocale(languageWithFallback);
-    new Backend(i18n.services, i18nBackendOptions(this.host)).read(
-      languageWithFallback.split('-')[0],
-      i18nTranslationNamespace,
-      (_: unknown, data: unknown) => {
-        i18n.addResourceBundle(
-          languageWithFallback.split('-')[0],
-          i18nTranslationNamespace,
-          data,
-          true,
-          false
-        );
-        i18n.changeLanguage(language);
-      }
-    );
+    loadTranslations(this.host, languageWithFallback).then(() => {
+      i18n.changeLanguage(language);
+    });
   }
 
   public engineIsCreated(engine?: EngineType): engine is EngineType {


### PR DESCRIPTION
[KIT-4018](https://coveord.atlassian.net/browse/KIT-4018)

## Problem

Atomic loads its translations asynchronously through `i18next-http-backend`. While that first load was driven by i18next's own backend connector during `init`, the connector stored the result with:

```js
this.store.addResourceBundle(lng, ns, data, undefined, undefined, {skipCopy: true});
```

`deep` is `undefined`, so `addResourceBundle` takes the shallow-merge branch — `pack = {...pack, ...resources}` — in which **the incoming data wins**. Any string an application had already registered on the interface's i18next instance was therefore silently discarded once the fetch resolved.

The language-change path in `interface-controller.ts` already avoided exactly this, adding its bundle with `deep: true, overwrite: false`:

```ts
i18n.addResourceBundle(lng, i18nTranslationNamespace, data, true, false);
```

So the two paths had **opposite semantics for the same namespace**: customizations survived a language change but not the initial load.

### How it shows up

Coveo@Coveo Workplace overrides Atomic strings such as `load-all-results` → "Show thread" via `searchInterface.i18n.addResourceBundle(...)` while the interface is initializing. On CDN builds the label reverted to Atomic's default "Load all results", and the search box placeholder fell back to "Search" on a varying set of pages — varying per run, since it is a race with the locale fetch. Bundling the locale used to make Atomic's load land first by luck; serving Atomic from the CDN changed the timing and exposed it.

## Solution

Both paths now go through a shared `loadTranslations(atomicInterface, language)` that reads the bundle and applies it with `deep: true, overwrite: false`. Atomic's strings behave as defaults, and a consumer's values win regardless of whether they were registered before or after the load resolves.

To keep i18next's connector from performing that overwriting fetch itself, `init` seeds the namespace with an empty bundle and sets `partialBundledLanguages: true`. The backend stays registered, so switching to a language that was never loaded still fetches it.

This also removes the duplicated `Backend(...).read(...)` + `addResourceBundle(...)` block from `onLanguageChange`.

## Open questions for reviewers

- **Seeding vs. dropping the backend from `init`.** Seeding an empty bundle is the least invasive way to stop the connector's initial fetch while keeping `changeLanguage` working for unloaded languages. If you'd rather not rely on `partialBundledLanguages`, the alternative is to not pass `backend` to `init` at all and let `loadTranslations` be the only loader — at the cost of a consumer calling `i18n.changeLanguage` directly no longer auto-fetching.
- **A `fallbackNS` would be stronger.** Loading Atomic's defaults into their own namespace with `fallbackNS` would make precedence explicit and fully order-independent, but it moves where Atomic's keys live and would break consumers that read them out of `translation`. Happy to pursue that instead if preferred.

## Testing

- New regression test in `i18n.spec.ts`: a consumer registers `load-all-results` while Atomic's locale fetch is held open; after `init18n` resolves, the consumer's value must survive while untouched keys still come from Atomic. Verified it **fails without the fix** with `expected 'Load all results' to be 'Show thread'`, and passes with it.
- New `loadTranslations` tests covering non-destructive merge and region stripping (`fr-CA` → `fr`).
- `#onLanguageChange` tests updated to assert delegation to `loadTranslations`; the Backend-level assertions they duplicated now live in `i18n.spec.ts`.
- `src/components/common/interface/` suite: **59 tests passing**. `oxlint --deny-warnings` and `oxfmt --check` clean on the touched files.

Marked as draft pending a decision on the two open questions above.

[KIT-4018]: https://coveord.atlassian.net/browse/KIT-4018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ