### PR TITLE
test(ci): validate Chromatic bypass at stack level one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
 
   chromatic:
     name: 'Run Chromatic visual tests on Atomic'
-    needs: [affected, build]
+    needs: [build]
     if: ${{ always() && !cancelled() }} # Run even if build is skipped
     runs-on: ubuntu-latest
     steps:
@@ -425,12 +425,9 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Run Chromatic visual tests
         uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
-        id: chromatic-run
         # Set the CHROMATIC_RENOVATE_ALLOWLIST repository variable to a JSON array of exact branch names.
         # Example: `["renovate/playwright", "renovate/chromatic"]`
         if: >-
-          needs.build.result == 'success' &&
-          contains(needs.affected.outputs.tasks, '"@coveo/atomic#build"') &&
           github.event_name == 'pull_request' &&
           (!startsWith(github.head_ref, 'renovate/') ||
           contains(fromJSON(vars.CHROMATIC_RENOVATE_ALLOWLIST || '[]'), github.head_ref))
@@ -439,7 +436,11 @@ jobs:
           workingDir: packages/atomic
       - name: Skip Chromatic visual tests
         uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
-        if: steps.chromatic-run.outcome == 'skipped'
+        if: >-
+          github.event_name == 'merge_group' ||
+          (github.event_name == 'pull_request' &&
+          startsWith(github.head_ref, 'renovate/') &&
+          !contains(fromJSON(vars.CHROMATIC_RENOVATE_ALLOWLIST || '[]'), github.head_ref))
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           skip: true

--- a/chromatic-bypass-validation/stack-level-1.md
+++ b/chromatic-bypass-validation/stack-level-1.md
@@ -3,3 +3,5 @@
 This temporary non-UI change verifies that an intercalary pull request receives a bypassed Chromatic build with zero billed snapshots.
 
 Do not merge this validation file.
+
+Synchronization marker: level-one default-base validation.

--- a/chromatic-bypass-validation/stack-level-1.md
+++ b/chromatic-bypass-validation/stack-level-1.md
@@ -1,0 +1,5 @@
+# Chromatic bypass validation: stack level 1
+
+This temporary non-UI change verifies that an intercalary pull request receives a bypassed Chromatic build with zero billed snapshots.
+
+Do not merge this validation file.


### PR DESCRIPTION
## Motivation

Validate that the all-PR Chromatic workflow produces a bypassed build with zero billed snapshots when a stacked PR has no file changes.

## Changes

- Add one empty commit above PR #8358.
- Provide the first temporary intercalary branch in the Chromatic bypass validation stack.

This PR is test infrastructure only and must not be merged.

## Validation

- [ ] Chromatic runs a real build rather than the explicit `skip` path
- [ ] TurboSnap reports the build as bypassed
- [ ] Chromatic reports zero billed snapshots
- [ ] The next stacked PR can use this commit without an unexpected UI Review comparison failure

## Checklist

- [x] PR title follows Conventional Commits 1.0.0
- [x] No changeset is required because the commit changes no files

<!-- no-visual-delta -->
**Why no screenshot:** This validation PR contains an empty commit and changes no rendered UI.

no linked issue: this is a temporary validation PR that will be closed after evidence is collected.