### PR TITLE
fix(ci): build Atomic themes for wrapper E2E

### DIFF
--- a/packages/atomic-angular/turbo.json
+++ b/packages/atomic-angular/turbo.json
@@ -10,7 +10,12 @@
       "outputs": ["projects/atomic-angular/src/lib/generated/**/*"]
     },
     "build:assets": {
-      "dependsOn": ["build:bundles", "@coveo/atomic#build:locales", "@coveo/atomic#build:assets"],
+      "dependsOn": [
+        "build:bundles",
+        "@coveo/atomic#build:locales",
+        "@coveo/atomic#build:assets",
+        "@coveo/atomic#build:themes"
+      ],
       "outputs": ["projects/atomic-angular/dist/assets/**", "projects/atomic-angular/dist/lang/**"]
     },
     "build:bundles": {

--- a/packages/atomic-react/turbo.json
+++ b/packages/atomic-react/turbo.json
@@ -14,7 +14,11 @@
       "outputs": ["./dist/types/**"]
     },
     "build:assets": {
-      "dependsOn": ["@coveo/atomic#build:assets", "@coveo/atomic#build:locales"],
+      "dependsOn": [
+        "@coveo/atomic#build:assets",
+        "@coveo/atomic#build:locales",
+        "@coveo/atomic#build:themes"
+      ],
       "outputs": ["./dist/assets/**", "./dist/lang/**"]
     },
     "gen:lit": {


### PR DESCRIPTION
**Jira:** [KIT-6079](https://coveord.atlassian.net/browse/KIT-6079)

## Issue

Wrapper E2E sample servers can resolve Atomic's `coveo.css` before Atomic themes are built. This splits the standalone fix from #8251 so it can merge independently.

## Solution

Make Atomic's theme build an explicit dependency of the Atomic Angular and React wrapper `build:assets` tasks.

[KIT-6079]: https://coveord.atlassian.net/browse/KIT-6079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ