### PR TITLE
chore(deps): raise renovate pr hourly limit to 5

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,9 @@
   labels: ['dependencies'],
   dependencyDashboard: true,
   minimumReleaseAge: '7 days',
+  // Raised from the config:recommended default of 2 so the weekly schedule window can drain
+  // more of the backlog. prConcurrentLimit stays at its default of 10 to bound CI load.
+  prHourlyLimit: 5,
   packageRules: [
     {
       groupName: 'all production dependencies',


### PR DESCRIPTION
## Problem

Renovate only manages to open about 4 dependency PRs per week, while the [dependency dashboard](https://github.com/coveo/ui-kit/issues/4704) has 26 updates stuck under *Awaiting Schedule*.

Two settings combine to cause this:

- `github>coveo/renovate-presets//schedule/weekly.json` restricts branch creation to `before 6:00am on Tuesday` (timezone `America/Toronto`), so there is a single ~6 hour window per week.
- `prHourlyLimit` is left at the `config:recommended` default of `2`, and neither `renovate.json5` nor the Coveo presets override it.

This week's PRs show the effect precisely — two bot runs inside the window, capped at 2 PRs each:

```
08:13:03Z  #8329  all dev dependencies
08:13:56Z  #8330  all non-major dependencies (js/ts)
09:08:26Z  #8331  angular-cli monorepo
09:08:40Z  #8332  awscli
```

Concurrency is not the constraint: `prConcurrentLimit` defaults to 10 and only 5 Renovate PRs are open. At ~4 PRs per week the 26-item backlog would take roughly six weeks to drain, and it grows faster than that.

## Solution

Set `prHourlyLimit: 5` so each run inside the weekly window can open more of the backlog.

`prConcurrentLimit` is deliberately left at its default of 10, which still bounds how many Renovate PRs are in flight and therefore how much CI runs concurrently. Widening the schedule was the alternative but would multiply CI load by five, so raising the hourly limit is the cheaper lever.

## Validation

- `renovate-config-validator` passes on the updated `renovate.json5`.
- A local dry run (`renovate --platform=local --dry-run=extract`) confirms the resolved repository config reports `"prHourlyLimit": 5`, so the value is not overridden by any inherited preset.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changeset not required — bot configuration only, no package source changed