### PR TITLE
ci: configure Chromatic pull request metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,6 +407,10 @@ jobs:
     needs: [affected, build]
     if: ${{ always() && !cancelled() }} # Run even if build is skipped
     runs-on: ubuntu-latest
+    env:
+      CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
+      CHROMATIC_SLUG: ${{ github.repository }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
+      CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       CHROMATIC_SLUG: ${{ github.repository }}
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Motivation

Chromatic builds triggered by `pull_request` need explicit PR-head metadata to avoid associating visual baselines with GitHub's ephemeral merge commit.

## Changes

- Provide Chromatic with the pull request head branch and SHA.
- Use the event commit SHA for non-PR events such as merge-group skip builds.
- Provide the repository slug expected by the Chromatic action.
- Keep the existing PR-head checkout and merge-group skip behavior unchanged.

## Validation

- [x] `pnpm run lint:fix`
- [x] `npm run build`
- [x] `npm test`
- [x] YAML syntax validation and `git diff --check`
- [x] Local read-only review found no Critical/High issues
- [x] Focused review verified the non-PR SHA fallback correction
- [x] All existing tests pass without modification
- [x] No new features or bug fixes are included in this PR
- [x] Public API surface is unchanged

## Checklist

- [x] PR title follows Conventional Commits 1.0.0
- [x] No changeset is required because no public package source changed

No linked issue: this is a small CI configuration correction.
