### PR TITLE
ci(cdn): isolate npm publishing from all post-release work

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,15 +10,22 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 jobs:
-  # ⚠️ Everything after `Create release PR or publish` in this job runs when npm
-  # has ALREADY been published to. A failure in any of those steps fails the whole
-  # job, and anything that declares a bare `needs: release` is then skipped.
-  # That is how @coveo/atomic 3.60.x reached npm without ever reaching the CDN
-  # (run 31519447241: `Read create-ui version` failed after a successful publish,
-  # and `Upload commit artifacts to S3` was skipped).
+  # ⚠️ INVARIANT: this job publishes to npm and does NOTHING else.
   #
-  # If you add a post-publish step here, it MUST be `continue-on-error: true`.
-  # Better still, put it in its own job that depends on this one.
+  # Every other concern — the release/v3 bookmark, Sentry source maps, Quantic
+  # promotion, typedoc, docs, the CDN dispatch — lives in its own job that depends
+  # on this one. That is deliberate and load-bearing: it is what makes
+  # "`release` succeeded" mean exactly "npm was published to", so a failure in
+  # unrelated post-release work can never suppress the CDN deployment.
+  #
+  # It used to be otherwise. In run 31519447241 a post-publish telemetry step
+  # (`Read create-ui version`) failed after `changeset publish` had already pushed
+  # to npm, which failed the whole job and skipped `Upload commit artifacts to S3`.
+  # The published version got no CDN folder and returned 403 indefinitely, because
+  # a later release only ever writes its own version folders. That is how
+  # @coveo/atomic 3.59.3 through 3.60.6 reached npm but never reached the CDN.
+  #
+  # Do not add steps here. Add a job.
   release:
     concurrency:
       group: release-${{ github.ref }}
@@ -31,6 +38,7 @@ jobs:
       id-token: write
     outputs:
       published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -62,19 +70,71 @@ jobs:
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      # A partial publish is deliberately NOT a failure: some packages reached npm,
+      # so downstream jobs must still run. Only a publish that made zero progress
+      # fails this job, and in that case nothing is on npm and there is no gap.
       - name: Fail if publishing made no progress
         if: ${{ steps.changesets.outcome == 'failure' && steps.changesets.outputs.published != 'true' }}
         run: |
           echo "The publish command failed before any package was published." >&2
           exit 1
+
+  # The release/v3 tag is a human-facing bookmark for "what was last released".
+  # It is no longer load-bearing: the jobs that used to check it out now use the
+  # release commit directly, which is what `github.sha` already is on a push to
+  # main. Keep it that way — reintroducing a dependency on this tag would make
+  # every downstream job wait on, and fail with, a bookkeeping step.
+  release-bookmark:
+    name: Update release/v3 bookmark
+    needs: release
+    if: ${{ needs.release.outputs.published == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_PRIVATE_KEY }}
+          owner: coveo
+          repositories: 'ui-kit'
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+      - name: Move the bookmark to the released commit
+        run: |
+          git tag -f release/v3
+          git push origin refs/tags/release/v3 --force
+
+  create-ui-sentry:
+    name: Upload create-ui source maps to Sentry
+    needs: release
+    if: ${{ needs.release.outputs.published == 'true' && contains(needs.release.outputs.publishedPackages, '@coveo/create-ui') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: ./.github/actions/setup
+      # The source maps used to come for free from the build that `pnpm run release`
+      # ran in the release job. Rebuilding here keeps this job independent; the
+      # Turbo remote cache makes it a restore rather than a real build.
+      - name: Build create-ui
+        run: pnpm exec turbo run build --filter=@coveo/create-ui
       - name: Read create-ui version
         id: create-ui-version
-        if: ${{ steps.changesets.outputs.published == 'true' && contains(steps.changesets.outputs.publishedPackages, '@coveo/create-ui') }}
-        continue-on-error: true
-        working-directory: packages/create-ui
-        run: echo "version=$(jq -r '.version' package.json)" >> "$GITHUB_OUTPUT"
-      - name: Upload create-ui source maps to Sentry
-        if: ${{ steps.changesets.outputs.published == 'true' && contains(steps.changesets.outputs.publishedPackages, '@coveo/create-ui') && steps.create-ui-version.outputs.version != '' }}
+        run: echo "version=$(jq -r '.version' packages/create-ui/package.json)" >> "$GITHUB_OUTPUT"
+      - name: Upload source maps
         continue-on-error: true
         uses: step-security/getsentry-action-release@4530160f6bc962e1dd67e2703064a7a5cfd401fb # v3.7.0
         with:
@@ -88,16 +148,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: coveo-platform
           SENTRY_PROJECT: create-ui
-      # Four jobs below check out `refs/tags/release/v3`, so this step is a
-      # prerequisite for them, not just a convenience marker. It deliberately has
-      # no `continue-on-error`: if the tag does not move, those jobs must skip
-      # rather than silently operate on the previous release. The CDN dispatch is
-      # protected from this failure by its own `always()` condition.
-      - name: Update release/v3 bookmark
-        if: ${{ steps.changesets.outputs.published == 'true' }}
-        run: |
-          git tag -f release/v3
-          git push origin refs/tags/release/v3 --force
+
   quantic-prod:
     if: ${{ needs.release.outputs.published == 'true' }}
     needs: release
@@ -113,9 +164,12 @@ jobs:
         with:
           egress-policy: audit
 
+      # The default checkout is `github.sha`, which on a push to main IS the
+      # released commit: `changeset version` ran in the Version Packages PR, so
+      # package.json already carries the published versions. Do not reintroduce
+      # `ref: refs/tags/release/v3` — it would make this job depend on a
+      # bookkeeping step it has no reason to wait for.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          ref: 'refs/tags/release/v3'
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/setup-sfdx
       - name: Promote SFDX package to production
@@ -141,10 +195,9 @@ jobs:
         with:
           egress-policy: audit
 
+      # Checks out `github.sha`, the released commit. See the note in quantic-prod.
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          ref: 'refs/tags/release/v3'
 
       - name: Set up and build the project
         uses: ./.github/actions/setup
@@ -181,10 +234,9 @@ jobs:
         with:
           egress-policy: audit
 
+      # Checks out `github.sha`, the released commit. See the note in quantic-prod.
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          ref: 'refs/tags/release/v3'
 
       - name: Set up and build the project
         uses: ./.github/actions/setup
@@ -222,9 +274,8 @@ jobs:
         with:
           egress-policy: audit
 
+      # Checks out `github.sha`, the released commit. See the note in quantic-prod.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          ref: 'refs/tags/release/v3'
       - uses: ./.github/actions/setup
       - name: Create GitHub App token for docs dispatch
         id: app-token
@@ -254,13 +305,12 @@ jobs:
   commit-artifact-upload:
     name: Upload commit artifacts to S3
     needs: [build-cdn, release]
-    # `always()` is load-bearing: do not replace this with a bare `needs:`.
-    #
-    # This dispatch is the only signal ui-kit-cd ever receives. With a bare
-    # `needs: release`, any failure in the `release` job skips this job — including
-    # failures in steps that run AFTER `changeset publish` has already pushed to
-    # npm. npm then permanently leads the CDN, because a later release only writes
-    # its own version folders. Recovery is the `Redeploy CDN` workflow.
+    # Kept as `always()` on purpose, as defence in depth rather than the primary
+    # fix. The primary fix is the `release` job's invariant: it publishes and does
+    # nothing else, so it can only fail when the publish made zero progress, which
+    # means nothing reached npm and there is no CDN gap to create. If someone ever
+    # breaks that invariant by adding post-publish work back into `release`, this
+    # condition is what keeps the CDN deployment from being skipped.
     #
     # `build-cdn` stays a hard gate: it is the same build ui-kit-cd will run, so a
     # red one means the deployment cannot succeed anyway.

--- a/internal-docs/release-process.md
+++ b/internal-docs/release-process.md
@@ -57,27 +57,113 @@ When the "Version Packages" PR is merged, the CD workflow runs `pnpm run release
 
 Publishing uses [**OIDC trusted publishing**](https://docs.npmjs.com/trusted-publishers) (npm provenance via the `id-token: write` permission) — no long-lived npm tokens are needed.
 
-## The `release/v3` bookmark
+## Job structure: publish is isolated on purpose
 
-After a successful publish, the CD workflow force-pushes the current `main` HEAD to the `release/v3` branch:
+The `release` job publishes to npm and does **nothing else**. Every other concern
+lives in its own job that depends on it.
 
-```yaml
-git push origin HEAD:refs/heads/release/v3 --force
-```
+This is not stylistic. It makes "`release` succeeded" mean exactly "npm was
+published to", which is what allows the CDN deployment to be gated on the publish
+without also being gated on unrelated post-release work.
 
-This branch acts as a bookmark pointing to the latest released commit. Downstream jobs (Quantic production promotion, typedoc generation, docs notification) check out `release/v3` so they operate on the exact code that was just published.
+It used to be otherwise, and it caused a real outage. In run `31519447241`, a
+post-publish telemetry step (`Read create-ui version`) failed *after*
+`changeset publish` had already pushed to npm. That failed the whole `release`
+job, which skipped `Upload commit artifacts to S3` — the only signal the CDN ever
+receives. The published version got no CDN folder and returned 403 indefinitely.
+Because a release only ever writes its own version folders, a later release does
+not heal the gap. That mechanism is how `@coveo/atomic` 3.59.3 through 3.60.6
+reached npm but never reached the CDN.
+
+**If you need to do something after publishing, add a job, not a step.**
 
 ## Post-publish jobs
 
-All post-publish jobs are gated on `published == 'true'` from the changesets step and check out `release/v3`:
+All post-publish jobs are gated on `published == 'true'` from the changesets step,
+and each depends only on `release`:
 
 | Job                      | Purpose                                                                                                  |
 | ------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `release-bookmark`       | Force-pushes the `release/v3` tag to the released commit                                                 |
+| `create-ui-sentry`       | Uploads `@coveo/create-ui` source maps to Sentry                                                          |
 | `quantic-prod`           | Promotes the Quantic SFDX package to production (requires the "Quantic Production" environment approval) |
 | `typedoc-headless`       | Builds and uploads Headless API reference docs                                                           |
 | `typedoc-headless-react` | Builds and uploads Headless React API reference docs                                                     |
 | `docs-prod`              | Notifies the docs system of a new release (requires the "Docs Production" environment approval)          |
+| `commit-artifact-upload` | Dispatches the CDN deployment to `coveo-platform/ui-kit-cd`                                              |
+| `cdn-signal-guard`       | Fails the run if npm published but the CDN deployment was never dispatched                                |
+
+These jobs check out the default ref, `github.sha`, which on a push to `main` **is**
+the released commit: `changeset version` ran back in the "Version Packages" PR, so
+`package.json` already carries the published versions at that commit.
+
+## The `release/v3` tag
+
+After a successful publish, `release-bookmark` force-pushes the `release/v3` **tag**
+to the released commit:
+
+```sh
+git tag -f release/v3
+git push origin refs/tags/release/v3 --force
+```
+
+It is a human-facing marker for "what was last released" and is **not** load-bearing.
+Post-publish jobs deliberately do not check it out; doing so would make them wait
+on, and fail with, a bookkeeping step.
 
 ## CDN deployment
 
-After publishing, the CD workflow dispatches a `deploy` event to the `coveo-platform/ui-kit-cd` repository, which handles CDN deployment (S3 upload, CloudFront invalidation).
+After publishing, `commit-artifact-upload` dispatches a `deploy-commit`
+repository dispatch to `coveo-platform/ui-kit-cd`, which builds the artifacts from
+the commit, uploads them to `commits/<sha>/`, and updates pointer files.
+
+The `channels` payload decides which pointers are updated:
+
+| Situation             | `channels`        | Pointers written                                     |
+| --------------------- | ----------------- | ---------------------------------------------------- |
+| Regular merge to main | `private`         | `private/v<major>/`                                  |
+| Release commit        | `private,preview` | the above, then `preview/`, then stable after approval |
+| Hotfix branch push    | `hotfix`          | `v<major>/`, `v<minor>/`, `preview/v<major>/`         |
+
+Version folders are derived from `package.json` at the deployed commit, so
+`v3.60.4/` exists only if some deployment ran for a commit whose `atomic` version
+was `3.60.4`. Stable is the only channel that writes the **patch** folder, and it
+requires the `cdn-stable` environment approval in `ui-kit-cd`.
+
+## Recovering a release that reached npm but not the CDN
+
+Symptom: a version is on npm and in the changelog, but
+`https://static.cloud.coveo.com/atomic/v<version>/index.esm.js` returns 403.
+
+`cdn-signal-guard` should have failed the release run with these instructions. To
+recover, run the **Redeploy CDN** workflow (`.github/workflows/redeploy-cdn.yml`):
+
+| Input      | Value                                                    |
+| ---------- | -------------------------------------------------------- |
+| `ref`      | the release tag, e.g. `@coveo/atomic@3.60.4`, or its SHA  |
+| `channels` | `private,preview`                                        |
+
+Then approve the `cdn-stable` gate in `ui-kit-cd`. The workflow refuses any ref
+whose CDN package versions are not on npm, so it cannot create a folder for a
+version that does not exist.
+
+If the deployment itself is what is broken, fix forward without moving the version:
+
+```sh
+git checkout -b fix/cdn-<something> @coveo/atomic@3.60.4
+git cherry-pick <fix-sha>   # add NO changeset: the versions must not change
+git push origin fix/cdn-<something>
+```
+
+then redeploy with `ref` set to that branch. The fixed artifacts land in the same
+`v3.60.4/` folders.
+
+Two things to avoid:
+
+- **Do not re-run all jobs** on a release run. `release` would re-run, find no
+  pending changesets, flip `published` to `false`, and degrade the dispatch to the
+  `private` channel — which never writes version folders — while the run goes
+  green. Re-run **failed jobs only**, or use **Redeploy CDN**.
+- **Do not use the `hotfix` channel** to repair a published version. Its
+  deployment config has no patch phase, so it cannot create `v3.60.4/`.
+


### PR DESCRIPTION
> Based on #8283. Review that first; this diff is `cd.yml` + release docs.

## Problem

#8283 stops the CDN dispatch from being skipped, but it does so by patching around the real issue: the `release` job mixes npm publishing with unrelated post-release bookkeeping. As long as that is true, `needs: release` cannot mean "npm published", `always()` has to stay load-bearing, and the next person to add a step to that job can reintroduce the same outage.

There is also an ordering constraint that has no reason to exist. Four jobs check out `refs/tags/release/v3`, so they depend on a bookkeeping step that force-pushes a tag.

## Solution

Make the invariant true instead of patched: **`release` publishes to npm and does nothing else.**

Everything else becomes a leaf that depends only on `release`:

```
build-cdn ──────────────────┐
                            ├─→ commit-artifact-upload ─→ cdn-signal-guard
release (publish only) ─────┘
   ├─→ release-bookmark          leaf
   ├─→ create-ui-sentry          leaf
   ├─→ quantic-prod              leaf
   ├─→ typedoc-headless          leaf
   ├─→ typedoc-headless-react    leaf
   └─→ docs-prod                 leaf
```

With this shape, `release` can only fail when the publish made **zero** progress — which means nothing reached npm and there is no CDN gap to create. A partial publish is deliberately still a success, so downstream jobs run.

- **Move the `release/v3` bookmark and the create-ui Sentry upload into their own jobs.** `create-ui-sentry` rebuilds `create-ui` rather than relying on the build `pnpm run release` happened to leave behind; with the Turbo remote cache that is a restore, not a real build.
- **Stop checking out `refs/tags/release/v3`** in `quantic-prod`, `docs-prod` and both typedoc jobs. The default checkout is `github.sha`, which on a push to `main` *is* the released commit — `changeset version` ran back in the Version Packages PR, so `package.json` already carries the published versions there. Verified: tag `@coveo/atomic@3.60.4` → `48d9c784`, whose `packages/atomic/package.json` reads `3.60.4`.

  I confirmed `release/v3` is referenced **only** in `cd.yml` and `internal-docs/release-process.md` — nothing in `coveo-platform/ui-kit-cd` touches it (checked every blob in that repo). It is kept as a human-facing "what was last released" marker, now explicitly non-load-bearing.
- **Expose `publishedPackages`** as a job output, needed now that the create-ui gating moved to the job level.
- **Keep the `always()` from #8283** as defence in depth, with the comment updated to say so: the invariant is the primary fix, `always()` is what saves us if someone breaks it.

### Docs

Rewrote the relevant sections of `internal-docs/release-process.md` for the new job graph, and fixed two pre-existing inaccuracies:

- it described force-pushing a **branch** (`refs/heads/release/v3`); `cd.yml` pushes a **tag**;
- it described dispatching a `deploy` event; the actual event is `deploy-commit`.

Added the channel → pointer mapping (including that stable is the only channel writing the patch folder) and the recovery runbook for a release that reached npm but not the CDN.

## Testing

- `actionlint` on `cd.yml`: 8 findings, identical to the base branch (all pre-existing `SC2086` info in the typedoc jobs). No new findings.
- Job graph verified after the refactor: `release` has no `needs`; every post-publish job depends only on `release`.
- `cspell` on the changed markdown: clean.

## Risk

Wider blast radius than #8283 — it touches `quantic-prod`, `docs-prod` and the typedoc jobs, and it changes what `create-ui-sentry` builds. The behavioural changes are: those four jobs now check out `github.sha` instead of a tag pointing at the same commit, and the Sentry upload gets its source maps from a fresh (cached) build. Worth a real release to confirm end to end, which is why it is the top of the stack rather than folded into #8283.

## Notes

No changeset: CI-only.

