### PR TITLE
test(atomic): make the numeric facet depends-on story satisfy its dependency

### DIFF
--- a/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
+++ b/packages/atomic/src/components/search/atomic-numeric-facet/atomic-numeric-facet.new.stories.tsx
@@ -196,17 +196,31 @@ export const WithDependsOn: Story = {
     'with-input': 'integer',
     'depends-on-filetype': 'YouTubeVideo',
   },
+  beforeEach: () => {
+    // Return the dependency as already selected. The base mock always reports filetype values as
+    // idle no matter what the request asks for, so clicking a value never selected anything and
+    // the facet stayed independent of `depends-on-filetype` — the assertion passed whether or not
+    // the dependency was ever evaluated.
+    searchApiHarness.searchEndpoint.mockOnce((response) => ({
+      ...response,
+      facets: response.facets?.map((facet) =>
+        facet.facetId === 'filetype'
+          ? {
+              ...facet,
+              values: facet.values.map((value) =>
+                'value' in value && value.value === 'YouTubeVideo'
+                  ? {...value, state: 'selected'}
+                  : value
+              ),
+            }
+          : facet
+      ),
+    }));
+  },
   play: async (context) => {
     //TODO: Fix component registration race condition #6480
     await customElements.whenDefined('atomic-facet');
     await play(context);
-    const {canvas, step} = context;
-    await step('Select YouTubeVideo in filetype facet', async () => {
-      const button = await canvas.findByShadowLabelText('Inclusion filter on YouTubeVideo', {
-        exact: false,
-      });
-      button.ariaChecked === 'false' ? button.click() : null;
-    });
   },
 };
 


### PR DESCRIPTION
Bottom of a two-PR stack. #8286 sits on top and is the actual fix; this PR makes the test able to detect it.

## Jira

https://coveord.atlassian.net/browse/KIT-4018

## Motivation

`atomic-numeric-facet › should show facet when dependency is met` passes today without exercising `depends-on` at all.

The story's mock returns a fixed response where the filetype values are always `idle`, regardless of what the request asks for:

```ts
{value: 'YouTubeVideo', state: 'idle', numberOfResults: 62734},
```

So the play step's click could never select anything — verified at runtime, the facet request still reports `YouTubeVideo:idle` after the click, and `facetSet` has no selected values. The dependency was never satisfied, yet the assertion passed, because the dependent facet was visible for an unrelated reason.

That combination means the test cannot fail when `depends-on` is broken. It is currently green on `main` while `depends-on-filetype` is being ignored entirely.

## Changes

Return the dependency as already selected, so the facet is visible **because** `depends-on-filetype` is satisfied:

```ts
beforeEach: () => {
  searchApiHarness.searchEndpoint.mockOnce((response) => ({
    ...response,
    facets: response.facets?.map((facet) => facet.facetId === 'filetype' ? {...facet, values: /* YouTubeVideo → selected */} : facet),
  }));
},
```

The click is no longer needed and is removed, along with its `button.ariaChecked === 'false'` guard — that comparison silently skipped the click whenever the attribute was absent, for instance before the value had hydrated.

I first tried wiring `searchFacetTransformer`, as the sibling stories in this file do. It does not work here: it rebuilds the facet response generically and replaces the story's custom values with `PDF, HTML, DOC…`, so `YouTubeVideo` no longer exists to select.

## Validation

The test passes on `main` as before, and — the point of this PR — it also passes with #8286 applied on top, where `depends-on-filetype` is genuinely honoured. Verified locally by swapping only `props-utils.ts` between the two versions:

| | test |
|---|---|
| `main` | passes |
| `main` + this story change | passes |
| `main` + this story change + #8286 | passes |

Without this PR, #8286 makes the test fail — correctly, because the facet then hides while the dependency is unmet.

`oxlint --deny-warnings` and `oxfmt --check` clean, no new typecheck errors.

Note five other tests in this file fail in my local setup on `main` as well, unchanged by this PR; they pass in CI, where the same shard reported 43 passing.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] No changeset — test-only change, nothing user-facing