### PR TITLE
ci(cdn): add manual CDN redeploy workflow

### DIFF
--- a/.github/workflows/redeploy-cdn.yml
+++ b/.github/workflows/redeploy-cdn.yml
@@ -1,0 +1,141 @@
+# Redeploy CDN
+#
+# Manual recovery for the case where npm publishing succeeded but the CDN never
+# received (or never completed) its deployment, leaving the published version's
+# folder returning 403 forever. A regular release cannot repair this: it only
+# writes its own version folders, so a skipped version stays missing.
+#
+# Why this exists even though `cd.yml` can be re-run:
+#   - GitHub only allows re-running a workflow run for ~30 days. After that there
+#     is no other recovery path.
+#   - Re-running ALL jobs of a release run is actively harmful: the `release` job
+#     re-runs, finds no pending changesets, so `published` becomes 'false' and
+#     the dispatch degrades to the `private` channel, which never writes version
+#     folders. Re-run FAILED jobs only, or use this workflow.
+#   - If the `ui-kit-cd` run failed for a reason that needs a code change in
+#     ui-kit, replaying the same commit fails forever. See "fix forward" below.
+#   - The `cdn-stable` approval in `ui-kit-cd` expires; the run is then cancelled
+#     and stable pointers are never written.
+#
+# Usage — replay a release that npm published but the CDN missed:
+#   ref      = @coveo/atomic@3.60.4   (the release tag, or its commit SHA)
+#   channels = private,preview
+#
+# Usage — fix forward when the deployment itself is broken:
+#   git checkout -b fix/cdn-<something> @coveo/atomic@3.60.4
+#   git cherry-pick <fix-sha>     # add NO changeset: versions must not change
+#   git push origin fix/cdn-<something>
+#   ref      = fix/cdn-<something>
+#   channels = private,preview
+#   The fixed artifacts land in the same v3.60.4/ folders, because folders are
+#   derived from package.json at the deployed commit.
+#
+# Do NOT use the `hotfix` channel to repair a published version: `hotfix.json` in
+# ui-kit-cd writes the major, minor and `preview/<major>` folders only — it has no
+# patch phase, so it cannot create `v3.60.4/`. The `private,preview` channels go
+# through preview -> `cdn-stable` approval -> stable, and stable writes major,
+# minor AND patch. That is the correct path for a repair.
+#
+# See: internal-docs/release-process.md
+name: Redeploy CDN
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref to deploy: a release tag (@coveo/atomic@3.60.4), a commit SHA, or a branch. Required — there is deliberately no default, because the release/v3 bookmark is skipped when a release job fails and would point at the wrong commit in exactly the incident this workflow recovers from.'
+        required: true
+        type: string
+      channels:
+        description: 'CDN pointer channels to update.'
+        required: true
+        default: 'private,preview'
+        type: choice
+        options:
+          - 'private,preview'
+          - 'private'
+
+permissions:
+  contents: read
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
+jobs:
+  verify:
+    name: Verify ref is published on npm
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+      - name: Resolve ref to a commit SHA
+        id: resolve
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      # The CDN version folders come from package.json at this commit, so a ref
+      # whose versions are not on npm would mint folders for a version that does
+      # not exist. Refuse that before anything is built.
+      - name: Verify CDN package versions are published on npm
+        run: node ./scripts/deploy/verify-npm-published.mjs
+        env:
+          COMMIT_SHA: ${{ steps.resolve.outputs.sha }}
+          CHANNELS: ${{ inputs.channels }}
+
+  build-cdn:
+    name: Build CDN
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.ref }}
+      # Pre-flight only: ui-kit-cd rebuilds from the commit itself. This catches a
+      # broken build before burning a deployment run.
+      - uses: ./.github/actions/build-cdn
+        with:
+          commit-sha: ${{ needs.verify.outputs.sha }}
+
+  redeploy:
+    name: Dispatch CDN redeploy
+    needs: [verify, build-cdn]
+    runs-on: ubuntu-latest
+    # TODO(KIT-5712): Rename to 'CDN Deploy' once token vending machine is available
+    environment: 'Prerelease (CDN)'
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: ./.github/actions/setup
+      # SHA is passed explicitly: on a workflow_dispatch run `context.sha` is the
+      # default branch's HEAD, not the ref that was checked out above.
+      - name: Trigger commit artifact upload and pointer update
+        run: node ./scripts/deploy/trigger-commit-upload.mjs
+        env:
+          GH_TOKEN: ${{ secrets.UI_KIT_CD_DISPATCHER }}
+          SHA: ${{ needs.verify.outputs.sha }}
+          CHANNELS: ${{ inputs.channels }}
+      - name: Summarize
+        run: |
+          {
+            echo "## Dispatched"
+            echo
+            echo "Commit: \`${{ needs.verify.outputs.sha }}\`"
+            echo "Channels: \`${{ inputs.channels }}\`"
+            echo
+            echo "Follow the run in [coveo-platform/ui-kit-cd](https://github.com/coveo-platform/ui-kit-cd/actions)."
+            echo "The \`cdn-stable\` environment gate there must be approved to write the released version folders."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/deploy/trigger-commit-upload.mjs
+++ b/scripts/deploy/trigger-commit-upload.mjs
@@ -1,15 +1,56 @@
+// Dispatches the `deploy-commit` event that tells coveo-platform/ui-kit-cd to
+// build and upload CDN artifacts for a ui-kit commit.
+//
+// This dispatch is the ONLY signal ui-kit-cd receives. If it never fires, npm
+// ends up ahead of the CDN and the published version's folder returns 403
+// forever, because a later release only ever writes its own version folders.
+// Treat a failure here as a release incident, not a flake.
+//
+// Environment:
+//   GH_TOKEN  (required) token able to dispatch to coveo-platform/ui-kit-cd
+//   CHANNELS  (required) comma-separated pointer channels: private | private,preview | hotfix
+//   SHA       (optional) ui-kit commit to deploy. Defaults to the SHA of the
+//             running workflow. `redeploy-cdn.yml` sets this explicitly because
+//             a workflow_dispatch run reports the default branch's SHA in
+//             `context.sha`, not the SHA of the ref it checked out.
 import {context, getOctokit} from '@actions/github';
+
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 5000;
 
 const octokit = getOctokit(process.env.GH_TOKEN);
 const channels = process.env.CHANNELS;
+const sha = process.env.SHA || context.sha;
 
-await octokit.rest.repos.createDispatchEvent({
-  event_type: 'deploy-commit',
-  client_payload: {
-    run_id: context.runId,
-    sha: context.sha,
-    channels,
-  },
-  owner: 'coveo-platform',
-  repo: 'ui-kit-cd',
-});
+if (!channels) {
+  throw new Error('CHANNELS is required (private | private,preview | hotfix)');
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// A transient failure here is indistinguishable from a CDN deployment that was
+// never requested, so retry rather than let one bad response create a gap.
+for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+  try {
+    await octokit.rest.repos.createDispatchEvent({
+      event_type: 'deploy-commit',
+      client_payload: {
+        run_id: context.runId,
+        sha,
+        channels,
+      },
+      owner: 'coveo-platform',
+      repo: 'ui-kit-cd',
+    });
+    console.log(`Dispatched deploy-commit for ${sha} (channels: ${channels})`);
+    break;
+  } catch (error) {
+    if (attempt === MAX_ATTEMPTS) {
+      throw error;
+    }
+    console.warn(
+      `Dispatch attempt ${attempt}/${MAX_ATTEMPTS} failed: ${error.message}. Retrying in ${RETRY_DELAY_MS}ms.`
+    );
+    await sleep(RETRY_DELAY_MS);
+  }
+}

--- a/scripts/deploy/verify-npm-published.mjs
+++ b/scripts/deploy/verify-npm-published.mjs
@@ -1,0 +1,117 @@
+// Guard for `redeploy-cdn.yml`.
+//
+// A CDN version folder is derived from the `version` field of each package's
+// package.json at the deployed commit, so replaying an arbitrary commit would
+// happily create a folder for a version that was never published to npm. This
+// script refuses that: every CDN package version in the current checkout must
+// already exist on the npm registry.
+//
+// It also prints the resolved version -> CDN folder mapping to the job summary
+// so whoever approves the `cdn-stable` gate can see what is about to be written.
+//
+// Environment:
+//   COMMIT_SHA (required) the ui-kit commit being replayed, for the summary
+//   CHANNELS   (required) comma-separated pointer channels
+import {appendFileSync, readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+
+// ⚠️ Keep in sync with coveo-platform/ui-kit-cd
+// `scripts/deploy/utils/cdn-packages.mjs`. Only the package directory is needed
+// here; all CDN packages are published under the @coveo scope.
+const CDN_PACKAGES = [
+  'atomic',
+  'atomic-hosted-page',
+  'atomic-react',
+  'bueno',
+  'headless',
+  'relay',
+  'shopify',
+];
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function readVersion(pkg) {
+  const path = resolve(process.cwd(), 'packages', pkg, 'package.json');
+  const {version} = JSON.parse(readFileSync(path, 'utf-8'));
+  if (typeof version !== 'string' || !/^\d+\.\d+\.\d+/.test(version)) {
+    throw new Error(`Invalid version "${version}" in ${path}`);
+  }
+  return version;
+}
+
+async function isPublished(pkg, version) {
+  const specifier = encodeURIComponent(`@coveo/${pkg}`);
+  const response = await fetch(`https://registry.npmjs.org/${specifier}/${version}`);
+  if (response.status === 200) {
+    return true;
+  }
+  if (response.status === 404) {
+    return false;
+  }
+  throw new Error(
+    `Unexpected npm registry response for @coveo/${pkg}@${version}: ${response.status}`
+  );
+}
+
+const commitSha = requireEnv('COMMIT_SHA');
+const channels = requireEnv('CHANNELS');
+
+const checked = await Promise.all(
+  CDN_PACKAGES.map(async (pkg) => {
+    const version = readVersion(pkg);
+    return {pkg, version, published: await isPublished(pkg, version)};
+  })
+);
+
+const rows = checked
+  .map(
+    ({pkg, version, published}) =>
+      `| \`@coveo/${pkg}\` | \`${version}\` | \`/${pkg}/v${version}/\` | ${published ? 'yes' : '**NO**'} |`
+  )
+  .join('\n');
+
+const summary = `## CDN redeploy plan
+
+Commit: \`${commitSha}\`
+Channels: \`${channels}\`
+
+| Package | Version | Stable folder | On npm |
+| --- | --- | --- | --- |
+${rows}
+
+Stable pointers are written to the major, minor and patch folders for each
+version above. Approve the \`cdn-stable\` gate in \`coveo-platform/ui-kit-cd\` to
+promote past preview.
+`;
+
+console.log(summary);
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+}
+
+// The private channel only writes `private/v<major>/`, a rolling pointer rather
+// than a released version, so an unpublished version is harmless there. Only
+// channels that can reach a released version folder are gated.
+if (!channels.includes('preview') && !channels.includes('hotfix')) {
+  console.log('Channels cannot reach a released version folder; skipping the npm check.');
+  process.exit(0);
+}
+
+const missing = checked.filter(({published}) => !published);
+if (missing.length > 0) {
+  const list = missing.map(({pkg, version}) => `  @coveo/${pkg}@${version}`).join('\n');
+  throw new Error(
+    `Refusing to redeploy: these versions are not published on npm:\n${list}\n\n` +
+      'A CDN version folder must never exist for a version npm does not have.\n' +
+      'Pass a ref whose package.json versions match a published release, such as\n' +
+      'a release tag (`@coveo/atomic@<version>`) or a branch cut from one.'
+  );
+}
+
+console.log('All CDN package versions are published on npm.');


### PR DESCRIPTION
## Problem

When npm publishing succeeds but the CDN deployment signal never lands, the published version's CDN folder never gets created and returns 403 forever. A later release does **not** heal it, because a release only ever writes its own version folders.

That is not hypothetical. Right now:

| | |
|---|---|
| npm `@coveo/atomic` | 3.58.0 … **3.59.3 → 3.60.6** … 3.60.7 |
| CDN `v<x>/index.esm.js` | 3.59.2 → 200, 3.60.4 → **403**, 3.60.7 → 200 |
| Gap | 16 versions, 2026-06-03 → 2026-08-13 |

Two customers opened tickets after reading versions off the changelog and getting 403s.

There is currently no way to deploy the CDN for a commit outside of its original release run. Re-running the run works, but only for ~30 days, only if you re-run *failed jobs only*, and not at all if the deployment needs a code fix.

## Solution

A manual `Redeploy CDN` workflow, plus the plumbing it needs.

The key property that makes this safe and simple: **a CDN deployment is fully determined by the ui-kit commit SHA.** `ui-kit-cd` re-checks-out ui-kit at the SHA and rebuilds; `run_id` is only used to name the deployment package, so there is no dependency on expiring GitHub artifacts. Version folders come from `package.json` at that SHA, and every published version has a tag (`@coveo/atomic@3.60.4` → `48d9c784`).

- **`.github/workflows/redeploy-cdn.yml`** — dispatches a CDN deployment for an arbitrary ref through the normal `private,preview` channels. Those reach the stable pointers, which are the only ones that write the **patch** folder. `ref` is required with no default: the `release/v3` bookmark is skipped when a release job fails, so it would point at the wrong commit in exactly the incident this recovers from.
- **`scripts/deploy/verify-npm-published.mjs`** — refuses any ref whose CDN package versions are not on npm, so a replay can never mint a folder for a version that does not exist. Also prints the version → folder mapping to the job summary, so whoever approves the `cdn-stable` gate can see what is about to be written. Skipped for `private`-only channels, which write a rolling pointer rather than a released version.
- **`scripts/deploy/trigger-commit-upload.mjs`** — accepts an explicit `SHA` (on a `workflow_dispatch` run `context.sha` is the default branch HEAD, not the checked-out ref), and retries the dispatch, since a transient failure there is indistinguishable from a deployment that was never requested. `cd.yml` and `hotfix.yml` are unchanged.

It also documents, in the workflow header, that the `hotfix` channel must **not** be used to repair a published version: `hotfix.json` in `ui-kit-cd` writes the major, minor and `preview/<major>` folders only, with no patch phase, so it structurally cannot create `v3.60.4/`.

### Fix-forward path

When the deployment itself is broken, branch from the release tag, cherry-pick the fix, add **no** changeset so the versions do not move, and redeploy that branch. The fixed artifacts land in the same `v3.60.4/` folders.

## Testing

- `verify-npm-published.mjs` run against current `main`: all 7 CDN packages resolve and report published.
- Verified the registry returns 404 for a bogus version, and that the `private`-only path skips the check.
- `actionlint` on the new workflow: clean.
- `oxlint` / `oxfmt`: clean.

## Notes

No changeset: CI-only, no public package source touched.

`CDN_PACKAGES` in the verify script duplicates the list in `ui-kit-cd`'s `scripts/deploy/utils/cdn-packages.mjs`. That file already carries a "⚠️ keep in sync" comment for the same reason, so this follows the existing convention rather than inventing a cross-repo mechanism.

