### PR TITLE
fix(samples, platform-mock-api): render commerce results when enableResults is set

### DIFF
--- a/.changeset/ssr-commerce-nextjs-enable-results.md
+++ b/.changeset/ssr-commerce-nextjs-enable-results.md
@@ -1,0 +1,5 @@
+---
+'@coveo/ui-kit-sample-headless-ssr-commerce-nextjs': patch
+---
+
+Render products from `results` when the product list controller opts into `enableResults`. The sample previously read only `products`, which the Commerce API leaves empty for those requests, so no products appeared on the listing and search pages.

--- a/.changeset/ssr-commerce-nextjs-enable-results.md
+++ b/.changeset/ssr-commerce-nextjs-enable-results.md
@@ -1,5 +1,0 @@
----
-'@coveo/ui-kit-sample-headless-ssr-commerce-nextjs': patch
----
-
-Render products from `results` when the product list controller opts into `enableResults`. The sample previously read only `products`, which the Commerce API leaves empty for those requests, so no products appeared on the listing and search pages.

--- a/packages/platform-mock-api/src/commerce/enable-results-transformer.ts
+++ b/packages/platform-mock-api/src/commerce/enable-results-transformer.ts
@@ -1,0 +1,31 @@
+interface EnableResultsRequest {
+  enableResults?: boolean;
+}
+
+interface WithProductsAndResults {
+  products: unknown[];
+  results: unknown[];
+}
+
+/**
+ * Request transformer for commerce endpoints that reproduces the `enableResults`
+ * behavior of the Commerce API: when a request opts in, items are returned under
+ * `results` — which may also hold spotlight content — and `products` is left empty.
+ *
+ * Without this transformer, a mock always answers with `products`, which hides
+ * bugs in consumers that read `products` while opting into `results`.
+ */
+export function commerceEnableResultsTransformer<T extends WithProductsAndResults>(
+  body: unknown,
+  response: T
+): T {
+  if (!(body as EnableResultsRequest | null)?.enableResults) {
+    return response;
+  }
+
+  return {
+    ...response,
+    products: [],
+    results: response.results.length > 0 ? response.results : response.products,
+  };
+}

--- a/packages/platform-mock-api/src/commerce/index.ts
+++ b/packages/platform-mock-api/src/commerce/index.ts
@@ -6,6 +6,7 @@ import * as searchResponses from './search-response.js';
 
 export {MockCommerceApi} from './mock.js';
 export {commerceFacetTransformer, createFacetSearchTransformer} from './facet-transformer.js';
+export {commerceEnableResultsTransformer} from './enable-results-transformer.js';
 export {commercePaginationTransformer} from './pagination-transformer.js';
 export type {FacetSearchResponse as CommerceFacetSearchResponse} from './facet-transformer.js';
 export type {CommerceSearchResponse} from './search-response.js';

--- a/packages/platform-mock-api/src/commerce/mock.ts
+++ b/packages/platform-mock-api/src/commerce/mock.ts
@@ -1,6 +1,7 @@
 import type {HttpHandler} from 'msw';
 import {EndpointHarness, type MockApi} from '../_base.js';
 import type {APIErrorWithStatusCode} from '../_common/error.js';
+import {commerceEnableResultsTransformer} from './enable-results-transformer.js';
 import type {FacetSearchResponse} from './facet-transformer.js';
 import {richResponse as baseListingResponse} from './listing-response.js';
 import {baseResponse as baseProductSuggestResponse} from './productSuggest-response.js';
@@ -29,7 +30,7 @@ export class MockCommerceApi implements MockApi {
       'POST',
       `${basePath}/rest/organizations/:orgId/commerce/v2/search`,
       baseSearchResponse
-    );
+    ).addRequestTransformer<CommerceSearchResponse>(commerceEnableResultsTransformer);
 
     this.recommendationEndpoint = new EndpointHarness(
       'POST',
@@ -50,7 +51,7 @@ export class MockCommerceApi implements MockApi {
       'POST',
       `${basePath}/rest/organizations/:orgId/commerce/v2/listing`,
       baseListingResponse
-    );
+    ).addRequestTransformer(commerceEnableResultsTransformer);
 
     this.facetSearchEndpoint = new EndpointHarness<FacetSearchResponse>(
       'POST',

--- a/samples/headless-ssr/commerce-nextjs/README.md
+++ b/samples/headless-ssr/commerce-nextjs/README.md
@@ -58,9 +58,9 @@ pnpm add @coveo/headless-react@<version>
 
 ## How the tests stay deterministic
 
-The Playwright tests never call a live Commerce API. During `pnpm e2e`, Playwright starts a standalone Express server powered by [`@mswjs/http-middleware`](https://www.npmjs.com/package/@mswjs/http-middleware) (see `mocks/mock-server.mjs`) and passes its URL through `NEXT_PUBLIC_MOCK_API_URL` (see `playwright.config.ts`). The commerce engine then uses `proxyBaseUrl` to route both the server-side `fetchStaticState` calls and the client-side hydration/interactions through that mock server (see `lib/commerce-engine-config.ts`). The mock server reuses the handlers from `@coveo/platform-mock-api`.
+The Playwright tests never call a live Commerce API. During `pnpm e2e`, Playwright starts a standalone Express server powered by [`@mswjs/http-middleware`](https://www.npmjs.com/package/@mswjs/http-middleware) (see `mocks/mock-server.mjs`) and passes its URL to the Next.js server as `MOCK_API_URL` (see `playwright.config.ts`). The commerce engine then uses `proxyBaseUrl` to route both the server-side `fetchStaticState` calls and the client-side hydration/interactions through that mock server (see `lib/commerce-engine-config.ts`). The mock server reuses the handlers from `@coveo/platform-mock-api`.
 
-Next.js bakes `NEXT_PUBLIC_*` variables into the client bundle at build time, so the Playwright web server builds the app itself rather than reusing the output of the package's `build` task. Without that, only the server half would reach the mock and the hydrated page would query the live API. A fixture in `e2e/fixtures.ts` fails any test whose browser reaches a non-local Commerce API, so this cannot regress unnoticed.
+`MOCK_API_URL` is deliberately not a `NEXT_PUBLIC_*` variable: Next.js would bake it into the client bundle at build time, forcing the test suite to build the app itself. Instead the root layout publishes it to the browser at runtime (see `lib/mock-api-url.ts`), so a single production build works for both. A fixture in `e2e/fixtures.ts` fails any test whose browser reaches a non-local Commerce API, so this cannot regress unnoticed.
 
 ## Learn more
 

--- a/samples/headless-ssr/commerce-nextjs/README.md
+++ b/samples/headless-ssr/commerce-nextjs/README.md
@@ -58,7 +58,9 @@ pnpm add @coveo/headless-react@<version>
 
 ## How the tests stay deterministic
 
-The Playwright tests never call a live API. During `pnpm e2e`, Playwright starts a standalone Express server powered by [`@mswjs/http-middleware`](https://www.npmjs.com/package/@mswjs/http-middleware) (see `mocks/mock-server.mjs`) and passes its URL to the Next.js server through `NEXT_PUBLIC_MOCK_API_URL` (see `playwright.config.ts`). The commerce engine then uses `proxyBaseUrl` to route both the server-side `fetchStaticState` calls and the client-side hydration/interactions through that mock server (see `lib/commerce-engine-config.ts`). The mock server reuses the handlers from `@coveo/platform-mock-api`.
+The Playwright tests never call a live Commerce API. During `pnpm e2e`, Playwright starts a standalone Express server powered by [`@mswjs/http-middleware`](https://www.npmjs.com/package/@mswjs/http-middleware) (see `mocks/mock-server.mjs`) and passes its URL through `NEXT_PUBLIC_MOCK_API_URL` (see `playwright.config.ts`). The commerce engine then uses `proxyBaseUrl` to route both the server-side `fetchStaticState` calls and the client-side hydration/interactions through that mock server (see `lib/commerce-engine-config.ts`). The mock server reuses the handlers from `@coveo/platform-mock-api`.
+
+Next.js bakes `NEXT_PUBLIC_*` variables into the client bundle at build time, so the Playwright web server builds the app itself rather than reusing the output of the package's `build` task. Without that, only the server half would reach the mock and the hydrated page would query the live API. A fixture in `e2e/fixtures.ts` fails any test whose browser reaches a non-local Commerce API, so this cannot regress unnoticed.
 
 ## Learn more
 

--- a/samples/headless-ssr/commerce-nextjs/app/layout.tsx
+++ b/samples/headless-ssr/commerce-nextjs/app/layout.tsx
@@ -1,5 +1,6 @@
 import type {ReactNode} from 'react';
 import Header from '@/components/header';
+import {MOCK_API_URL_GLOBAL} from '@/lib/mock-api-url';
 import './globals.css';
 
 export const metadata = {
@@ -10,9 +11,25 @@ export const metadata = {
 };
 
 export default function RootLayout({children}: {children: ReactNode}) {
+  const mockApiUrl = process.env.MOCK_API_URL;
+
   return (
     <html lang="en">
       <body>
+        {/*
+          Used internally in https://github.com/coveo/ui-kit for testing purposes,
+          not needed in your own implementation. Hands the mock API server URL to
+          the browser at runtime so the commerce engine can route client-side calls
+          through it. Runs before the app bundle, which is when the engine
+          configuration is evaluated.
+        */}
+        {mockApiUrl && (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window[${JSON.stringify(MOCK_API_URL_GLOBAL)}]=${JSON.stringify(mockApiUrl)}`,
+            }}
+          />
+        )}
         <div className="Layout">
           <Header />
           <main className="Page">{children}</main>

--- a/samples/headless-ssr/commerce-nextjs/components/product-list.tsx
+++ b/samples/headless-ssr/commerce-nextjs/components/product-list.tsx
@@ -1,19 +1,34 @@
 'use client';
 
+import {ResultType} from '@coveo/headless-react/ssr-commerce';
 import {useCart, useContext, useProductList} from '@/lib/commerce-engine';
 import {addToCart} from '@/utils/cart';
 import ProductButtonWithImage from './product-button-with-image';
 import ProductPrice from './product-price';
 import ProductVariants from './product-variants';
+import SpotlightContentCard from './spotlight-content-card';
 
 export default function ProductList() {
   const {state, methods} = useProductList();
   const {state: cartState, methods: cartMethods} = useCart();
   const {state: contextState} = useContext();
 
+  // The controller is configured with `enableResults`, so the API returns items
+  // under `results`, which may also contain spotlight content. `products` is
+  // only populated for requests that did not opt into `results`.
+  const items = state.results.length > 0 ? state.results : state.products;
+
   return (
     <ul aria-label="Product List" className="ProductList">
-      {state.products.map((item) => {
+      {items.map((item) => {
+        if (item.resultType === ResultType.SPOTLIGHT) {
+          return (
+            <li key={item.id} className="ProductCard">
+              <SpotlightContentCard methods={methods} spotlightContent={item} />
+            </li>
+          );
+        }
+
         const quantityInCart =
           cartState.items.find((cartItem) => cartItem.productId === item.ec_product_id)?.quantity ??
           0;

--- a/samples/headless-ssr/commerce-nextjs/components/spotlight-content-card.tsx
+++ b/samples/headless-ssr/commerce-nextjs/components/spotlight-content-card.tsx
@@ -1,0 +1,43 @@
+import type {ProductList, SpotlightContent} from '@coveo/headless-react/ssr-commerce';
+
+interface SpotlightContentCardProps {
+  methods: Omit<ProductList, 'state' | 'subscribe'> | undefined;
+  spotlightContent: SpotlightContent;
+}
+
+/**
+ * Renders a spotlight content item. Spotlight content is merchandising material
+ * (banners, promotions) that the Commerce API can interleave with products when
+ * the request opts into `results`.
+ */
+export default function SpotlightContentCard({
+  methods,
+  spotlightContent,
+}: SpotlightContentCardProps) {
+  const onSpotlightClick = () => {
+    methods?.interactiveSpotlightContent({options: {spotlightContent}}).select();
+    window.open(spotlightContent.clickUri, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <button type="button" className="ProductLink" disabled={!methods} onClick={onSpotlightClick}>
+      <img
+        className="ProductImage"
+        src={spotlightContent.desktopImage}
+        alt={spotlightContent.altText ?? spotlightContent.name ?? ''}
+        width={150}
+        height={150}
+      />
+      {spotlightContent.name && (
+        <span className="ProductName" style={{color: spotlightContent.nameFontColor}}>
+          {spotlightContent.name}
+        </span>
+      )}
+      {spotlightContent.description && (
+        <span className="ProductDescription" style={{color: spotlightContent.descriptionFontColor}}>
+          {spotlightContent.description}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/samples/headless-ssr/commerce-nextjs/e2e/fixtures.ts
+++ b/samples/headless-ssr/commerce-nextjs/e2e/fixtures.ts
@@ -1,36 +1,52 @@
 import {expect, test as base} from '@playwright/test';
 
+const isCommerceApiCall = (url: string) => url.includes('/commerce/v2');
+
 /**
  * Every Coveo Commerce API call — server-side (SSR) and client-side (hydration /
  * interactions) — is routed to the @mswjs/http-middleware mock server through the
- * engine's proxyBaseUrl.
+ * engine's proxyBaseUrl. The client half depends on the root layout publishing
+ * MOCK_API_URL to the browser.
  *
- * The client half of that only works when NEXT_PUBLIC_MOCK_API_URL is set at build
- * time, since Next.js bakes it into the client bundle. This fixture fails the test
- * when the browser reaches the live API instead, which would otherwise turn these
- * tests into flaky assertions against production data.
+ * This fixture fails the test when a browser Commerce API call either reaches the
+ * live API or does not succeed against the mock. Both cases otherwise go unnoticed:
+ * headless leaves the server-rendered state in place when a request fails, so
+ * assertions keep passing against stale data instead of what they mean to check.
  *
  * Analytics events are not proxied and still reach the live endpoint, so they are
  * deliberately left alone here.
  */
-export const test = base.extend<{blockLiveApiCalls: void}>({
-  blockLiveApiCalls: [
+export const test = base.extend<{checkCommerceApiCalls: void}>({
+  checkCommerceApiCalls: [
     async ({page}, use) => {
-      const liveCalls: string[] = [];
+      const problems: string[] = [];
 
       await page.route(
-        (url) => url.hostname !== 'localhost' && url.pathname.includes('/commerce/v2'),
+        (url) => url.hostname !== 'localhost' && isCommerceApiCall(url.pathname),
         async (route) => {
-          liveCalls.push(route.request().url());
+          problems.push(`reached the live API: ${route.request().url()}`);
           await route.abort();
         }
       );
 
+      page.on('requestfailed', (request) => {
+        const url = request.url();
+        if (isCommerceApiCall(url) && new URL(url).hostname === 'localhost') {
+          problems.push(`request failed: ${url} (${request.failure()?.errorText})`);
+        }
+      });
+
+      page.on('response', (response) => {
+        if (isCommerceApiCall(response.url()) && !response.ok()) {
+          problems.push(`responded ${response.status()}: ${response.url()}`);
+        }
+      });
+
       await use();
 
       expect(
-        liveCalls,
-        'The browser called the live Coveo API instead of the mock server. Check that NEXT_PUBLIC_MOCK_API_URL is set when the app is built.'
+        problems,
+        'Commerce API calls made by the browser did not all reach the mock server'
       ).toEqual([]);
     },
     {auto: true},

--- a/samples/headless-ssr/commerce-nextjs/e2e/fixtures.ts
+++ b/samples/headless-ssr/commerce-nextjs/e2e/fixtures.ts
@@ -1,5 +1,40 @@
-// All API calls — both server-side (SSR) and client-side (hydration /
-// interactions) — are routed to the @mswjs/http-middleware mock server via
-// the engine's proxyBaseUrl configuration.  No browser-level interception is
-// needed here.
-export {test, expect} from '@playwright/test';
+import {expect, test as base} from '@playwright/test';
+
+/**
+ * Every Coveo Commerce API call — server-side (SSR) and client-side (hydration /
+ * interactions) — is routed to the @mswjs/http-middleware mock server through the
+ * engine's proxyBaseUrl.
+ *
+ * The client half of that only works when NEXT_PUBLIC_MOCK_API_URL is set at build
+ * time, since Next.js bakes it into the client bundle. This fixture fails the test
+ * when the browser reaches the live API instead, which would otherwise turn these
+ * tests into flaky assertions against production data.
+ *
+ * Analytics events are not proxied and still reach the live endpoint, so they are
+ * deliberately left alone here.
+ */
+export const test = base.extend<{blockLiveApiCalls: void}>({
+  blockLiveApiCalls: [
+    async ({page}, use) => {
+      const liveCalls: string[] = [];
+
+      await page.route(
+        (url) => url.hostname !== 'localhost' && url.pathname.includes('/commerce/v2'),
+        async (route) => {
+          liveCalls.push(route.request().url());
+          await route.abort();
+        }
+      );
+
+      await use();
+
+      expect(
+        liveCalls,
+        'The browser called the live Coveo API instead of the mock server. Check that NEXT_PUBLIC_MOCK_API_URL is set when the app is built.'
+      ).toEqual([]);
+    },
+    {auto: true},
+  ],
+});
+
+export {expect};

--- a/samples/headless-ssr/commerce-nextjs/lib/commerce-engine-config.ts
+++ b/samples/headless-ssr/commerce-nextjs/lib/commerce-engine-config.ts
@@ -16,8 +16,24 @@ import {
   defineSummary,
   getSampleCommerceEngineConfiguration,
 } from '@coveo/headless-react/ssr-commerce';
+import {MOCK_API_URL_GLOBAL} from './mock-api-url';
 
 const sampleCommerceEngineConfiguration = getSampleCommerceEngineConfiguration();
+
+// Used internally in https://github.com/coveo/ui-kit for testing purposes, not
+// needed in your own implementation.
+//
+// On the server this reads the environment directly. In the browser it reads the
+// value published by the root layout, so the mock URL stays a runtime concern and
+// never has to be baked into the client bundle at build time.
+function getMockApiUrl() {
+  if (typeof window === 'undefined') {
+    return process.env.MOCK_API_URL;
+  }
+  return window[MOCK_API_URL_GLOBAL];
+}
+
+const mockApiUrl = getMockApiUrl();
 
 export default {
   // By default, the logger level is set to 'warn'. To get more detailed error
@@ -26,10 +42,10 @@ export default {
   configuration: {
     ...sampleCommerceEngineConfiguration,
     // Used internally in https://github.com/coveo/ui-kit for testing purposes, not needed in your own implementation.
-    // When NEXT_PUBLIC_MOCK_API_URL is set (e.g. during e2e tests), route all API calls
+    // When MOCK_API_URL is set (e.g. during e2e tests), route all API calls
     // through the local @mswjs/http-middleware mock server.
-    ...(process.env.NEXT_PUBLIC_MOCK_API_URL && {
-      proxyBaseUrl: `${process.env.NEXT_PUBLIC_MOCK_API_URL}/rest/organizations/${sampleCommerceEngineConfiguration.organizationId}/commerce/v2`,
+    ...(mockApiUrl && {
+      proxyBaseUrl: `${mockApiUrl}/rest/organizations/${sampleCommerceEngineConfiguration.organizationId}/commerce/v2`,
     }),
   },
   controllers: {

--- a/samples/headless-ssr/commerce-nextjs/lib/mock-api-url.ts
+++ b/samples/headless-ssr/commerce-nextjs/lib/mock-api-url.ts
@@ -1,0 +1,16 @@
+/**
+ * Used internally in https://github.com/coveo/ui-kit for testing purposes, not
+ * needed in your own implementation.
+ *
+ * Name of the global the root layout publishes so the browser can discover the
+ * mock API server at runtime. Next.js only exposes `NEXT_PUBLIC_*` variables to
+ * the client by baking them into the bundle at build time, which would force the
+ * e2e suite to build the app itself; a server-rendered global avoids that.
+ */
+export const MOCK_API_URL_GLOBAL = '__coveoMockApiUrl';
+
+declare global {
+  interface Window {
+    [MOCK_API_URL_GLOBAL]?: string;
+  }
+}

--- a/samples/headless-ssr/commerce-nextjs/mocks/mock-server.mjs
+++ b/samples/headless-ssr/commerce-nextjs/mocks/mock-server.mjs
@@ -8,6 +8,17 @@ const baseUrl = `http://localhost:${port}`;
 const api = new MockCommerceApi(baseUrl);
 const app = express();
 
+// The app and this server run on different ports, so client-side calls are
+// cross-origin. Without these headers the browser rejects every response and the
+// engine silently falls back to whatever state the server already rendered.
+app.use((_req, res, next) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', '*');
+  next();
+});
+app.options('*splat', (_req, res) => res.sendStatus(204));
+
 // Playwright polls this route to know when the server is ready.
 app.get('/health', (_req, res) => res.status(200).send('ok'));
 // Load mocks

--- a/samples/headless-ssr/commerce-nextjs/playwright.config.ts
+++ b/samples/headless-ssr/commerce-nextjs/playwright.config.ts
@@ -23,9 +23,6 @@ export default defineConfig({
   webServer: [
     {
       // Standalone Express server powered by @mswjs/http-middleware.
-      // All Coveo Commerce API calls (SSR and client-side) are intercepted here
-      // because the Next.js server is started with MOCK_API_URL, which the
-      // headless engine uses as its proxyBaseUrl.
       command: 'node mocks/mock-server.mjs',
       url: `${MOCK_API_URL}/health`,
       reuseExistingServer: !process.env.CI,
@@ -34,10 +31,15 @@ export default defineConfig({
     },
     {
       // Run the production build so tests exercise the same output users ship.
-      command: 'pnpm start',
+      //
+      // The build must happen here rather than through the package's `build`
+      // task: NEXT_PUBLIC_MOCK_API_URL is inlined into the client bundle at
+      // build time, and without it the hydrated page calls the live Coveo API
+      // instead of the mock server.
+      command: 'pnpm build && pnpm start',
       url: 'http://localhost:3000',
       reuseExistingServer: false,
-      timeout: 120 * 1000,
+      timeout: 180 * 1000,
       env: {NEXT_PUBLIC_MOCK_API_URL: MOCK_API_URL},
     },
   ],

--- a/samples/headless-ssr/commerce-nextjs/playwright.config.ts
+++ b/samples/headless-ssr/commerce-nextjs/playwright.config.ts
@@ -31,16 +31,13 @@ export default defineConfig({
     },
     {
       // Run the production build so tests exercise the same output users ship.
-      //
-      // The build must happen here rather than through the package's `build`
-      // task: NEXT_PUBLIC_MOCK_API_URL is inlined into the client bundle at
-      // build time, and without it the hydrated page calls the live Coveo API
-      // instead of the mock server.
-      command: 'pnpm build && pnpm start',
+      // MOCK_API_URL is read at runtime, both by the server and — through the
+      // global published by the root layout — by the browser.
+      command: 'pnpm start',
       url: 'http://localhost:3000',
       reuseExistingServer: false,
-      timeout: 180 * 1000,
-      env: {NEXT_PUBLIC_MOCK_API_URL: MOCK_API_URL},
+      timeout: 120 * 1000,
+      env: {MOCK_API_URL},
     },
   ],
 });


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6101

## Motivation

`E2E: @coveo/ui-kit-sample-headless-ssr-commerce-nextjs#e2e` intermittently fails on `smoke.spec.ts > search page > renders products for a query` ([example run](https://github.com/coveo/ui-kit/actions/runs/32731810630/job/97447044175) — failed all three attempts, passed on job re-run).

Investigating it surfaced a bigger problem: the sample renders **zero** products against the real Commerce API. With no mock, `/surf-accessories` reports "Showing results 1 - 13 of 13" with 30 facet values and no product cards.

## Root Cause

Three layered problems, all sharing one failure mode — when a Commerce request does not land, headless leaves the server-rendered state in place, so assertions keep passing against stale data.

1. **The sample read the wrong state.** The controller is configured with `defineProductList({enableResults: true})`, so the API returns items under `results` and leaves `products` empty. `components/product-list.tsx` mapped `state.products`. The `commerce-nextjs-v4` sample already handles this correctly.
2. **Client-side calls were never mocked.** `lib/commerce-engine-config.ts` gated `proxyBaseUrl` on `process.env.NEXT_PUBLIC_MOCK_API_URL`, but `playwright.config.ts` set it only on the `pnpm start` web server. Next.js bakes `NEXT_PUBLIC_*` into the client bundle at build time, so SSR reached the mock while the hydrated page reached `searchuisamples.org.coveo.com`. The flake is the race between the live response landing and the assertion: fast egress fails, slow or failed egress passes because the SSR products are still in the DOM.
3. **The mock server had no CORS headers.** The app and the mock run on different ports, so once client-side calls did point at the mock, the browser rejected every response — reproducing the same false pass through a different cause. This one only became visible after fixing 2.

`@coveo/platform-mock-api` also ignored `enableResults` and always answered with `products` populated, which is why the suite never caught issue 1.

## Changes

- `components/product-list.tsx` renders `state.results` with a fallback to `state.products`, matching the `commerce-nextjs-v4` pattern. Adds `spotlight-content-card.tsx`, since `results` may contain spotlight content.
- The mock URL is now a **runtime** value rather than a build-time one: `MOCK_API_URL` (no `NEXT_PUBLIC_` prefix) is read from the environment on the server and from a global published by the root layout in the browser (`lib/mock-api-url.ts`). This keeps a single production build — the e2e suite tests exactly what the `build` task produces, and no test-only value is baked into `.next`.
- `mocks/mock-server.mjs` sends CORS headers and answers preflight requests.
- `e2e/fixtures.ts` gains an auto fixture that fails on any browser Commerce API call that reaches the live API *or* does not succeed against the mock. Analytics events are not proxied and are deliberately left alone.
- `MockCommerceApi` registers a new `commerceEnableResultsTransformer` on its search and listing endpoints, so the mock mirrors the real response shape.

## Validation

- Sample suite: 6/6 pass against an unmodified `pnpm build` output.
- Client-side calls positively confirmed to reach the mock: `200 /search/querySuggest`, `200 /search/productSuggest`, `200 /search`, all on the mock host, with the summary updating to "Showing results 1 - 48 of 632 for kayak". Verifying this rather than trusting a green suite is what exposed the CORS problem.
- Counterfactual 1 — restoring the pre-fix `product-list.tsx` and rebuilding fails 3 tests, so the mock now catches the rendering bug instead of hiding it.
- Counterfactual 2 — removing the CORS headers makes the new fixture fail with `request failed: .../commerce/v2/search (net::ERR_FAILED)`, so a silent client-side breakage cannot come back.
- Mock behavior checked directly: `enableResults: true` → `products 0 / results 48` (search), `results 13` (listing); `false` → `products 48 / results 0`.
- Sibling suites using the mock all pass: `headless-commerce-react`, `headless-commerce-vite`, `atomic-commerce-react`, `atomic-commerce-vite`. They must run sequentially locally since they share port 4173.
- `pnpm run lint:check` clean, `tsc --noEmit` clean for `platform-mock-api`, sample `next build` clean.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`fix(<scope>): <description>`)
- [ ] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code — not applicable, the change only touches sample and test-mock code
