### PR TITLE
fix(atomic): read prefixed map attributes once connected, not only in the constructor

### DIFF
--- a/.changeset/brave-otters-remember.md
+++ b/.changeset/brave-otters-remember.md
@@ -2,16 +2,9 @@
 '@coveo/atomic': patch
 ---
 
-Fix prefixed map properties being empty when components are created programmatically.
+Fix `must-match-*`, `must-not-match-*` and `depends-on-*` attributes being ignored when a component
+is created in JavaScript rather than written in HTML.
 
-Properties declared with `mapProperty` — `must-match-*` and `must-not-match-*` on the result,
-product and children templates and the field conditions, and `depends-on-*` on the facets — read
-their attributes from a Lit initializer, which runs in the constructor. An element parsed from
-markup already has its attributes at that point, but one created programmatically does not: a
-framework calls `document.createElement`, sets the attributes, then inserts the element. Those
-attributes are prefixed, so they never map to a reactive property Lit would observe, and the value
-stayed empty for the element's whole lifetime.
-
-For result templates this meant `must-match-*` conditions were dropped, so every template matched
-every result and the last registered one won — typically a catch-all. Attributes are now read again
-once the element is connected.
+These attributes were only read in the constructor, before `setAttribute` had been called. On result
+templates the conditions were dropped, so every template matched every result and a catch-all won.
+They are now read again once the element is connected.

--- a/.changeset/brave-otters-remember.md
+++ b/.changeset/brave-otters-remember.md
@@ -1,0 +1,17 @@
+---
+'@coveo/atomic': patch
+---
+
+Fix prefixed map properties being empty when components are created programmatically.
+
+Properties declared with `mapProperty` — `must-match-*` and `must-not-match-*` on the result,
+product and children templates and the field conditions, and `depends-on-*` on the facets — read
+their attributes from a Lit initializer, which runs in the constructor. An element parsed from
+markup already has its attributes at that point, but one created programmatically does not: a
+framework calls `document.createElement`, sets the attributes, then inserts the element. Those
+attributes are prefixed, so they never map to a reactive property Lit would observe, and the value
+stayed empty for the element's whole lifetime.
+
+For result templates this meant `must-match-*` conditions were dropped, so every template matched
+every result and the last registered one won — typically a catch-all. Attributes are now read again
+once the element is connected.

--- a/packages/atomic/src/utils/props-utils.spec.ts
+++ b/packages/atomic/src/utils/props-utils.spec.ts
@@ -133,4 +133,45 @@ describe('mapProperty', () => {
 
     document.body.removeChild(element);
   });
+
+  it('should map attributes set after creation, before insertion', async () => {
+    // The ordering a framework produces when it renders these components dynamically:
+    // createElement, then set attributes, then insert. Reading the attributes only from the
+    // constructor missed them entirely, which silently emptied every prefixed map property.
+    class TestElement4 extends LitElement {
+      @mapProperty({splitValues: true, attributePrefix: 'must-match'})
+      public mustMatch!: Record<string, string[]>;
+    }
+
+    customElement('test-map-property-4')(TestElement4);
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- Testing dynamic property access
+    const element = document.createElement('test-map-property-4') as any;
+    element.setAttribute('must-match-source', 'Workday - People');
+    document.body.appendChild(element);
+    await element.updateComplete;
+
+    expect(element.mustMatch).toEqual({source: ['Workday - People']});
+
+    document.body.removeChild(element);
+  });
+
+  it('should not clobber a value assigned directly to the property', async () => {
+    class TestElement5 extends LitElement {
+      @mapProperty({splitValues: true, attributePrefix: 'must-match'})
+      public mustMatch!: Record<string, string[]>;
+    }
+
+    customElement('test-map-property-5')(TestElement5);
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- Testing dynamic property access
+    const element = document.createElement('test-map-property-5') as any;
+    element.mustMatch = {filetype: ['pdf']};
+    document.body.appendChild(element);
+    await element.updateComplete;
+
+    expect(element.mustMatch).toEqual({filetype: ['pdf']});
+
+    document.body.removeChild(element);
+  });
 });

--- a/packages/atomic/src/utils/props-utils.ts
+++ b/packages/atomic/src/utils/props-utils.ts
@@ -29,21 +29,16 @@ export function mapProperty<Element extends ReactiveElement>(options?: MapPropOp
         return props;
       };
 
-      // Initializers run from the constructor. An element parsed from markup is upgraded with
-      // its attributes already in place, so reading them here is enough for that case.
+      // Covers elements written in markup: they are upgraded with their attributes already set.
       (instance as Instance)[propertyKey] = readMappedAttributes() as Instance[K];
 
-      // An element created programmatically has no attributes yet when the constructor runs:
-      // frameworks call `document.createElement`, then set attributes, then insert. Reading
-      // only in the constructor left the property empty forever, since these attributes are
-      // prefixed (`must-match-source`, `depends-on-category`) and so never map to a reactive
-      // property that Lit would observe. Read again once connected, which is after the
-      // attributes have been set.
+      // Covers elements built in code, where the order is createElement, setAttribute, insert.
+      // The constructor sees no attributes yet, and these are prefixed (`must-match-source`,
+      // `depends-on-category`) so Lit never observes them either. Read once more on connect.
       instance.addController({
         hostConnected: () => {
           const props = readMappedAttributes();
-          // Only overwrite when attributes were actually found, so a value assigned straight to
-          // the property before insertion is preserved.
+          // Skip when there are no attributes, to keep a value assigned to the property directly.
           if (Object.keys(props).length > 0) {
             (instance as Instance)[propertyKey] = props as Instance[K];
           }

--- a/packages/atomic/src/utils/props-utils.ts
+++ b/packages/atomic/src/utils/props-utils.ts
@@ -16,17 +16,39 @@ export function mapProperty<Element extends ReactiveElement>(options?: MapPropOp
     ctor.createProperty(propertyKey, {type: Object});
 
     ctor.addInitializer((instance) => {
-      const props = {};
       const prefix = options?.attributePrefix || camelToKebab(propertyKey.toString());
 
-      mapAttributesToProp(
-        prefix,
-        props,
-        Array.from(instance.attributes),
-        options?.splitValues ?? false
-      );
+      const readMappedAttributes = () => {
+        const props = {};
+        mapAttributesToProp(
+          prefix,
+          props,
+          Array.from(instance.attributes),
+          options?.splitValues ?? false
+        );
+        return props;
+      };
 
-      (instance as Instance)[propertyKey] = props as Instance[K];
+      // Initializers run from the constructor. An element parsed from markup is upgraded with
+      // its attributes already in place, so reading them here is enough for that case.
+      (instance as Instance)[propertyKey] = readMappedAttributes() as Instance[K];
+
+      // An element created programmatically has no attributes yet when the constructor runs:
+      // frameworks call `document.createElement`, then set attributes, then insert. Reading
+      // only in the constructor left the property empty forever, since these attributes are
+      // prefixed (`must-match-source`, `depends-on-category`) and so never map to a reactive
+      // property that Lit would observe. Read again once connected, which is after the
+      // attributes have been set.
+      instance.addController({
+        hostConnected: () => {
+          const props = readMappedAttributes();
+          // Only overwrite when attributes were actually found, so a value assigned straight to
+          // the property before insertion is preserved.
+          if (Object.keys(props).length > 0) {
+            (instance as Instance)[propertyKey] = props as Instance[K];
+          }
+        },
+      });
     });
   };
 }


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-4018

## Motivation

Components created programmatically lose their prefixed map attributes. Found via Coveo@Coveo Workplace, a Stencil SPA: navigating to `/people` **by clicking the header link** renders every result with the catch-all template, so employee photos are missing. Loading `/people` directly, or reloading, renders correctly.

Measured on the same URL with the same results and the same six registered templates, only the navigation path differing:

| template | direct load | client-side navigation |
|---|---|---|
| `must-match-source="Workday - People"` | `conditions: 1`, matches `true` | **`conditions: 0`** |
| four other `must-match-source` templates | `conditions: 1`, matches `false` | **`conditions: 0`** |
| catch-all | `conditions: 0` | `conditions: 0` |

With no conditions every template matches, so the last registered one wins — the catch-all. No error is logged, and it persists for the session: re-running the search does not fix it.

## Root Cause

`mapProperty` reads the element's attributes from a Lit initializer, and initializers run in the **constructor**:

```ts
ctor.addInitializer((instance) => {
  mapAttributesToProp(prefix, props, Array.from(instance.attributes), ...);
  instance[propertyKey] = props;
});
```

An element parsed from markup is upgraded with its attributes already present, so this works. An element created programmatically has none yet — a framework calls `document.createElement`, sets attributes, then inserts.

Nothing reads them afterwards. These attributes are **prefixed** (`must-match-source`, `depends-on-category`), so they do not correspond to a reactive property and Lit never notifies about them. The property stays `{}` for the element's lifetime, `makeMatchConditions` returns nothing, and template selection degenerates.

This affects **27 declarations across 20 components**: `must-match-*` / `must-not-match-*` on `atomic-result-template`, `atomic-product-template`, both children templates, `atomic-field-condition` and `atomic-product-field-condition`; and `depends-on-*` on every facet.

Note the pre-Lit Stencil implementation read these in `componentWillLoad`, which runs after props are assigned, so this is a regression from the Lit migration — `4b6574dacf` (#6159), first released in `@coveo/atomic` 3.36.0.

## Changes

Read the mapped attributes again in `hostConnected`, which runs after they have been set. The constructor read is kept so the markup path is unchanged.

The value is only overwritten when attributes are actually found, so assigning directly to the property before insertion — `element.mustMatch = {...}` — is preserved.

Fixing this in `mapProperty` fixes all 20 components at once; the alternative of recomputing conditions in each component would leave the underlying property empty and would not help the facets' `depends-on`.

## Validation

New test: `createElement`, `setAttribute('must-match-source', ...)`, then insert, and expect the property to be populated. Confirmed it **fails without the fix** with `expected {} to deeply equal { source: [ 'Workday - People' ] }`.

Second new test: assigning straight to the property before insertion is not clobbered.

48 tests pass across `props-utils`, both result templates, the children template, and both field conditions. `oxlint --deny-warnings`, `oxfmt --check` and Knip clean.

Verifying against the real app on a local CDN next; will update with the result.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`fix(<scope>): <description>`)
- [x] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code