### PR TITLE
chore(KIT-6102): optimize CI checkout depth

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -295,6 +295,7 @@ jobs:
         with:
           egress-policy: audit
 
+      # Chromatic needs full history to update the main branch baseline.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           egress-policy: audit
 
+      # Full history is required to calculate the base-to-head range and publish the minimum depth.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
@@ -413,6 +414,7 @@ jobs:
         with:
           egress-policy: audit
 
+      # Chromatic needs full history to compare the checked-out revision with its baseline.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         if: ${{ github.event_name == 'pull_request' }}
         with:
@@ -560,6 +562,7 @@ jobs:
         with:
           egress-policy: audit
 
+      # The Storybook suite requires origin/main for baseline-aware tests.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.head_ref }}
-          fetch-depth: 0
+          fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/run-affected
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.head_ref }}
-          fetch-depth: 0
+          fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/run-affected
@@ -177,7 +177,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/run-affected
@@ -243,7 +243,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/run-affected
@@ -263,7 +263,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
       - run: pnpm exec turbo run validate:light-dom-styles --filter=@coveo/atomic
@@ -280,7 +280,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
       - run: pnpm exec turbo run validate:no-new-light-dom --filter=@coveo/atomic
@@ -339,7 +339,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
       - run: pnpm exec turbo run validate:test:dts:ci --filter=@coveo/thermidor
@@ -355,7 +355,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
       - run: pnpm exec node ./scripts/ci/validate-publint-tasks.mjs
@@ -376,7 +376,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/run-affected
@@ -592,7 +592,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
       - name: 'Download a11y shard reports'
@@ -732,7 +732,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
       - run: pnpm exec turbo run build --filter='!./samples/**'

--- a/.github/workflows/secrets-in-workflow-warning.yml
+++ b/.github/workflows/secrets-in-workflow-warning.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           egress-policy: audit
 
+      # Full history is required to compare the pull request commit range.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6102

## Motivation

CI jobs that consume affected-task results should not download repository history they do not need. Reducing unnecessary full-history checkouts lowers CI transfer and setup overhead while preserving the history required by affected-task calculation and CI tooling.

## Changes

- Use shallow checkout behavior for CI jobs that only need the checked-out revision.
- Use the calculated affected-task checkout depth for jobs that require the commit range.
- Document the CI jobs that intentionally retain full history for affected-task calculation, Chromatic comparisons, Storybook baseline setup, and workflow diff inspection.

## Validation

- `pnpm run lint:check`
- Targeted Oxfmt validation
- No new features or bug fixes are included in this PR

## Checklist

- [x] PR title follows Conventional Commits format (`chore(<scope>): <description>`)
- [ ] Added a changeset if modifying public package source code (not applicable: CI-only changes)
