### PR TITLE
fix(atomic): wait for quickview iframe content

### DIFF
--- a/.changeset/quick-dots-wait.md
+++ b/.changeset/quick-dots-wait.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Wait for Quick View iframe content to load before rendering keyword highlights.

--- a/packages/atomic/src/components/search/result-template-components/quickview-iframe/quickview-iframe.spec.ts
+++ b/packages/atomic/src/components/search/result-template-components/quickview-iframe/quickview-iframe.spec.ts
@@ -1,8 +1,11 @@
 import type {SearchEngine} from '@coveo/headless';
 import {html} from 'lit';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {eventPromise} from '@/src/utils/event-utils';
 import {renderFunctionFixture} from '@/vitest-utils/testing-helpers/fixture';
 import {renderQuickviewIframe} from './quickview-iframe';
+
+vi.mock('@/src/utils/event-utils', {spy: true});
 
 describe('#renderQuickviewIframe', () => {
   let mockOnSetIframeRef: (ref: HTMLIFrameElement) => void;
@@ -276,6 +279,54 @@ describe('#renderQuickviewIframe', () => {
   });
 
   describe('async behavior', () => {
+    it('should wait for the iframe content to load before setting the iframe reference', async () => {
+      let resolveContentLoaded!: (event: Event) => void;
+      vi.mocked(eventPromise)
+        .mockResolvedValueOnce(new Event('load'))
+        .mockReturnValueOnce(
+          new Promise<Event>((resolve) => {
+            resolveContentLoaded = resolve;
+          })
+        );
+
+      const iframe = await renderComponent({
+        title: 'Test Title',
+        content: '<p>Async Content</p>',
+        onSetIframeRef: mockOnSetIframeRef,
+        uniqueIdentifier: 'async-load-test',
+      });
+
+      expect(eventPromise).toHaveBeenCalledWith(iframe, 'load', 5000);
+      expect(mockOnSetIframeRef).not.toHaveBeenCalled();
+
+      resolveContentLoaded(new Event('load'));
+
+      await vi.waitFor(() => {
+        expect(mockOnSetIframeRef).toHaveBeenCalledWith(iframe);
+      });
+    });
+
+    it('should set the iframe reference when waiting for the content times out', async () => {
+      vi.mocked(eventPromise)
+        .mockResolvedValueOnce(new Event('load'))
+        .mockRejectedValueOnce(new Error('Promise timed out.'));
+
+      const iframe = await renderComponent({
+        title: 'Test Title',
+        content: '<p>Async Content</p>',
+        onSetIframeRef: mockOnSetIframeRef,
+        uniqueIdentifier: 'async-timeout-test',
+        logger: mockLogger,
+      });
+
+      await vi.waitFor(() => {
+        expect(mockOnSetIframeRef).toHaveBeenCalledWith(iframe);
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Quickview timed out waiting for the iframe content to load.'
+      );
+    });
+
     it('should call onSetIframeRef after content is written asynchronously', async () => {
       const callOrder: string[] = [];
 

--- a/packages/atomic/src/components/search/result-template-components/quickview-iframe/quickview-iframe.spec.ts
+++ b/packages/atomic/src/components/search/result-template-components/quickview-iframe/quickview-iframe.spec.ts
@@ -296,7 +296,9 @@ describe('#renderQuickviewIframe', () => {
         uniqueIdentifier: 'async-load-test',
       });
 
-      expect(eventPromise).toHaveBeenCalledWith(iframe, 'load', 5000);
+      expect(eventPromise).toHaveBeenCalledTimes(2);
+      expect(eventPromise).toHaveBeenNthCalledWith(1, iframe, 'load', 1000);
+      expect(eventPromise).toHaveBeenNthCalledWith(2, iframe, 'load', 5000);
       expect(mockOnSetIframeRef).not.toHaveBeenCalled();
 
       resolveContentLoaded(new Event('load'));
@@ -318,6 +320,10 @@ describe('#renderQuickviewIframe', () => {
         uniqueIdentifier: 'async-timeout-test',
         logger: mockLogger,
       });
+
+      expect(eventPromise).toHaveBeenCalledTimes(2);
+      expect(eventPromise).toHaveBeenNthCalledWith(1, iframe, 'load', 1000);
+      expect(eventPromise).toHaveBeenNthCalledWith(2, iframe, 'load', 5000);
 
       await vi.waitFor(() => {
         expect(mockOnSetIframeRef).toHaveBeenCalledWith(iframe);

--- a/packages/atomic/src/components/search/result-template-components/quickview-iframe/quickview-iframe.ts
+++ b/packages/atomic/src/components/search/result-template-components/quickview-iframe/quickview-iframe.ts
@@ -73,13 +73,6 @@ interface QuickviewIframeProps {
 export const renderQuickviewIframe: FunctionalComponent<QuickviewIframeProps> = ({props}) => {
   const {title, onSetIframeRef, uniqueIdentifier, content, sandbox, src, logger} = props;
 
-  // When a document is written with document.open/document.write/document.close
-  // it is not synchronous and the content of the iframe is only available to be queried at the end of the current call stack.
-  // This adds a "wait" (setTimeout 0) before calling the `onSetIframeRef` from the parent modal quickview
-  const waitForIframeContentToBeWritten = () => {
-    return new Promise((resolve) => setTimeout(resolve));
-  };
-
   const handleRef = (el: Element | undefined) => {
     if (!el) return;
 
@@ -106,10 +99,13 @@ export const renderQuickviewIframe: FunctionalComponent<QuickviewIframeProps> = 
         return;
       }
 
+      const contentLoaded = eventPromise(iframeRef, 'load', 5000);
       writeDocument(documentWriter, content);
       ensureSameResultIsNotOverwritten(documentWriter, uniqueIdentifier);
 
-      await waitForIframeContentToBeWritten();
+      await contentLoaded.catch(() => {
+        logger?.warn('Quickview timed out waiting for the iframe content to load.');
+      });
       onSetIframeRef(iframeRef);
     };
 


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6122

## Motivation

Chrome can intermittently render the Quick View preview without the existing Keywords highlight sidebar. The iframe content is present, but the keyword scan can run before the written document has finished loading.

Support case: https://discuss.coveo.com/t/support-00141264-atomic-quick-view-keywords-highlights-section-not-always-showing-up/14752

## Root Cause

Quick View wrote iframe HTML with `document.write()` and only yielded to a zero-delay task before downstream initialization. That did not guarantee Chromium had parsed the written document. Because keyword highlights are scanned once, observing zero highlights permanently suppressed the sidebar for that preview.

## Changes

- Register an iframe `load` wait before writing Quick View content.
- Bound the wait to five seconds and log a warning on timeout.
- Continue initializing after timeout so Quick View cannot remain stuck.
- Add Chromium regression coverage for successful content loading and timeout fallback.
- Add an `@coveo/atomic` patch changeset.

## Validation

- Manually verified the iframe `load` wait resolves the Chrome reproduction.
- Targeted Chromium Quick View iframe suite: 25/25 passed.
- Atomic TypeScript check passed.
- Targeted formatting and lint checks passed.
- Full Atomic validation passed: 1,138 tests plus Atomic and Storybook builds.
- Repository `pnpm run lint:fix` passed with cspell.
- Repository-wide `pnpm run build` passed.
- Repository-wide `pnpm run test` passed.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`fix(<scope>): <description>`)
- [x] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code