### PR TITLE
chore: remove obsolete Biome remnants

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -23,7 +23,6 @@
     "azerty",
     "bazz",
     "behaviour",
-    "biomejs",
     "bivariance",
     "bloup",
     "bpsb",

--- a/packages/atomic-a11y/test/reporter-gating.test.ts
+++ b/packages/atomic-a11y/test/reporter-gating.test.ts
@@ -105,7 +105,7 @@ describe('VitestA11yReporter — run-end gating', () => {
     const reporter = new VitestA11yReporter({outputFile, packageJsonPath});
 
     reporter.onTestCaseResult(
-      // biome-ignore lint/suspicious/noExplicitAny: simplified test fixture
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- simplified test fixture
       buildTestCase({
         storyId: 'atomic-tab--default',
         modulePath: 'src/components/common/atomic-tab/atomic-tab.stories.tsx',
@@ -133,7 +133,7 @@ describe('VitestA11yReporter — run-end gating', () => {
     const reporter = new VitestA11yReporter({outputFile, packageJsonPath});
 
     reporter.onTestCaseResult(
-      // biome-ignore lint/suspicious/noExplicitAny: simplified test fixture
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- simplified test fixture
       buildTestCase({
         storyId: 'atomic-tab--broken',
         modulePath: 'src/components/common/atomic-tab/atomic-tab.stories.tsx',
@@ -169,7 +169,7 @@ describe('VitestA11yReporter — run-end gating', () => {
 
     reporter.onTestRunStart();
     reporter.onTestCaseResult(
-      // biome-ignore lint/suspicious/noExplicitAny: simplified test fixture
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- simplified test fixture
       buildTestCase({
         storyId: 'atomic-tab--broken',
         modulePath: 'src/components/common/atomic-tab/atomic-tab.stories.tsx',
@@ -187,7 +187,7 @@ describe('VitestA11yReporter — run-end gating', () => {
 
     reporter.onTestRunStart();
     reporter.onTestCaseResult(
-      // biome-ignore lint/suspicious/noExplicitAny: simplified test fixture
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- simplified test fixture
       buildTestCase({
         storyId: 'atomic-tab--broken',
         modulePath: 'src/components/common/atomic-tab/atomic-tab.stories.tsx',
@@ -218,7 +218,7 @@ describe('VitestA11yReporter — run-end gating', () => {
     });
 
     reporter.onTestCaseResult(
-      // biome-ignore lint/suspicious/noExplicitAny: simplified test fixture
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- simplified test fixture
       buildTestCase({
         storyId: 'atomic-tab--broken',
         modulePath: 'src/components/common/atomic-tab/atomic-tab.stories.tsx',
@@ -238,7 +238,7 @@ describe('VitestA11yReporter — run-end gating', () => {
     const reporter = new VitestA11yReporter({outputFile, packageJsonPath});
 
     reporter.onTestCaseResult(
-      // biome-ignore lint/suspicious/noExplicitAny: simplified test fixture
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- simplified test fixture
       buildTestCase({
         storyId: 'atomic-tab--broken',
         modulePath: 'src/components/common/atomic-tab/atomic-tab.stories.tsx',

--- a/packages/atomic/.storybook/main.ts
+++ b/packages/atomic/.storybook/main.ts
@@ -274,7 +274,7 @@ const svgTransform = (): Plugin => {
  * directives, so the CSS must be fully resolved before reaching the browser.
  */
 const processInlineCssImports = (): Plugin => {
-  // biome-ignore lint/suspicious/noExplicitAny: PostCSS plugin types are complex
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any -- PostCSS plugin types are complex
   let postcssPlugins: any[];
   let initialized = false;
 

--- a/packages/atomic/.storybook/public/mockServiceWorker.js
+++ b/packages/atomic/.storybook/public/mockServiceWorker.js
@@ -1,7 +1,5 @@
 /* eslint-disable */
 /* tslint:disable */
-// biome-ignore-all lint: generated
-// biome-ignore-all assist: generated
 
 /**
  * Mock Service Worker.


### PR DESCRIPTION
## Motivation

Biome was replaced by Oxlint and Oxfmt, but obsolete Biome suppressions and a spell-check allowance still remained. Keeping them made the active lint configuration misleading and left ineffective directives in maintained files.

## Changes

- Replace seven `biome-ignore` comments with equivalent Oxlint suppressions.
- Remove obsolete Biome directives from the generated MSW worker.
- Remove `biomejs` from the cspell allowlist.
- Preserve package changelog references because they document released history rather than active tooling.

## Validation

- [x] `pnpm run lint:fix`
- [x] `pnpm run build`
- [x] `pnpm run test`
- [x] Verified no active Biome references remain outside package changelogs and unrelated biometrics catalog content.
- [x] All existing tests pass without modification
- [x] No new features or bug fixes are included in this PR
- [x] Public API surface is unchanged

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`chore(<scope>): <description>`)
- [x] No changeset is needed because this only updates internal lint directives and tooling metadata.

no linked issue: trivial internal tooling cleanup with no Jira work item.

<!-- no-visual-delta -->
**Why no screenshot:** The changes only update lint directives and tooling metadata; rendered output is unchanged.
