### PR TITLE
feat(ci): include expanded dependent tasks in affected calculation

### DIFF
--- a/.github/actions/build-cdn/action.yml
+++ b/.github/actions/build-cdn/action.yml
@@ -10,14 +10,10 @@ runs:
   using: composite
   steps:
     - uses: ./.github/actions/setup
-    - uses: ./.github/actions/run-affected
-      with:
-        tasks: build
-        # Samples are not CDN artifacts. Exclude them so the CDN build does not try
-        # to bundle samples that depend on CDN-externalized packages.
-        packages: |
-          !@samples/*
-          !@coveo/ui-kit-sample-*
+      # Samples are not CDN artifacts. Exclude them so the CDN build does not try
+      # to bundle samples that depend on CDN-externalized packages.
+    - run: pnpm exec turbo build --filter='!./samples/**'
+      shell: bash
       env:
         DEPLOYMENT_ENVIRONMENT: CDN
         CDN_COMMIT_SHA: ${{ inputs.commit-sha }}

--- a/.github/actions/calculate-affected/action.yml
+++ b/.github/actions/calculate-affected/action.yml
@@ -10,7 +10,7 @@ inputs:
 outputs:
   fetch-depth:
     description: Minimum checkout depth required for the calculated commit range.
-    value: ${{ steps.calculate.outputs.fetch-depth }}
+    value: ${{ steps.git.outputs.fetch-depth }}
   tasks:
     description: Affected Turbo task identifiers as a single-line JSON array of strings.
     value: ${{ steps.calculate.outputs.tasks }}
@@ -28,77 +28,25 @@ runs:
       with:
         install: true
         cache: true
+
+    - name: Calculate Git fetch depth
+      id: git
+      shell: bash
+      env:
+        TURBO_SCM_BASE: ${{ inputs.base-sha }}
+        TURBO_SCM_HEAD: ${{ inputs.head-sha }}
+      run: |
+        GIT_NO_LAZY_FETCH=1 git rev-parse --verify "${TURBO_SCM_BASE}^{commit}"
+        GIT_NO_LAZY_FETCH=1 git rev-parse --verify "${TURBO_SCM_HEAD}^{commit}"
+
+        range_count="$(git rev-list --count "${TURBO_SCM_BASE}..${TURBO_SCM_HEAD}")"
+        fetch_depth=$((range_count + 1))
+        echo "fetch-depth=$fetch_depth" >> "$GITHUB_OUTPUT"
+
     - name: Calculate and publish affected data
       id: calculate
       shell: bash
       env:
         TURBO_SCM_BASE: ${{ inputs.base-sha }}
         TURBO_SCM_HEAD: ${{ inputs.head-sha }}
-        # Inspired from https://github.com/vercel/turborepo/discussions/12949
-        QUERY: |
-          query {
-            affectedTasks(base: "${{ inputs.base-sha }}", head: "${{ inputs.head-sha }}") {
-              items {
-                name
-                fullName
-                package {
-                  name
-                }
-                reason {
-                  __typename
-                  ... on TaskFileChanged { filePath }
-                  ... on TaskDependencyTaskChanged { taskName packageName }
-                  ... on TaskPackageDependencyChanged { packageName }
-                  ... on TaskGlobalFileChanged { filePath }
-                  ... on TaskGlobalDepsChanged { filePath }
-                  ... on TaskAllChanged { description }
-                }
-              }
-            }
-          }
-      run: |
-        set -euo pipefail
-
-        GIT_NO_LAZY_FETCH=1 git rev-parse --verify "${TURBO_SCM_BASE}^{commit}"
-        GIT_NO_LAZY_FETCH=1 git rev-parse --verify "${TURBO_SCM_HEAD}^{commit}"
-
-        range_count="$(git rev-list --count "${TURBO_SCM_BASE}..${TURBO_SCM_HEAD}")"
-        fetch_depth=$((range_count + 1))
-
-        turbo_version="$(node -p "require('./package.json').devDependencies.turbo")"
-        affected_tasks="$(
-          pnpm dlx "turbo@$turbo_version" query --no-update-notifier "${QUERY}" \
-             | jq -c '.data.affectedTasks.items | sort_by(.fullName)'
-        )"
-
-        jq_output() {
-          local name="$1"
-          local query="$2"
-          local value
-
-          value="$(jq -c "$query" <<< "${affected_tasks}")"
-          echo "$name=$value" >> "$GITHUB_OUTPUT"
-        }
-
-        echo "fetch-depth=$fetch_depth" >> "$GITHUB_OUTPUT"
-
-        jq_output tasks    'map(.fullName)'
-        jq_output projects 'map(.package.name) | unique'
-        jq_output samples  'map(.fullName | select(test("^@(samples/|coveo/ui-kit-sample-)[^#]+#e2e$")))'
-
-        {
-          echo '### Affected tasks'
-          echo '| package | task | reason | description |'
-          echo '| --- | --- | --- | --- |'
-
-          jq -r '
-            .[]
-            | .reason as $reason
-            | ($reason | .description // .filePath // "\(.packageName)#\(.taskName)" // "") as $description
-            | [.package.name, .name, $reason.__typename, $description]
-            | map("`\(.)`")
-            | "| \(. | join(" | ")) |"
-          ' <<< "${affected_tasks}"
-        } >> "${GITHUB_STEP_SUMMARY}"
-
-        echo "Affected tasks summary: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+      run: node "$GITHUB_ACTION_PATH/affected.mjs"

--- a/.github/actions/calculate-affected/affected.mjs
+++ b/.github/actions/calculate-affected/affected.mjs
@@ -1,0 +1,182 @@
+import {execFileSync} from 'node:child_process';
+import {appendFileSync, existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {join} from 'node:path';
+
+const {
+  GITHUB_OUTPUT,
+  GITHUB_REPOSITORY,
+  GITHUB_RUN_ID,
+  GITHUB_SERVER_URL,
+  GITHUB_STEP_SUMMARY,
+  TURBO_SCM_BASE,
+  TURBO_SCM_HEAD,
+} = process.env;
+
+const rootPackage = JSON.parse(readFileSync('package.json', 'utf8'));
+const turboVersion = rootPackage.devDependencies.turbo;
+const turboMaxBuffer = 100 * 1024 * 1024;
+
+const turboCommand = (...args) => {
+  return execFileSync('pnpm', ['dlx', `turbo@${turboVersion}`, ...args], {
+    encoding: 'utf8',
+    maxBuffer: turboMaxBuffer,
+  });
+};
+
+const query = `
+query {
+  packages {
+    items {
+      name
+      path
+    }
+  }
+  affectedTasks(base: "${TURBO_SCM_BASE}", head: "${TURBO_SCM_HEAD}") {
+    items {
+      name
+      fullName
+      package {
+        name
+      }
+      reason {
+        __typename
+        ... on TaskFileChanged { filePath }
+        ... on TaskDependencyTaskChanged { taskName packageName }
+        ... on TaskPackageDependencyChanged { packageName }
+        ... on TaskGlobalFileChanged { filePath }
+        ... on TaskGlobalDepsChanged { filePath }
+        ... on TaskAllChanged { description }
+      }
+    }
+  }
+}
+`;
+const queryOutput = JSON.parse(turboCommand('query', '--no-update-notifier', query));
+
+const sortBy = (property) => (left, right) => left[property].localeCompare(right[property]);
+
+const writeOutput = (name, value) => {
+  appendFileSync(GITHUB_OUTPUT, `${name}=${JSON.stringify(value)}\n`);
+};
+
+// All packages / tasks
+
+const getTurboFiles = (packages) => {
+  return packages.map(({path}) => join(path, 'turbo.json')).filter((path) => existsSync(path));
+};
+
+const getAllTasks = (turboFiles) => {
+  const tasks = new Set();
+
+  for (const turboFile of turboFiles) {
+    const {tasks: packageTasks = {}} = JSON.parse(readFileSync(turboFile, 'utf8'));
+    for (const task of Object.keys(packageTasks)) {
+      tasks.add(task.replace(/^\/\/#/, ''));
+    }
+  }
+
+  return [...tasks].sort();
+};
+
+const allPackages = [...queryOutput.data.packages.items].sort(sortBy('name'));
+const allTasks = getAllTasks(getTurboFiles(allPackages));
+
+// Task graph
+
+const getTasksGraph = (dryRun) => {
+  return dryRun.tasks
+    .sort(sortBy('taskId'))
+    .map(({package: packageName, task, dependents}) => ({
+      packageName,
+      task,
+      dependents,
+    }))
+    .reduce((graph, {packageName, task, dependents}) => {
+      graph[packageName] ??= {};
+      graph[packageName][task] = dependents;
+      return graph;
+    }, {});
+};
+
+const dryRun = JSON.parse(turboCommand('run', '--dry=json', ...allTasks));
+const tasksGraph = getTasksGraph(dryRun);
+
+// Affected tasks
+
+/**
+ * If a task is affected, all its dependents tasks are.
+ * This is important because Turbo doesn't return tasks without a "command" in the output of affectedTasks.
+ * You must attempt to call the tasks to know which dependencies are actually called.
+ */
+const expandAffectedTasks = (tasksGraph, affectedTasks) => {
+  const affected = new Set(affectedTasks);
+  const queue = [...affectedTasks];
+
+  while (queue.length > 0) {
+    const task = queue.shift();
+    const [packageName, taskName] = task.split('#');
+    const dependents = tasksGraph[packageName][taskName];
+
+    for (const dependent of dependents) {
+      if (!affected.has(dependent)) {
+        affected.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+
+  return [...affected].sort();
+};
+
+const packagesFromTasks = (taskIds) => {
+  const packageNames = taskIds.map((taskId) => taskId.split('#')[0]);
+
+  return [...new Set(packageNames)].sort();
+};
+
+const affectedTasks = [...queryOutput.data.affectedTasks.items].sort(sortBy('fullName'));
+const affectedTaskNames = expandAffectedTasks(
+  tasksGraph,
+  affectedTasks.map(({fullName}) => fullName)
+);
+const affectedPackageNames = packagesFromTasks(affectedTaskNames);
+const affectedSamples = affectedTaskNames.filter((fullName) =>
+  /^@(samples\/|coveo\/ui-kit-sample-)[^#]+#e2e$/.test(fullName)
+);
+
+writeOutput('tasks', affectedTaskNames);
+writeOutput('projects', affectedPackageNames);
+writeOutput('samples', affectedSamples);
+
+// Output markdown table for the run summary
+
+const markdownTable = (headers, rows, quote = '') => {
+  const header = `| ${headers.join(' | ')} |`;
+  const separator = `| ${headers.map(() => '---').join(' | ')} |`;
+  const processCell = (cell) => `${quote}${String(cell).replaceAll('|', '\\|')}${quote}`;
+  const body = rows.map((row) => `| ${row.map(processCell).join(' | ')} |`).join('\n');
+
+  return [header, separator, body, ''].join('\n');
+};
+
+const getSummaryDescription = (reason) => {
+  if (reason.__typename === 'TaskDependencyTaskChanged') {
+    return `${reason.packageName}#${reason.taskName}`;
+  }
+
+  return reason.description ?? reason.filePath ?? '';
+};
+
+// Don't use the "expanded" affected tasks here, it would far too noisy.
+const affectedRows = affectedTasks.map(({package: packageInfo, name, reason}) => [
+  packageInfo.name,
+  name,
+  reason.__typename,
+  getSummaryDescription(reason),
+]);
+
+const summary = markdownTable(['package', 'task', 'reason', 'description'], affectedRows);
+appendFileSync(GITHUB_STEP_SUMMARY, summary);
+
+const githubRunUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+console.log(`Affected tasks summary: ${githubRunUrl}`);

--- a/.github/actions/calculate-affected/affected.mjs
+++ b/.github/actions/calculate-affected/affected.mjs
@@ -1,5 +1,5 @@
 import {execFileSync} from 'node:child_process';
-import {appendFileSync, existsSync, readFileSync, writeFileSync} from 'node:fs';
+import {appendFileSync, existsSync, readFileSync} from 'node:fs';
 import {join} from 'node:path';
 
 const {

--- a/.github/actions/run-affected/action.yml
+++ b/.github/actions/run-affected/action.yml
@@ -2,9 +2,8 @@ name: 'Run affected Turbo tasks'
 description: 'Select affected Turbo tasks from the current task graph and run them.'
 inputs:
   affected-tasks:
-    description: 'Affected Turbo task identifiers as a JSON array. When not specified, run all tasks in the selected graph. When the array is empty, run no tasks.'
-    required: false
-    default: ''
+    description: 'Affected Turbo task identifiers as a JSON array. When the array is empty, run no tasks.'
+    required: true
   tasks:
     description: 'Turbo target task names, one per line.'
     required: false

--- a/.github/actions/run-affected/resolve-tasks.mjs
+++ b/.github/actions/run-affected/resolve-tasks.mjs
@@ -1,9 +1,3 @@
-import {existsSync, globSync, readFileSync, statSync} from 'node:fs';
-import {resolve} from 'node:path';
-import {parse} from 'yaml';
-
-const root = resolve(process.env.GITHUB_WORKSPACE ?? process.cwd());
-
 const splitLines = (value = '') =>
   value
     .split('\n')
@@ -27,79 +21,66 @@ const globToRegExp = (pattern) => {
 
 const matchesPattern = (value, pattern) => globToRegExp(pattern).test(value);
 
-const matchesPackage = (project, packageName) => matchesPattern(project.name, packageName);
-
 const parsePackages = (value) => {
-  const packages = splitLines(value).map((packageName) => {
-    const negative = packageName.startsWith('!');
+  const rules = splitLines(value).map((packageName) => {
+    const included = !packageName.startsWith('!');
     return {
-      negative,
-      pattern: packageName.slice(negative ? 1 : 0),
+      included,
+      pattern: packageName.slice(included ? 0 : 1),
     };
   });
 
-  const positive = packages.filter(({negative}) => !negative);
-  const negative = packages.filter(({negative}) => negative);
+  // If it contains any "inclusion" rules, default to false
+  // Otherwise (including if empty), default to true
+  const defaultIncluded = !rules.some((rule) => rule.included);
 
   return (project) => {
-    const included =
-      positive.length === 0 || positive.some(({pattern}) => matchesPackage(project, pattern));
-    const excluded = negative.some(({pattern}) => matchesPackage(project, pattern));
-    return included && !excluded;
+    let included = defaultIncluded;
+    // Last rule wins
+    for (const rule of rules) {
+      if (matchesPattern(project, rule.pattern)) {
+        included = rule.included;
+      }
+    }
+    return included;
   };
 };
 
-const readPackage = (directory) => {
-  const path = resolve(root, directory, 'package.json');
-  const pkg = JSON.parse(readFileSync(path, 'utf8'));
+const parseJsonInput = (varName) => {
+  const input = process.env[varName] ?? '';
 
-  return {
-    name: pkg.name,
-    scripts: pkg.scripts ?? {},
-  };
-};
-
-const readWorkspacePackages = () => {
-  const workspace = parse(readFileSync(resolve(root, 'pnpm-workspace.yaml'), 'utf8'));
-  const directories = new Set(
-    (workspace.packages ?? []).flatMap((pattern) => globSync(pattern, {cwd: root}))
-  );
-  return [...directories]
-    .filter((directory) => statSync(resolve(root, directory)).isDirectory())
-    .filter((directory) => existsSync(resolve(root, directory, 'package.json')))
-    .map(readPackage);
-};
-
-const parseInputs = () => {
-  const requestedTasks = splitLines(process.env.TASKS || 'build');
-  const matchesPackage = parsePackages(process.env.PACKAGES);
-
-  const affectedInput = process.env.AFFECTED_TASKS ?? '';
-  const affectedTasks = affectedInput == '' ? null : JSON.parse(affectedInput);
-
-  if (
-    affectedInput != '' &&
-    (!Array.isArray(affectedTasks) || affectedTasks.some((task) => typeof task !== 'string'))
-  ) {
-    throw new TypeError('AFFECTED_TASKS must be a JSON array of strings.');
+  if (input === '') {
+    throw new TypeError(`${varName} must be defined.`);
   }
 
-  return {requestedTasks, matchesPackage, affectedTasks};
+  let value;
+
+  try {
+    value = JSON.parse(input);
+  } catch (error) {
+    throw new TypeError(`${varName} is not valid JSON: ${error}`);
+  }
+
+  if (value === null) {
+    throw new TypeError(`${varName} must be defined.`);
+  }
+
+  return value;
 };
+
+const parseInputs = () => ({
+  requestedTasks: new Set(splitLines(process.env.TASKS || 'build')),
+  matchesPackage: parsePackages(process.env.PACKAGES),
+  affectedTasks: parseJsonInput('AFFECTED_TASKS'),
+});
 
 const resolveTasks = () => {
   const {requestedTasks, matchesPackage, affectedTasks} = parseInputs();
-  const packages = readWorkspacePackages();
-  const projects = matchesPackage ? packages.filter(matchesPackage) : packages;
-  const tasks = projects.flatMap((project) =>
-    Object.keys(project.scripts).map((task) => ({project, task}))
-  );
 
-  return tasks
-    .filter(({task}) => requestedTasks.includes(task))
-    .map(({project, task}) => `${project.name}#${task}`)
-    .filter((task) => affectedTasks === null || affectedTasks.includes(task))
-    .sort();
+  return affectedTasks.filter((taskId) => {
+    const [project, task] = taskId.split('#');
+    return requestedTasks.has(task) && matchesPackage(project);
+  });
 };
 
 const tasks = resolveTasks();

--- a/.github/actions/run-affected/test-resolve-tasks.mjs
+++ b/.github/actions/run-affected/test-resolve-tasks.mjs
@@ -64,9 +64,18 @@ run(
   {
     TASKS: 'test\npublint',
     PACKAGES: '@coveo/atomic',
-    AFFECTED_TASKS: '["@coveo/atomic#test", "@coveo/atomic#publint"]',
+    AFFECTED_TASKS: '["@coveo/atomic#publint","@coveo/atomic#test"]',
   },
   ['@coveo/atomic#publint', '@coveo/atomic#test']
+);
+run(
+  'filters affected root generation tasks',
+  {
+    TASKS: 'generate:catalog-info\ngenerate:all',
+    PACKAGES: '',
+    AFFECTED_TASKS: '["//#generate:catalog-info"]',
+  },
+  ['//#generate:catalog-info']
 );
 run(
   'does not resolve an explicit empty affected list',
@@ -77,23 +86,14 @@ run(
   },
   []
 );
-for (const invalidAffectedTasks of ['null', '{}', '["@coveo/atomic#build", 1]']) {
+for (const invalidAffectedTasks of ['null', '']) {
   runFailure(
     `rejects invalid affected tasks: ${invalidAffectedTasks}`,
     {
       GITHUB_WORKSPACE: resolve(directory, 'missing-workspace'),
       AFFECTED_TASKS: invalidAffectedTasks,
     },
-    /AFFECTED_TASKS must be a JSON array of strings\./
+    /AFFECTED_TASKS/
   );
 }
-run(
-  'resolves the selected workspace when affected tasks are not provided',
-  {
-    TASKS: 'publint',
-    PACKAGES: '@coveo/atomic',
-    AFFECTED_TASKS: '',
-  },
-  ['@coveo/atomic#publint']
-);
 console.log('All resolve-tasks scenarios passed.');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,8 @@ jobs:
   unit-test:
     name: 'Run unit tests'
     needs: affected
+    # Best effort at short-circuiting
+    if: contains(needs.affected.outputs.tasks, '#test')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
             !@coveo/ui-kit-sample-*
         env:
           DEPLOYMENT_ENVIRONMENT: CDN
-          CDN_COMMIT_SHA: ${{ inputs.commit-sha }}
+          CDN_COMMIT_SHA: ${{ github.sha }}
 
   knip:
     name: 'Look for unused code or dependencies'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,9 +147,21 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: ./.github/actions/build-cdn
+      - uses: ./.github/actions/setup
+      # Note that this does not use .github/actions/build-cdn/action.yml.
+      # It purposefully doesn't support affected because it's used by the cd and hotfix workflows.
+      - uses: ./.github/actions/run-affected
         with:
-          commit-sha: ${{ github.sha }}
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
+          tasks: build
+          # Samples are not CDN artifacts. Exclude them so the CDN build does not try
+          # to bundle samples that depend on CDN-externalized packages.
+          packages: |
+            !@samples/*
+            !@coveo/ui-kit-sample-*
+        env:
+          DEPLOYMENT_ENVIRONMENT: CDN
+          CDN_COMMIT_SHA: ${{ inputs.commit-sha }}
 
   knip:
     name: 'Look for unused code or dependencies'


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6096

## Motivation

Turbo can omit commandless virtual tasks from affected-task results even when their dependencies are affected. This will enable next PRs in this stack to use such virtual tasks.

Upstream bug: https://github.com/vercel/turborepo/issues/13790

## Changes

- Move the `affected` script to a dedicated file and translate to JS for more flexibility. 
- Expand Turbo's resolved task graph through direct and transitive dependents.
- Publish the expanded task results for downstream CI jobs.
- Simplify affected-task resolution so downstream jobs always consume the `affected` list.
- Because `affected-tasks` is now mandatory, `build-cdn` is now restored to a regular `turbo build`
- Bonus: Adds support for root-level and package-level task identifiers in the affected calculation.

## Validation

- Resolver scenarios cover root-level tasks, package filtering, empty affected results, and invalid affected-task input.
- Full composite-action execution is not validated locally.

Determining tasks that need to run for a given step now takes a [whopping 0s](https://github.com/coveo/ui-kit/actions/runs/32504952607/job/96843642524?pr=8256) 🎉 

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`feat(<scope>): <description>`)
- [ ] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code
