### PR TITLE
fix(atomic): remove a stale sourceMappingURL comment from the autoloader

### DIFF
--- a/.changeset/atomic-autoloader-sourcemap-comment.md
+++ b/.changeset/atomic-autoloader-sourcemap-comment.md
@@ -1,0 +1,11 @@
+---
+'@coveo/atomic': patch
+---
+
+Remove a stale `sourceMappingURL` comment from the autoloader source.
+
+`src/autoloader/index.ts` ended with `//# sourceMappingURL=index.js.map`, a fragment of compiled
+output pasted into the file when the Lit migration was scaffolded. No source map is emitted for that
+module, so the reference never resolved. Production bundles are unaffected — the comment is stripped
+during the build — but any tool that consumes Atomic source directly, such as Storybook or the
+playground, logged a source map read error for the module on every dev server start.

--- a/packages/atomic/src/autoloader/index.ts
+++ b/packages/atomic/src/autoloader/index.ts
@@ -142,4 +142,3 @@ export function registerAutoloader(
     initializeDiscovery();
   }
 }
-//# sourceMappingURL=index.js.map


### PR DESCRIPTION
**Jira:** [KIT-6053](https://coveord.atlassian.net/browse/KIT-6053)

## Issue

`packages/atomic/src/autoloader/index.ts` ends with `//# sourceMappingURL=index.js.map`. It is a fragment of compiled output that was pasted into the file when the Lit migration was scaffolded in #4834 — in that commit the comment sat indented *inside* the function body, which is not where a build ever emits one. A later refactor moved it to the end of the file, where it looked legitimate.

Nothing could ever satisfy the reference. The path resolves relative to the source file, and no source map is emitted for this module anyway (`dist/esm` contains no `.map` files). So every tool that consumes Atomic source logs this on startup:

```
[vite] (client) Failed to load source map for packages/atomic/src/autoloader/index.ts.
Error: ENOENT: no such file or directory, open 'packages/atomic/src/autoloader/index.js.map'
```

Production bundles are unaffected — the build strips the comment — so this is dev-only noise.

## Solution

Delete the comment.

Split out of #8294 to keep that PR scoped to the Atomic playground. Note that `packages/atomic-hosted-page/src/autoloader/index.ts:90` carries the identical line from the same migration; left alone to keep this scoped to one package.

[KIT-6053]: https://coveord.atlassian.net/browse/KIT-6053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ