### PR TITLE
fix(headless): stop warning about peer dependencies consumers do not need

### DIFF
--- a/.changeset/headless-optional-peers.md
+++ b/.changeset/headless-optional-peers.md
@@ -1,0 +1,11 @@
+---
+'@coveo/headless': patch
+---
+
+Stop warning consumers about peer dependencies they do not need.
+
+`pino-pretty` is now marked optional. It is only needed by consumers who opt into pretty-printed logs; nothing in Headless configures a `pino-pretty` transport.
+
+`encoding` is removed from `peerDependencies`. It was the optional charset peer of `node-fetch`, which is now a development-only dependency used in tests. Consumers of Headless never need it.
+
+Neither change affects what Headless does at runtime.

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -126,11 +126,13 @@
     "vitest": "catalog:"
   },
   "peerDependencies": {
-    "encoding": "^0.1.13",
     "pino-pretty": "^6.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
     "typescript": "catalog:peer-compatibility"
   },
   "peerDependenciesMeta": {
+    "pino-pretty": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1154,9 +1154,6 @@ importers:
       dayjs:
         specifier: 'catalog:'
         version: 1.11.23
-      encoding:
-        specifier: ^0.1.13
-        version: 0.1.13
       exponential-backoff:
         specifier: 'catalog:'
         version: 3.1.3
@@ -25946,6 +25943,7 @@ snapshots:
   encoding@0.1.13:
     dependencies:
       iconv-lite: 0.6.3
+    optional: true
 
   end-of-stream@1.4.5:
     dependencies:


### PR DESCRIPTION
[KIT-6103](https://coveord.atlassian.net/browse/KIT-6103)

## Problem

`@coveo/headless` declares two peer dependencies that consumers do not need, so anyone installing it sees warnings for packages that are irrelevant to them.

`pino-pretty` is declared as a required peer. `pino` itself is a real dependency, but source only uses `import type {Logger}` and nothing configures a `pino-pretty` transport, so the formatter is never loaded at runtime.

`encoding` is declared as a peer. It is the optional charset peer of `node-fetch`, which is a development-only dependency used in tests. It never reaches a consumer.

## Solution

Mark `pino-pretty` optional via `peerDependenciesMeta`, so consumers who opt into pretty-printed logs still get a correct range while everyone else stops seeing the warning. Remove `encoding` outright.

Neither change affects runtime behaviour.

## Notes

Previously the top rung of stack #8388. The rest of that stack has merged and #8324 was closed, so this now stands alone on `main`. The lockfile was regenerated against current `main` and matches with no drift.

[KIT-6103]: https://coveord.atlassian.net/browse/KIT-6103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ