### PR TITLE
fix(KIT-6105): resolve preview catalog versions

### DIFF
--- a/packages/pkg-new-template/scripts/flatten-catalog.mjs
+++ b/packages/pkg-new-template/scripts/flatten-catalog.mjs
@@ -17,25 +17,35 @@ const pkgDir = path.dirname(pkgPath);
 
 const pkgJson = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
 
-function resolveCatalogEntries(deps) {
-  if (!deps) return;
-  for (const [name, version] of Object.entries(deps)) {
-    if (version !== 'catalog:') continue;
-    const output = execSync(`pnpm list ${name} --json --depth 0`, {
+function listDependencies() {
+  const output = execSync(
+    `pnpm ls --filter . --json --depth 0 | jq '.[0] | {dependencies, devDependencies}'`,
+    {
       cwd: pkgDir,
       encoding: 'utf8',
-    });
-    const parsed = JSON.parse(output)[0];
-    const resolved =
-      parsed.dependencies?.[name]?.version || parsed.devDependencies?.[name]?.version;
-    if (resolved) {
-      deps[name] = `^${resolved}`;
-      console.log(`Resolved ${name} "catalog:" → "^${resolved}"`);
+    }
+  );
+
+  return JSON.parse(output);
+}
+
+function resolveCatalogEntries(configuration, resolved) {
+  if (!configuration) return;
+
+  for (const [name, version] of Object.entries(configuration)) {
+    if (version !== 'catalog:') continue;
+
+    const resolvedVersion = resolved[name]?.version;
+    if (resolvedVersion) {
+      configuration[name] = `^${resolvedVersion}`;
+      console.log(`Resolved ${name} "catalog:" → "^${resolvedVersion}"`);
     }
   }
 }
 
-resolveCatalogEntries(pkgJson.dependencies);
-resolveCatalogEntries(pkgJson.devDependencies);
+const {dependencies, devDependencies} = listDependencies();
+
+resolveCatalogEntries(pkgJson.dependencies, dependencies);
+resolveCatalogEntries(pkgJson.devDependencies, devDependencies);
 
 fs.writeFileSync(pkgPath, JSON.stringify(pkgJson, null, 2) + '\n');


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6105

## Motivation

The pkg.pr.new preview template can be published with unresolved `catalog:` dependency versions. This prevents the standalone preview template from resolving its dependencies outside the monorepo.

## Root Cause

https://github.com/coveo/ui-kit/pull/8303 upgraded the repository to pnpm 11.17.0 on 2026-08-25.

With pnpm 10.34.5, pnpm list @playwright/test --json --depth 0 returned @coveo/pkg-new-template first, including the target dependency version. With pnpm 11.17.0, the same command returns the workspace root ui-kit first, without the target dependency. The resolver reads only result [0], so it misses the version and leaves the catalog: value unchanged.

## Changes

- Query the current package explicitly with `pnpm ls --filter . --json --depth 0`.
- Bonus: This now calls `pnpm ls` only once.

## Validation

- `pnpm run lint:fix`
- `git diff --check`
- `node --check packages/pkg-new-template/scripts/flatten-catalog.mjs`
- `pnpm exec oxfmt --check packages/pkg-new-template/scripts/flatten-catalog.mjs`
- Verified pnpm 10.34.5 returns the template package first and pnpm 11.17.0 returns `ui-kit` first.
- Verified the filtered query returns `@playwright/test@1.60.0` and `vite@8.2.1`.

## Checklist

- [x] PR title follows Conventional Commits 1.0.0 format.
- [x] No changeset required: this is private package tooling.