### PR TITLE
fix(ci): gate jobs by affected Turbo tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
   build-windows:
     name: 'Build Windows'
     needs: affected
-    if: ${{ needs.affected.outputs.projects != '[]' && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) }}
+    if: ${{ contains(needs.affected.outputs.tasks, '#build') && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) }}
     runs-on: windows-latest
     permissions:
       contents: read
@@ -68,7 +68,7 @@ jobs:
   build-missing:
     name: 'Build & commit missing generated files'
     needs: [affected, build]
-    if: ${{ needs.affected.outputs.projects != '[]' && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) }}
+    if: ${{ contains(needs.affected.outputs.tasks, '#build') && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -116,7 +116,7 @@ jobs:
   build:
     name: 'Build'
     needs: affected
-    if: needs.affected.outputs.projects != '[]'
+    if: contains(needs.affected.outputs.tasks, '#build')
     runs-on: ubuntu-latest
     environment: PR Artifacts
     steps:
@@ -139,7 +139,7 @@ jobs:
   build-cdn:
     name: Build CDN
     needs: affected
-    if: ${{ needs.affected.outputs.projects != '[]' && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) }}
+    if: ${{ contains(needs.affected.outputs.tasks, '#build') && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -165,7 +165,7 @@ jobs:
 
   knip:
     name: 'Look for unused code or dependencies'
-    if: ${{ needs.affected.outputs.projects != '[]' }}
+    if: ${{ contains(needs.affected.outputs.tasks, '#build') }}
     runs-on: ubuntu-latest
     needs: affected
     steps:
@@ -184,15 +184,20 @@ jobs:
           tasks: build
       - name: Run selected Knip workspaces
         env:
-          PROJECTS: ${{ needs.affected.outputs.projects }}
+          TASKS: ${{ needs.affected.outputs.tasks }}
+          JQ_QUERY: |
+            [.[] | select(contains("#build")) | split("#")[0]]
+            | unique
+            | .[]
+            | "--workspace " + (if . == "//" then "." else . end)
         run: |
-          jq -r '.[] | "--workspace " + (if . == "//" then "." else . end)' <<< "${PROJECTS}" \
+          jq -r "${JQ_QUERY}" <<< "${TASKS}" \
             | xargs pnpm exec knip --exclude catalog
 
   cdn-checks:
     name: 'CDN Checks'
     needs: [affected, build-cdn]
-    if: needs.build-cdn.result == 'success' && (contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic') || contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic-hosted-page'))
+    if: needs.build-cdn.result == 'success' && (contains(needs.affected.outputs.tasks, '"@coveo/atomic#build"') || contains(needs.affected.outputs.tasks, '"@coveo/atomic-hosted-page#build"'))
     env:
       DEPLOYMENT_ENVIRONMENT: CDN
     runs-on: ubuntu-latest
@@ -236,7 +241,7 @@ jobs:
   validate-light-dom-styles:
     name: 'Validate Light DOM styles'
     needs: affected
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/atomic#validate:light-dom-styles"')
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -249,15 +254,11 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: validate:light-dom-styles
-          packages: '@coveo/atomic'
+      - run: pnpm exec turbo run validate:light-dom-styles --filter=@coveo/atomic
   validate-no-new-light-dom:
     name: 'Validate no new Light DOM components'
     needs: affected
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/atomic#validate:no-new-light-dom"')
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -270,11 +271,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: validate:no-new-light-dom
-          packages: '@coveo/atomic'
+      - run: pnpm exec turbo run validate:no-new-light-dom --filter=@coveo/atomic
   unit-test:
     name: 'Run unit tests'
     needs: affected
@@ -301,10 +298,10 @@ jobs:
         with:
           affected-tasks: ${{ needs.affected.outputs.tasks }}
           tasks: test
-  relay-tests:
-    name: 'Run Relay functional and playground smoke tests'
+  relay-functional-tests:
+    name: 'Run Relay functional tests'
     needs: [affected, build]
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/relay') || contains(fromJSON(needs.affected.outputs.projects), '@coveo/relay-playground')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/relay#functional-test"')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -316,20 +313,11 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: functional-test
-          packages: '@coveo/relay'
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: test
-          packages: '@coveo/relay-playground'
+      - run: pnpm exec turbo run functional-test --filter=@coveo/relay
   validate-dts:
     name: 'Validate DTS API surface'
     needs: [affected, build]
-    if: ${{ contains(fromJSON(needs.affected.outputs.projects), '@coveo/thermidor') }}
+    if: ${{ contains(needs.affected.outputs.tasks, '"@coveo/thermidor#validate:test:dts:ci"') }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -342,11 +330,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: test:dts:ci
-          packages: '@coveo/thermidor'
+      - run: pnpm exec turbo run validate:test:dts:ci --filter=@coveo/thermidor
   package-compatibility:
     name: 'Verify compatibility of packages'
     needs: [affected, build]
@@ -370,7 +354,7 @@ jobs:
   typedoc:
     name: 'Build typedoc'
     needs: [affected, build]
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/headless') || contains(fromJSON(needs.affected.outputs.projects), '@coveo/headless-react')
+    if: contains(needs.affected.outputs.tasks, '#build:typedoc"')
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -390,7 +374,7 @@ jobs:
   puppeteer-atomic-csp:
     name: 'Run e2e tests on Atomic CSP'
     needs: [affected, build]
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/atomic#build"')
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -433,7 +417,7 @@ jobs:
         # Example: `["renovate/playwright", "renovate/chromatic"]`
         if: >-
           needs.build.result == 'success' &&
-          contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic') &&
+          contains(needs.affected.outputs.tasks, '"@coveo/atomic#build"') &&
           github.event_name == 'pull_request' &&
           (!startsWith(github.head_ref, 'renovate/') ||
           contains(fromJSON(vars.CHROMATIC_RENOVATE_ALLOWLIST || '[]'), github.head_ref))
@@ -451,7 +435,7 @@ jobs:
   playwright-atomic:
     name: 'Run Playwright tests for Atomic'
     needs: [affected, build]
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/atomic#build"')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -504,7 +488,7 @@ jobs:
   playwright-atomic-theming:
     name: 'Run theming smoke tests for Atomic'
     needs: [affected, build]
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic-theming-e2e')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/atomic-theming-e2e#build"')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -524,7 +508,7 @@ jobs:
   storybook-atomic:
     name: 'Run Storybook tests'
     needs: [affected, build]
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/atomic#test:storybook"')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -546,13 +530,7 @@ jobs:
           filter: blob:none
       - run: git branch main origin/main
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          packages: '@coveo/atomic'
-          tasks: test:storybook
-          arguments: |
-            --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      - run: pnpm exec turbo run test:storybook --filter=@coveo/atomic -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: 'Upload a11y shard report'
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -567,7 +545,7 @@ jobs:
     if: >-
       ${{
         always() &&
-        contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic')
+        contains(needs.affected.outputs.tasks, '"@coveo/atomic#test:storybook"')
       }}
     runs-on: ubuntu-latest
     steps:
@@ -637,7 +615,7 @@ jobs:
   playwright-pkg-new-template-test:
     name: 'Run smoke tests on pkg-new-template'
     needs: [affected, build]
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/pkg-new-template')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/pkg-new-template#build"')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -658,7 +636,7 @@ jobs:
   playwright-atomic-hosted-page-test:
     name: 'Run e2e tests for Atomic Hosted Page'
     needs: [affected, build]
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic-hosted-page')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/atomic-hosted-page#build"')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -681,7 +659,7 @@ jobs:
     needs: [affected, build]
     if: >-
       ${{
-        contains(fromJSON(needs.affected.outputs.projects), '@coveo/quantic') &&
+        contains(needs.affected.outputs.tasks, '"@coveo/quantic#build"') &&
         !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-quantic'))
       }}
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
     name: 'Look for unused code or dependencies'
     if: ${{ contains(needs.affected.outputs.tasks, '#build"') }}
     runs-on: ubuntu-latest
-    needs: affected
+    needs: [affected, build]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -281,7 +281,7 @@ jobs:
       - run: pnpm exec turbo run validate:no-new-light-dom --filter=@coveo/atomic
   unit-test:
     name: 'Run unit tests'
-    needs: affected
+    needs: [affected, build]
     # Best effort at short-circuiting
     if: contains(needs.affected.outputs.tasks, '#test"')
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
     name: 'Look for unused code or dependencies'
     if: ${{ contains(needs.affected.outputs.tasks, '#build') }}
     runs-on: ubuntu-latest
-    needs: affected
+    needs: [affected, build]
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -274,7 +274,7 @@ jobs:
       - run: pnpm exec turbo run validate:no-new-light-dom --filter=@coveo/atomic
   unit-test:
     name: 'Run unit tests'
-    needs: affected
+    needs: [affected, build]
     # Best effort at short-circuiting
     if: contains(needs.affected.outputs.tasks, '#test')
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
   build-windows:
     name: 'Build Windows'
     needs: affected
-    if: ${{ needs.affected.outputs.projects != '[]' && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) }}
+    if: ${{ contains(needs.affected.outputs.tasks, '#build"') && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) }}
     runs-on: windows-latest
     permissions:
       contents: read
@@ -68,7 +68,7 @@ jobs:
   build-missing:
     name: 'Build & commit missing generated files'
     needs: [affected, build]
-    if: ${{ needs.affected.outputs.projects != '[]' && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) }}
+    if: ${{ contains(needs.affected.outputs.tasks, '#build"') && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -116,7 +116,7 @@ jobs:
   build:
     name: 'Build'
     needs: affected
-    if: needs.affected.outputs.projects != '[]'
+    if: contains(needs.affected.outputs.tasks, '#build"')
     runs-on: ubuntu-latest
     environment: PR Artifacts
     steps:
@@ -139,7 +139,7 @@ jobs:
   build-cdn:
     name: Build CDN
     needs: affected
-    if: ${{ needs.affected.outputs.projects != '[]' && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) }}
+    if: ${{ contains(needs.affected.outputs.tasks, '#build"') && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'changeset-release/')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -165,7 +165,7 @@ jobs:
 
   knip:
     name: 'Look for unused code or dependencies'
-    if: ${{ needs.affected.outputs.projects != '[]' }}
+    if: ${{ contains(needs.affected.outputs.tasks, '#build"') }}
     runs-on: ubuntu-latest
     needs: affected
     steps:
@@ -184,9 +184,14 @@ jobs:
           tasks: build
       - name: Run selected Knip workspaces
         env:
-          PROJECTS: ${{ needs.affected.outputs.projects }}
+          TASKS: ${{ needs.affected.outputs.tasks }}
+          JQ_QUERY: |
+            [.[] | select(contains("#build")) | split("#")[0]]
+            | unique
+            | .[]
+            | "--workspace " + (if . == "//" then "." else . end)
         run: |
-          jq -r '.[] | "--workspace " + (if . == "//" then "." else . end)' <<< "${PROJECTS}" \
+          jq -r "${JQ_QUERY}" <<< "${TASKS}" \
             | xargs pnpm exec knip --exclude catalog
 
   cdn-checks:
@@ -224,7 +229,7 @@ jobs:
         run: pnpm exec turbo run @coveo/atomic-hosted-page#e2e
   lint-check:
     name: 'Check with linter'
-    if: ${{ needs.affected.outputs.projects != '[]' }}
+    if: contains(needs.affected.outputs.tasks, '#lint:check"')
     needs: affected
     runs-on: ubuntu-latest
     steps:
@@ -243,7 +248,7 @@ jobs:
   validate-light-dom-styles:
     name: 'Validate Light DOM styles'
     needs: affected
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/atomic#validate:light-dom-styles"')
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -256,15 +261,11 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: validate:light-dom-styles
-          packages: '@coveo/atomic'
+      - run: pnpm exec turbo run validate:light-dom-styles --filter=@coveo/atomic
   validate-no-new-light-dom:
     name: 'Validate no new Light DOM components'
     needs: affected
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/atomic#validate:no-new-light-dom"')
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -277,16 +278,12 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: validate:no-new-light-dom
-          packages: '@coveo/atomic'
+      - run: pnpm exec turbo run validate:no-new-light-dom --filter=@coveo/atomic
   unit-test:
     name: 'Run unit tests'
     needs: affected
     # Best effort at short-circuiting
-    if: contains(needs.affected.outputs.tasks, '#test')
+    if: contains(needs.affected.outputs.tasks, '#test"')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -308,10 +305,10 @@ jobs:
         with:
           affected-tasks: ${{ needs.affected.outputs.tasks }}
           tasks: test
-  relay-tests:
-    name: 'Run Relay functional and playground smoke tests'
+  relay-functional-tests:
+    name: 'Run Relay functional tests'
     needs: [affected, build]
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/relay') || contains(fromJSON(needs.affected.outputs.projects), '@coveo/relay-playground')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/relay#functional-test"')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -323,20 +320,11 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: functional-test
-          packages: '@coveo/relay'
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: test
-          packages: '@coveo/relay-playground'
+      - run: pnpm exec turbo run functional-test --filter=@coveo/relay
   validate-dts:
     name: 'Validate DTS API surface'
     needs: [affected, build]
-    if: ${{ contains(fromJSON(needs.affected.outputs.projects), '@coveo/thermidor') }}
+    if: ${{ contains(needs.affected.outputs.tasks, '"@coveo/thermidor#validate:test:dts:ci"') }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -349,11 +337,7 @@ jobs:
           fetch-depth: 0
           filter: blob:none
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: test:dts:ci
-          packages: '@coveo/thermidor'
+      - run: pnpm exec turbo run validate:test:dts:ci --filter=@coveo/thermidor
   package-compatibility:
     name: 'Verify compatibility of packages'
     needs: [affected, build]
@@ -377,7 +361,7 @@ jobs:
   typedoc:
     name: 'Build typedoc'
     needs: [affected, build]
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/headless') || contains(fromJSON(needs.affected.outputs.projects), '@coveo/headless-react')
+    if: contains(needs.affected.outputs.tasks, '#build:typedoc"')
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -411,11 +395,7 @@ jobs:
           fetch-tags: false
           filter: blob:none
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: e2e:csp
-          packages: '@coveo/atomic'
+      - run: pnpm exec turbo run '@coveo/atomic#e2e:csp'
 
   chromatic:
     name: 'Run Chromatic visual tests on Atomic'
@@ -445,7 +425,7 @@ jobs:
         # Example: `["renovate/playwright", "renovate/chromatic"]`
         if: >-
           needs.build.result == 'success' &&
-          contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic') &&
+          contains(needs.affected.outputs.tasks, '"@coveo/atomic#build"') &&
           github.event_name == 'pull_request' &&
           (!startsWith(github.head_ref, 'renovate/') ||
           contains(fromJSON(vars.CHROMATIC_RENOVATE_ALLOWLIST || '[]'), github.head_ref))
@@ -487,14 +467,8 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Run Playwright tests
         id: playwright
-        uses: ./.github/actions/run-affected
+        run: pnpm exec turbo run '@coveo/atomic#e2e' -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         continue-on-error: true
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: e2e
-          packages: '@coveo/atomic'
-          arguments: |
-            --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
@@ -554,11 +528,7 @@ jobs:
           fetch-tags: false
           filter: blob:none
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          packages: '@coveo/atomic-theming-e2e'
-          tasks: e2e
+      - run: pnpm exec turbo run '@coveo/atomic-theming-e2e#e2e'
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
@@ -568,7 +538,7 @@ jobs:
   storybook-atomic:
     name: 'Run Storybook tests'
     needs: [affected, build]
-    if: contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic')
+    if: contains(needs.affected.outputs.tasks, '"@coveo/atomic#test:storybook"')
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.60.0-noble
@@ -590,13 +560,7 @@ jobs:
           filter: blob:none
       - run: git branch main origin/main
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          packages: '@coveo/atomic'
-          tasks: test:storybook
-          arguments: |
-            --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      - run: pnpm exec turbo run test:storybook --filter=@coveo/atomic -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: 'Upload a11y shard report'
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -611,7 +575,7 @@ jobs:
     if: >-
       ${{
         always() &&
-        contains(fromJSON(needs.affected.outputs.projects), '@coveo/atomic')
+        contains(needs.affected.outputs.tasks, '"@coveo/atomic#test:storybook"')
       }}
     runs-on: ubuntu-latest
     steps:
@@ -699,11 +663,7 @@ jobs:
           fetch-tags: false
           filter: blob:none
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: e2e
-          packages: '@coveo/pkg-new-template'
+      - run: pnpm exec turbo run '@coveo/pkg-new-template#e2e'
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
@@ -729,11 +689,7 @@ jobs:
           fetch-tags: false
           filter: blob:none
       - uses: ./.github/actions/setup
-      - uses: ./.github/actions/run-affected
-        with:
-          affected-tasks: ${{ needs.affected.outputs.tasks }}
-          tasks: e2e
-          packages: '@coveo/atomic-hosted-page'
+      - run: pnpm exec turbo run '@coveo/atomic-hosted-page#e2e'
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6099

## Motivation

After [KIT-6096](https://coveord.atlassian.net/browse/KIT-6096), Turbo's affected-task result can include dependent and virtual tasks. CI used a non-empty `projects` output to decide whether many jobs should run. A task such as `lint:check:all` could therefore make a project look stale and trigger unrelated builds and checks.

## Root Cause

CI gates used project-level affectedness, which discarded the task name. The workflow could not distinguish a build task from an unrelated lint, test, or validation task. Knip also selected workspaces from all affected projects instead of the projects with affected build tasks.

## Changes

- Gate build-related jobs on affected `#build` tasks.
- Gate specialized jobs on their exact affected task identifiers.
- Derive unique Knip workspaces from affected build tasks, including the repository root workspace.
- Run exact Turbo tasks directly for jobs that already use task-specific conditions.

## Validation

- `pnpm run lint:fix`
- `actionlint -shellcheck= .github/workflows/ci.yml`
- `git diff --check`
- Tested the Knip jq query with duplicate build tasks, a root task, and a non-build task.

## Checklist

- [ ] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`fix(<scope>): <description>`)
- [ ] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code

---

<sub>Stack created with <a href=\"https://github.com/github/gh-stack\">GitHub Stacks CLI</a> • <a href=\"https://gh.io/stacks-feedback\">Give Feedback 💬</a></sub>

[KIT-6096]: https://coveord.atlassian.net/browse/KIT-6096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ