### PR TITLE
fix(atomic): preserve product cards when loading more

### DIFF
--- a/.changeset/calm-products-stay.md
+++ b/.changeset/calm-products-stay.md
@@ -1,0 +1,5 @@
+---
+'@coveo/atomic': patch
+---
+
+Preserve existing commerce product cards when loading more products.

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.spec.ts
@@ -375,6 +375,65 @@ describe('atomic-commerce-product-list', () => {
       .toBeInTheDocument();
   });
 
+  describe.each<{display: ItemDisplayLayout}>([
+    {display: 'grid'},
+    {display: 'list'},
+    {display: 'table'},
+  ])('when appending products in the $display display', ({display}) => {
+    it('should preserve the existing atomic-product element', async () => {
+      const existingProduct = buildFakeProduct({
+        permanentid: 'existing-product',
+        responseId: 'initial-response',
+      });
+      const appendedProduct = buildFakeProduct({
+        permanentid: 'appended-product',
+        responseId: 'appended-response',
+      });
+
+      vi.mocked(buildProductListing).mockImplementation(() =>
+        buildFakeProductListing({
+          implementation: {
+            interactiveProduct,
+            promoteChildToParent,
+            summary,
+          },
+          state: {
+            products: [existingProduct],
+            responseId: 'initial-response',
+          },
+        })
+      );
+
+      const element = await setupElement({display});
+
+      if (display === 'table') {
+        const mockTableTemplate = document.createDocumentFragment();
+        mockTableTemplate.appendChild(document.createElement('atomic-table-element'));
+        vi.spyOn(
+          // @ts-expect-error - mocking method on private property
+          element.productTemplateProvider,
+          'getTemplateContent'
+        ).mockReturnValue(mockTableTemplate);
+        element.requestUpdate();
+        await element.updateComplete;
+      }
+
+      const existingElement = element.shadowRoot?.querySelector('atomic-product');
+
+      element.searchOrListingState = {
+        ...element.searchOrListingState,
+        products: [existingProduct, appendedProduct],
+        responseId: 'appended-response',
+      };
+      await element.updateComplete;
+
+      const productElements = element.shadowRoot?.querySelectorAll('atomic-product');
+
+      expect(productElements).toHaveLength(2);
+      expect(productElements?.item(0)).toBe(existingElement);
+    });
+  });
+
   describe.each<{display: ItemDisplayLayout}>([{display: 'grid'}, {display: 'list'}])(
     'when #display is $display',
     ({display}) => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-product-list/atomic-commerce-product-list.ts
@@ -393,6 +393,15 @@ export class AtomicCommerceProductList
     );
   }
 
+  private getProductId(product: ProductListingState['products'][number]) {
+    return this.productListCommon.getResultId(
+      product.permanentid,
+      product.responseId ?? this.searchOrListingState.responseId,
+      this.density,
+      this.imageSize
+    );
+  }
+
   private renderGrid() {
     return html`${map(this.searchOrListingState.products, (product, index) => {
       return renderGridLayout({
@@ -409,12 +418,7 @@ export class AtomicCommerceProductList
         },
       })(
         html`${keyed(
-          this.productListCommon.getResultId(
-            product.permanentid,
-            this.searchOrListingState.responseId,
-            this.density,
-            this.imageSize
-          ),
+          this.getProductId(product),
           html`<atomic-product
             .content=${this.productTemplateProvider.getTemplateContent(product)}
             .density=${this.density}
@@ -437,12 +441,7 @@ export class AtomicCommerceProductList
   private renderList() {
     return html`${map(this.searchOrListingState.products, (product, index) => {
       return html`${keyed(
-        this.productListCommon.getResultId(
-          product.permanentid,
-          this.searchOrListingState.responseId,
-          this.density,
-          this.imageSize
-        ),
+        this.getProductId(product),
         html`<atomic-product
           part="outline"
           ${ref(
@@ -487,12 +486,7 @@ export class AtomicCommerceProductList
           },
         })(
           html`${map(this.searchOrListingState.products, (product, index) => {
-            const key = this.productListCommon.getResultId(
-              product.permanentid,
-              this.searchOrListingState.responseId,
-              this.density,
-              this.imageSize
-            );
+            const key = this.getProductId(product);
             return renderTableRow({
               props: {
                 key,

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.spec.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.spec.ts
@@ -246,6 +246,51 @@ describe('atomic-commerce-recommendation-list', () => {
   });
 
   describe.each<{display: ItemDisplayBasicLayout}>([{display: 'grid'}, {display: 'list'}])(
+    'when appending products in the $display display',
+    ({display}) => {
+      it('should preserve the existing atomic-product element', async () => {
+        const existingProduct = buildFakeProduct({
+          permanentid: 'existing-product',
+          responseId: 'initial-response',
+        });
+        const appendedProduct = buildFakeProduct({
+          permanentid: 'appended-product',
+          responseId: 'appended-response',
+        });
+
+        vi.mocked(buildRecommendations).mockImplementation(() =>
+          buildFakeRecommendations({
+            implementation: {
+              interactiveProduct,
+              promoteChildToParent,
+              summary,
+            },
+            state: {
+              products: [existingProduct],
+              responseId: 'initial-response',
+            },
+          })
+        );
+
+        const element = await setupElement({display});
+        const existingElement = element.shadowRoot?.querySelector('atomic-product');
+
+        element.recommendationsState = {
+          ...element.recommendationsState,
+          products: [existingProduct, appendedProduct],
+          responseId: 'appended-response',
+        };
+        await element.updateComplete;
+
+        const productElements = element.shadowRoot?.querySelectorAll('atomic-product');
+
+        expect(productElements).toHaveLength(2);
+        expect(productElements?.item(0)).toBe(existingElement);
+      });
+    }
+  );
+
+  describe.each<{display: ItemDisplayBasicLayout}>([{display: 'grid'}, {display: 'list'}])(
     'when #display is $display',
     ({display}) => {
       describe('when app is loaded', () => {

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.ts
@@ -367,6 +367,15 @@ export class AtomicCommerceRecommendationList
     });
   }
 
+  private getProductId(product: Product) {
+    return this.productListCommon.getResultId(
+      product.permanentid,
+      product.responseId ?? this.recommendationsState.responseId,
+      this.density,
+      this.imageSize
+    );
+  }
+
   private getAtomicProductProps(product: Product) {
     const linkContent = this.productTemplateProvider.getLinkTemplateContent(product);
 
@@ -377,12 +386,7 @@ export class AtomicCommerceRecommendationList
       product: product,
       renderingFunction: this.itemRenderingFunction,
       loadingFlag: this.loadingFlag,
-      key: this.productListCommon.getResultId(
-        product.permanentid,
-        this.recommendationsState.responseId,
-        this.density,
-        this.imageSize
-      ),
+      key: this.getProductId(product),
       content: this.productTemplateProvider.getTemplateContent(product),
       linkContent,
       stopPropagation: !!linkContent,

--- a/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.spec.ts
+++ b/packages/atomic/src/components/search/atomic-result-list/atomic-result-list.spec.ts
@@ -322,6 +322,60 @@ describe('atomic-result-list', () => {
       .toBeInTheDocument();
   });
 
+  describe.each<{display: ItemDisplayLayout}>([
+    {display: 'grid'},
+    {display: 'list'},
+    {display: 'table'},
+  ])('when appending results in the $display display', ({display}) => {
+    it('should preserve the existing atomic-result element', async () => {
+      const existingResult = buildFakeResult({
+        uniqueId: 'existing-result',
+        searchUid: 'initial-response',
+      });
+      const appendedResult = buildFakeResult({
+        uniqueId: 'appended-result',
+        searchUid: 'appended-response',
+      });
+
+      vi.mocked(buildResultList).mockReturnValue(
+        buildFakeResultList({
+          state: {
+            results: [existingResult],
+            searchResponseId: 'initial-response',
+          },
+        })
+      );
+
+      const element = await setupElement({display});
+
+      if (display === 'table') {
+        const mockTableTemplate = document.createDocumentFragment();
+        mockTableTemplate.appendChild(document.createElement('atomic-table-element'));
+        vi.spyOn(
+          // @ts-expect-error - mocking method on private property
+          element.resultTemplateProvider,
+          'getTemplateContent'
+        ).mockReturnValue(mockTableTemplate);
+        element.requestUpdate();
+        await element.updateComplete;
+      }
+
+      const existingElement = element.shadowRoot?.querySelector('atomic-result');
+
+      element.resultListState = {
+        ...element.resultListState,
+        results: [existingResult, appendedResult],
+        searchResponseId: 'initial-response',
+      };
+      await element.updateComplete;
+
+      const resultElements = element.shadowRoot?.querySelectorAll('atomic-result');
+
+      expect(resultElements).toHaveLength(2);
+      expect(resultElements?.item(0)).toBe(existingElement);
+    });
+  });
+
   describe.each<{display: ItemDisplayLayout}>([{display: 'grid'}, {display: 'list'}])(
     'when #display is $display',
     ({display}) => {


### PR DESCRIPTION
Jira: [KIT-6135](https://coveord.atlassian.net/browse/KIT-6135)

## Motivation

Loading more commerce products could destroy and recreate previously rendered product cards. The repeated work grows with the loaded product count, causing increasingly long main-thread stalls and cumulative detached DOM generations during deep infinite scroll.

Reported in [Coveo Discuss](https://discuss.coveo.com/t/atomic-product-list-re-render-and-memory-growth-at-depth/14757).

## Root Cause

Commerce product cards were keyed with the product permanent ID plus the list controller's latest response ID. Headless advances that list-level response ID after fetch-more requests while preserving each product's originating response ID, so Lit interpreted existing cards as different items.

## Changes

- Key commerce product-list and recommendation-list cards with each product's own response ID, falling back to the list response ID for compatibility.
- Apply the stable key consistently to product-list grid, list, and table displays and recommendation-list grid/list displays.
- Add browser unit coverage proving existing `atomic-product` DOM instances survive appended responses.
- Add explicit `atomic-result-list` coverage proving its existing stable `searchResponseId` contract preserves `atomic-result` instances in grid, list, and table displays.
- Add a patch changeset for `@coveo/atomic`.

### Cross-list audit

- `atomic-commerce-product-list`: vulnerable and fixed.
- `atomic-commerce-recommendation-list`: its Headless pagination reducer can append products while advancing `responseId`; vulnerable and fixed.
- `atomic-result-list`, `atomic-folded-result-list`, and their Insight variants: already safe because Headless preserves `searchResponseId` during `fetchMoreResults`; explicit result-list DOM-identity coverage was added.
- `atomic-recs-list` and `atomic-ipx-recs-list`: recommendation sets are replaced rather than appended across response IDs, so they do not exhibit this fetch-more invalidation path.

## Validation

- `pnpm turbo run @coveo/atomic#build` (includes Atomic type checking)
- Commerce product + recommendation browser suites: 176 tests passed
- Search result-list browser suite: 90 tests passed, 6 pre-existing skips
- `pnpm run lint:fix`
- `git diff --check`

### Proposed before/after demo

Use identical mocked 30-product load-more batches with a stable instance marker assigned to each `atomic-product`, plus an overlay showing:

- total products loaded;
- cards created in the current batch;
- percentage of prior cards preserved;
- load-more render duration.

Before this fix, all markers change and cards created per batch grow from 30 to 60 to 90. After this fix, prior markers remain, preservation stays at 100%, and each batch creates only the 30 appended cards.

<!-- no-visual-delta -->
**Why no screenshot:** The rendered products are visually identical; this changes DOM instance reuse and load-more performance only.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`fix(<scope>): <description>`)
- [x] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code


[KIT-6135]: https://coveord.atlassian.net/browse/KIT-6135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ