### PR TITLE
chore(deps): upgrade pnpm to 11.17.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir -p /pnpm/store && chown -R node:node /pnpm
 USER node
 
 # Pre-install pnpm as the node user so it's ready to use
-RUN corepack prepare pnpm@10.24.0 --activate
+RUN corepack prepare pnpm@11.17.0 --activate
 
 # Install turbo globally so it's available in terminal
 RUN pnpm add -g turbo@2.5.5

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -25,7 +25,7 @@ With prebuilds enabled, your codespace will be ready in ~30 seconds instead of 5
 Following [pnpm Docker best practices](https://pnpm.io/docker), we use a custom Dockerfile that:
 
 - Uses Node.js 22 LTS (jod) via the `node:jod-bookworm` image
-- Enables pnpm 10.24.0 via corepack (matching `packageManager` in `package.json`)
+- Enables pnpm 11.17.0 via corepack (matching `packageManager` in `package.json`)
 - Runs as the `node` user to avoid permission issues
 - Includes git and essential development tools
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -24,7 +24,7 @@ With prebuilds enabled, your codespace will be ready in ~30 seconds instead of 5
 
 Following [pnpm Docker best practices](https://pnpm.io/docker), we use a custom Dockerfile that:
 
-- Uses Node.js 22 LTS (jod) via the `node:jod-bookworm` image
+- Uses Node.js 22 LTS via the `node:krypton-bookworm` image (pinned by digest)
 - Enables pnpm 11.17.0 via corepack (matching `packageManager` in `package.json`)
 - Runs as the `node` user to avoid permission issues
 - Includes git and essential development tools

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ min_version = "2026.7.0"
 [tools]
 awscli = "2.36.20"
 node = "24.18.1"
-pnpm = "10.34.5"
+pnpm = "11.17.0"
 
 [tasks.install]
 run = "pnpm install"

--- a/package.json
+++ b/package.json
@@ -52,24 +52,7 @@
   },
   "engines": {
     "node": "^22.14.0 || ^24.11.0",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=11.17.0"
   },
-  "packageManager": "pnpm@10.34.5",
-  "pnpm": {
-    "patchedDependencies": {
-      "@stencil/core@4.20.0": "patches/@stencil+core+4.20.0.patch",
-      "jest-environment-jsdom@29.7.0": "patches/jest-environment-jsdom+29.7.0.patch",
-      "@wc-toolkit/storybook-helpers@10.5.1": "patches/@wc-toolkit__storybook-helpers@10.5.1.patch"
-    },
-    "overrides": {
-      "braces": "3.0.3",
-      "react": "catalog:",
-      "react-dom": "catalog:",
-      "typescript": "catalog:",
-      "html-minifier": "npm:html-minifier-terser@^7.2.0",
-      "@angular/core": "catalog:",
-      "@angular/common": "catalog:",
-      "undici@^7": "^7.29.0"
-    }
-  }
+  "packageManager": "pnpm@11.17.0"
 }

--- a/packages/atomic-legacy/package.json
+++ b/packages/atomic-legacy/package.json
@@ -7,6 +7,9 @@
     "url": "git+https://github.com/coveo/ui-kit.git",
     "directory": "packages/atomic-legacy"
   },
+  "files": [
+    "dist/"
+  ],
   "type": "module",
   "exports": {
     "./atomic-suggestion-renderer": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -159,3 +159,31 @@ minimumReleaseAgeExclude:
 # Allow using the shell emulator for all commands, which is required for some commands to work properly on Windows.
 # https://pnpm.io/cli/run#shellemulator
 shellEmulator: true
+
+overrides:
+  braces: 3.0.3
+  react: 'catalog:'
+  react-dom: 'catalog:'
+  typescript: 'catalog:'
+  html-minifier: npm:html-minifier-terser@^7.2.0
+  '@angular/core': 'catalog:'
+  '@angular/common': 'catalog:'
+  undici@^7: ^7.29.0
+
+patchedDependencies:
+  '@stencil/core@4.20.0': patches/@stencil+core+4.20.0.patch
+  'jest-environment-jsdom@29.7.0': patches/jest-environment-jsdom+29.7.0.patch
+  '@wc-toolkit/storybook-helpers@10.5.1': patches/@wc-toolkit__storybook-helpers@10.5.1.patch
+
+allowBuilds:
+  '@parcel/watcher': false
+  core-js: false
+  esbuild: false
+  fsevents: false
+  lmdb: false
+  msgpackr-extract: false
+  msw: false
+  puppeteer: false
+  rs-module-lexer: false
+  sharp: false
+  unrs-resolver: false


### PR DESCRIPTION
## Jira

[KIT-6100](https://coveord.atlassian.net/browse/KIT-6100)

## Motivation

UI Kit needs pnpm 11 for its newer package-resolution capabilities. This upgrade also keeps local development, devcontainers, and CI on the same package-manager version.

## Changes

- Upgrade pnpm to 11.17.0 in the root package metadata, mise configuration, and devcontainer.
- Move pnpm settings from `package.json` to `pnpm-workspace.yaml`, as required by pnpm 11.
- Explicitly declare allowed dependency build scripts.
- Add a `dist/` publication allowlist for `@coveo/atomic-legacy` so its exported files remain included by `pnpm pack`.

## Validation

- All GitHub CI checks passed, including build, lint, unit, E2E, package compatibility, and security checks.
- Confirmed the `@coveo/atomic-legacy` pnpm 11 tarball contains all exported JavaScript and declaration files.
- Ran Publint for `@coveo/atomic-legacy`: all checks passed.

- [x] All existing tests pass without modification
- [x] No new features or runtime bug fixes are included in this PR
- [x] Public API surface is unchanged

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changeset not required because no public package source or API behavior changed

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


[KIT-6100]: https://coveord.atlassian.net/browse/KIT-6100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ