### PR TITLE
chore(deps): keep pnpm version in lockstep across renovate managers

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -63,6 +63,29 @@
       description: 'Keep the Playwright CI container image (mcr.microsoft.com/playwright) in lockstep with the playwright/@playwright/test packages so browser binaries always match the installed version',
       matchPackageNames: ['mcr.microsoft.com/playwright', 'playwright', '@playwright/test'],
     },
+    {
+      groupName: 'pnpm',
+      groupSlug: 'pnpm',
+      description: 'Keep pnpm in lockstep across the packageManager field, mise.toml and the devcontainer, since the mise and custom managers are not part of the js category and would otherwise get their own PRs',
+      matchDatasources: ['npm'],
+      matchPackageNames: ['pnpm'],
+    },
+  ],
+  customManagers: [
+    {
+      customType: 'regex',
+      description: 'Detect the pnpm version activated through corepack in the devcontainer',
+      managerFilePatterns: [
+        '/^\\.devcontainer\\/Dockerfile$/',
+        '/^\\.devcontainer\\/README\\.md$/',
+      ],
+      matchStrings: [
+        'corepack prepare pnpm@(?<currentValue>\\d+\\.\\d+\\.\\d+)',
+        'pnpm (?<currentValue>\\d+\\.\\d+\\.\\d+) via corepack',
+      ],
+      depNameTemplate: 'pnpm',
+      datasourceTemplate: 'npm',
+    },
   ],
   lockFileMaintenance: {
     enabled: true,


### PR DESCRIPTION
## Problem

The pnpm version is declared in four places, and Renovate only kept one of them up to date:

- `package.json` `packageManager` — detected by the `npm` manager, bumped in the grouped JS/TS PR (e.g. #8330).
- `mise.toml` — detected by the `mise` manager, but that manager is not in the `js` category, so it never joins the `all non-major dependencies (JS/TS)` group from `group/all-non-major-js-ts.json`. It gets its own PR on a separate schedule (branch `renovate/pnpm-11.x`), exactly like `awscli`.
- `.devcontainer/Dockerfile` (`corepack prepare pnpm@<version> --activate`) — not detected at all. The Dockerfile manager only parses `FROM`/`COPY --from` images.
- `.devcontainer/README.md` — not detected at all.

The result is that a pnpm bump lands piecemeal: `packageManager` moves ahead while `mise.toml` and the devcontainer drift behind, so local, mise, and devcontainer environments no longer agree on the pnpm version. #8303 had to update all four by hand.

## Solution

- Add a `regex` custom manager that reads the corepack-activated pnpm version from `.devcontainer/Dockerfile` and the matching prose line in `.devcontainer/README.md`, mapped to the `npm` datasource so it resolves the same versions as the other managers.
- Add a `pnpm` package rule matching `matchDatasources: ['npm']` + `matchPackageNames: ['pnpm']` so the `npm`, `mise`, and new custom manager updates all land in a single PR instead of three.

## Validation

`renovate-config-validator` passes on the updated `renovate.json5` (validated as repo config via auto-discovery, not just as global config).

A local Renovate dry run against this branch confirms the intended behavior:

```sh
GITHUB_COM_TOKEN="$(gh auth token)" LOG_LEVEL=debug \
  npx --package renovate renovate --platform=local --dry-run=lookup \
  --enabled-managers=npm,mise,custom.regex
```

- The custom manager matches both files: `Matched 2 file(s) for manager regex: .devcontainer/Dockerfile, .devcontainer/README.md`, extracting `pnpm 11.17.0` with `replaceString` `corepack prepare pnpm@11.17.0` and `pnpm 11.17.0 via corepack`.
- All four pnpm update sites resolve to the single branch `renovate/pnpm` for `11.22.0`: `mise.toml`, `package.json` (`packageManager`), `.devcontainer/Dockerfile`, and `.devcontainer/README.md`. No separate `renovate/pnpm-11.x` branch is computed anymore.
- The `engines.pnpm: ">=11.17.0"` entry yields `updates: []`, since the existing range already satisfies the new version. That is intentional and unchanged.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changeset not required — bot configuration only, no package source changed