### PR TITLE
ci(cdn): do not skip the CDN dispatch when a post-publish step fails

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,15 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 jobs:
+  # ⚠️ Everything after `Create release PR or publish` in this job runs when npm
+  # has ALREADY been published to. A failure in any of those steps fails the whole
+  # job, and anything that declares a bare `needs: release` is then skipped.
+  # That is how @coveo/atomic 3.60.x reached npm without ever reaching the CDN
+  # (run 31519447241: `Read create-ui version` failed after a successful publish,
+  # and `Upload commit artifacts to S3` was skipped).
+  #
+  # If you add a post-publish step here, it MUST be `continue-on-error: true`.
+  # Better still, put it in its own job that depends on this one.
   release:
     concurrency:
       group: release-${{ github.ref }}
@@ -79,6 +88,11 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: coveo-platform
           SENTRY_PROJECT: create-ui
+      # Four jobs below check out `refs/tags/release/v3`, so this step is a
+      # prerequisite for them, not just a convenience marker. It deliberately has
+      # no `continue-on-error`: if the tag does not move, those jobs must skip
+      # rather than silently operate on the previous release. The CDN dispatch is
+      # protected from this failure by its own `always()` condition.
       - name: Update release/v3 bookmark
         if: ${{ steps.changesets.outputs.published == 'true' }}
         run: |
@@ -240,6 +254,17 @@ jobs:
   commit-artifact-upload:
     name: Upload commit artifacts to S3
     needs: [build-cdn, release]
+    # `always()` is load-bearing: do not replace this with a bare `needs:`.
+    #
+    # This dispatch is the only signal ui-kit-cd ever receives. With a bare
+    # `needs: release`, any failure in the `release` job skips this job — including
+    # failures in steps that run AFTER `changeset publish` has already pushed to
+    # npm. npm then permanently leads the CDN, because a later release only writes
+    # its own version folders. Recovery is the `Redeploy CDN` workflow.
+    #
+    # `build-cdn` stays a hard gate: it is the same build ui-kit-cd will run, so a
+    # red one means the deployment cannot succeed anyway.
+    if: ${{ always() && needs.build-cdn.result == 'success' && needs.release.result != 'cancelled' }}
     runs-on: ubuntu-latest
     # TODO(KIT-5712): Rename to 'CDN Deploy' once token vending machine is available
     environment: 'Prerelease (CDN)'
@@ -257,7 +282,55 @@ jobs:
           # Comma-separated list of CDN channels to update (e.g. "private" or "private,preview").
           # On release commits, update both private and preview pointers.
           # On regular merges, only update private pointers.
+          #
+          # ⚠️ `published` is only 'true' on the run that actually publishes. If you
+          # re-run ALL jobs of a release run, `release` re-runs, finds no pending
+          # changesets, and `published` flips to 'false' — this silently degrades to
+          # `private`, which never writes version folders, and the run goes green.
+          # To recover a release run, re-run FAILED jobs only, or use the
+          # `Redeploy CDN` workflow.
           CHANNELS: ${{ needs.release.outputs.published == 'true' && 'private,preview' || 'private' }}
+
+  # Turns "npm published but the CDN was never told" into a red run with a runbook,
+  # instead of a half-green release nobody notices. This checks only that the
+  # dispatch was sent; ui-kit-cd reports its own deployment failures to Slack.
+  cdn-signal-guard:
+    name: Verify the CDN was notified of the release
+    needs: [release, commit-artifact-upload]
+    if: ${{ always() && needs.release.outputs.published == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+      - name: Fail if the CDN deployment was never dispatched
+        if: ${{ needs.commit-artifact-upload.result != 'success' }}
+        run: |
+          {
+            echo "## Release published to npm, but the CDN was not notified"
+            echo
+            echo "\`commit-artifact-upload\` finished as \`${{ needs.commit-artifact-upload.result }}\`."
+            echo "The published version has no CDN folder and will return 403 until this is fixed."
+            echo "A later release will NOT heal it: releases only write their own version folders."
+            echo
+            echo "### Recovery"
+            echo
+            echo "Run the **Redeploy CDN** workflow with:"
+            echo
+            echo "- \`ref\`: \`${{ github.sha }}\`"
+            echo "- \`channels\`: \`private,preview\`"
+            echo
+            echo "Then approve the \`cdn-stable\` gate in coveo-platform/ui-kit-cd."
+            echo
+            echo "Alternatively, re-run **failed jobs only** on this run."
+            echo "Do NOT re-run all jobs: \`release\` would find no changesets, \`published\`"
+            echo "would flip to 'false', and the dispatch would degrade to the \`private\`"
+            echo "channel, which never writes version folders."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "npm published but the CDN deployment was not dispatched. See the job summary." >&2
+          exit 1
+
   chromatic-update-main:
     name: 'Update Chromatic baseline on main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
> Based on #8282. Review that first; this diff is only `cd.yml`.

## Problem

`commit-artifact-upload` — the job that sends the **only** signal `ui-kit-cd` ever receives — declared a bare `needs: [build-cdn, release]`. Any failure in the `release` job therefore skipped it, **including failures in steps that run after `changeset publish` has already pushed to npm**.

That is what happened in run [31519447241](https://github.com/coveo/ui-kit/actions/runs/31519447241):

```
success  Create release PR or publish     ← npm published
failure  Read create-ui version
skipped  Upload create-ui source maps to Sentry
skipped  Update release/v3 bookmark
```

```
failure  release
skipped  Upload commit artifacts to S3    ← the signal was never sent
skipped  quantic-prod / docs-prod / typedoc-headless / typedoc-headless-react
```

A post-publish telemetry step failed, and the CDN was never told about a version that was already on npm. `build-cdn` was green, so this is not a build problem.

`continue-on-error: true` was added to those two steps in 81ef4eb324 as a point fix. It works, but every future post-publish step has to remember it, and the run still looked half-green with nobody alerted.

## Solution

Minimal, surgical hardening of `cd.yml`. No job restructuring — that is 3/3.

- **Gate the dispatch on `always()`** plus the `build-cdn` result, so only a broken build or a cancelled run can stop it. `build-cdn` stays a hard gate on purpose: it is the same build `ui-kit-cd` will run, so a red one means the deployment cannot succeed anyway.
- **Add `cdn-signal-guard`** — fails the run with a recovery runbook in the job summary when `published == 'true'` but the dispatch did not succeed. It checks only that the dispatch was *sent*; `ui-kit-cd` reports its own deployment failures to Slack. This turns a half-green release into an unambiguous red one with instructions attached.
- **Comment the fragile lines**, since the failure mode is entirely non-obvious:
  - why `always()` is load-bearing and must not become a bare `needs:`;
  - that re-running **all** jobs silently degrades the channels to `private` (the `release` job re-runs, finds no pending changesets, `published` flips to `false`, no version folders are written, and the run goes green) — re-run **failed jobs only**, or use `Redeploy CDN`;
  - that any post-publish step added to `release` must be `continue-on-error: true`, or better, its own job;
  - that four jobs check out the `release/v3` bookmark, so that step is a prerequisite and deliberately has no `continue-on-error` — if the tag does not move those jobs must skip rather than operate on the previous release.

## Testing

- `actionlint` on `cd.yml`: 8 findings, identical to the base branch (all pre-existing `SC2086` info in the typedoc jobs). No new findings.
- YAML parses; job graph verified.

## Notes

No changeset: CI-only.

This PR alone is enough to stop the bleeding, which is why it is separate from 3/3. If the structural refactor stalls in review, this still ships.

