### PR TITLE
chore(quantic): align linting with repository conventions

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -9,6 +9,7 @@
     "**/.agents/**/*",
     "AGENTS.md",
     "**/packages/quantic/**/*",
+    "!**/packages/quantic/*.json",
     "!**/packages/quantic/catalog-info.yaml",
     "**/packages/create-atomic-template/**/*",
     "**/packages/create-atomic-component/template/**/*",

--- a/packages/quantic/force-app/custom-token/test/classes/CustomTokenProviderTest.cls
+++ b/packages/quantic/force-app/custom-token/test/classes/CustomTokenProviderTest.cls
@@ -47,10 +47,7 @@ private class CustomTokenProviderTest {
   @IsTest
   static void withEmptyOrgId() {
     Test.startTest();
-    CustomTokenProviderTest.setupTokenSettings(
-      '',
-      'someToken'
-    );
+    CustomTokenProviderTest.setupTokenSettings('', 'someToken');
     try {
       CustomTokenProvider.getHeadlessConfiguration();
     } catch (Exception e) {
@@ -61,10 +58,7 @@ private class CustomTokenProviderTest {
 
   @IsTest
   static void withEmptyApiKey() {
-    CustomTokenProviderTest.setupTokenSettings(
-      'someOrgId',
-      ''
-    );
+    CustomTokenProviderTest.setupTokenSettings('someOrgId', '');
     try {
       CustomTokenProvider.getHeadlessConfiguration();
     } catch (Exception e) {
@@ -78,10 +72,7 @@ private class CustomTokenProviderTest {
       'foo1',
       'System Administrator'
     );
-    CustomTokenProviderTest.setupTokenSettings(
-      'someOrgId',
-      'someToken'
-    );
+    CustomTokenProviderTest.setupTokenSettings('someOrgId', 'someToken');
     Test.setMock(
       HttpCalloutMock.class,
       new MockHttpTokenResponse(

--- a/packages/quantic/force-app/main/default/classes/OrganizationEndpointsTest.cls
+++ b/packages/quantic/force-app/main/default/classes/OrganizationEndpointsTest.cls
@@ -5,17 +5,36 @@ public class OrganizationEndpointsTest {
     String orgId = 'testOrgId';
     String env = 'prod';
 
-    Map<String, String> endpoints = OrganizationEndpoints.getOrganizationEndpoints(orgId, env);
+    Map<String, String> endpoints = OrganizationEndpoints.getOrganizationEndpoints(
+      orgId,
+      env
+    );
 
     String expectedPlatform = 'https://testOrgId.org.coveo.com';
     String expectedAnalytics = 'https://testOrgIdanalytics.org.coveo.com';
     String expectedSearch = expectedPlatform + '/rest/search/v2';
     String expectedAdmin = 'https://testOrgIdadmin.org.coveo.com';
 
-    System.assertEquals(expectedPlatform, endpoints.get('platform'), 'Platform URL mismatch for prod');
-    System.assertEquals(expectedAnalytics, endpoints.get('analytics'), 'Analytics URL mismatch for prod');
-    System.assertEquals(expectedSearch, endpoints.get('search'), 'Search URL mismatch for prod');
-    System.assertEquals(expectedAdmin, endpoints.get('admin'), 'Admin URL mismatch for prod');
+    System.assertEquals(
+      expectedPlatform,
+      endpoints.get('platform'),
+      'Platform URL mismatch for prod'
+    );
+    System.assertEquals(
+      expectedAnalytics,
+      endpoints.get('analytics'),
+      'Analytics URL mismatch for prod'
+    );
+    System.assertEquals(
+      expectedSearch,
+      endpoints.get('search'),
+      'Search URL mismatch for prod'
+    );
+    System.assertEquals(
+      expectedAdmin,
+      endpoints.get('admin'),
+      'Admin URL mismatch for prod'
+    );
   }
 
   @isTest
@@ -23,33 +42,70 @@ public class OrganizationEndpointsTest {
     String orgId = 'testOrgId';
     String env = 'dev';
 
-    Map<String, String> endpoints = OrganizationEndpoints.getOrganizationEndpoints(orgId, env);
+    Map<String, String> endpoints = OrganizationEndpoints.getOrganizationEndpoints(
+      orgId,
+      env
+    );
 
     String expectedPlatform = 'https://testOrgId.orgdev.coveo.com';
     String expectedAnalytics = 'https://testOrgIdanalytics.orgdev.coveo.com';
     String expectedSearch = expectedPlatform + '/rest/search/v2';
     String expectedAdmin = 'https://testOrgIdadmin.orgdev.coveo.com';
 
-    System.assertEquals(expectedPlatform, endpoints.get('platform'), 'Platform URL mismatch for dev');
-    System.assertEquals(expectedAnalytics, endpoints.get('analytics'), 'Analytics URL mismatch for dev');
-    System.assertEquals(expectedSearch, endpoints.get('search'), 'Search URL mismatch for dev');
-    System.assertEquals(expectedAdmin, endpoints.get('admin'), 'Admin URL mismatch for dev');
+    System.assertEquals(
+      expectedPlatform,
+      endpoints.get('platform'),
+      'Platform URL mismatch for dev'
+    );
+    System.assertEquals(
+      expectedAnalytics,
+      endpoints.get('analytics'),
+      'Analytics URL mismatch for dev'
+    );
+    System.assertEquals(
+      expectedSearch,
+      endpoints.get('search'),
+      'Search URL mismatch for dev'
+    );
+    System.assertEquals(
+      expectedAdmin,
+      endpoints.get('admin'),
+      'Admin URL mismatch for dev'
+    );
   }
 
   @isTest
   static void testGetOrganizationEndpointsWithoutEnv() {
     String orgId = 'testOrgId';
 
-    Map<String, String> endpoints = OrganizationEndpoints.getOrganizationEndpoints(orgId);
+    Map<String, String> endpoints = OrganizationEndpoints.getOrganizationEndpoints(
+      orgId
+    );
 
     String expectedPlatform = 'https://testOrgId.org.coveo.com';
     String expectedAnalytics = 'https://testOrgIdanalytics.org.coveo.com';
     String expectedSearch = expectedPlatform + '/rest/search/v2';
     String expectedAdmin = 'https://testOrgIdadmin.org.coveo.com';
 
-    System.assertEquals(expectedPlatform, endpoints.get('platform'), 'Platform URL mismatch');
-    System.assertEquals(expectedAnalytics, endpoints.get('analytics'), 'Analytics URL mismatch');
-    System.assertEquals(expectedSearch, endpoints.get('search'), 'Search URL mismatch');
-    System.assertEquals(expectedAdmin, endpoints.get('admin'), 'Admin URL mismatch');
+    System.assertEquals(
+      expectedPlatform,
+      endpoints.get('platform'),
+      'Platform URL mismatch'
+    );
+    System.assertEquals(
+      expectedAnalytics,
+      endpoints.get('analytics'),
+      'Analytics URL mismatch'
+    );
+    System.assertEquals(
+      expectedSearch,
+      endpoints.get('search'),
+      'Search URL mismatch'
+    );
+    System.assertEquals(
+      expectedAdmin,
+      endpoints.get('admin'),
+      'Admin URL mismatch'
+    );
   }
 }

--- a/packages/quantic/jsdoc-config.json
+++ b/packages/quantic/jsdoc-config.json
@@ -2,11 +2,7 @@
   "tags": {
     "allowUnknownTags": true
   },
-  "plugins": [
-    "plugins/markdown",
-    "jsdoc-plugins/export-fixer",
-    "jsdoc-tsimport-plugin/index.js"
-  ],
+  "plugins": ["plugins/markdown", "jsdoc-plugins/export-fixer", "jsdoc-tsimport-plugin/index.js"],
   "recurseDepth": 10,
   "source": {
     "include": ["force-app/main/default/lwc"],

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -2,14 +2,26 @@
   "name": "@coveo/quantic",
   "version": "3.44.0",
   "description": "A Salesforce Lightning Web Component (LWC) library for building modern UIs interfacing with the Coveo platform",
-  "author": "coveo.com",
   "homepage": "https://coveo.com",
   "license": "Apache-2.0",
-  "main": "index.js",
+  "author": "coveo.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/coveo/ui-kit.git"
   },
+  "files": [
+    "force-app/main/default/classes/*",
+    "force-app/main/default/labels/*",
+    "force-app/main/default/lwc/*",
+    "!force-app/main/default/lwc/testUtils",
+    "force-app/main/default/cspTrustedSites/*",
+    "force-app/main/default/staticresources/*",
+    "scripts/npm",
+    "docs/out/quantic-docs.json",
+    "!force-app/main/default/lwc/**/__tests__",
+    "!force-app/main/default/lwc/**/e2e"
+  ],
+  "main": "index.js",
   "scripts": {
     "lint:check:tests": "eslint force-app/main/default/lwc/ --format junit -o reports/eslint.xml",
     "lint:check": "eslint force-app/main/default/lwc/ && eslint force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.js\" --check",
@@ -52,9 +64,6 @@
     "dompurify": "catalog:",
     "marked": "catalog:"
   },
-  "engines": {
-    "node": "^20.9.0 || ^22.11.0 || ^24.11.0"
-  },
   "devDependencies": {
     "@babel/cli": "7.28.3",
     "@babel/plugin-transform-async-to-generator": "7.27.1",
@@ -81,16 +90,7 @@
     "wait-on": "9.1.0",
     "xml2js": "0.6.2"
   },
-  "files": [
-    "force-app/main/default/classes/*",
-    "force-app/main/default/labels/*",
-    "force-app/main/default/lwc/*",
-    "!force-app/main/default/lwc/testUtils",
-    "force-app/main/default/cspTrustedSites/*",
-    "force-app/main/default/staticresources/*",
-    "scripts/npm",
-    "docs/out/quantic-docs.json",
-    "!force-app/main/default/lwc/**/__tests__",
-    "!force-app/main/default/lwc/**/e2e"
-  ]
+  "engines": {
+    "node": "^20.9.0 || ^22.11.0 || ^24.11.0"
+  }
 }

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -23,7 +23,6 @@
   ],
   "main": "index.js",
   "scripts": {
-    "lint:check:tests": "eslint force-app/main/default/lwc/ --format junit -o reports/eslint.xml",
     "lint:check": "eslint force-app/main/default/lwc/ force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.{js,cls,trigger}\" --check",
     "lint:fix": "eslint --fix force-app/main/default/lwc/ force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.{js,cls,trigger}\" --write",
     "build:staticresources": "node build-static-resources.js",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -24,8 +24,8 @@
   "main": "index.js",
   "scripts": {
     "lint:check:tests": "eslint force-app/main/default/lwc/ --format junit -o reports/eslint.xml",
-    "lint:check": "eslint force-app/main/default/lwc/ && eslint force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.{js,cls,trigger}\" --check",
-    "lint:fix": "eslint --fix force-app/main/default/lwc/ && eslint --fix force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.{js,cls,trigger}\" --write",
+    "lint:check": "eslint force-app/main/default/lwc/ force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.{js,cls,trigger}\" --check",
+    "lint:fix": "eslint --fix force-app/main/default/lwc/ force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.{js,cls,trigger}\" --write",
     "build:staticresources": "node build-static-resources.js",
     "dev": "node ../../utils/ci/rm-rf.mjs .localdevserver && pnpm run build:staticresources && pnpm run dev:sfdx",
     "dev:sfdx": "sf project deploy start --source-dir force-app/main && sfdx force:lightning:lwc:start --port 3334",

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -2,14 +2,26 @@
   "name": "@coveo/quantic",
   "version": "3.44.1",
   "description": "A Salesforce Lightning Web Component (LWC) library for building modern UIs interfacing with the Coveo platform",
-  "author": "coveo.com",
   "homepage": "https://coveo.com",
   "license": "Apache-2.0",
-  "main": "index.js",
+  "author": "coveo.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/coveo/ui-kit.git"
   },
+  "files": [
+    "force-app/main/default/classes/*",
+    "force-app/main/default/labels/*",
+    "force-app/main/default/lwc/*",
+    "!force-app/main/default/lwc/testUtils",
+    "force-app/main/default/cspTrustedSites/*",
+    "force-app/main/default/staticresources/*",
+    "scripts/npm",
+    "docs/out/quantic-docs.json",
+    "!force-app/main/default/lwc/**/__tests__",
+    "!force-app/main/default/lwc/**/e2e"
+  ],
+  "main": "index.js",
   "scripts": {
     "lint:check:tests": "eslint force-app/main/default/lwc/ --format junit -o reports/eslint.xml",
     "lint:check": "eslint force-app/main/default/lwc/ && eslint force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.js\" --check",
@@ -52,9 +64,6 @@
     "dompurify": "catalog:",
     "marked": "catalog:"
   },
-  "engines": {
-    "node": "^20.9.0 || ^22.11.0 || ^24.11.0"
-  },
   "devDependencies": {
     "@babel/cli": "7.28.3",
     "@babel/plugin-transform-async-to-generator": "7.27.1",
@@ -81,16 +90,7 @@
     "wait-on": "9.1.0",
     "xml2js": "0.6.2"
   },
-  "files": [
-    "force-app/main/default/classes/*",
-    "force-app/main/default/labels/*",
-    "force-app/main/default/lwc/*",
-    "!force-app/main/default/lwc/testUtils",
-    "force-app/main/default/cspTrustedSites/*",
-    "force-app/main/default/staticresources/*",
-    "scripts/npm",
-    "docs/out/quantic-docs.json",
-    "!force-app/main/default/lwc/**/__tests__",
-    "!force-app/main/default/lwc/**/e2e"
-  ]
+  "engines": {
+    "node": "^20.9.0 || ^22.11.0 || ^24.11.0"
+  }
 }

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -24,9 +24,8 @@
   "main": "index.js",
   "scripts": {
     "lint:check:tests": "eslint force-app/main/default/lwc/ --format junit -o reports/eslint.xml",
-    "lint:check": "eslint force-app/main/default/lwc/ && eslint force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.js\" --check",
-    "lint:fix": "eslint --fix force-app/main/default/lwc/ && eslint --fix force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.js\" --write",
-    "lint:fix:apex": "prettier \"force-app/{,**}/*.{cls,trigger}\" --write",
+    "lint:check": "eslint force-app/main/default/lwc/ && eslint force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.{js,cls,trigger}\" --check",
+    "lint:fix": "eslint --fix force-app/main/default/lwc/ && eslint --fix force-app/examples/main/lwc/ && prettier \"force-app/{,**}/*.{js,cls,trigger}\" --write",
     "build:staticresources": "node build-static-resources.js",
     "dev": "node ../../utils/ci/rm-rf.mjs .localdevserver && pnpm run build:staticresources && pnpm run dev:sfdx",
     "dev:sfdx": "sf project deploy start --source-dir force-app/main && sfdx force:lightning:lwc:start --port 3334",

--- a/packages/quantic/tsconfig.json
+++ b/packages/quantic/tsconfig.json
@@ -17,23 +17,13 @@
       "coveo": ["../../../../coveo"],
       "c/exampleSearch": ["exampleSearch/exampleSearch"],
       "c/quanticDateFacet": ["quanticDateFacet/quanticDateFacet.js"],
-      "c/quanticHeadlessLoader": [
-        "quanticHeadlessLoader/quanticHeadlessLoader.js"
-      ],
+      "c/quanticHeadlessLoader": ["quanticHeadlessLoader/quanticHeadlessLoader.js"],
       "c/quanticNoResults": ["quanticNoResults/quanticNoResults.js"],
-      "c/quanticDateFacetValue": [
-        "quanticDateFacetValue/quanticDateFacetValue.js"
-      ],
+      "c/quanticDateFacetValue": ["quanticDateFacetValue/quanticDateFacetValue.js"],
       "c/quanticDidYouMean": ["quanticDidYouMean/quanticDidYouMean.js"],
-      "c/quanticCategoryFacet": [
-        "quanticCategoryFacet/quanticCategoryFacet.js"
-      ],
-      "c/quanticCategoryFacetParent": [
-        "quanticCategoryFacetParent/quanticCategoryFacetParent.js"
-      ],
-      "c/quanticCategoryFacetValue": [
-        "quanticCategoryFacetValue/quanticCategoryFacetValue.js"
-      ],
+      "c/quanticCategoryFacet": ["quanticCategoryFacet/quanticCategoryFacet.js"],
+      "c/quanticCategoryFacetParent": ["quanticCategoryFacetParent/quanticCategoryFacetParent.js"],
+      "c/quanticCategoryFacetValue": ["quanticCategoryFacetValue/quanticCategoryFacetValue.js"],
       "c/quanticFacet": ["quanticFacet/quanticFacet.js"],
       "c/quanticPager": ["quanticPager/quanticPager.js"],
       "c/quanticPlaceholder": ["quanticPlaceholder/quanticPlaceholder.js"],
@@ -41,57 +31,33 @@
       "c/quanticResult": ["quanticResult/quanticResult.js"],
       "c/quanticResultTag": ["quanticResultTag/quanticResultTag.js"],
       "c/quanticResultLabel": ["quanticResultLabel/quanticResultLabel.js"],
-      "c/quanticResultPrintableUri": [
-        "quanticResultPrintableUri/quanticResultPrintableUri.js"
-      ],
+      "c/quanticResultPrintableUri": ["quanticResultPrintableUri/quanticResultPrintableUri.js"],
       "c/quanticResultList": ["quanticResultList/quanticResultList.js"],
       "c/quanticResultLink": ["quanticResultLink/quanticResultLink.js"],
       "c/quanticSort": ["quanticSort/quanticSort.js"],
       "c/quanticSummary": ["quanticSummary/quanticSummary.js"],
       "c/quanticFacetValue": ["quanticFacetValue/quanticFacetValue.js"],
       "c/quanticNumericFacet": ["quanticNumericFacet/quanticNumericFacet.js"],
-      "c/quanticNumericFacetValue": [
-        "quanticNumericFacetValue/quanticNumericFacetValue.js"
-      ],
-      "c/quanticResultQuickview": [
-        "quanticResultQuickview/quanticResultQuickview.js"
-      ],
-      "c/quanticRecentQueriesList": [
-        "quanticRecentQueriesList/quanticRecentQueriesList.js"
-      ],
-      "c/quanticRecentResultsList": [
-        "quanticRecentResultsList/quanticRecentResultsList.js"
-      ],
-      "c/quanticResultsPerPage": [
-        "quanticResultsPerPage/quanticResultsPerPage.js"
-      ],
+      "c/quanticNumericFacetValue": ["quanticNumericFacetValue/quanticNumericFacetValue.js"],
+      "c/quanticResultQuickview": ["quanticResultQuickview/quanticResultQuickview.js"],
+      "c/quanticRecentQueriesList": ["quanticRecentQueriesList/quanticRecentQueriesList.js"],
+      "c/quanticRecentResultsList": ["quanticRecentResultsList/quanticRecentResultsList.js"],
+      "c/quanticResultsPerPage": ["quanticResultsPerPage/quanticResultsPerPage.js"],
       "c/quanticSearchBox": ["quanticSearchBox/quanticSearchBox.js"],
       "c/quanticSearchBoxSuggestionsList": [
         "quanticSearchBoxSuggestionsList/quanticSearchBoxSuggestionsList.js"
       ],
-      "c/quanticSearchBoxInput": [
-        "quanticSearchBoxInput/quanticSearchBoxInput.js"
-      ],
-      "c/quanticSearchInterface": [
-        "quanticSearchInterface/quanticSearchInterface.js"
-      ],
-      "c/quanticInsightInterface": [
-        "quanticInsightInterface/quanticInsightInterface.js"
-      ],
+      "c/quanticSearchBoxInput": ["quanticSearchBoxInput/quanticSearchBoxInput.js"],
+      "c/quanticSearchInterface": ["quanticSearchInterface/quanticSearchInterface.js"],
+      "c/quanticInsightInterface": ["quanticInsightInterface/quanticInsightInterface.js"],
       "c/quanticNumberButton": ["quanticNumberButton/quanticNumberButton.js"],
       "c/quanticPill": ["quanticPill/quanticPill.js"],
       "c/quanticSvg": ["quanticSvg/quanticSvg.js"],
       "c/quanticUtils": ["quanticUtils/quanticUtils.js"],
       "c/testUtils": ["testUtils/testUtils.js"],
-      "c/quanticTimeframeFacet": [
-        "quanticTimeframeFacet/quanticTimeframeFacet.js"
-      ],
-      "c/quanticFeedbackModal": [
-        "quanticFeedbackModal/quanticFeedbackModal.js"
-      ],
-      "c/quanticFeedbackModalQna": [
-        "quanticFeedbackModalQna/quanticFeedbackModalQna.js"
-      ]
+      "c/quanticTimeframeFacet": ["quanticTimeframeFacet/quanticTimeframeFacet.js"],
+      "c/quanticFeedbackModal": ["quanticFeedbackModal/quanticFeedbackModal.js"],
+      "c/quanticFeedbackModalQna": ["quanticFeedbackModalQna/quanticFeedbackModalQna.js"]
     }
   },
   "include": [

--- a/packages/quantic/turbo.json
+++ b/packages/quantic/turbo.json
@@ -33,12 +33,7 @@
     },
     "test": {
       "outputs": [],
-      "dependsOn": [
-        "test:unit",
-        "lint:check:tests",
-        "validate:types",
-        "validate:types:build-scripts"
-      ]
+      "dependsOn": ["test:unit", "validate:types", "validate:types:build-scripts"]
     },
     "test:unit": {
       "dependsOn": ["build"],
@@ -55,10 +50,6 @@
       "outputs": []
     },
     "validate:types:build-scripts": {
-      "outputs": []
-    },
-    "lint:check:tests": {
-      "dependsOn": ["build"],
       "outputs": []
     }
   }

--- a/packages/quantic/turbo.json
+++ b/packages/quantic/turbo.json
@@ -2,12 +2,8 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": [
-        "build:staticresources",
-        "build:doc",
-        "babel:headless"
-      ],
-      "outputs":[]
+      "dependsOn": ["build:staticresources", "build:doc", "babel:headless"],
+      "outputs": []
     },
     "build:staticresources": {
       "dependsOn": ["^build", "babel:headless"],
@@ -25,9 +21,7 @@
     },
     "babel:headless": {
       "dependsOn": ["^build"],
-      "outputs": [
-        ".tmp/quantic-compiled/**"
-      ]
+      "outputs": [".tmp/quantic-compiled/**"]
     },
     "promote:sfdx": {
       "dependsOn": ["build"],
@@ -39,7 +33,12 @@
     },
     "test": {
       "outputs": [],
-      "dependsOn": ["test:unit", "lint:check:tests", "validate:types", "validate:types:build-scripts"]
+      "dependsOn": [
+        "test:unit",
+        "lint:check:tests",
+        "validate:types",
+        "validate:types:build-scripts"
+      ]
     },
     "test:unit": {
       "dependsOn": ["build"],


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6097

## Motivation

Quantic's linting and formatting tasks use package-specific wiring that differs from the rest of the repository. Oxlint, Oxfmt, and CSpell are more efficient as repository-root tasks, while Quantic uses targeted ESLint and Prettier checks for its Salesforce-specific files. Aligning these tasks with the shared Turbo and formatter conventions keeps local and CI validation consistent and removes redundant task configuration without changing component behavior.

## Changes

- Consolidated the LWC ESLint paths into one invocation for `lint:check` and `lint:fix`.
- Merged Apex class and trigger formatting into `lint:fix` and removed the obsolete `lint:fix:apex` script.
- Removed the redundant `lint:check:tests` task, already covered by `lint:check`.
- Formatted Quantic JSON and configuration files with oxfmt.

## Validation

- [x] All existing tests pass without modification
- [x] No new features or bug fixes are included in this PR

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`chore(<scope>): <description>`)
- [ ] [Added a changeset](https://changesets.dev/guide/getting-started) if modifying public package source code