### PR TITLE
chore(thermidor-schema): register generated schemas with Knip

### DIFF
--- a/knip.js
+++ b/knip.js
@@ -84,6 +84,12 @@ export default {
         '**/*.css', //TODO: Find a better solution
       ],
     },
+    'packages/thermidor-schema': {
+      entry: ['src/index.ts', 'src/generated/schemas.ts'],
+      ignoreUnresolved: [
+        /^\.\.\/\.\.\/thermidor-contracts\/src\/generated\/catalog-contracts\.js$/,
+      ],
+    },
     'samples/headless/commerce-react': {
       // ShowMore and ProductsPerPage are kept as reference examples but are not
       // wired into the UI, so Knip should not flag them as unused files.


### PR DESCRIPTION
## Motivation

Thermidor Schema's generated exports and optional equivalence-test import need explicit Knip configuration so the package passes both standalone and affected-workspace unused-code checks.

## Changes

- Register `src/index.ts` and `src/generated/schemas.ts` as package entry points.
- Ignore only the intentionally optional `../../thermidor-contracts/src/generated/catalog-contracts.js` test import.

## Validation

- `pnpm knip` against this standalone layer
- `pnpm knip` against the dependent package/declaration layer
- Independent read-only review confirmed this layer is valid directly on `thermidor-demo-schema-react` and introduces no dependency on later layers.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`chore(<scope>): <description>`)
- [x] No changeset is required because this is tooling-only configuration