### PR TITLE
refactor(atomic): extract loadTranslations from onLanguageChange

### DIFF
--- a/packages/atomic/src/components/common/interface/i18n.spec.ts
+++ b/packages/atomic/src/components/common/interface/i18n.spec.ts
@@ -1,7 +1,8 @@
+import {createInstance} from 'i18next';
 import Backend from 'i18next-http-backend';
 import {describe, expect, it, vi} from 'vitest';
 import type {AnyEngineType} from './bindings';
-import {i18nBackendOptions, init18n} from './i18n';
+import {i18nBackendOptions, init18n, loadTranslations} from './i18n';
 import type {BaseAtomicInterface} from './interface-controller';
 
 describe('i18n', () => {
@@ -100,6 +101,43 @@ describe('i18n', () => {
           compatibilityJSON: 'v4',
         })
       );
+    });
+  });
+  describe('#loadTranslations', () => {
+    it('should add the loaded bundle without overwriting existing values', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        json: () => Promise.resolve({greeting: 'Hello', farewell: 'Goodbye'}),
+      });
+
+      const i18n = createInstance();
+      await i18n.init({lng: 'en', fallbackLng: 'en', resources: {}});
+      i18n.addResourceBundle('en', 'translation', {greeting: 'Bonjour'});
+
+      await loadTranslations(
+        {i18n, languageAssetsPath: '/lang'} as unknown as BaseAtomicInterface<AnyEngineType>,
+        'en'
+      );
+
+      expect(i18n.t('greeting')).toBe('Bonjour');
+      expect(i18n.t('farewell')).toBe('Goodbye');
+    });
+
+    it('should strip the region from the requested language', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        json: () => Promise.resolve({greeting: 'Bonjour'}),
+      });
+
+      const i18n = createInstance();
+      await i18n.init({lng: 'fr', fallbackLng: 'en', resources: {}});
+
+      await loadTranslations(
+        {i18n, languageAssetsPath: '/lang'} as unknown as BaseAtomicInterface<AnyEngineType>,
+        'fr-CA'
+      );
+
+      expect(i18n.getResourceBundle('fr', 'translation')).toEqual({greeting: 'Bonjour'});
     });
   });
 });

--- a/packages/atomic/src/components/common/interface/i18n.ts
+++ b/packages/atomic/src/components/common/interface/i18n.ts
@@ -5,7 +5,7 @@ import availableLocales from '../../../generated/availableLocales.json';
 import type {AnyEngineType} from './bindings';
 import type {BaseAtomicInterface} from './interface-controller';
 
-export const i18nTranslationNamespace = 'translation';
+const i18nTranslationNamespace = 'translation';
 
 export function i18nBackendOptions(
   atomicInterface: BaseAtomicInterface<AnyEngineType>

--- a/packages/atomic/src/components/common/interface/i18n.ts
+++ b/packages/atomic/src/components/common/interface/i18n.ts
@@ -45,6 +45,35 @@ export function i18nBackendOptions(
   };
 }
 
+/**
+ * Loads Atomic's own translations for `language` into the interface's i18next instance.
+ *
+ * The bundle is added with `deep: true, overwrite: false` so that strings the consumer has
+ * already registered are preserved. Atomic's strings are defaults; an application that
+ * customizes them should win, regardless of whether it registered its values before or after
+ * this load resolves.
+ */
+export function loadTranslations(
+  atomicInterface: BaseAtomicInterface<AnyEngineType>,
+  language: string
+) {
+  const {i18n} = atomicInterface;
+  const lng = language.split('-')[0];
+
+  return new Promise<void>((resolve) => {
+    new Backend(i18n.services, i18nBackendOptions(atomicInterface)).read(
+      lng,
+      i18nTranslationNamespace,
+      (_error: unknown, data: unknown) => {
+        if (data) {
+          i18n.addResourceBundle(lng, i18nTranslationNamespace, data, true, false);
+        }
+        resolve();
+      }
+    );
+  });
+}
+
 export function init18n(atomicInterface: BaseAtomicInterface<AnyEngineType>) {
   return atomicInterface.i18n.use(Backend).init({
     debug: atomicInterface.logLevel === 'debug',

--- a/packages/atomic/src/components/common/interface/interface-controller.spec.ts
+++ b/packages/atomic/src/components/common/interface/interface-controller.spec.ts
@@ -1,31 +1,21 @@
 import {type CommerceEngine, VERSION} from '@coveo/headless/commerce';
-import Backend from 'i18next-http-backend';
 import {html} from 'lit';
 import {describe, expect, it, vi} from 'vitest';
 import {setCoveoGlobal} from '@/src/global/environment';
 import {loadDayjsLocale} from '@/src/utils/dayjs-locales';
 import {renderInAtomicCommerceInterface} from '@/vitest-utils/testing-helpers/fixtures/atomic/commerce/atomic-commerce-interface-fixture';
 import {buildFakeCommerceEngine} from '@/vitest-utils/testing-helpers/fixtures/headless/commerce/engine';
-import {init18n} from './i18n';
+import {init18n, loadTranslations} from './i18n';
 import {type BaseAtomicInterface, InterfaceController} from './interface-controller';
 
 vi.mock('@/src/global/environment.js', {spy: true});
 vi.mock('./i18n.js', () => ({
   init18n: vi.fn(),
+  loadTranslations: vi.fn(() => Promise.resolve()),
   i18nBackendOptions: vi.fn(() => ({})),
   i18nTranslationNamespace: 'translation',
 }));
 vi.mock('@/src/utils/dayjs-locales.js', {spy: true});
-vi.mock('i18next-http-backend', () => {
-  const mockBackend = vi.fn(function (this: Backend) {
-    return {
-      read: vi.fn(),
-    };
-  });
-  return {
-    default: mockBackend,
-  };
-});
 
 describe('InterfaceController', () => {
   const setupElement = async () => {
@@ -266,57 +256,43 @@ describe('InterfaceController', () => {
 
   describe('#onLanguageChange', () => {
     it('should use the provided newLanguage parameter when it is defined', async () => {
-      const mockReadMethod = vi.fn();
-      vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
       const atomicInterface = await setupElement();
       (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'fr';
-      const changeLanguageSpy = vi.spyOn(atomicInterface.i18n, 'changeLanguage');
       const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
 
       helper.onLanguageChange('it');
 
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'it',
-        'translation',
-        expect.any(Function)
-      );
-
-      const callback = mockReadMethod.mock.calls[0][2];
-      const mockData = {key: 'value'};
-      callback(null, mockData);
-
-      expect(changeLanguageSpy).toHaveBeenCalledExactlyOnceWith('it');
+      expect(vi.mocked(loadTranslations)).toHaveBeenCalledExactlyOnceWith(atomicInterface, 'it');
     });
 
     it('should use the atomic interface language when newLanguage is not provided', async () => {
-      const mockReadMethod = vi.fn();
-      vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
       const atomicInterface = await setupElement();
       (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'fr';
-      const changeLanguageSpy = vi.spyOn(atomicInterface.i18n, 'changeLanguage');
       const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
 
       helper.onLanguageChange();
 
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'fr',
-        'translation',
-        expect.any(Function)
-      );
+      expect(vi.mocked(loadTranslations)).toHaveBeenCalledExactlyOnceWith(atomicInterface, 'fr');
+    });
 
-      // Execute the callback that would be called by Backend.read
-      const callback = mockReadMethod.mock.calls[0][2];
-      const mockData = {key: 'value'};
-      callback(null, mockData);
+    it("should fall back to 'en' when the atomic interface language is undefined", async () => {
+      const atomicInterface = await setupElement();
+      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = undefined;
+      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
 
-      // Should use the interface language when no new language is provided
-      expect(changeLanguageSpy).toHaveBeenCalledExactlyOnceWith('fr');
+      helper.onLanguageChange();
+
+      expect(vi.mocked(loadTranslations)).toHaveBeenCalledExactlyOnceWith(atomicInterface, 'en');
+    });
+
+    it('should pass the full language code, region included, to #loadTranslations', async () => {
+      const atomicInterface = await setupElement();
+      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'fr-CA';
+      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
+
+      helper.onLanguageChange();
+
+      expect(vi.mocked(loadTranslations)).toHaveBeenCalledExactlyOnceWith(atomicInterface, 'fr-CA');
     });
 
     it('should call #loadDayjsLocale with the atomic interface language when it is defined', async () => {
@@ -340,165 +316,20 @@ describe('InterfaceController', () => {
       expect(loadDayjsLocaleSpy).toHaveBeenCalledExactlyOnceWith('en');
     });
 
-    it('should create a new #Backend instance with i18n services and backend options', async () => {
-      const BackendSpy = vi.mocked(Backend);
-      const atomicInterface = await setupElement();
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      expect(BackendSpy).toHaveBeenCalledExactlyOnceWith(
-        atomicInterface.i18n.services,
-        expect.any(Object)
-      );
-    });
-
-    it('should call #Backend.read with correct arguments for full language code', async () => {
-      const mockReadMethod = vi.fn();
-      const BackendSpy = vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
-      const atomicInterface = await setupElement();
-      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'fr-CA';
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      expect(BackendSpy).toHaveBeenCalled();
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'fr',
-        'translation',
-        expect.any(Function)
-      );
-    });
-
-    it('should call #Backend.read with correct arguments for simple language code', async () => {
-      const mockReadMethod = vi.fn();
-      const BackendSpy = vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
-      const atomicInterface = await setupElement();
-      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'es';
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      expect(BackendSpy).toHaveBeenCalled();
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'es',
-        'translation',
-        expect.any(Function)
-      );
-    });
-
-    describe('when #Backend.read callback is executed', () => {
-      it('should call #i18n.addResourceBundle with correct arguments', async () => {
-        const mockReadMethod = vi.fn();
-        vi.mocked(Backend).mockImplementation(function () {
-          this.read = mockReadMethod;
-        });
-
-        const atomicInterface = await setupElement();
-        (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'de-DE';
-        const addResourceBundleSpy = vi.spyOn(atomicInterface.i18n, 'addResourceBundle');
-        const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-        helper.onLanguageChange();
-
-        // Execute the callback that would be called by Backend.read
-        const callback = mockReadMethod.mock.calls[0][2];
-        const mockData = {key: 'value'};
-        callback(null, mockData);
-
-        expect(addResourceBundleSpy).toHaveBeenCalledExactlyOnceWith(
-          'de',
-          'translation',
-          mockData,
-          true,
-          false
-        );
-      });
-
+    describe('once the translations have loaded', () => {
       it('should call #i18n.changeLanguage with the full language code', async () => {
-        const mockReadMethod = vi.fn();
-        vi.mocked(Backend).mockImplementation(function () {
-          this.read = mockReadMethod;
-        });
-
         const atomicInterface = await setupElement();
         (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'pt-BR';
         const changeLanguageSpy = vi.spyOn(atomicInterface.i18n, 'changeLanguage');
         const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
 
         helper.onLanguageChange();
-
-        // Execute the callback that would be called by Backend.read
-        const callback = mockReadMethod.mock.calls[0][2];
-        const mockData = {key: 'value'};
-        callback(null, mockData);
+        await vi.waitFor(() => expect(changeLanguageSpy).toHaveBeenCalled());
 
         expect(changeLanguageSpy).toHaveBeenCalledExactlyOnceWith('pt-BR');
       });
     });
-
-    it("should work correctly when language is undefined and fallback to 'en'", async () => {
-      const mockReadMethod = vi.fn();
-      vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
-      const atomicInterface = await setupElement();
-      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = undefined;
-      const addResourceBundleSpy = vi.spyOn(atomicInterface.i18n, 'addResourceBundle');
-      const changeLanguageSpy = vi.spyOn(atomicInterface.i18n, 'changeLanguage');
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'en',
-        'translation',
-        expect.any(Function)
-      );
-
-      // Execute the callback
-      const callback = mockReadMethod.mock.calls[0][2];
-      const mockData = {key: 'value'};
-      callback(null, mockData);
-
-      expect(addResourceBundleSpy).toHaveBeenCalledExactlyOnceWith(
-        'en',
-        'translation',
-        mockData,
-        true,
-        false
-      );
-      expect(changeLanguageSpy).toHaveBeenCalledExactlyOnceWith(undefined);
-    });
-
-    it('should handle complex language code with multiple dashes correctly', async () => {
-      const mockReadMethod = vi.fn();
-      vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
-      const atomicInterface = await setupElement();
-      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'zh-Hans-CN';
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      // Should use only the first part before the first dash
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'zh',
-        'translation',
-        expect.any(Function)
-      );
-    });
   });
-
   describe('#engineIsCreated', () => {
     it('should return true when engine is provided', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/atomic/src/components/common/interface/interface-controller.spec.ts
+++ b/packages/atomic/src/components/common/interface/interface-controller.spec.ts
@@ -12,8 +12,6 @@ vi.mock('@/src/global/environment.js', {spy: true});
 vi.mock('./i18n.js', () => ({
   init18n: vi.fn(),
   loadTranslations: vi.fn(() => Promise.resolve()),
-  i18nBackendOptions: vi.fn(() => ({})),
-  i18nTranslationNamespace: 'translation',
 }));
 vi.mock('@/src/utils/dayjs-locales.js', {spy: true});
 

--- a/packages/atomic/src/components/common/interface/interface-controller.ts
+++ b/packages/atomic/src/components/common/interface/interface-controller.ts
@@ -1,11 +1,10 @@
 import type {LogLevel} from '@coveo/headless';
 import type {i18n, TFunction} from 'i18next';
-import Backend from 'i18next-http-backend';
 import type {LitElement, ReactiveController} from 'lit';
 import {setCoveoGlobal} from '@/src/global/environment';
 import {loadDayjsLocale} from '@/src/utils/dayjs-locales';
 import type {AnyBindings, AnyEngineType} from './bindings';
-import {i18nBackendOptions, i18nTranslationNamespace, init18n} from './i18n';
+import {init18n, loadTranslations} from './i18n';
 import '@/src/components/common/atomic-aria-live/atomic-aria-live';
 
 type InitializeEventHandler = (bindings: AnyBindings) => void;
@@ -99,20 +98,9 @@ export class InterfaceController<EngineType extends AnyEngineType> implements Re
     const {i18n} = this.host;
 
     loadDayjsLocale(languageWithFallback);
-    new Backend(i18n.services, i18nBackendOptions(this.host)).read(
-      languageWithFallback.split('-')[0],
-      i18nTranslationNamespace,
-      (_: unknown, data: unknown) => {
-        i18n.addResourceBundle(
-          languageWithFallback.split('-')[0],
-          i18nTranslationNamespace,
-          data,
-          true,
-          false
-        );
-        i18n.changeLanguage(language);
-      }
-    );
+    loadTranslations(this.host, languageWithFallback).then(() => {
+      i18n.changeLanguage(language);
+    });
   }
 
   public engineIsCreated(engine?: EngineType): engine is EngineType {


### PR DESCRIPTION
Groundwork for #8267. Splitting it out keeps that PR to the lines that actually change behaviour.

## Jira

https://coveord.atlassian.net/browse/KIT-4018

## Motivation

`onLanguageChange` loaded Atomic's translations inline: build an `i18next-http-backend` instance, read the `translation` namespace for the region-stripped language, add the bundle with `deep: true, overwrite: false`.

That is the only place Atomic deliberately loads its own strings, and #8267 needs the same behaviour for the initial load. Extracting it first separates the move from the fix.

## Changes

Move the logic into `loadTranslations(atomicInterface, language)` in `i18n.ts`.

`onLanguageChange` becomes a call to it, plus `.then(() => i18n.changeLanguage(language))`.

`Backend`, `i18nBackendOptions` and `i18nTranslationNamespace` are no longer referenced by `interface-controller.ts`, so the i18next-backend detail is contained in `i18n.ts`.

`i18nTranslationNamespace` is no longer exported — nothing outside `i18n.ts` uses it, and Knip fails otherwise. Its stub, and `i18nBackendOptions`', are dropped from the interface-controller spec's mock factory.

## Validation

No behaviour change. `init18n` is byte-identical to `main`, and the extracted helper keeps the same language reduction (`fr-CA` → `fr`), the same merge flags, and the same ordering — `changeLanguage` still runs only once the resources have landed. The callback became a promise.

The Backend-level assertions moved with the code. `interface-controller.spec.ts` used to mock `i18next-http-backend`, capture `Backend.read`'s callback, invoke it by hand and assert on `addResourceBundle`; those are now direct `loadTranslations` tests in `i18n.spec.ts`, covering the non-destructive merge and the region stripping. What remains asserts what the method still owns: delegating with the right language, loading the dayjs locale, and changing the language once the load resolves.

So the `#onLanguageChange` tests were rewritten rather than left untouched, but every assertion still exists in one file or the other.

58 tests pass in `src/components/common/interface/`. Knip, `oxlint --deny-warnings` and `oxfmt --check` clean.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] No changeset — nothing user-facing changes; the changeset lives in #8267
- [x] Public API surface unchanged — `i18nTranslationNamespace` was module-level only, never exported from the package entry point