### PR TITLE
ci: never skip the CDN deploy when the release job fails

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,6 +22,7 @@ jobs:
       id-token: write
     outputs:
       published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -58,15 +59,33 @@ jobs:
         run: |
           echo "The publish command failed before any package was published." >&2
           exit 1
+      - name: Update release/v3 bookmark
+        if: ${{ steps.changesets.outputs.published == 'true' }}
+        run: |
+          git tag -f release/v3
+          git push origin refs/tags/release/v3 --force
+  sentry-create-ui:
+    name: Upload create-ui source maps to Sentry
+    needs: release
+    if: ${{ contains(needs.release.outputs.publishedPackages, '@coveo/create-ui') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: 'refs/tags/release/v3'
+      - uses: ./.github/actions/setup
+      - name: Build create-ui
+        run: pnpm exec turbo run build --filter=@coveo/create-ui
       - name: Read create-ui version
         id: create-ui-version
-        if: ${{ steps.changesets.outputs.published == 'true' && contains(steps.changesets.outputs.publishedPackages, '@coveo/create-ui') }}
-        continue-on-error: true
         working-directory: packages/create-ui
         run: echo "version=$(jq -r '.version' package.json)" >> "$GITHUB_OUTPUT"
-      - name: Upload create-ui source maps to Sentry
-        if: ${{ steps.changesets.outputs.published == 'true' && contains(steps.changesets.outputs.publishedPackages, '@coveo/create-ui') && steps.create-ui-version.outputs.version != '' }}
-        continue-on-error: true
+      - name: Upload source maps
         uses: step-security/getsentry-action-release@4530160f6bc962e1dd67e2703064a7a5cfd401fb # v3.7.0
         with:
           release: create-ui@${{ steps.create-ui-version.outputs.version }}
@@ -79,11 +98,6 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: coveo-platform
           SENTRY_PROJECT: create-ui
-      - name: Update release/v3 bookmark
-        if: ${{ steps.changesets.outputs.published == 'true' }}
-        run: |
-          git tag -f release/v3
-          git push origin refs/tags/release/v3 --force
   quantic-prod:
     if: ${{ needs.release.outputs.published == 'true' }}
     needs: release

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -240,6 +240,10 @@ jobs:
   commit-artifact-upload:
     name: Upload commit artifacts to S3
     needs: [build-cdn, release]
+    # `release` is a soft dependency: it is only read to decide which channels to
+    # update. If npm was published, the CDN must follow, so a failure anywhere in
+    # the release job must never skip this deploy.
+    if: ${{ !cancelled() && needs.build-cdn.result == 'success' }}
     runs-on: ubuntu-latest
     # TODO(KIT-5712): Rename to 'CDN Deploy' once token vending machine is available
     environment: 'Prerelease (CDN)'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,16 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 jobs:
+  # ⚠️  Keep this job limited to publishing and tagging.
+  #
+  # A failing step here fails the whole job, and anything that runs after the
+  # publish step then never happens — including the release/v3 tag. Post-release
+  # side work (source maps, docs, notifications) belongs in its own job below,
+  # so that it cannot take the release down with it.
+  #
+  # `commit-artifact-upload` is deliberately insulated from this job: see the
+  # `if:` on it. Do not add `needs: release` gating that would let a failure
+  # here skip the CDN deploy.
   release:
     concurrency:
       group: release-${{ github.ref }}


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6113

## Motivation

We cannot have a state where npm published but the CDN did not follow. That has happened.

Run history for `cd.yml` shows two distinct failure shapes:

- **Sibling job failures are harmless to the CDN.** `quantic-prod` failed on Aug 24, Aug 18 and Aug 13, and `chromatic` failed five times in early August. In every one of those runs `Upload commit artifacts to S3` **succeeded** — GitHub does not fail-fast across jobs. These runs go red but the CDN ships.
- **`release` job failures skip the CDN.** Three runs did this: Aug 17, Aug 11, Aug 4. `commit-artifact-upload` declares `needs: [build-cdn, release]`, so any failing step in `release` skips the deploy.

Run [31519447241](https://github.com/coveo/ui-kit/actions/runs/31519447241) (Aug 11) is the bad one:

```
8.  success   Create release PR or publish            ← npm published
9.  skipped   Fail if publishing made no progress
10. failure   Read create-ui version                  ← shell quoting bug
11. skipped   Upload create-ui source maps to Sentry
12. skipped   Update release/v3 bookmark
```

npm published, then a one-liner reading a version number failed, which failed the job, skipped the CDN deploy, and left `release/v3` pointing at the previous release. #8018 and #8227 each patched the offending step with `continue-on-error`, which means the next step added without it reintroduces the same outcome.

## Changes

Three commits, reviewable in order. Only the first is load-bearing; the other two are cleanup and can be dropped without weakening the fix.

**1. `ci: never skip the CDN deploy when the release job fails`** (+4)

Gates `commit-artifact-upload` on `!cancelled() && needs.build-cdn.result == 'success'`. `release` becomes a soft dependency, still read for its `published` output to choose CDN channels (`private,preview` vs `private`), but no longer able to skip the deploy. Same idiom as `cdn-checks` in `ci.yml`. This alone fixes the invariant.

**2. `ci: move create-ui source map upload out of the release job`** (+24 −10)

`Read create-ui version` is the step that broke Aug 11. It only lived in the release job because `pnpm run release` had already built `packages/create-ui/dist` there — convenience, not a dependency. Moved both steps into a `sentry-create-ui` job so `release` only publishes and tags, making its red/green signal mean "publishing is broken". The `continue-on-error` band-aids are dropped, since the job boundary now does that work and a swallowed source map failure is worse than a visible one. The `release/v3` tag push **stays** in the release job, so `quantic-prod`, both typedoc jobs and `docs-prod` keep their existing `needs: release` and nothing downstream is rewired.

**3. `ci: document the release job invariant`** (+10)

A comment above `release`, so the reason is visible where someone would add a step.

Applied to history, this makes Aug 11 deploy with `private,preview`, and Aug 17 / Aug 4 deploy with `private` — those two published nothing, so skipping their private-pointer update was needless.

Residual, and unavoidable: if `build-cdn` itself fails, npm can publish without a CDN deploy, because there are no artifacts to ship.

## Validation

- `actionlint .github/workflows/cd.yml` after **each** commit reports the same 8 pre-existing `SC2086` info findings as `main` and no other diagnostics, so every commit is independently valid.
- Confirmed against real run data (`gh run view`) that sibling failures did not skip the CDN upload and that the three `release` failures did.
- Verified the `release` job now contains only: Harden Runner, Generate a token, checkout, setup, publish, publish-progress gate, tag.
- Worth eyeballing on the first release after merge: `needs.release.outputs.published` is expected to still be readable from a failed `release` job. If it were not, the expression falls back to `private` — the preview pointer would not advance but the commit artifacts would still upload.
- Commit 2 trades byte-identical source maps for a rebuild. `tsc` is deterministic for a given commit and the toolchain is pinned by `mise.toml`, so the maps should match the published tarball.

- [x] All existing tests pass without modification
- [x] No new features or bug fixes are included in this PR
- [x] Public API surface is unchanged

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code — n/a, CI-only change