### PR TITLE
chore(ci): publish only affected preview packages

### DIFF
--- a/.github/actions/publish-preview/action.yml
+++ b/.github/actions/publish-preview/action.yml
@@ -1,0 +1,39 @@
+name: Publish preview packages
+description: Publish affected public packages to pkg.pr.new.
+inputs:
+  affected-tasks:
+    description: Affected Turbo task identifiers as a JSON array.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Resolve preview package paths
+      id: resolve
+      shell: bash
+      env:
+        AFFECTED_TASKS: ${{ inputs.affected-tasks }}
+      run: |
+        package_paths="$(node "$GITHUB_ACTION_PATH/resolve-packages.mjs")"
+        {
+          echo 'packages<<EOF'
+          echo "$package_paths"
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+    - name: Resolve catalog references in pkg.pr.new templates
+      if: ${{ steps.resolve.outputs.packages != '' }}
+      shell: bash
+      run: node packages/pkg-new-template/scripts/flatten-catalog.mjs
+    - name: Publish to pkg.pr.new
+      if: ${{ steps.resolve.outputs.packages != '' }}
+      shell: bash
+      env:
+        PACKAGE_PATHS: ${{ steps.resolve.outputs.packages }}
+      run: |
+        package_paths=()
+        while IFS= read -r package_path; do
+          [[ -z "$package_path" ]] || package_paths+=("$package_path")
+        done <<< "$PACKAGE_PATHS"
+
+        pnpm dlx pkg-pr-new publish --pnpm \
+          --template './packages/pkg-new-template' \
+          "${package_paths[@]}"

--- a/.github/actions/publish-preview/action.yml
+++ b/.github/actions/publish-preview/action.yml
@@ -19,6 +19,18 @@ runs:
           echo "$package_paths"
           echo EOF
         } >> "$GITHUB_OUTPUT"
+    - name: Build
+      if: ${{ steps.resolve.outputs.packages != '' }}
+      shell: bash
+      env:
+        PACKAGE_PATHS: ${{ steps.resolve.outputs.packages }}
+      run: |
+        filters=()
+        while IFS= read -r package_path; do
+          [[ -z "$package_path" ]] || filters+=("--filter=${package_path}")
+        done <<< "$PACKAGE_PATHS"
+
+        pnpm exec turbo run build "${filters[@]}"
     - name: Resolve catalog references in pkg.pr.new templates
       if: ${{ steps.resolve.outputs.packages != '' }}
       shell: bash

--- a/.github/actions/publish-preview/resolve-packages.mjs
+++ b/.github/actions/publish-preview/resolve-packages.mjs
@@ -1,0 +1,68 @@
+import {execFileSync} from 'node:child_process';
+import {join, relative, resolve, sep} from 'node:path';
+
+const root = resolve(process.env.GITHUB_WORKSPACE ?? process.cwd());
+const buildTaskSuffix = '#build';
+
+const parseAffectedTasks = () => {
+  const input = process.env.AFFECTED_TASKS ?? '';
+  const affectedTasks = JSON.parse(input);
+
+  if (!Array.isArray(affectedTasks) || affectedTasks.some((task) => typeof task !== 'string')) {
+    throw new TypeError('AFFECTED_TASKS must be a JSON array of strings.');
+  }
+
+  return affectedTasks;
+};
+
+const getWorkspacePackages = () => {
+  const output = execFileSync('pnpm', ['list', '--recursive', '--depth', '-1', '--json'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  const packages = JSON.parse(output);
+
+  return new Map(packages.map((workspacePackage) => [workspacePackage.name, workspacePackage]));
+};
+
+const toWorkspacePath = (workspacePackage) => {
+  const relativePath = join(relative(root, workspacePackage.path));
+  return `.${sep}${relativePath}`;
+};
+
+const isSamplePackage = (workspacePackage) =>
+  relative(root, workspacePackage.path).split(sep)[0] === 'samples';
+
+const shouldPublishPackage = (workspacePackage) => {
+  return !workspacePackage.private && !isSamplePackage(workspacePackage);
+};
+
+const getAffectedPackages = () =>
+  new Set(
+    parseAffectedTasks()
+      .filter((task) => task.endsWith(buildTaskSuffix))
+      .map((task) => task.slice(0, -buildTaskSuffix.length))
+      .filter((packageName) => packageName !== '//')
+  );
+
+const resolvePreviewPackages = () => {
+  const workspacePackages = getWorkspacePackages();
+
+  return [...getAffectedPackages()]
+    .map((packageName) => {
+      if (!workspacePackages.has(packageName)) {
+        throw new Error(`Could not resolve affected workspace package: ${packageName}`);
+      }
+      return workspacePackages.get(packageName);
+    })
+    .filter(shouldPublishPackage)
+    .map(toWorkspacePath)
+    .sort();
+};
+
+const packages = resolvePreviewPackages();
+console.error(`Preview packages${packages.length === 0 ? '' : ':'}`);
+for (const packagePath of packages) {
+  console.error(packagePath);
+  console.log(packagePath);
+}

--- a/.github/actions/publish-preview/resolve-packages.mjs
+++ b/.github/actions/publish-preview/resolve-packages.mjs
@@ -3,6 +3,7 @@ import {join, relative, resolve, sep} from 'node:path';
 
 const root = resolve(process.env.GITHUB_WORKSPACE ?? process.cwd());
 const buildTaskSuffix = '#build';
+const turboMaxBuffer = 100 * 1024 * 1024;
 
 const parseAffectedTasks = () => {
   const input = process.env.AFFECTED_TASKS ?? '';
@@ -13,6 +14,24 @@ const parseAffectedTasks = () => {
   }
 
   return affectedTasks;
+};
+
+const resolveAffectedTasks = () => {
+  const affectedTasks = parseAffectedTasks().filter((task) => task.endsWith(buildTaskSuffix));
+
+  if (affectedTasks.length === 0) {
+    return [];
+  }
+
+  const output = execFileSync('pnpm', ['exec', 'turbo', 'run', ...affectedTasks, '--dry=json'], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: turboMaxBuffer,
+  });
+  const dryRun = JSON.parse(output);
+  const taskIds = dryRun.tasks.map(({taskId}) => taskId);
+
+  return taskIds;
 };
 
 const getWorkspacePackages = () => {
@@ -37,13 +56,14 @@ const shouldPublishPackage = (workspacePackage) => {
   return !workspacePackage.private && !isSamplePackage(workspacePackage);
 };
 
-const getAffectedPackages = () =>
-  new Set(
-    parseAffectedTasks()
-      .filter((task) => task.endsWith(buildTaskSuffix))
-      .map((task) => task.slice(0, -buildTaskSuffix.length))
-      .filter((packageName) => packageName !== '//')
-  );
+const getAffectedPackages = () => {
+  const tasks = resolveAffectedTasks();
+  const projects = tasks
+    .map((task) => task.split('#')[0])
+    .filter((packageName) => packageName !== '//');
+
+  return new Set(projects);
+};
 
 const resolvePreviewPackages = () => {
   const workspacePackages = getWorkspacePackages();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,7 +678,7 @@ jobs:
       SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   publish-preview:
-    if: ${{ !cancelled() && github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/') }}
+    if: ${{ !cancelled() && contains(needs.affected.outputs.tasks, '#build') && github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/') }}
     needs: [affected, build]
     name: 'Publish Preview Packages'
     runs-on: ubuntu-latest
@@ -692,29 +692,9 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo run build --filter='!./samples/**'
-      - name: Resolve catalog references in pkg.pr.new templates
-        run: node packages/pkg-new-template/scripts/flatten-catalog.mjs
-      - name: Publish to pkg.pr.new
-        run: |
-          pnpm dlx pkg-pr-new publish --pnpm \
-            --template './packages/pkg-new-template' \
-            './packages/atomic' \
-            './packages/atomic-hosted-page' \
-            './packages/atomic-legacy' \
-            './packages/atomic-react' \
-            './packages/auth' \
-            './packages/bueno' \
-            './packages/create-atomic' \
-            './packages/create-atomic-component' \
-            './packages/create-atomic-component-project' \
-            './packages/create-atomic-result-component' \
-            './packages/create-atomic-rollup-plugin' \
-            './packages/create-ui' \
-            './packages/headless' \
-            './packages/headless-react' \
-            './packages/relay' \
-            './packages/shopify'
+      - uses: ./.github/actions/publish-preview
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
   is-valid-pr:
     name: 'Confirm build is valid (PR)'
     if: ${{ always() && github.event_name == 'pull_request'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,7 +721,7 @@ jobs:
       SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   publish-preview:
-    if: ${{ !cancelled() && contains(needs.affected.outputs.tasks, '#build') && github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/') }}
+    if: ${{ !cancelled() && contains(needs.affected.outputs.tasks, '#build"') && github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/') }}
     needs: [affected, build]
     name: 'Publish Preview Packages'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,7 +721,7 @@ jobs:
       SFDX_AUTH_JWT_KEY: ${{ secrets.SFDX_AUTH_JWT_KEY }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   publish-preview:
-    if: ${{ !cancelled() && github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/') }}
+    if: ${{ !cancelled() && contains(needs.affected.outputs.tasks, '#build') && github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/') }}
     needs: [affected, build]
     name: 'Publish Preview Packages'
     runs-on: ubuntu-latest
@@ -735,29 +735,9 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo run build --filter='!./samples/**'
-      - name: Resolve catalog references in pkg.pr.new templates
-        run: node packages/pkg-new-template/scripts/flatten-catalog.mjs
-      - name: Publish to pkg.pr.new
-        run: |
-          pnpm dlx pkg-pr-new publish --pnpm \
-            --template './packages/pkg-new-template' \
-            './packages/atomic' \
-            './packages/atomic-hosted-page' \
-            './packages/atomic-legacy' \
-            './packages/atomic-react' \
-            './packages/auth' \
-            './packages/bueno' \
-            './packages/create-atomic' \
-            './packages/create-atomic-component' \
-            './packages/create-atomic-component-project' \
-            './packages/create-atomic-result-component' \
-            './packages/create-atomic-rollup-plugin' \
-            './packages/create-ui' \
-            './packages/headless' \
-            './packages/headless-react' \
-            './packages/relay' \
-            './packages/shopify'
+      - uses: ./.github/actions/publish-preview
+        with:
+          affected-tasks: ${{ needs.affected.outputs.tasks }}
   is-valid-pr:
     name: 'Confirm build is valid (PR)'
     if: ${{ always() && github.event_name == 'pull_request'}}


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6098

## Motivation

The PR preview job published a fixed package set for every eligible pull request, including unchanged packages. This added unnecessary preview publication work.

## Changes

- Added a composite `publish-preview` action.
- Selects affected `#build` tasks and resolves them to workspace package paths.
- Excludes private packages and samples.
- Skips catalog flattening and publication when no public package is affected.
- Replaced the hard-coded package list in `ci.yml`.

## Validation

- Resolver smoke check with affected, private, sample, and root tasks.
  ```
  AFFECTED_TASKS='["@coveo/atomic#build", "@coveo/shopify#build", "@coveo/ui-kit-sample-headless-search-vite"]' GITHUB_WORKSPACE="$(pwd)" node '/Users/slavoie2/src/github.com/coveo/ui-kit/.github/actions/publish-preview/resolve-packages.mjs' 2>/dev/null
  ./packages/atomic
  ./packages/shopify
  ```
- Verified the generated package list matches the previous package set.
- You can see [here](https://github.com/coveo/ui-kit/actions/runs/32527128351/job/96912066834?pr=8316) that only atomic got published, despite changes to the headless unit tests (not production code) and samples production code.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`chore(<scope>): <description>`)
- [ ] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code