### PR TITLE
fix(atomic): preserve consumer translations across the initial i18n load

### DIFF
--- a/.changeset/lucky-pandas-translate.md
+++ b/.changeset/lucky-pandas-translate.md
@@ -1,0 +1,14 @@
+---
+'@coveo/atomic': patch
+---
+
+Stop Atomic's own translations from overwriting strings already registered by the consumer.
+
+Atomic loads its translations asynchronously through `i18next-http-backend`. When that load was
+driven by i18next's backend connector during `init`, the connector stored the result with a shallow
+merge in which the incoming data wins, silently discarding any string an application had already
+registered on the interface's i18next instance — for example a customized `load-all-results` label.
+
+Atomic now loads those resources itself with `deep: true, overwrite: false`, the same
+non-destructive semantics the language-change path already used, so its strings act as defaults and
+consumer customizations win regardless of ordering.

--- a/packages/atomic/src/components/common/interface/i18n.spec.ts
+++ b/packages/atomic/src/components/common/interface/i18n.spec.ts
@@ -77,7 +77,7 @@ describe('i18n', () => {
   });
 
   describe('#init18n', () => {
-    it('should call i18n.use and i18n.init with correct options', () => {
+    it('should call i18n.init with correct options, without registering the backend', async () => {
       const use = vi.fn().mockReturnThis();
       const init = vi.fn();
       const atomicInterface = {
@@ -89,20 +89,83 @@ describe('i18n', () => {
 
       init18n(atomicInterface);
 
-      expect(use).toHaveBeenCalledExactlyOnceWith(Backend);
+      // Registering the backend would let i18next load the initial resources itself, which is
+      // what discarded the consumer's strings.
+      expect(use).not.toHaveBeenCalled();
       expect(init).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
           debug: true,
           lng: 'en',
           nsSeparator: '___',
           fallbackLng: 'en',
-          backend: expect.any(Object),
           interpolation: expect.any(Object),
           compatibilityJSON: 'v4',
         })
       );
     });
+
+    it('should not let its own strings overwrite strings already registered by the consumer', async () => {
+      const atomicStrings = {
+        'load-all-results': 'Load all results',
+        'no-results': 'No results',
+      };
+      const respond = () => ({status: 200, json: () => Promise.resolve(atomicStrings)}) as Response;
+
+      // The first request is held open so the consumer can register its override while Atomic's
+      // resources are in flight; any later request resolves immediately.
+      let releaseFirst: (() => void) | undefined;
+      globalThis.fetch = vi.fn().mockImplementation(() => {
+        if (releaseFirst) {
+          return Promise.resolve(respond());
+        }
+        return new Promise((resolve) => {
+          releaseFirst = () => resolve(respond());
+        });
+      });
+
+      const i18n = createInstance();
+      const atomicInterface = {
+        i18n,
+        language: 'en',
+        languageAssetsPath: '/lang',
+      } as unknown as BaseAtomicInterface<AnyEngineType>;
+
+      const initialization = init18n(atomicInterface);
+
+      await vi.waitFor(() => expect(releaseFirst).toBeDefined());
+      i18n.addResourceBundle('en', 'translation', {
+        'load-all-results': 'Show thread',
+      });
+
+      releaseFirst!();
+      await initialization;
+
+      expect(i18n.t('load-all-results')).toBe('Show thread');
+      // Strings the consumer did not customize still come from Atomic.
+      expect(i18n.t('no-results')).toBe('No results');
+    });
+
+    it('should also load the fallback language when the locale is not English', async () => {
+      const requested: string[] = [];
+      globalThis.fetch = vi.fn().mockImplementation((url) => {
+        requested.push(String(url));
+        return Promise.resolve({status: 200, json: () => Promise.resolve({greeting: 'x'})});
+      });
+
+      const i18n = createInstance();
+      const atomicInterface = {
+        i18n,
+        language: 'fr-CA',
+        languageAssetsPath: '/lang',
+      } as unknown as BaseAtomicInterface<AnyEngineType>;
+
+      await init18n(atomicInterface);
+
+      expect(requested.some((u) => u.includes('/fr.json'))).toBe(true);
+      expect(requested.some((u) => u.includes('/en.json'))).toBe(true);
+    });
   });
+
   describe('#loadTranslations', () => {
     it('should add the loaded bundle without overwriting existing values', async () => {
       globalThis.fetch = vi.fn().mockResolvedValue({

--- a/packages/atomic/src/components/common/interface/i18n.spec.ts
+++ b/packages/atomic/src/components/common/interface/i18n.spec.ts
@@ -1,7 +1,8 @@
+import {createInstance} from 'i18next';
 import Backend from 'i18next-http-backend';
 import {describe, expect, it, vi} from 'vitest';
 import type {AnyEngineType} from './bindings';
-import {i18nBackendOptions, init18n} from './i18n';
+import {i18nBackendOptions, init18n, loadTranslations} from './i18n';
 import type {BaseAtomicInterface} from './interface-controller';
 
 describe('i18n', () => {
@@ -100,6 +101,43 @@ describe('i18n', () => {
           compatibilityJSON: 'v4',
         })
       );
+    });
+  });
+  describe('#loadTranslations', () => {
+    it('should add the loaded bundle without overwriting existing values', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        json: () => Promise.resolve({greeting: 'Hello', farewell: 'Goodbye'}),
+      });
+
+      const i18n = createInstance();
+      await i18n.init({lng: 'en', fallbackLng: 'en', resources: {}});
+      i18n.addResourceBundle('en', 'translation', {greeting: 'Bonjour'});
+
+      await loadTranslations(
+        {i18n, languageAssetsPath: '/lang'} as unknown as BaseAtomicInterface<AnyEngineType>,
+        'en'
+      );
+
+      expect(i18n.t('greeting')).toBe('Bonjour');
+      expect(i18n.t('farewell')).toBe('Goodbye');
+    });
+
+    it('should strip the region from the requested language', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        json: () => Promise.resolve({greeting: 'Bonjour'}),
+      });
+
+      const i18n = createInstance();
+      await i18n.init({lng: 'fr', fallbackLng: 'en', resources: {}});
+
+      await loadTranslations(
+        {i18n, languageAssetsPath: '/lang'} as unknown as BaseAtomicInterface<AnyEngineType>,
+        'fr-CA'
+      );
+
+      expect(i18n.getResourceBundle('fr', 'translation')).toEqual({greeting: 'Bonjour'});
     });
   });
 });

--- a/packages/atomic/src/components/common/interface/i18n.ts
+++ b/packages/atomic/src/components/common/interface/i18n.ts
@@ -5,7 +5,7 @@ import availableLocales from '../../../generated/availableLocales.json';
 import type {AnyEngineType} from './bindings';
 import type {BaseAtomicInterface} from './interface-controller';
 
-export const i18nTranslationNamespace = 'translation';
+const i18nTranslationNamespace = 'translation';
 
 export function i18nBackendOptions(
   atomicInterface: BaseAtomicInterface<AnyEngineType>

--- a/packages/atomic/src/components/common/interface/i18n.ts
+++ b/packages/atomic/src/components/common/interface/i18n.ts
@@ -6,6 +6,7 @@ import type {AnyEngineType} from './bindings';
 import type {BaseAtomicInterface} from './interface-controller';
 
 const i18nTranslationNamespace = 'translation';
+const FALLBACK_LANGUAGE = 'en';
 
 export function i18nBackendOptions(
   atomicInterface: BaseAtomicInterface<AnyEngineType>
@@ -74,18 +75,33 @@ export function loadTranslations(
   });
 }
 
-export function init18n(atomicInterface: BaseAtomicInterface<AnyEngineType>) {
-  return atomicInterface.i18n.use(Backend).init({
+export async function init18n(atomicInterface: BaseAtomicInterface<AnyEngineType>) {
+  const language = atomicInterface.language || FALLBACK_LANGUAGE;
+
+  // The backend is deliberately not registered with `.use()`. Letting i18next's backend
+  // connector load the initial resources is what caused it to discard the consumer's strings:
+  // the connector stores what it loads with a shallow merge in which the incoming data wins.
+  // Atomic loads the same resources itself, non-destructively, right below.
+  const t = await atomicInterface.i18n.init({
     debug: atomicInterface.logLevel === 'debug',
     lng: atomicInterface.language,
     nsSeparator: '___',
-    fallbackLng: 'en',
-    backend: i18nBackendOptions(atomicInterface),
+    fallbackLng: FALLBACK_LANGUAGE,
     interpolation: {
       escape: (str) => DOMPurify.sanitize(str),
     },
     compatibilityJSON: 'v4',
   });
+
+  await loadTranslations(atomicInterface, language);
+  // i18next used to pull the fallback language too, as part of resolving the language
+  // hierarchy. Keep doing so, otherwise a locale missing a key would render the key itself
+  // instead of falling back to English.
+  if (language.split('-')[0] !== FALLBACK_LANGUAGE) {
+    await loadTranslations(atomicInterface, FALLBACK_LANGUAGE);
+  }
+
+  return t;
 }
 
 function isI18nLocaleAvailable(locale: string) {

--- a/packages/atomic/src/components/common/interface/i18n.ts
+++ b/packages/atomic/src/components/common/interface/i18n.ts
@@ -45,6 +45,35 @@ export function i18nBackendOptions(
   };
 }
 
+/**
+ * Loads Atomic's own translations for `language` into the interface's i18next instance.
+ *
+ * The bundle is added with `deep: true, overwrite: false` so that strings the consumer has
+ * already registered are preserved. Atomic's strings are defaults; an application that
+ * customizes them should win, regardless of whether it registered its values before or after
+ * this load resolves.
+ */
+export function loadTranslations(
+  atomicInterface: BaseAtomicInterface<AnyEngineType>,
+  language: string
+) {
+  const {i18n} = atomicInterface;
+  const lng = language.split('-')[0];
+
+  return new Promise<void>((resolve) => {
+    new Backend(i18n.services, i18nBackendOptions(atomicInterface)).read(
+      lng,
+      i18nTranslationNamespace,
+      (_error: unknown, data: unknown) => {
+        if (data) {
+          i18n.addResourceBundle(lng, i18nTranslationNamespace, data, true, false);
+        }
+        resolve();
+      }
+    );
+  });
+}
+
 export function init18n(atomicInterface: BaseAtomicInterface<AnyEngineType>) {
   return atomicInterface.i18n.use(Backend).init({
     debug: atomicInterface.logLevel === 'debug',

--- a/packages/atomic/src/components/common/interface/interface-controller.spec.ts
+++ b/packages/atomic/src/components/common/interface/interface-controller.spec.ts
@@ -1,31 +1,21 @@
 import {type CommerceEngine, VERSION} from '@coveo/headless/commerce';
-import Backend from 'i18next-http-backend';
 import {html} from 'lit';
 import {describe, expect, it, vi} from 'vitest';
 import {setCoveoGlobal} from '@/src/global/environment';
 import {loadDayjsLocale} from '@/src/utils/dayjs-locales';
 import {renderInAtomicCommerceInterface} from '@/vitest-utils/testing-helpers/fixtures/atomic/commerce/atomic-commerce-interface-fixture';
 import {buildFakeCommerceEngine} from '@/vitest-utils/testing-helpers/fixtures/headless/commerce/engine';
-import {init18n} from './i18n';
+import {init18n, loadTranslations} from './i18n';
 import {type BaseAtomicInterface, InterfaceController} from './interface-controller';
 
 vi.mock('@/src/global/environment.js', {spy: true});
 vi.mock('./i18n.js', () => ({
   init18n: vi.fn(),
+  loadTranslations: vi.fn(() => Promise.resolve()),
   i18nBackendOptions: vi.fn(() => ({})),
   i18nTranslationNamespace: 'translation',
 }));
 vi.mock('@/src/utils/dayjs-locales.js', {spy: true});
-vi.mock('i18next-http-backend', () => {
-  const mockBackend = vi.fn(function (this: Backend) {
-    return {
-      read: vi.fn(),
-    };
-  });
-  return {
-    default: mockBackend,
-  };
-});
 
 describe('InterfaceController', () => {
   const setupElement = async () => {
@@ -266,57 +256,43 @@ describe('InterfaceController', () => {
 
   describe('#onLanguageChange', () => {
     it('should use the provided newLanguage parameter when it is defined', async () => {
-      const mockReadMethod = vi.fn();
-      vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
       const atomicInterface = await setupElement();
       (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'fr';
-      const changeLanguageSpy = vi.spyOn(atomicInterface.i18n, 'changeLanguage');
       const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
 
       helper.onLanguageChange('it');
 
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'it',
-        'translation',
-        expect.any(Function)
-      );
-
-      const callback = mockReadMethod.mock.calls[0][2];
-      const mockData = {key: 'value'};
-      callback(null, mockData);
-
-      expect(changeLanguageSpy).toHaveBeenCalledExactlyOnceWith('it');
+      expect(vi.mocked(loadTranslations)).toHaveBeenCalledExactlyOnceWith(atomicInterface, 'it');
     });
 
     it('should use the atomic interface language when newLanguage is not provided', async () => {
-      const mockReadMethod = vi.fn();
-      vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
       const atomicInterface = await setupElement();
       (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'fr';
-      const changeLanguageSpy = vi.spyOn(atomicInterface.i18n, 'changeLanguage');
       const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
 
       helper.onLanguageChange();
 
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'fr',
-        'translation',
-        expect.any(Function)
-      );
+      expect(vi.mocked(loadTranslations)).toHaveBeenCalledExactlyOnceWith(atomicInterface, 'fr');
+    });
 
-      // Execute the callback that would be called by Backend.read
-      const callback = mockReadMethod.mock.calls[0][2];
-      const mockData = {key: 'value'};
-      callback(null, mockData);
+    it("should fall back to 'en' when the atomic interface language is undefined", async () => {
+      const atomicInterface = await setupElement();
+      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = undefined;
+      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
 
-      // Should use the interface language when no new language is provided
-      expect(changeLanguageSpy).toHaveBeenCalledExactlyOnceWith('fr');
+      helper.onLanguageChange();
+
+      expect(vi.mocked(loadTranslations)).toHaveBeenCalledExactlyOnceWith(atomicInterface, 'en');
+    });
+
+    it('should pass the full language code, region included, to #loadTranslations', async () => {
+      const atomicInterface = await setupElement();
+      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'fr-CA';
+      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
+
+      helper.onLanguageChange();
+
+      expect(vi.mocked(loadTranslations)).toHaveBeenCalledExactlyOnceWith(atomicInterface, 'fr-CA');
     });
 
     it('should call #loadDayjsLocale with the atomic interface language when it is defined', async () => {
@@ -340,165 +316,20 @@ describe('InterfaceController', () => {
       expect(loadDayjsLocaleSpy).toHaveBeenCalledExactlyOnceWith('en');
     });
 
-    it('should create a new #Backend instance with i18n services and backend options', async () => {
-      const BackendSpy = vi.mocked(Backend);
-      const atomicInterface = await setupElement();
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      expect(BackendSpy).toHaveBeenCalledExactlyOnceWith(
-        atomicInterface.i18n.services,
-        expect.any(Object)
-      );
-    });
-
-    it('should call #Backend.read with correct arguments for full language code', async () => {
-      const mockReadMethod = vi.fn();
-      const BackendSpy = vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
-      const atomicInterface = await setupElement();
-      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'fr-CA';
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      expect(BackendSpy).toHaveBeenCalled();
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'fr',
-        'translation',
-        expect.any(Function)
-      );
-    });
-
-    it('should call #Backend.read with correct arguments for simple language code', async () => {
-      const mockReadMethod = vi.fn();
-      const BackendSpy = vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
-      const atomicInterface = await setupElement();
-      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'es';
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      expect(BackendSpy).toHaveBeenCalled();
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'es',
-        'translation',
-        expect.any(Function)
-      );
-    });
-
-    describe('when #Backend.read callback is executed', () => {
-      it('should call #i18n.addResourceBundle with correct arguments', async () => {
-        const mockReadMethod = vi.fn();
-        vi.mocked(Backend).mockImplementation(function () {
-          this.read = mockReadMethod;
-        });
-
-        const atomicInterface = await setupElement();
-        (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'de-DE';
-        const addResourceBundleSpy = vi.spyOn(atomicInterface.i18n, 'addResourceBundle');
-        const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-        helper.onLanguageChange();
-
-        // Execute the callback that would be called by Backend.read
-        const callback = mockReadMethod.mock.calls[0][2];
-        const mockData = {key: 'value'};
-        callback(null, mockData);
-
-        expect(addResourceBundleSpy).toHaveBeenCalledExactlyOnceWith(
-          'de',
-          'translation',
-          mockData,
-          true,
-          false
-        );
-      });
-
+    describe('once the translations have loaded', () => {
       it('should call #i18n.changeLanguage with the full language code', async () => {
-        const mockReadMethod = vi.fn();
-        vi.mocked(Backend).mockImplementation(function () {
-          this.read = mockReadMethod;
-        });
-
         const atomicInterface = await setupElement();
         (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'pt-BR';
         const changeLanguageSpy = vi.spyOn(atomicInterface.i18n, 'changeLanguage');
         const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
 
         helper.onLanguageChange();
-
-        // Execute the callback that would be called by Backend.read
-        const callback = mockReadMethod.mock.calls[0][2];
-        const mockData = {key: 'value'};
-        callback(null, mockData);
+        await vi.waitFor(() => expect(changeLanguageSpy).toHaveBeenCalled());
 
         expect(changeLanguageSpy).toHaveBeenCalledExactlyOnceWith('pt-BR');
       });
     });
-
-    it("should work correctly when language is undefined and fallback to 'en'", async () => {
-      const mockReadMethod = vi.fn();
-      vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
-      const atomicInterface = await setupElement();
-      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = undefined;
-      const addResourceBundleSpy = vi.spyOn(atomicInterface.i18n, 'addResourceBundle');
-      const changeLanguageSpy = vi.spyOn(atomicInterface.i18n, 'changeLanguage');
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'en',
-        'translation',
-        expect.any(Function)
-      );
-
-      // Execute the callback
-      const callback = mockReadMethod.mock.calls[0][2];
-      const mockData = {key: 'value'};
-      callback(null, mockData);
-
-      expect(addResourceBundleSpy).toHaveBeenCalledExactlyOnceWith(
-        'en',
-        'translation',
-        mockData,
-        true,
-        false
-      );
-      expect(changeLanguageSpy).toHaveBeenCalledExactlyOnceWith(undefined);
-    });
-
-    it('should handle complex language code with multiple dashes correctly', async () => {
-      const mockReadMethod = vi.fn();
-      vi.mocked(Backend).mockImplementation(function () {
-        this.read = mockReadMethod;
-      });
-
-      const atomicInterface = await setupElement();
-      (atomicInterface as BaseAtomicInterface<CommerceEngine>).language = 'zh-Hans-CN';
-      const helper = new InterfaceController(atomicInterface, 'CoveoAtomic', VERSION);
-
-      helper.onLanguageChange();
-
-      // Should use only the first part before the first dash
-      expect(mockReadMethod).toHaveBeenCalledExactlyOnceWith(
-        'zh',
-        'translation',
-        expect.any(Function)
-      );
-    });
   });
-
   describe('#engineIsCreated', () => {
     it('should return true when engine is provided', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/atomic/src/components/common/interface/interface-controller.spec.ts
+++ b/packages/atomic/src/components/common/interface/interface-controller.spec.ts
@@ -12,8 +12,6 @@ vi.mock('@/src/global/environment.js', {spy: true});
 vi.mock('./i18n.js', () => ({
   init18n: vi.fn(),
   loadTranslations: vi.fn(() => Promise.resolve()),
-  i18nBackendOptions: vi.fn(() => ({})),
-  i18nTranslationNamespace: 'translation',
 }));
 vi.mock('@/src/utils/dayjs-locales.js', {spy: true});
 

--- a/packages/atomic/src/components/common/interface/interface-controller.ts
+++ b/packages/atomic/src/components/common/interface/interface-controller.ts
@@ -1,11 +1,10 @@
 import type {LogLevel} from '@coveo/headless';
 import type {i18n, TFunction} from 'i18next';
-import Backend from 'i18next-http-backend';
 import type {LitElement, ReactiveController} from 'lit';
 import {setCoveoGlobal} from '@/src/global/environment';
 import {loadDayjsLocale} from '@/src/utils/dayjs-locales';
 import type {AnyBindings, AnyEngineType} from './bindings';
-import {i18nBackendOptions, i18nTranslationNamespace, init18n} from './i18n';
+import {init18n, loadTranslations} from './i18n';
 import '@/src/components/common/atomic-aria-live/atomic-aria-live';
 
 type InitializeEventHandler = (bindings: AnyBindings) => void;
@@ -99,20 +98,9 @@ export class InterfaceController<EngineType extends AnyEngineType> implements Re
     const {i18n} = this.host;
 
     loadDayjsLocale(languageWithFallback);
-    new Backend(i18n.services, i18nBackendOptions(this.host)).read(
-      languageWithFallback.split('-')[0],
-      i18nTranslationNamespace,
-      (_: unknown, data: unknown) => {
-        i18n.addResourceBundle(
-          languageWithFallback.split('-')[0],
-          i18nTranslationNamespace,
-          data,
-          true,
-          false
-        );
-        i18n.changeLanguage(language);
-      }
-    );
+    loadTranslations(this.host, languageWithFallback).then(() => {
+      i18n.changeLanguage(language);
+    });
   }
 
   public engineIsCreated(engine?: EngineType): engine is EngineType {


### PR DESCRIPTION
Stacked on #8266, a behaviour-neutral extraction. Review that one first; this PR is the behaviour change.

## Jira

https://coveord.atlassian.net/browse/KIT-4018

## Motivation

Strings an application customizes on an Atomic interface's i18next instance were silently discarded, reverting to Atomic's defaults.

Observed on Coveo@Coveo Workplace, which overrides Atomic's `search` placeholder per page, plus `load-all-results` → "Show thread" and `collapse-results` → "Hide thread" so folded threads read naturally. On CDN builds those reverted to Atomic's defaults — `Search`, `Load all results` — and which pages were affected changed from one load to the next, because it is a race with Atomic's locale fetch.

## Root Cause

Atomic loads its translations through `i18next-http-backend`. Registering that backend with `.use()` meant **i18next** performed the initial load, and whichever component loads is also the one that writes to the resource store:

```js
// i18next, BackendConnector.loaded
this.store.addResourceBundle(lng, ns, data, undefined, undefined, {skipCopy: true});
```

`deep` and `overwrite` are hardcoded to `undefined`. A falsy `deep` takes the shallow-merge branch, `pack = {...pack, ...resources}`, so **the incoming data wins** and anything the consumer had already registered is dropped. There is one such call site and no option feeding those two arguments, so it cannot be configured away.

`onLanguageChange` was already doing the right thing, adding its bundle with `deep: true, overwrite: false`. So the two paths had **opposite semantics for the same namespace**: a customization survived a language change but not the initial load.

This is not a timing bug. An instantaneous fetch would overwrite just as much; timing only decided whether a consumer value was present to overwrite, which is why it presented as a race.

## Changes

- `init18n` no longer registers the backend (`.use(Backend)` and the `backend:` option are gone) and calls `loadTranslations` instead, so the write stays inside Atomic and Atomic's strings behave as defaults.
- Safe to remove: `onLanguageChange` has always constructed its own `Backend` instance, so `.use()` only ever drove the initial load.
- `init18n` also loads the fallback language. i18next used to resolve the language hierarchy and fetch `en.json` alongside `fr.json`; without that, a locale missing a key would render the key instead of the English string.

**Trade-off for reviewers:** a consumer calling `i18n.changeLanguage('de')` *directly* will no longer auto-fetch German, since nothing is registered to fetch it. Every Atomic interface changes language through the `language` prop → `onLanguageChange`, which loads explicitly before calling `changeLanguage`, so the supported path is unaffected.

The alternative, if that matters more than the simplicity: load Atomic's defaults into their own namespace and set `fallbackNS`. Precedence becomes explicit and fully order-independent, at the cost of relocating Atomic's keys out of `translation` and breaking consumers that read them from there.

## Validation

### Reproducing on production

https://www.coveoat.coveo.com/ (Coveo SSO required).

1. Open the site and use the header navigation — **People**, **Discussion**, and the others.
2. Look at the search box placeholder. It should be the app's own copy, such as `Search for knowledge, people or tools...`.
3. On an affected load it shows Atomic's default `Search` instead.
4. Reload with <kbd>⌘</kbd><kbd>R</kbd> a few times, moving between those pages. The placeholder flips between the app's copy and `Search` — it is not stable per page, and a page that was correct a moment ago will be wrong on the next load.

The same cause shows up on folded results, where the show/hide control reads `Load all results` instead of `Show thread`.

### Reproducing without that app

Register an override on any Atomic interface right after it is created, then read it back once loading settles:

```js
searchInterface.i18n.addResourceBundle('en', 'translation', {'load-all-results': 'Show thread'});
// later
searchInterface.i18n.t('load-all-results'); // 'Load all results' before this fix
```

### Automated

New regression test: a consumer registers `load-all-results` while Atomic's locale fetch is held open; once `init18n` resolves, its value must survive while untouched keys still come from Atomic. Confirmed it **fails without the fix** with `expected 'Load all results' to be 'Show thread'`. Also new: `use()` is never called, and `fr-CA` fetches both `fr.json` and `en.json`. 60 tests pass in `src/components/common/interface/`.

### Against the app

Ran Coveo@Coveo Workplace against a local CDN serving this exact Atomic version (3.60.7), pre-fix and fixed builds side by side on separate ports, with the locale response delayed to widen the race. Pre-fix reproduces the reverted placeholder and label; fixed does not, across repeated loads. The fixed build also shows no untranslated keys, which confirms the fallback-language load.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`fix(<scope>): <description>`)
- [x] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code