### PR TITLE
test(atomic): KIT-6077 add failing coverage for field condition reevaluation

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.spec.ts
@@ -125,4 +125,30 @@ describe('atomic-product-field-condition', () => {
 
     expect(isContentVisible()).toBe(false);
   });
+
+  it('should reevaluate its conditions when they change after the initial render', async () => {
+    const {element, isContentVisible} = await renderProductFieldCondition({
+      mustMatch: {ec_brand: ['other-brand']},
+      productState: {ec_brand: 'brand'},
+    });
+
+    expect(isContentVisible()).toBe(false);
+
+    expect(element).not.toBeNull();
+    element.mustMatch = {ec_brand: ['brand']};
+    await element.updateComplete;
+
+    expect(isContentVisible()).toBe(true);
+  });
+
+  it('should stay in the DOM when its conditions are not met', async () => {
+    const {atomicProduct} = await renderProductFieldCondition({
+      ifDefined: 'ec_brand',
+      productState: {ec_brand: undefined},
+    });
+
+    expect(
+      atomicProduct.shadowRoot!.querySelector('atomic-product-field-condition')
+    ).not.toBeNull();
+  });
 });

--- a/packages/atomic/src/components/search/atomic-field-condition/atomic-field-condition.spec.ts
+++ b/packages/atomic/src/components/search/atomic-field-condition/atomic-field-condition.spec.ts
@@ -133,4 +133,19 @@ describe('atomic-field-condition', () => {
 
     expect(atomicResult.shadowRoot!.querySelector('atomic-field-condition')).not.toBeNull();
   });
+
+  it('should reevaluate its conditions when they change after the initial render', async () => {
+    const {element, isContentVisible} = await renderFieldCondition({
+      mustMatch: {filetype: ['pdf']},
+      resultState: {raw: {filetype: 'docx'}},
+    });
+
+    expect(isContentVisible()).toBe(false);
+
+    expect(element).not.toBeNull();
+    element.mustMatch = {filetype: ['docx']};
+    await element.updateComplete;
+
+    expect(isContentVisible()).toBe(true);
+  });
 });


### PR DESCRIPTION
> [!WARNING]
> CI is expected to be red on this PR. It only adds the tests that describe the desired
> behavior. Stacked on #8280; the fix is #8259.

[KIT-6077](https://coveord.atlassian.net/browse/KIT-6077)

## Problem

Neither field condition component can recover once its conditions have evaluated to false, in
two different ways.

`atomic-product-field-condition` calls `this.remove()` during `render()` whenever the product
context is unavailable or its conditions are false. Once the element is gone, its conditions can
never be reevaluated, so any transient state permanently drops the content.

`atomic-field-condition` sets `hidden = true` and never sets it back to `false`. Same
irrecoverability, expressed as a sticky attribute rather than a deletion.

Nothing in the test suite forbids either.

## Solution

Three tests, all failing here:

| Test | Component |
|---|---|
| should reevaluate its conditions when they change after the initial render | `atomic-product-field-condition` |
| should stay in the DOM when its conditions are not met | `atomic-product-field-condition` |
| should reevaluate its conditions when they change after the initial render | `atomic-field-condition` |

The reevaluation tests are the real contract: render with a failing condition, flip the
condition, expect the content to appear.

The "stays in the DOM" test pins the intent directly so a future change cannot reintroduce
self-deletion without a red test. `atomic-field-condition` gets the same guard, but it already
behaves that way so its version is green and lives in #8280 instead.

All three go green in #8259. The e2e suites are untouched here and stay green; only the unit
suites are red.

[KIT-6077]: https://coveord.atlassian.net/browse/KIT-6077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ