### PR TITLE
feat(atomic): improve scrolling behavior when moving focus

### DIFF
--- a/.changeset/calm-facets-focus.md
+++ b/.changeset/calm-facets-focus.md
@@ -1,0 +1,5 @@
+---
+"@coveo/atomic": minor
+---
+
+Improve focus scrolling after Atomic content updates and move focus to the first newly added facet value after **Show more**.

--- a/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-facet/atomic-commerce-facet.ts
@@ -8,6 +8,7 @@ import type {
 import {type CSSResultGroup, html, LitElement, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
+import {getFirstNewFacetValueIndex} from '@/src/components/common/facets/facet-common';
 import {renderFacetContainer} from '@/src/components/common/facets/facet-container/facet-container';
 import {renderFacetHeader} from '@/src/components/common/facets/facet-header/facet-header';
 import {renderFacetSearchInput} from '@/src/components/common/facets/facet-search/facet-search-input';
@@ -125,6 +126,7 @@ export class AtomicCommerceFacet
   private headerFocus!: FocusTargetController;
   private unsubscribeFacetController?: () => void;
   private ariaLiveRegion = new AriaLiveRegionController(this, 'facet-search');
+  private valuesBeforeShowMore = new Set<string>();
 
   public initialize() {
     this.validateFacet();
@@ -239,9 +241,15 @@ export class AtomicCommerceFacet
   }
 
   private renderValues() {
+    const firstNewValueIndex = getFirstNewFacetValueIndex(
+      this.facetState.values,
+      this.valuesBeforeShowMore
+    );
+
     return this.renderValuesContainer(
       this.facetState.values.map((value, i) => {
-        const shouldFocusAfterInteraction = i === 0;
+        const shouldFocusOnShowLessAfterInteraction = i === 0;
+        const shouldFocusOnShowMoreAfterInteraction = i === firstNewValueIndex;
 
         return renderFacetValue({
           props: {
@@ -252,10 +260,10 @@ export class AtomicCommerceFacet
             facetValue: value.value,
             facetState: value.state,
             setRef: (btn) => {
-              if (shouldFocusAfterInteraction) {
+              if (shouldFocusOnShowLessAfterInteraction) {
                 this.showLessFocus?.setTarget(btn as HTMLElement);
               }
-              if (shouldFocusAfterInteraction) {
+              if (shouldFocusOnShowMoreAfterInteraction) {
                 this.showMoreFocus?.setTarget(btn as HTMLElement);
               }
             },
@@ -278,6 +286,7 @@ export class AtomicCommerceFacet
             this.facet.showLessValues();
           },
           onShowMore: () => {
+            this.valuesBeforeShowMore = new Set(this.facetState.values.map(({value}) => value));
             this.focusTargets.showMore.focusAfterSearch();
             this.facet.showMoreValues();
           },

--- a/packages/atomic/src/components/common/facets/facet-common.spec.ts
+++ b/packages/atomic/src/components/common/facets/facet-common.spec.ts
@@ -4,6 +4,7 @@ import {
   collapseFacetsAfter,
   getAutomaticFacetGenerator,
   getFacetsInChildren,
+  getFirstNewFacetValueIndex,
   isAutomaticFacetGenerator,
   shouldDisplayInputForFacetRange,
   sortFacetVisibility,
@@ -19,6 +20,20 @@ describe('facet-common', () => {
     visibleFacet.isCollapsed = props.isCollapsed || false;
     return visibleFacet;
   };
+
+  describe('#getFirstNewFacetValueIndex', () => {
+    it('returns the first new value index after values are reordered', () => {
+      const values = [{value: 'April'}, {value: 'December'}, {value: 'August'}];
+
+      expect(getFirstNewFacetValueIndex(values, new Set(['April', 'August']))).toBe(1);
+    });
+
+    it('returns -1 when there are no new values', () => {
+      const values = [{value: 'April'}, {value: 'August'}];
+
+      expect(getFirstNewFacetValueIndex(values, new Set(['April', 'August']))).toBe(-1);
+    });
+  });
 
   describe('#shouldDisplayInputForFacetRange', () => {
     it('should return false when there is no input', () => {

--- a/packages/atomic/src/components/common/facets/facet-common.ts
+++ b/packages/atomic/src/components/common/facets/facet-common.ts
@@ -16,6 +16,13 @@ export interface FacetValuePropsBase {
   buttonRef?: RefOrCallback;
 }
 
+export function getFirstNewFacetValueIndex(
+  currentValues: readonly {value: string}[],
+  previouslyDisplayedValues: ReadonlySet<string>
+) {
+  return currentValues.findIndex(({value}) => !previouslyDisplayedValues.has(value));
+}
+
 export function shouldDisplayInputForFacetRange(facetRange: {
   hasInput: boolean;
   hasInputRange: boolean;

--- a/packages/atomic/src/components/insight/atomic-insight-facet/atomic-insight-facet.ts
+++ b/packages/atomic/src/components/insight/atomic-insight-facet/atomic-insight-facet.ts
@@ -17,6 +17,7 @@ import {html, LitElement, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 import {parseDependsOn} from '@/src/components/common/facets/depends-on';
+import {getFirstNewFacetValueIndex} from '@/src/components/common/facets/facet-common';
 import type {FacetInfo} from '@/src/components/common/facets/facet-common-store';
 import {renderFacetContainer} from '@/src/components/common/facets/facet-container/facet-container';
 import {renderFacetHeader} from '@/src/components/common/facets/facet-header/facet-header';
@@ -177,6 +178,7 @@ export class AtomicInsightFacet
   private headerFocus?: FocusTargetController;
   private facetConditionsManager?: InsightFacetConditionsManager;
   private facetSearchAriaLiveController!: AriaLiveRegionController;
+  private valuesBeforeShowMore = new Set<string>();
 
   constructor() {
     super();
@@ -301,10 +303,13 @@ export class AtomicInsightFacet
   }
 
   private renderValues() {
+    const firstNewValueIndex = getFirstNewFacetValueIndex(
+      this.facet.state.values,
+      this.valuesBeforeShowMore
+    );
     const values = this.facet.state.values.map((value, i) => {
       const shouldFocusOnShowLessAfterInteraction = i === 0;
-      const shouldFocusOnShowMoreAfterInteraction =
-        i === (this.sortCriteria === 'automatic' ? 0 : this.facetState.values.length - 1);
+      const shouldFocusOnShowMoreAfterInteraction = i === firstNewValueIndex;
 
       return renderFacetValue({
         props: {
@@ -338,6 +343,7 @@ export class AtomicInsightFacet
         label: this.label,
         i18n: this.bindings.i18n,
         onShowMore: () => {
+          this.valuesBeforeShowMore = new Set(this.facet.state.values.map(({value}) => value));
           this.focusTargets.showMore.focusAfterSearch();
           this.facet.showMoreValues();
         },

--- a/packages/atomic/src/components/search/atomic-color-facet/atomic-color-facet.ts
+++ b/packages/atomic/src/components/search/atomic-color-facet/atomic-color-facet.ts
@@ -22,6 +22,7 @@ import {css, html, LitElement, nothing} from 'lit';
 import {customElement, property, state} from 'lit/decorators.js';
 import {when} from 'lit/directives/when.js';
 import {parseDependsOn} from '@/src/components/common/facets/depends-on';
+import {getFirstNewFacetValueIndex} from '@/src/components/common/facets/facet-common';
 import facetCommonStyles from '@/src/components/common/facets/facet-common.tw.css';
 import type {FacetInfo} from '@/src/components/common/facets/facet-common-store';
 import {renderFacetContainer} from '@/src/components/common/facets/facet-container/facet-container';
@@ -388,7 +389,7 @@ export class AtomicColorFacet extends LitElement implements InitializableCompone
   private headerFocus?: FocusTargetController;
   private facetConditionsManager?: FacetConditionsManager;
   private facetSearchAriaLive?: AriaLiveRegionController;
-  private resultIndexToFocusOnShowMore = 0;
+  private valuesBeforeShowMore = new Set<string>();
 
   constructor() {
     super();
@@ -639,11 +640,15 @@ export class AtomicColorFacet extends LitElement implements InitializableCompone
   }
 
   private renderValues() {
+    const firstNewValueIndex = getFirstNewFacetValueIndex(
+      this.facet.state.values,
+      this.valuesBeforeShowMore
+    );
+
     return this.renderValuesContainer(
       this.facet.state.values.map((value, i) => {
         const shouldFocusOnShowLessAfterInteraction = i === 0;
-        const shouldFocusOnShowMoreAfterInteraction =
-          i === (this.sortCriteria === 'automatic' ? 0 : this.resultIndexToFocusOnShowMore);
+        const shouldFocusOnShowMoreAfterInteraction = i === firstNewValueIndex;
 
         return this.renderValue(
           value,
@@ -661,7 +666,7 @@ export class AtomicColorFacet extends LitElement implements InitializableCompone
         label: this.label,
         i18n: this.bindings.i18n,
         onShowMore: () => {
-          this.resultIndexToFocusOnShowMore = this.facet.state.values.length;
+          this.valuesBeforeShowMore = new Set(this.facet.state.values.map(({value}) => value));
           this.focusTargets.showMore.focusAfterSearch();
           this.facet.showMoreValues();
         },

--- a/packages/atomic/src/components/search/atomic-facet/atomic-facet.spec.ts
+++ b/packages/atomic/src/components/search/atomic-facet/atomic-facet.spec.ts
@@ -581,6 +581,42 @@ describe('atomic-facet', () => {
       expect(showMoreValues).toHaveBeenCalled();
     });
 
+    it('should focus the first newly added value when show more reorders values', async () => {
+      const showMoreValues = vi.fn();
+      const facet = buildFakeFacet({
+        implementation: {showMoreValues},
+        state: {
+          canShowMoreValues: true,
+          values: [
+            {value: 'April', state: 'idle', numberOfResults: 10},
+            {value: 'August', state: 'idle', numberOfResults: 5},
+          ],
+        },
+      });
+      showMoreValues.mockImplementation(() => {
+        Object.assign(facet.state, {
+          values: [
+            {value: 'April', state: 'idle', numberOfResults: 10},
+            {value: 'December', state: 'idle', numberOfResults: 8},
+            {value: 'August', state: 'idle', numberOfResults: 5},
+          ],
+        });
+      });
+      vi.mocked(buildFacet).mockReturnValue(facet);
+      const {element, locators} = await setupElement();
+      vi.mocked(element.bindings.store.getUniqueIDFromEngine)
+        .mockReturnValueOnce('before-show-more')
+        .mockReturnValue('after-show-more');
+
+      await userEvent.click(locators.showMore);
+      element.requestUpdate();
+      await element.updateComplete;
+
+      await vi.waitFor(() => {
+        expect(element.shadowRoot?.activeElement?.getAttribute('aria-label')).toContain('December');
+      });
+    });
+
     it('should call facet.showLessValues when the show less button is clicked', async () => {
       const showLessValues = vi.fn();
       vi.mocked(buildFacet).mockReturnValue(

--- a/packages/atomic/src/components/search/atomic-facet/atomic-facet.ts
+++ b/packages/atomic/src/components/search/atomic-facet/atomic-facet.ts
@@ -29,6 +29,7 @@ import {AriaLiveRegionController, FocusTargetController} from '@/src/utils/acces
 import {mapProperty} from '@/src/utils/props-utils';
 import {getFieldCaptions} from '../../../utils/field-utils';
 import {parseDependsOn} from '../../common/facets/depends-on';
+import {getFirstNewFacetValueIndex} from '../../common/facets/facet-common';
 import type {FacetInfo} from '../../common/facets/facet-common-store';
 import {renderFacetContainer} from '../../common/facets/facet-container/facet-container';
 import {renderFacetHeader} from '../../common/facets/facet-header/facet-header';
@@ -381,6 +382,7 @@ export class AtomicFacet extends LitElement implements InitializableComponent<Bi
   private headerFocus?: FocusTargetController;
   private facetConditionsManager?: FacetConditionsManager;
   private facetSearchAriaLive?: AriaLiveRegionController;
+  private valuesBeforeShowMore = new Set<string>();
 
   constructor() {
     super();
@@ -564,14 +566,15 @@ export class AtomicFacet extends LitElement implements InitializableComponent<Bi
   }
 
   private renderValues() {
+    const firstNewValueIndex = getFirstNewFacetValueIndex(
+      this.facet.state.values,
+      this.valuesBeforeShowMore
+    );
+
     return this.renderValuesContainer(
       this.facet.state.values.map((value, i) => {
         const shouldFocusOnShowLessAfterInteraction = i === 0;
-        const shouldFocusOnShowMoreAfterInteraction =
-          i ===
-          (this.sortCriteria === 'automatic'
-            ? 0
-            : this.facet.state.values.length - this.numberOfValues);
+        const shouldFocusOnShowMoreAfterInteraction = i === firstNewValueIndex;
 
         return renderFacetValue({
           props: {
@@ -604,6 +607,7 @@ export class AtomicFacet extends LitElement implements InitializableComponent<Bi
         label: this.label,
         i18n: this.bindings.i18n,
         onShowMore: () => {
+          this.valuesBeforeShowMore = new Set(this.facet.state.values.map(({value}) => value));
           this.focusTargets.showMore.focusAfterSearch();
           this.facet.showMoreValues();
         },

--- a/packages/atomic/src/utils/accessibility-utils.spec.ts
+++ b/packages/atomic/src/utils/accessibility-utils.spec.ts
@@ -247,11 +247,12 @@ describe('accessibility-utils', () => {
         expect(mockedDefer).toHaveBeenCalledOnce();
       });
 
-      it('should focus on the current element', async () => {
+      it('should focus on the current element with minimal scrolling', async () => {
         const {focusTargetController} = await renderComponent();
 
         const element = document.createElement('div');
         const elementFocusSpy = vi.spyOn(element, 'focus');
+        const scrollIntoViewSpy = vi.spyOn(element, 'scrollIntoView');
 
         focusTargetController.setTarget(element);
 
@@ -259,7 +260,11 @@ describe('accessibility-utils', () => {
 
         await focusTargetController.focus();
 
-        expect(elementFocusSpy).toHaveBeenCalledOnce();
+        expect(elementFocusSpy).toHaveBeenCalledExactlyOnceWith({preventScroll: true});
+        expect(scrollIntoViewSpy).toHaveBeenCalledExactlyOnceWith({
+          block: 'nearest',
+          inline: 'nearest',
+        });
       });
 
       it('should call the registered focus callbacks', async () => {
@@ -506,16 +511,21 @@ describe('accessibility-utils', () => {
           expect(mockedDefer).toHaveBeenCalledOnce();
         });
 
-        it('should focus on the target element', async () => {
+        it('should focus on the target element with minimal scrolling', async () => {
           const element = document.createElement('div');
           const elementFocusSpy = vi.spyOn(element, 'focus');
+          const scrollIntoViewSpy = vi.spyOn(element, 'scrollIntoView');
 
           await setup({element});
 
           component.requestUpdate();
           await vi.runAllTimersAsync();
 
-          expect(elementFocusSpy).toHaveBeenCalledOnce();
+          expect(elementFocusSpy).toHaveBeenCalledExactlyOnceWith({preventScroll: true});
+          expect(scrollIntoViewSpy).toHaveBeenCalledExactlyOnceWith({
+            block: 'nearest',
+            inline: 'nearest',
+          });
         });
 
         it('should call the registered focus callbacks', async () => {

--- a/packages/atomic/src/utils/accessibility-utils.ts
+++ b/packages/atomic/src/utils/accessibility-utils.ts
@@ -82,6 +82,14 @@ export class FocusTargetController implements ReactiveController {
     }
   }
 
+  private focusElement(element?: HTMLElement) {
+    if (!element) {
+      return;
+    }
+    element.focus({preventScroll: true});
+    element.scrollIntoView({block: 'nearest', inline: 'nearest'});
+  }
+
   public async setTarget(el?: HTMLElement) {
     if (!el) {
       return;
@@ -96,7 +104,7 @@ export class FocusTargetController implements ReactiveController {
   public async focus() {
     // Not sure why this is needed; should be investigated after Lit Migration (KIT-4235)
     await defer();
-    this.element?.focus();
+    this.focusElement(this.element);
     this.clearFocusCallbacks();
   }
 
@@ -131,7 +139,7 @@ export class FocusTargetController implements ReactiveController {
         const el = this.element;
         // The focus seems to be flaky without deferring, especially on iOS; should be investigated after Lit Migration (KIT-4235)
         await defer().then(() => {
-          el.focus();
+          this.focusElement(el);
           this.clearFocusCallbacks();
         });
       }


### PR DESCRIPTION
## Problem

Programmatic focus transitions managed by `FocusTargetController` use `HTMLElement.focus()` without options. Browsers can consequently center the focused element, causing disruptive page jumps—for example, when expanding an Atomic facet with **Show more**.

Support context: https://discuss.coveo.com/t/support-00141253-clicking-show-more-on-a-facet-for-more-facet-values-scrolls-up-so-the-facet-is-centered/14741

## Why it matters

Atomic intentionally moves focus after asynchronous content updates so keyboard and assistive-technology users do not lose their interaction point. The browser's default centering preserves focus visibility but can unnecessarily disorient users when the target was already visible.

## Fix (symptoms → root cause → change)

The page movement comes from the browser scrolling during `focus()`. Focus targets now first receive focus with `preventScroll`, then call `scrollIntoView` with nearest block and inline alignment. Already-visible targets stay in place, while off-screen targets still receive the minimum scrolling required to remain visible.

The behavior is centralized in `FocusTargetController`, covering both direct focus and post-search focus paths without changing unrelated local focus patterns.

For **Show more**, regular search, color, insight, and commerce facets now snapshot the displayed value identities before expansion and focus the first rendered value that was absent from that snapshot. This remains correct when automatic sorting interleaves existing and newly added values. Category facets are unchanged because they already target the first added child.

> [!NOTE]
> Per the [HTML spec §6.6.6](https://html.spec.whatwg.org/multipage/interaction.html#dom-focusoptions-preventscroll), the default focus() behavior (step 4) is: "scroll a target into view given this, 'auto', 'center', and 'center'". This is what causes the disruptive page jump. Our fix uses preventScroll: true followed by scrollIntoView({block: 'nearest', inline: 'nearest'}) — preserving the "scroll all ancestor containers" scope while replacing the centering alignment with minimum-displacement scrolling

## Tests

- Updated `accessibility-utils.spec.ts` to verify direct and post-search focus use `preventScroll` and nearest alignment.
- Added shared helper coverage for reordered and unchanged facet values.
- Added a component regression proving **Show more** focuses an interleaved newly added value rather than the old value at index `0`.
- Focused helper, focus-controller, search facet, color facet, insight facet, and commerce facet suites pass: 252 tests passed and 11 skipped.
- The full `@coveo/atomic` Turbo test task passes.
- Atomic type-check, the 17-task Atomic dependency build (including Storybook), repository lint/format checks, and diff integrity pass.

## Manual verification

The linked client search application did not initialize in browser automation. The browser-level Atomic tests verify the exact platform API calls in Chromium, and the affected browser-mode component tests verify the first-new-value focus transition.

## Screenshots

N/A — this changes scroll motion without changing rendered appearance; a still image cannot demonstrate the before/after behavior.

## Jira

- https://coveord.atlassian.net/browse/KIT-6083
