### PR TITLE
chore(deps): align Angular workspace dependency ranges with catalog

### DIFF
--- a/packages/atomic-angular/package.json
+++ b/packages/atomic-angular/package.json
@@ -23,7 +23,7 @@
     "ng-packagr": "20.3.2",
     "tslib": "catalog:",
     "typescript": "catalog:",
-    "vite": "^8.0.0"
+    "vite": "catalog:"
   },
   "peerDependencies": {
     "@coveo/headless": "workspace:^"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,7 +583,7 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.0.0
+        specifier: 'catalog:'
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.4.2)(sass@1.97.3)(terser@5.50.0)(yaml@2.9.0)
 
   packages/atomic-angular/projects/atomic-angular:
@@ -2153,9 +2153,6 @@ importers:
       tslib:
         specifier: 'catalog:'
         version: 2.8.1
-      vitest:
-        specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(less@4.9.0(supports-color@8.1.1))(sass@1.102.0)(terser@5.50.0)(yaml@2.9.0))
       zone.js:
         specifier: 'catalog:'
         version: 0.15.1

--- a/samples/headless/rga-angular/package.json
+++ b/samples/headless/rga-angular/package.json
@@ -27,8 +27,5 @@
     "@angular/cli": "catalog:",
     "@angular/compiler-cli": "catalog:",
     "typescript": "catalog:"
-  },
-  "peerDependencies": {
-    "vitest": "4.1.10"
   }
 }


### PR DESCRIPTION
[KIT-5995](https://coveord.atlassian.net/browse/KIT-5995)

## Problem

Two dependencies in the Angular workspaces bypassed the catalog:

- `vite` in `packages/atomic-angular/package.json` used a standalone `^8.0.0` range.
- `vitest` in `samples/headless/rga-angular/package.json` was pinned to `4.1.10`.

The ticket also listed `@angular/common` and `@angular/core` (`14 - 21`). Those are deliberately excluded here — they are the published peer range for `@coveo/atomic-angular` and are handled by KIT-5982 under the support policy decided in KIT-5980. Changing them is not catalog hygiene.

## Solution

- `vite` now resolves through `catalog:`. The resolved version is unchanged (`8.2.1`), so this is specifier-only.
- The `vitest` entry is removed rather than pointed at the catalog. It was declared under `peerDependencies` on a private, unpublished sample app, and it was the only vitest reference in `rga-angular` — no test script, no vitest config, no test files. Aligning a dead entry to the catalog would put it under catalog governance for no reason; deleting it removes the drift by removing the cause. The catalog value is `4.1.10` anyway, so nothing resolves differently either way.

## Note on the lockfile

The lockfile diff is deliberately minimal: one specifier line plus the removed importer entry.

Regenerating it with `pnpm install --lockfile-only` produced ~156 lines of unrelated churn, including `playwright` `1.60.0` -> `1.63.0-alpha-2026-08-05`. That drift is latent in the committed lockfile, which holds duplicate `@types/node` (24.13.3 / 26.2.0) and `vite` (7.3.6 / 8.2.1) subtrees. A pristine `main` install no-ops, so the drift only surfaces once any manifest changes and pnpm re-resolves. `@vitest/browser-playwright` has a loose optional `playwright` peer, and the alpha build is old enough to clear the `minimumReleaseAge: 10080` gate.

Pulling a Playwright prerelease into a dependency-alignment PR is not appropriate, so the importer records were edited directly instead. `pnpm install --frozen-lockfile` passes against the result.

This lockfile normalization hazard is worth its own ticket — any PR that touches a manifest will hit it.

[KIT-5995]: https://coveord.atlassian.net/browse/KIT-5995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ