### PR TITLE
test(atomic,headless,shopify): stub fetch with Vitest

### DIFF
--- a/packages/atomic/src/components/common/interface/i18n.spec.ts
+++ b/packages/atomic/src/components/common/interface/i18n.spec.ts
@@ -1,10 +1,14 @@
 import Backend from 'i18next-http-backend';
-import {describe, expect, it, vi} from 'vitest';
+import {afterEach, describe, expect, it, vi} from 'vitest';
 import type {AnyEngineType} from './bindings';
 import {i18nBackendOptions, init18n} from './i18n';
 import type {BaseAtomicInterface} from './interface-controller';
 
 describe('i18n', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   describe('#i18nBackendOptions', () => {
     it('should return an object with a loadPath and request function', () => {
       const atomicInterface = {
@@ -73,8 +77,6 @@ describe('i18n', () => {
         status: 200,
         data: {foo: 'bar'},
       });
-
-      vi.unstubAllGlobals();
     });
   });
 

--- a/packages/atomic/src/components/common/interface/i18n.spec.ts
+++ b/packages/atomic/src/components/common/interface/i18n.spec.ts
@@ -51,10 +51,13 @@ describe('i18n', () => {
     it('should execute callback with data for supported locale and namespace', async () => {
       vi.stubGlobal('isI18nLocaleAvailable', () => true);
 
-      globalThis.fetch = vi.fn().mockResolvedValue({
-        status: 200,
-        json: () => Promise.resolve({foo: 'bar'}),
-      });
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          status: 200,
+          json: () => Promise.resolve({foo: 'bar'}),
+        })
+      );
       const atomicInterface = {
         languageAssetsPath: '/foo',
       } as BaseAtomicInterface<AnyEngineType>;

--- a/packages/headless/src/api/knowledge/post-answer-evaluation.test.ts
+++ b/packages/headless/src/api/knowledge/post-answer-evaluation.test.ts
@@ -3,7 +3,6 @@ import type {Mock} from 'vitest';
 import {type AnswerEvaluationPOSTParams, answerEvaluation} from './post-answer-evaluation.js';
 
 const {Response} = await vi.importActual('node-fetch');
-const originalFetch = global.fetch;
 
 const mockEvaluationBody: AnswerEvaluationPOSTParams = {
   additionalNotes: null,
@@ -47,16 +46,13 @@ const buildStore = () =>
 describe('answerEvaluation', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    global.fetch = vi.fn();
+    vi.stubGlobal('fetch', vi.fn());
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
-  });
-
-  afterAll(() => {
-    global.fetch = originalFetch;
   });
 
   it('treats a failed evaluation request as an RTK Query error and expects the correct error object', async () => {

--- a/packages/headless/src/api/platform-client.test.ts
+++ b/packages/headless/src/api/platform-client.test.ts
@@ -17,7 +17,7 @@ import {
 } from './preprocess-request.js';
 
 const {Response} = await vi.importActual('node-fetch');
-global.fetch = vi.fn();
+vi.stubGlobal('fetch', vi.fn());
 const mockFetch = global.fetch as Mock;
 
 it.each([

--- a/packages/shopify/src/utilities/app-proxy.test.ts
+++ b/packages/shopify/src/utilities/app-proxy.test.ts
@@ -5,12 +5,13 @@ describe('fetchAppProxyConfig', () => {
   const mockFetch = vi.fn();
 
   beforeEach(() => {
-    global.fetch = mockFetch;
+    vi.stubGlobal('fetch', mockFetch);
     clearAppProxyCache();
     vi.clearAllMocks();
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
## Problem
Several Vitest suites replace the global `fetch` implementation through direct assignment. Those assignments bypass Vitest's global-stub tracking, and manual restoration is inconsistent across suites.

## Why it matters
Using Vitest's supported global-stub API keeps test isolation explicit and prevents mocked globals from leaking when test setup or teardown changes.

## Fix (symptoms → root cause → change)
Replace direct `global.fetch` and `globalThis.fetch` assignments with `vi.stubGlobal('fetch', implementation)`. Tests that install the stub per test now call `vi.unstubAllGlobals()` during teardown, replacing manual restoration where applicable.

## Tests
- Atomic i18n suite: 5 passed
- Headless evaluation and platform client suites: 32 passed
- Shopify app proxy suite: 8 passed
- `pnpm run lint:fix`

## Manual verification
N/A — this only changes test setup, and the four affected suites cover the behavior.

## Validation
- [x] All affected tests pass
- [x] No production code was modified (test files only)
- [x] No direct `global.fetch` or `globalThis.fetch` assignments remain in test files

## Checklist
- [x] PR title follows Conventional Commits 1.0.0
- [x] No changeset is included because no public package source code changed