### PR TITLE
feat(atomic): add Gen Q&A and Insight pages to the playground

### DIFF
--- a/knip.js
+++ b/knip.js
@@ -33,6 +33,12 @@ export default {
     'packages/atomic-theming-e2e': {
       entry: ['tests/**/*.spec.ts', 'fixtures/*.js'],
     },
+    'packages/atomic-playground': {
+      entry: ['*.js'],
+      ignoreDependencies: [
+        'dayjs', // Transitive dep pre-bundled via optimizeDeps.include in vite.config.ts.
+      ],
+    },
     'packages/atomic-angular': {
       ignoreDependencies: [
         // Can be removed once we bump our package to use more recent Angular versions that support Vite 7+.

--- a/packages/atomic-playground/genqa.html
+++ b/packages/atomic-playground/genqa.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Atomic playground: Gen Q&amp;A</title>
+    <link rel="icon" href="data:," />
+    <script type="module" src="./genqa.js"></script>
+    <style>
+      body {
+        margin: 0;
+      }
+    </style>
+  </head>
+
+  <body>
+    <atomic-search-interface language-assets-path="/lang" icon-assets-path="/assets">
+      <atomic-search-layout>
+        <atomic-layout-section section="search" expanding>
+          <atomic-search-box></atomic-search-box>
+        </atomic-layout-section>
+        <atomic-layout-section section="facets">
+          <atomic-facet-manager>
+            <atomic-facet field="author" label="Authors"></atomic-facet>
+            <atomic-facet field="source" label="Source" display-values-as="link"></atomic-facet>
+            <atomic-facet field="filetype" label="File type"></atomic-facet>
+          </atomic-facet-manager>
+        </atomic-layout-section>
+        <atomic-layout-section section="main">
+          <atomic-generated-answer></atomic-generated-answer>
+          <atomic-layout-section section="status">
+            <atomic-breadbox></atomic-breadbox>
+            <atomic-query-summary></atomic-query-summary>
+            <atomic-did-you-mean></atomic-did-you-mean>
+            <atomic-notifications></atomic-notifications>
+          </atomic-layout-section>
+          <atomic-layout-section section="results">
+            <atomic-result-list>
+              <atomic-result-template>
+                <template>
+                  <atomic-result-section-visual>
+                    <atomic-result-icon></atomic-result-icon>
+                  </atomic-result-section-visual>
+                  <atomic-result-section-title>
+                    <atomic-result-link></atomic-result-link>
+                  </atomic-result-section-title>
+                  <atomic-result-section-title-metadata>
+                    <atomic-result-printable-uri
+                      max-number-of-parts="3"
+                    ></atomic-result-printable-uri>
+                  </atomic-result-section-title-metadata>
+                  <atomic-result-section-excerpt>
+                    <atomic-result-text field="excerpt"></atomic-result-text>
+                  </atomic-result-section-excerpt>
+                </template>
+              </atomic-result-template>
+            </atomic-result-list>
+            <atomic-query-error></atomic-query-error>
+            <atomic-no-results></atomic-no-results>
+          </atomic-layout-section>
+          <atomic-layout-section section="pagination">
+            <atomic-pager></atomic-pager>
+            <atomic-results-per-page></atomic-results-per-page>
+          </atomic-layout-section>
+        </atomic-layout-section>
+      </atomic-search-layout>
+    </atomic-search-interface>
+  </body>
+</html>

--- a/packages/atomic-playground/genqa.js
+++ b/packages/atomic-playground/genqa.js
@@ -5,5 +5,10 @@ import {searchCredentials} from './sample-credentials.js';
 await customElements.whenDefined('atomic-search-interface');
 
 const searchInterface = document.querySelector('atomic-search-interface');
-await searchInterface.initialize(searchCredentials);
+await searchInterface.initialize({
+  ...searchCredentials,
+  search: {
+    pipeline: 'genqatest',
+  },
+});
 searchInterface.executeFirstSearch();

--- a/packages/atomic-playground/insight.html
+++ b/packages/atomic-playground/insight.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Atomic playground: Insight Panel</title>
+    <link rel="icon" href="data:," />
+    <script type="module" src="./insight.js"></script>
+    <style>
+      body {
+        margin: 0;
+      }
+
+      atomic-insight-interface:not([widget='false']),
+      atomic-insight-layout:not([widget='false']) {
+        width: 500px;
+        height: 1000px;
+        margin-left: auto;
+        margin-right: auto;
+        box-shadow: 0px 3px 24px 0px #0000001a;
+      }
+
+      .insight-status {
+        display: flex;
+        align-items: center;
+        background-color: #f1f2ff;
+      }
+
+      .insight-status atomic-insight-query-summary {
+        flex-grow: 1;
+      }
+
+      .insight-status atomic-insight-generate-answer-button {
+        padding: 0rem 1.5rem;
+      }
+    </style>
+  </head>
+
+  <body>
+    <button type="button" id="widget-view">Toggle widget view</button>
+    <atomic-insight-interface
+      fields-to-include='["sfid", "inat_kingdom", "inat_family", "inat_class"]'
+      language-assets-path="/lang"
+      icon-assets-path="/assets"
+    >
+      <atomic-insight-full-search-button
+        slot="full-search"
+        tooltip="Full Search Button Tooltip"
+      ></atomic-insight-full-search-button>
+      <atomic-insight-layout>
+        <atomic-layout-section section="search">
+          <atomic-insight-search-box></atomic-insight-search-box>
+          <atomic-insight-refine-toggle></atomic-insight-refine-toggle>
+          <atomic-insight-edit-toggle tooltip="This is a tooltip"></atomic-insight-edit-toggle>
+          <atomic-insight-history-toggle
+            tooltip="This is a tooltip"
+          ></atomic-insight-history-toggle>
+          <atomic-insight-tabs>
+            <atomic-insight-tab label="All" expression="" active></atomic-insight-tab>
+            <atomic-insight-tab
+              label="Folding"
+              expression="@source=iNaturalistTaxons"
+            ></atomic-insight-tab>
+            <atomic-insight-tab
+              label="Service Cases"
+              expression="@objecttype==Case"
+            ></atomic-insight-tab>
+          </atomic-insight-tabs>
+        </atomic-layout-section>
+        <atomic-layout-section section="facets">
+          <atomic-facet-manager>
+            <atomic-insight-facet
+              field="source"
+              label="Source"
+              display-values-as="link"
+            ></atomic-insight-facet>
+            <atomic-insight-facet field="filetype" label="Filetype"></atomic-insight-facet>
+          </atomic-facet-manager>
+        </atomic-layout-section>
+        <atomic-layout-section section="status">
+          <div class="insight-status">
+            <atomic-insight-query-summary></atomic-insight-query-summary>
+            <atomic-insight-generate-answer-button></atomic-insight-generate-answer-button>
+          </div>
+        </atomic-layout-section>
+        <atomic-layout-section section="results">
+          <atomic-insight-smart-snippet></atomic-insight-smart-snippet>
+          <atomic-insight-folded-result-list image-size="none">
+            <atomic-insight-result-template>
+              <template>
+                <atomic-insight-result-action-bar>
+                  <atomic-insight-result-action
+                    tooltip="Copy to Clipboard"
+                    tooltip-on-click="Copied!"
+                    action="copyToClipboard"
+                  ></atomic-insight-result-action>
+                  <atomic-insight-result-action
+                    tooltip="post to feed"
+                    action="postToFeed"
+                  ></atomic-insight-result-action>
+                  <atomic-insight-result-attach-to-case-action></atomic-insight-result-attach-to-case-action>
+                  <atomic-insight-result-quickview-action></atomic-insight-result-quickview-action>
+                </atomic-insight-result-action-bar>
+                <atomic-result-section-actions>
+                  <atomic-insight-result-attach-to-case-indicator></atomic-insight-result-attach-to-case-indicator>
+                </atomic-result-section-actions>
+                <atomic-result-section-title>
+                  <atomic-result-link></atomic-result-link>
+                </atomic-result-section-title>
+                <atomic-result-section-excerpt>
+                  <atomic-result-text field="excerpt"></atomic-result-text>
+                </atomic-result-section-excerpt>
+              </template>
+            </atomic-insight-result-template>
+          </atomic-insight-folded-result-list>
+          <atomic-insight-no-results></atomic-insight-no-results>
+          <atomic-insight-query-error></atomic-insight-query-error>
+        </atomic-layout-section>
+        <atomic-layout-section section="pagination">
+          <atomic-insight-pager></atomic-insight-pager>
+        </atomic-layout-section>
+      </atomic-insight-layout>
+    </atomic-insight-interface>
+  </body>
+</html>

--- a/packages/atomic-playground/insight.js
+++ b/packages/atomic-playground/insight.js
@@ -1,0 +1,51 @@
+import {loadCaseContextActions} from '@coveo/headless/insight';
+import './load-atomic.js';
+import './nav.js';
+import {insightCredentials} from './sample-credentials.js';
+
+const SAMPLE_CASE_ID = '1234';
+
+await customElements.whenDefined('atomic-insight-interface');
+await customElements.whenDefined('atomic-insight-layout');
+
+const insightInterface = document.querySelector('atomic-insight-interface');
+await insightInterface.initialize(insightCredentials);
+
+const {setCaseId} = loadCaseContextActions(insightInterface.engine);
+insightInterface.engine.dispatch(setCaseId(SAMPLE_CASE_ID));
+insightInterface.executeFirstSearch();
+
+await customElements.whenDefined('atomic-insight-full-search-button');
+document.querySelector('atomic-insight-full-search-button').clickCallback = () => {
+  console.log('Full search button clicked');
+};
+
+const widgetElements = [insightInterface, document.querySelector('atomic-insight-layout')];
+let isWidgetView = true;
+
+const applyWidgetView = () => {
+  for (const element of widgetElements) {
+    element.setAttribute('widget', String(isWidgetView));
+  }
+};
+
+document.getElementById('widget-view').addEventListener('click', () => {
+  isWidgetView = !isWidgetView;
+  applyWidgetView();
+});
+
+applyWidgetView();
+
+document.addEventListener('atomicInsightResultActionClicked', (event) => {
+  console.log('Result action clicked', event.detail);
+});
+
+document.addEventListener('atomic/insight/attachToCase/attach', (event) => {
+  console.log('attach', event.detail);
+  event.detail.controller.attach();
+});
+
+document.addEventListener('atomic/insight/attachToCase/detach', (event) => {
+  console.log('detach', event.detail);
+  event.detail.controller.detach();
+});

--- a/packages/atomic-playground/load-atomic.js
+++ b/packages/atomic-playground/load-atomic.js
@@ -1,0 +1,4 @@
+import {defineCustomElements} from '@coveo/atomic/loader';
+import '@coveo/atomic/themes/coveo.css';
+
+defineCustomElements();

--- a/packages/atomic-playground/nav.js
+++ b/packages/atomic-playground/nav.js
@@ -1,0 +1,39 @@
+const pages = [
+  {href: '/', label: 'Search'},
+  {href: '/genqa.html', label: 'Gen Q&A'},
+  {href: '/insight.html', label: 'Insight Panel'},
+];
+
+const style = document.createElement('style');
+style.textContent = `
+  .playground-nav {
+    display: flex;
+    gap: 1rem;
+    padding: 0.75rem 1.25rem;
+    font-family: system-ui, sans-serif;
+    font-size: 0.875rem;
+    border-bottom: 1px solid #d3d5db;
+  }
+
+  .playground-nav a {
+    color: #1372ec;
+    text-decoration: none;
+  }
+
+  .playground-nav a[aria-current='page'] {
+    font-weight: 700;
+    color: #282c34;
+  }
+`;
+
+const nav = document.createElement('nav');
+nav.className = 'playground-nav';
+nav.innerHTML = pages
+  .map(
+    ({href, label}) =>
+      `<a href="${href}"${href === window.location.pathname ? ' aria-current="page"' : ''}>${label}</a>`
+  )
+  .join('');
+
+document.head.appendChild(style);
+document.body.insertAdjacentElement('afterbegin', nav);

--- a/packages/atomic-playground/sample-credentials.js
+++ b/packages/atomic-playground/sample-credentials.js
@@ -1,0 +1,14 @@
+const organizationId = 'searchuisamples';
+
+export const searchCredentials = {
+  organizationId,
+  // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
+  accessToken: 'xx564559b1-0045-48e1-953c-3addd1ee4457',
+};
+
+export const insightCredentials = {
+  organizationId,
+  // This API key is intentionally public — it belongs to a sample organization used for samples/docs.
+  accessToken: 'xx9446b04d-45d4-44a6-880c-22c6c04573ff',
+  insightId: 'fc2ee6e0-8bda-4883-bfc6-ffc1b0ce34c7',
+};


### PR DESCRIPTION
Give the playground the two scenarios contributors reproduce against a
real interface: Gen Q&A on the genqatest pipeline, and an Insight panel
with case context, the widget-view toggle and the result action events.

The Insight page imports loadCaseContextActions from @coveo/headless,
so it exercises the Headless public API surface Atomic consumes and not
just the runtime bundle.

Page scripts now share the Atomic bootstrap, sample credentials and a
small nav, and the search entry point is renamed to match its page.
