### PR TITLE
ci(chromatic): ignore orphaned unaffected baselines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,9 +435,10 @@ jobs:
           contains(fromJSON(vars.CHROMATIC_RENOVATE_ALLOWLIST || '[]'), github.head_ref))
         with:
           # Unaffected PRs should have one reachable baseline so unchanged Storybooks use
-          # TurboSnap bypass pricing. Reachable same-branch builds are still found in Git history;
-          # this only drops Chromatic's continuity fallback for an orphaned branch build.
-          ignoreLastBuildOnBranch: ${{ !contains(needs.affected.outputs.tasks, '"@coveo/atomic#build"') && github.head_ref || '' }}
+          # TurboSnap bypass pricing. If affected calculation fails, keep normal baseline selection.
+          # Reachable same-branch builds are still found in Git history; this only drops Chromatic's
+          # continuity fallback for an orphaned branch build.
+          ignoreLastBuildOnBranch: ${{ needs.affected.result == 'success' && !contains(needs.affected.outputs.tasks, '"@coveo/atomic#build"') && github.head_ref || '' }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/atomic
       - name: Skip Chromatic visual tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,7 +405,7 @@ jobs:
 
   chromatic:
     name: 'Run Chromatic visual tests on Atomic'
-    needs: [build]
+    needs: [affected, build]
     if: ${{ always() && !cancelled() }} # Run even if build is skipped
     runs-on: ubuntu-latest
     steps:
@@ -434,6 +434,10 @@ jobs:
           (!startsWith(github.head_ref, 'renovate/') ||
           contains(fromJSON(vars.CHROMATIC_RENOVATE_ALLOWLIST || '[]'), github.head_ref))
         with:
+          # Unaffected PRs should have one reachable baseline so unchanged Storybooks use
+          # TurboSnap bypass pricing. Reachable same-branch builds are still found in Git history;
+          # this only drops Chromatic's continuity fallback for an orphaned branch build.
+          ignoreLastBuildOnBranch: ${{ !contains(needs.affected.outputs.tasks, '"@coveo/atomic#build"') && github.head_ref || '' }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/atomic
       - name: Skip Chromatic visual tests


### PR DESCRIPTION
## Jira

[KIT-6137](https://coveord.atlassian.net/browse/KIT-6137)

## Motivation

Chromatic intentionally runs on every eligible pull request. That guarantees the required visual-test statuses and preserves branch metadata even when Atomic is unaffected.

After a force-push or rebase, however, Chromatic can retain the latest same-branch build after its commit leaves Git history. It then combines that orphaned build with a reachable ancestor build. In [run 33097527367](https://github.com/coveo/ui-kit/actions/runs/33097527367) for [PR #8324](https://github.com/coveo/ui-kit/pull/8324), the checked-out PR head had one Git parent while Chromatic reported two parent builds: an orphaned latest branch build plus a reachable Git ancestor.

For an Atomic-unaffected PR, that second baseline is unnecessary. Full TurboSnap should inherit the unchanged Storybook from one reachable ancestor and use Chromatic's bypass pricing path.

## Why not skip unaffected PRs?

[PR #8358](https://github.com/coveo/ui-kit/pull/8358) deliberately removed the affected-only gate so every eligible PR reaches Chromatic. Restoring that gate would lose statuses and branch history. This change keeps the run-all policy and narrows only baseline selection.

## Policy

| Atomic affected? | `ignoreLastBuildOnBranch` | Result |
| --- | --- | --- |
| No, calculated successfully | Exact PR branch | Ignore only Chromatic's orphaned same-branch continuity fallback; reachable builds remain discoverable through Git ancestry. |
| Yes, calculated successfully | Empty | Preserve normal cross-rebase branch continuity and accepted visual baselines. |
| Unknown because affected calculation failed | Empty | Fail safe to normal baseline continuity rather than misclassifying the PR as unaffected. |
| Merge group or non-allowlisted Renovate | Not used | Preserve the existing `skip: true` action and required statuses. |

## Changes

- Add `affected` as a direct dependency of the Chromatic job so its task output is available.
- Set `ignoreLastBuildOnBranch` to `github.head_ref` only when the affected-task job succeeded and `@coveo/atomic#build` is absent from its output.
- Leave real-run eligibility and both existing skip paths unchanged.
- Document why reachable same-branch builds are still safe and only orphaned continuity is discarded.

## Validation

- `pnpm run lint:fix`
- `pnpm run lint:check`
- `npm run build`
- `npm test`
- Parsed `.github/workflows/ci.yml` with the repository's pinned `yaml` package.
- Asserted the real action receives the conditional input while the skip action retains only `skip: true`.
- Exercised the successful/unaffected, successful/affected, and failed/no-output expression truth table.
- `git diff --check`

no linked issue: Jira tracks this CI policy change.

[KIT-6137]: https://coveord.atlassian.net/browse/KIT-6137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ