### PR TITLE
test(atomic): assert visibility in field condition tests

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-field-condition/atomic-product-field-condition.spec.ts
@@ -22,7 +22,7 @@ describe('atomic-product-field-condition', () => {
   } = {}) => {
     const product = buildFakeProduct(productState);
 
-    const {element} = await renderInAtomicProduct<AtomicProductFieldCondition>({
+    const {element, atomicProduct} = await renderInAtomicProduct<AtomicProductFieldCondition>({
       template: html`
         <atomic-product-field-condition
           if-defined="${ifDefined}"
@@ -37,86 +37,92 @@ describe('atomic-product-field-condition', () => {
       product,
     });
 
-    return {
-      element,
-      content: element?.querySelector('#condition-met'),
+    // Deliberately queried from the product rather than from the condition element, and
+    // returned as a boolean, so that the assertions describe what the user can see instead
+    // of how the component hides its content.
+    const isContentVisible = () => {
+      const content = atomicProduct.shadowRoot!.querySelector<HTMLElement>('#condition-met');
+      return content !== null && content.checkVisibility();
     };
+
+    return {element, atomicProduct, isContentVisible};
   };
 
   it('should render its content when no conditions are defined', async () => {
-    const {content} = await renderProductFieldCondition();
-    expect(content).toBeInTheDocument();
+    const {isContentVisible} = await renderProductFieldCondition();
+
+    expect(isContentVisible()).toBe(true);
   });
 
   it('should render its content when an if-defined condition is met', async () => {
-    const {content} = await renderProductFieldCondition({
+    const {isContentVisible} = await renderProductFieldCondition({
       ifDefined: 'ec_brand',
       productState: {ec_brand: 'brand'},
     });
 
-    expect(content).toBeInTheDocument();
+    expect(isContentVisible()).toBe(true);
   });
 
   it('should not render its content when an if-defined condition is not met', async () => {
-    const {content} = await renderProductFieldCondition({
+    const {isContentVisible} = await renderProductFieldCondition({
       ifDefined: 'ec_brand',
       productState: {ec_brand: undefined},
     });
 
-    expect(content).toBeUndefined();
+    expect(isContentVisible()).toBe(false);
   });
 
   it('should render its content when an if-not-defined condition is met', async () => {
-    const {content} = await renderProductFieldCondition({
+    const {isContentVisible} = await renderProductFieldCondition({
       ifNotDefined: 'ec_brand',
       productState: {ec_brand: undefined},
     });
 
-    expect(content).toBeInTheDocument();
+    expect(isContentVisible()).toBe(true);
   });
 
   it('should not render its content when an if-not-defined condition is not met', async () => {
-    const {content} = await renderProductFieldCondition({
+    const {isContentVisible} = await renderProductFieldCondition({
       ifNotDefined: 'ec_brand',
       productState: {ec_brand: 'brand'},
     });
 
-    expect(content).toBeUndefined();
+    expect(isContentVisible()).toBe(false);
   });
 
   it('should render its content when a must-match condition is met', async () => {
-    const {content} = await renderProductFieldCondition({
+    const {isContentVisible} = await renderProductFieldCondition({
       mustMatch: {ec_brand: ['brand']},
       productState: {ec_brand: 'brand'},
     });
 
-    expect(content).toBeInTheDocument();
+    expect(isContentVisible()).toBe(true);
   });
 
   it('should not render its content when a must-match condition is not met', async () => {
-    const {content} = await renderProductFieldCondition({
+    const {isContentVisible} = await renderProductFieldCondition({
       mustMatch: {ec_brand: ['brand']},
       productState: {ec_brand: 'other-brand'},
     });
 
-    expect(content).toBeUndefined();
+    expect(isContentVisible()).toBe(false);
   });
 
   it('should render its content when a must-not-match condition is met', async () => {
-    const {content} = await renderProductFieldCondition({
+    const {isContentVisible} = await renderProductFieldCondition({
       mustNotMatch: {ec_brand: ['other-brand']},
       productState: {ec_brand: 'brand'},
     });
 
-    expect(content).toBeInTheDocument();
+    expect(isContentVisible()).toBe(true);
   });
 
   it('should not render its content when a must-not-match condition is not met', async () => {
-    const {content} = await renderProductFieldCondition({
+    const {isContentVisible} = await renderProductFieldCondition({
       mustNotMatch: {ec_brand: ['other-brand']},
       productState: {ec_brand: 'other-brand'},
     });
 
-    expect(content).toBeUndefined();
+    expect(isContentVisible()).toBe(false);
   });
 });

--- a/packages/atomic/src/components/commerce/atomic-product-field-condition/e2e/atomic-product-field-condition.e2e.ts
+++ b/packages/atomic/src/components/commerce/atomic-product-field-condition/e2e/atomic-product-field-condition.e2e.ts
@@ -33,8 +33,8 @@ test.describe('atomic-product-field-condition', () => {
     page,
   }) => {
     await productFieldCondition.load({args: {'if-not-defined': 'ec_name'}});
+    await page.locator('atomic-product.hydrated').first().waitFor({state: 'attached'});
 
-    const elements = await page.locator('atomic-product-field-condition').all();
-    expect(elements.length).toBe(0);
+    await expect(productFieldCondition.visibleConditions).toHaveCount(0);
   });
 });

--- a/packages/atomic/src/components/search/atomic-field-condition/atomic-field-condition.spec.ts
+++ b/packages/atomic/src/components/search/atomic-field-condition/atomic-field-condition.spec.ts
@@ -22,7 +22,7 @@ describe('atomic-field-condition', () => {
   } = {}) => {
     const result = buildFakeResult(resultState);
 
-    const {element} = await renderInAtomicResult<AtomicFieldCondition>({
+    const {element, atomicResult} = await renderInAtomicResult<AtomicFieldCondition>({
       template: html`
         <atomic-field-condition
           if-defined="${ifDefined}"
@@ -37,91 +37,100 @@ describe('atomic-field-condition', () => {
       result,
     });
 
-    return {
-      element,
-      content: element?.querySelector('#condition-met'),
+    // Deliberately queried from the result rather than from the condition element, and
+    // returned as a boolean, so that the assertions describe what the user can see instead
+    // of how the component hides its content.
+    const isContentVisible = () => {
+      const content = atomicResult.shadowRoot!.querySelector<HTMLElement>('#condition-met');
+      return content !== null && content.checkVisibility();
     };
+
+    return {element, atomicResult, isContentVisible};
   };
 
   it('should render its content when no conditions are defined', async () => {
-    const {element, content} = await renderFieldCondition();
-    expect(element?.hidden).toBe(false);
-    expect(content).toBeInTheDocument();
+    const {isContentVisible} = await renderFieldCondition();
+    expect(isContentVisible()).toBe(true);
   });
 
   it('should render its content when an if-defined condition is met', async () => {
-    const {element, content} = await renderFieldCondition({
+    const {isContentVisible} = await renderFieldCondition({
       ifDefined: 'author',
       resultState: {raw: {author: 'John Doe'}},
     });
 
-    expect(element?.hidden).toBe(false);
-    expect(content).toBeInTheDocument();
+    expect(isContentVisible()).toBe(true);
   });
 
   it('should not render its content when an if-defined condition is not met', async () => {
-    const {element} = await renderFieldCondition({
+    const {isContentVisible} = await renderFieldCondition({
       ifDefined: 'author',
       resultState: {raw: {}},
     });
 
-    expect(element?.hidden).toBe(true);
+    expect(isContentVisible()).toBe(false);
   });
 
   it('should render its content when an if-not-defined condition is met', async () => {
-    const {element, content} = await renderFieldCondition({
+    const {isContentVisible} = await renderFieldCondition({
       ifNotDefined: 'author',
       resultState: {raw: {}},
     });
 
-    expect(element?.hidden).toBe(false);
-    expect(content).toBeInTheDocument();
+    expect(isContentVisible()).toBe(true);
   });
 
   it('should not render its content when an if-not-defined condition is not met', async () => {
-    const {element} = await renderFieldCondition({
+    const {isContentVisible} = await renderFieldCondition({
       ifNotDefined: 'author',
       resultState: {raw: {author: 'John Doe'}},
     });
 
-    expect(element?.hidden).toBe(true);
+    expect(isContentVisible()).toBe(false);
   });
 
   it('should render its content when a must-match condition is met', async () => {
-    const {element, content} = await renderFieldCondition({
+    const {isContentVisible} = await renderFieldCondition({
       mustMatch: {filetype: ['pdf']},
       resultState: {raw: {filetype: 'pdf'}},
     });
 
-    expect(element?.hidden).toBe(false);
-    expect(content).toBeInTheDocument();
+    expect(isContentVisible()).toBe(true);
   });
 
   it('should not render its content when a must-match condition is not met', async () => {
-    const {element} = await renderFieldCondition({
+    const {isContentVisible} = await renderFieldCondition({
       mustMatch: {filetype: ['pdf']},
       resultState: {raw: {filetype: 'docx'}},
     });
 
-    expect(element?.hidden).toBe(true);
+    expect(isContentVisible()).toBe(false);
   });
 
   it('should render its content when a must-not-match condition is met', async () => {
-    const {element, content} = await renderFieldCondition({
+    const {isContentVisible} = await renderFieldCondition({
       mustNotMatch: {filetype: ['docx']},
       resultState: {raw: {filetype: 'pdf'}},
     });
 
-    expect(element?.hidden).toBe(false);
-    expect(content).toBeInTheDocument();
+    expect(isContentVisible()).toBe(true);
   });
 
   it('should not render its content when a must-not-match condition is not met', async () => {
-    const {element} = await renderFieldCondition({
+    const {isContentVisible} = await renderFieldCondition({
       mustNotMatch: {filetype: ['docx']},
       resultState: {raw: {filetype: 'docx'}},
     });
 
-    expect(element?.hidden).toBe(true);
+    expect(isContentVisible()).toBe(false);
+  });
+
+  it('should stay in the DOM when its conditions are not met', async () => {
+    const {atomicResult} = await renderFieldCondition({
+      ifDefined: 'author',
+      resultState: {raw: {}},
+    });
+
+    expect(atomicResult.shadowRoot!.querySelector('atomic-field-condition')).not.toBeNull();
   });
 });

--- a/packages/atomic/src/components/search/atomic-field-condition/e2e/atomic-field-condition.e2e.ts
+++ b/packages/atomic/src/components/search/atomic-field-condition/e2e/atomic-field-condition.e2e.ts
@@ -24,9 +24,11 @@ test.describe('atomic-field-condition', () => {
 
   test('should not render its content when if-not-defined condition is not met', async ({
     fieldCondition,
+    page,
   }) => {
     await fieldCondition.load({args: {'if-not-defined': 'title'}});
+    await page.locator('atomic-result.hydrated').first().waitFor({state: 'attached'});
 
-    expect(fieldCondition.hydrated).not.toBeVisible;
+    await expect(fieldCondition.visibleCondition).toHaveCount(0);
   });
 });


### PR DESCRIPTION
> [!NOTE]
> Bottom of a 3-PR stack: this one → #8276 (failing tests, red) → #8259 (fix).
> No behavior change here, CI is green.

Groundwork for [KIT-6077](https://coveord.atlassian.net/browse/KIT-6077), covering both field
condition components: `atomic-product-field-condition` (commerce) and `atomic-field-condition`
(search).

## Problem

The assertions were coupled to *how* each component hides its content rather than to the
outcome, and two of them could not fail at all.

**`atomic-product-field-condition`** calls `this.remove()` when its conditions are false, and
the tests asserted precisely that deletion:

```ts
expect(content).toBeUndefined();   // unit: querySelector found nothing
expect(elements.length).toBe(0);   // e2e: no element in the DOM at all
```

`toBeUndefined()` on a `querySelector` result is a proxy for "the element was deleted", not for
"the content is not visible". Consumers depend on the latter.

**`atomic-field-condition`** asserted its `hidden` property, paired with:

```ts
expect(content).toBeInTheDocument();
```

That assertion can never fail. `content` is a light-DOM child and the component never removes
itself, so the content is in the document whether or not the condition passes. The positive
tests were only really checking `hidden === false`.

Its e2e assertion was worse:

```ts
expect(fieldCondition.hydrated).not.toBeVisible;
```

Missing `()`, so it is a property access that evaluates nothing. That test passed against any
implementation.

## Solution

Both specs now assert visibility through an `isContentVisible()` helper that queries the
slotted content from the parent (`atomic-product` / `atomic-result`) and returns a boolean, so
it reports `false` whether the element was removed or merely hidden. Both e2e suites assert
that no condition is visible, keying their wait off `atomic-product.hydrated` /
`atomic-result.hydrated` being attached, which exists in either case.

Also adds `should stay in the DOM when its conditions are not met` for
`atomic-field-condition`. It already behaves that way, so the test is green and belongs here
rather than in the red PR — but nothing pinned the intent, and a TODO in the component asked
for `hidden` to be replaced by `this.remove()`, which this test now blocks. The equivalent
test for `atomic-product-field-condition` is red and lives in #8276.

Verified green against the current implementations and against the fix at the top of the stack.
That is the point: these assertions no longer care which mechanism is used.

[KIT-6077]: https://coveord.atlassian.net/browse/KIT-6077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ