### PR TITLE
fix(samples): echo the requested page in the commerce express e2e mock

### DIFF
--- a/samples/headless-ssr/commerce-express/e2e/fixtures.ts
+++ b/samples/headless-ssr/commerce-express/e2e/fixtures.ts
@@ -1,12 +1,12 @@
-import {MockCommerceApi} from '@coveo/platform-mock-api';
 import {defineNetworkFixture, type NetworkFixture} from '@msw/playwright';
 import {test as base, expect} from '@playwright/test';
+import {createCommerceApi} from '../mocks/commerce-api.js';
 
 interface Fixtures {
   network: NetworkFixture;
 }
 
-const commerceApi = new MockCommerceApi();
+const commerceApi = createCommerceApi();
 
 /**
  * Extends the Playwright test with an MSW network fixture that mocks the Coveo

--- a/samples/headless-ssr/commerce-express/mocks/commerce-api.ts
+++ b/samples/headless-ssr/commerce-express/mocks/commerce-api.ts
@@ -1,0 +1,19 @@
+import {commercePaginationTransformer, MockCommerceApi} from '@coveo/platform-mock-api/commerce';
+
+/**
+ * Builds the Coveo Commerce API mock used by both mock layers of the e2e suite:
+ * the MSW server preloaded into the Express process (`mocks/node.ts`) and the
+ * MSW network fixture running in the browser (`e2e/fixtures.ts`).
+ *
+ * The search and listing endpoints echo the requested `page` and `perPage` back
+ * in the response. Without it the mock always answers with `page: 0`, so a
+ * `nextPage()` call moves the state to page 2 only until the response lands and
+ * resets it — leaving assertions to race the response instead of observing the
+ * settled state.
+ */
+export function createCommerceApi(basePath?: string): MockCommerceApi {
+  const api = basePath ? new MockCommerceApi(basePath) : new MockCommerceApi();
+  api.searchEndpoint.addRequestTransformer(commercePaginationTransformer);
+  api.productListingEndpoint.addRequestTransformer(commercePaginationTransformer);
+  return api;
+}

--- a/samples/headless-ssr/commerce-express/mocks/node.ts
+++ b/samples/headless-ssr/commerce-express/mocks/node.ts
@@ -1,5 +1,5 @@
-import {MockCommerceApi} from '@coveo/platform-mock-api';
 import {setupServer} from 'msw/node';
+import {createCommerceApi} from './commerce-api.js';
 
 /**
  * MSW mock server returning deterministic Coveo Commerce API responses.
@@ -10,6 +10,6 @@ import {setupServer} from 'msw/node';
  * `pnpm dev` / `pnpm start`, where the sample talks to the public
  * `searchuisamples` organization.
  */
-const commerceApi = new MockCommerceApi();
+const commerceApi = createCommerceApi();
 
 export const server = setupServer(...commerceApi.handlers);


### PR DESCRIPTION
[KIT-6123](https://coveord.atlassian.net/browse/KIT-6123)

## Problem

`E2E: @coveo/ui-kit-sample-headless-ssr-commerce-express#e2e` intermittently fails on `smoke.spec.ts > commerce SSR search page > paginates through results` ([example run](https://github.com/coveo/ui-kit/actions/runs/33014299940/job/98329067273) — failed all three attempts). The test clicks `.NextPage` and expects the pagination nav to contain `Page 2 of`, but every poll observes `Page 1 of 14`.

`MockCommerceApi` does not register `commercePaginationTransformer` on its search and listing endpoints, so every mocked response echoes the canned `pagination.page: 0` no matter which page was requested. After the click:

1. `pagination.nextPage()` updates the state synchronously → `page: 1` → the nav re-renders as `Page 2 of 14`
2. the mocked search response lands with `page: 0` → the nav reverts to `Page 1 of 14`

The test only passes when the assertion happens to observe step 1 before step 2 lands, which makes the result depend on response timing. On a local machine it fails 15/15, because the in-browser MSW response resolves fast enough that page 2 never reaches a frame the assertion can observe; in CI the race resolves the other way most of the time, so it presents as flakiness.

This is the same failure mode as [KIT-6101](https://coveord.atlassian.net/browse/KIT-6101) / #8327 — an assertion racing the Commerce response — with a different underlying cause. The neighbouring `reflects pagination in the URL` test keeps passing because it only asserts the URL, which `parameterManager` writes and does not revert.

## Solution

A shared `createCommerceApi()` in `mocks/commerce-api.ts` registers `commercePaginationTransformer` on the search and listing endpoints, and both mock layers of the suite use it: the MSW server preloaded into the Express process (`mocks/node.ts`) and the browser network fixture (`e2e/fixtures.ts`). `nextPage()` now gets a response with `page: 1`, so page 2 is the settled state rather than a transient one.

The transformer already exists in `@coveo/platform-mock-api`, and the Atomic pager, facet, breadbox, and products-per-page stories all opt into it explicitly for this reason — the express sample never did.

This is scoped to the sample rather than made a default on `MockCommerceApi` on purpose. Enabling it globally would change the `perPage`/`totalPages` echoes for every Atomic story, the theming e2e suite, the CDN smoke tests, and the other commerce samples, producing Chromatic churn for no benefit here.

## Validation

- `paginates through results` + `reflects pagination in the URL`: **30/30 pass** with the fix, **15/15 fail** without it. The test is now a deterministic guard against a mock regression instead of a flaky one.
- Full express suite: 56/56 across two repeats.
- `tsc --noEmit` clean, `pnpm run lint:fix` clean.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`fix(<scope>): <description>`)
- [ ] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code — not applicable, the change only touches sample and test-mock code


[KIT-6123]: https://coveord.atlassian.net/browse/KIT-6123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIT-6101]: https://coveord.atlassian.net/browse/KIT-6101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ