### PR TITLE
feat(headless): add watchable ESM and definition builds

### DIFF
--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -80,6 +80,8 @@
     "build:bundles": "node esbuild.mjs",
     "build:esm": "node ./scripts/build.mjs --config=tsconfig.build-esm.json",
     "build:definitions": "tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",
+    "dev:esm": "node ./scripts/build.mjs --config=tsconfig.build-esm.json --watch",
+    "dev:definitions": "pnpm run build:definitions --watch",
     "clean": "node ../../utils/ci/rm-rf.mjs dist/*",
     "test": "vitest run --exclude \"src/integration-tests/**\"",
     "test:watch": "vitest --exclude \"src/integration-tests/**\"",

--- a/packages/headless/scripts/build.mjs
+++ b/packages/headless/scripts/build.mjs
@@ -2,9 +2,13 @@ import {basename, dirname, relative} from 'node:path';
 import {argv} from 'node:process';
 import {fileURLToPath} from 'node:url';
 import {
+  createEmitAndSemanticDiagnosticsBuilderProgram,
   createProgram,
+  createWatchCompilerHost,
+  createWatchProgram,
   DiagnosticCategory,
   flattenDiagnosticMessageText,
+  formatDiagnostic,
   getLineAndCharacterOfPosition,
   getPreEmitDiagnostics,
   parseJsonConfigFileContent,
@@ -25,6 +29,7 @@ if (configArg === undefined) {
   throw new Error('Missing --config=[PATH] argument');
 }
 const tsConfigPath = configArg.split('=')[1];
+const watchMode = args.includes('--watch');
 const transformers = [versionTransformer, analyticsTransformer, wildcardExportTransformer];
 
 function loadTsConfig(configPath) {
@@ -94,9 +99,65 @@ function compileWithTransformer() {
   process.exit(exitCode);
 }
 
+/**
+ * Recompiles on every change, applying the same custom transformers as a one-shot build.
+ *
+ * TypeScript's watch API emits through the builder program it creates, so the transformers
+ * have to be injected by taking over `afterProgramCreate` rather than by calling `emit`
+ * directly as the one-shot path does. The write callback is supplied explicitly because the
+ * watch host does not persist emitted output on its own.
+ */
+function watchWithTransformer() {
+  console.log(colors.blue('Using tsconfig:'), colors.green(basename(tsConfigPath)));
+
+  const host = createWatchCompilerHost(
+    tsConfigPath,
+    {},
+    sys,
+    createEmitAndSemanticDiagnosticsBuilderProgram,
+    (diagnostic) => process.stderr.write(formatDiagnostic(diagnostic, formatHost)),
+    (diagnostic) =>
+      console.log(colors.blue(flattenDiagnosticMessageText(diagnostic.messageText, '\n')))
+  );
+
+  host.afterProgramCreate = (builderProgram) => {
+    let emittedFileCount = 0;
+    const targetSourceFile = undefined;
+    const cancellationToken = undefined;
+    const emitOnlyDtsFiles = false;
+
+    builderProgram.emit(
+      targetSourceFile,
+      (fileName, text, writeByteOrderMark) => {
+        sys.writeFile(fileName, text, writeByteOrderMark);
+        emittedFileCount++;
+      },
+      cancellationToken,
+      emitOnlyDtsFiles,
+      {before: transformers}
+    );
+
+    console.log(colors.green(`Emitted ${emittedFileCount} files.`));
+  };
+
+  watchProgram = createWatchProgram(host);
+}
+
+let watchProgram;
+
+const formatHost = {
+  getCanonicalFileName: (fileName) => fileName,
+  getCurrentDirectory: sys.getCurrentDirectory,
+  getNewLine: () => sys.newLine,
+};
+
 try {
   console.log(colors.blue('Starting TypeScript compilation'));
-  compileWithTransformer();
+  if (watchMode) {
+    watchWithTransformer();
+  } else {
+    compileWithTransformer();
+  }
 } catch (error) {
   console.error(colors.red('Build failed:'), error);
   process.exit(1);

--- a/packages/headless/tsconfig.build-esm.json
+++ b/packages/headless/tsconfig.build-esm.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/esm",
+    "rootDir": "src",
     "verbatimModuleSyntax": true
   },
   "include": ["src/**/*"],

--- a/packages/headless/turbo.json
+++ b/packages/headless/turbo.json
@@ -1,0 +1,15 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "dev:esm": {
+      "dependsOn": ["build"],
+      "cache": false,
+      "persistent": true
+    },
+    "dev:definitions": {
+      "dependsOn": ["build"],
+      "cache": false,
+      "persistent": true
+    }
+  }
+}


### PR DESCRIPTION
## Issue

[KIT-6086 — Add watchable Headless ESM and definition builds](https://coveord.atlassian.net/browse/KIT-6086)

Part of [KIT-6084 — Migrate legacy Atomic development examples to owned modules](https://coveord.atlassian.net/browse/KIT-6084)

## Summary

Adds watch-mode equivalents of the two Headless build outputs that Atomic resolves at runtime, so a dev server can pick up Headless edits without a full rebuild. This is the prerequisite for an Atomic playground that hot reloads changes to both packages.

## What it does

- `dev:esm` recompiles `dist/esm` incrementally, applying the same version, analytics and wildcard-export transformers as `build:esm`. TypeScript's watch API emits through its own builder program, so the transformers are injected via `afterProgramCreate` and the write callback is supplied explicitly.
- `dev:definitions` runs the existing declaration build in watch mode, refreshing `dist/definitions` so editors and Atomic's type checks follow Headless public API changes.
- Both are declared as persistent, uncached Turbo tasks that depend on `build`.

`tsconfig.build-esm.json` now sets `rootDir` explicitly. It was previously inferred from the resolved root files, and the watch program resolves a wider set than the one-shot program, which placed output under `dist/esm/src` instead of `dist/esm`. The one-shot build emits the same 1198 files in the same layout as before.

## Usage

```sh
pnpm turbo run @coveo/headless#dev:esm
pnpm turbo run @coveo/headless#dev:definitions
```

