### PR TITLE
ci: test Chromatic bypass behavior for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
 
   chromatic:
     name: 'Run Chromatic visual tests on Atomic'
-    needs: [affected, build]
+    needs: [build]
     if: ${{ always() && !cancelled() }} # Run even if build is skipped
     runs-on: ubuntu-latest
     steps:
@@ -425,12 +425,9 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Run Chromatic visual tests
         uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
-        id: chromatic-run
         # Set the CHROMATIC_RENOVATE_ALLOWLIST repository variable to a JSON array of exact branch names.
         # Example: `["renovate/playwright", "renovate/chromatic"]`
         if: >-
-          needs.build.result == 'success' &&
-          contains(needs.affected.outputs.tasks, '"@coveo/atomic#build"') &&
           github.event_name == 'pull_request' &&
           (!startsWith(github.head_ref, 'renovate/') ||
           contains(fromJSON(vars.CHROMATIC_RENOVATE_ALLOWLIST || '[]'), github.head_ref))
@@ -439,7 +436,11 @@ jobs:
           workingDir: packages/atomic
       - name: Skip Chromatic visual tests
         uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
-        if: steps.chromatic-run.outcome == 'skipped'
+        if: >-
+          github.event_name == 'merge_group' ||
+          (github.event_name == 'pull_request' &&
+          startsWith(github.head_ref, 'renovate/') &&
+          !contains(fromJSON(vars.CHROMATIC_RENOVATE_ALLOWLIST || '[]'), github.head_ref))
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           skip: true


### PR DESCRIPTION
## Motivation

Stacked pull requests can use an intercalary PR as their merge base. When that PR only receives a Chromatic `skip` status, Chromatic has no build for the merge-base commit and UI Review cannot establish the expected comparison.

## Changes

- Run a real Chromatic build for every non-Renovate pull request, even when Atomic is not reported as affected or the shared build job is skipped.
- Continue running real builds for Renovate branches explicitly listed in `CHROMATIC_RENOVATE_ALLOWLIST`.
- Use `skip: true` only for merge-group runs and non-allowlisted Renovate branches.
- Remove the unused direct dependency on the `affected` job while retaining `build` ordering for cache reuse.

`onlyChanged: true` remains enabled in Atomic’s Chromatic configuration, allowing unchanged Storybooks to use TurboSnap bypassed builds while preserving Chromatic ancestry.

## Validation

- [x] `pnpm run lint:fix`
- [x] `npm run build`
- [x] `npm test`
- [x] YAML syntax parsing and `git diff --check`
- [x] Focused event truth-table and GitHub Actions expression review
- [x] Local read-only review found no Critical/High findings
- [x] All existing tests pass without modification
- [x] No new features or bug fixes are included in this PR
- [x] Public API surface is unchanged

## Checklist

- [x] PR title follows Conventional Commits 1.0.0
- [x] No changeset is required because no public package source changed

<!-- no-visual-delta -->
**Why no screenshot:** This changes CI execution and has no rendered UI impact.

no linked issue: this is a focused CI correction discovered while investigating stacked-PR Chromatic comparisons.