### PR TITLE
feat(quantic): resume timed-out Salesforce deployments

### DIFF
--- a/.changeset/kit-6132-resume-deployments.md
+++ b/.changeset/kit-6132-resume-deployments.md
@@ -1,0 +1,5 @@
+---
+"@coveo/quantic": patch
+---
+
+Improved Salesforce community setup reliability by resuming timed-out metadata deployments and reporting step durations.

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -33,6 +33,7 @@
     "dev": "node ../../utils/ci/rm-rf.mjs .localdevserver && pnpm run build:staticresources && pnpm run dev:sfdx",
     "dev:sfdx": "sf project deploy start --source-dir force-app/main && sfdx force:lightning:lwc:start --port 3334",
     "test:unit": "lwc-jest",
+    "test:build-scripts": "TS_NODE_PROJECT=scripts/build/tsconfig.json node --test --require ts-node/register scripts/build/*.node-test.ts scripts/build/util/*.node-test.ts",
     "test:unit:debug": "lwc-jest --debug",
     "test:unit:watch": "lwc-jest --watch",
     "test:unit:coverage": "lwc-jest --coverage",

--- a/packages/quantic/scripts/build/deploy-community.node-test.ts
+++ b/packages/quantic/scripts/build/deploy-community.node-test.ts
@@ -1,0 +1,370 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+import {
+  DeploymentDependencies,
+  isCommunityMetadataReadinessFailure,
+  Options,
+  runCommunityDeployment,
+} from './deploy-community';
+import {
+  MetadataDeploymentPolicy,
+  MetadataDeploymentRetryError,
+} from './util/metadata-deployment';
+import {
+  SfdxMetadataDeployResponse,
+  SfdxPublishCommunityResponse,
+} from './util/sfdx-commands';
+import {DEPLOYMENT_TELEMETRY_PREFIX} from './util/telemetry';
+
+const SOURCE_DEPLOYMENT_ID = '0Af000000000001AAA';
+const COMMUNITY_DEPLOYMENT_ID = '0Af000000000002AAA';
+const SECOND_COMMUNITY_DEPLOYMENT_ID = '0Af000000000003AAA';
+const POLICY: MetadataDeploymentPolicy = {
+  maxResumeAttempts: 2,
+  overallTimeoutMs: 1000,
+  retryDelayMs: 0,
+  waitMinutes: 1,
+};
+const OPTIONS: Options = {
+  ci: true,
+  community: {
+    name: 'Quantic Examples',
+    path: 'examples',
+    template: 'Build Your Own',
+  },
+  deleteOldOrgs: true,
+  deleteOrgOnError: true,
+  jwt: {
+    clientId: 'client-id-not-logged',
+    keyFile: 'key-file-not-logged',
+    username: 'username-not-logged',
+  },
+  scratchOrg: {
+    alias: 'test-org',
+    defFile: 'scratch-def.json',
+    duration: 1,
+    name: 'quantic-test',
+  },
+};
+
+function asyncSubmission(deploymentId: string): SfdxMetadataDeployResponse {
+  return {
+    result: {done: false, id: deploymentId, status: 'Queued'},
+    status: 0,
+  };
+}
+
+function deployResult(
+  deploymentId: string,
+  status = 'Succeeded'
+): SfdxMetadataDeployResponse {
+  return {
+    result: {
+      done: true,
+      id: deploymentId,
+      status,
+      success: status === 'Succeeded',
+    },
+    status: status === 'Succeeded' ? 0 : 1,
+  };
+}
+
+function readinessFailure(
+  deploymentId: string = COMMUNITY_DEPLOYMENT_ID
+): SfdxMetadataDeployResponse {
+  return {
+    result: {
+      details: {
+        componentFailures: {
+          componentType: 'ExperienceBundle',
+          fullName: 'Quantic_Examples1',
+          problem:
+            'In field: Network - no Network named Quantic Examples found',
+          problemType: 'Error',
+        },
+      },
+      done: true,
+      id: deploymentId,
+      status: 'Failed',
+      success: false,
+    },
+    status: 1,
+  };
+}
+
+function publishResponse(): SfdxPublishCommunityResponse {
+  return {
+    result: {url: 'https://example.invalid/community'},
+    status: 0,
+  };
+}
+
+interface DependencyOverrides {
+  metadataDeploymentPolicy?: MetadataDeploymentPolicy;
+  now?: () => number;
+  reportCleanupError?: (error: unknown) => void;
+  sfdx?: Partial<DeploymentDependencies['sfdx']>;
+  sleep?: (durationMs: number) => Promise<void>;
+}
+
+function createDependencies(
+  telemetryLines: string[],
+  overrides: DependencyOverrides = {}
+): DeploymentDependencies {
+  return {
+    metadataDeploymentPolicy: overrides.metadataDeploymentPolicy ?? POLICY,
+    now: overrides.now ?? (() => 0),
+    reportCleanupError: overrides.reportCleanupError ?? (() => {}),
+    sfdx: {
+      authorizeOrg: async () => {},
+      createCommunity: async () => {},
+      createScratchOrg: async () => {},
+      deleteOldScratchOrgs: async () => 0,
+      deleteOrg: async () => {},
+      deployCommunityMetadata: async () =>
+        asyncSubmission(COMMUNITY_DEPLOYMENT_ID),
+      deploySource: async () => asyncSubmission(SOURCE_DEPLOYMENT_ID),
+      orgExists: async () => false,
+      publishCommunity: async () => publishResponse(),
+      resumeMetadataDeployment: async ({deploymentId}) =>
+        deployResult(deploymentId),
+      ...overrides.sfdx,
+    },
+    sleep: overrides.sleep ?? (async () => {}),
+    waitForUrl: async () => {},
+    writeCommunityUrl: async () => {},
+    writeTelemetry: (line) => telemetryLines.push(line),
+  };
+}
+
+describe('runCommunityDeployment', () => {
+  it('records secret-free durations for every deployment phase on success', async () => {
+    const telemetryLines: string[] = [];
+
+    const url = await runCommunityDeployment(
+      OPTIONS,
+      'test-org',
+      createDependencies(telemetryLines)
+    );
+
+    assert.equal(url, 'https://example.invalid/community');
+    const events = telemetryLines.map((line) => {
+      assert.ok(line.startsWith(DEPLOYMENT_TELEMETRY_PREFIX));
+      return JSON.parse(line.slice(DEPLOYMENT_TELEMETRY_PREFIX.length)) as {
+        durationMs: number;
+        event: string;
+        status: string;
+        step: string;
+        version: number;
+      };
+    });
+    assert.deepEqual(
+      events.map(({step}) => step),
+      [
+        'authorization',
+        'old_org_deletion',
+        'scratch_org_creation',
+        'community_creation',
+        'source_deployment',
+        'community_metadata_deployment',
+        'publication',
+        'availability_checks',
+      ]
+    );
+    assert.ok(
+      events.every(
+        ({durationMs, event, status, version}) =>
+          durationMs >= 0 &&
+          event === 'step_duration' &&
+          status === 'success' &&
+          version === 1
+      )
+    );
+    assert.doesNotMatch(
+      telemetryLines.join('\n'),
+      /client-id-not-logged|key-file-not-logged|username-not-logged|example\.invalid/
+    );
+  });
+
+  it('classifies only the explicit Experience Cloud readiness fixture', () => {
+    const fixture = readinessFailure();
+    assert.equal(isCommunityMetadataReadinessFailure(fixture), true);
+    assert.equal(
+      isCommunityMetadataReadinessFailure({
+        ...fixture,
+        result: {
+          ...fixture.result,
+          details: {
+            componentFailures: {
+              componentType: 'ExperienceBundle',
+              fullName: 'Quantic_Examples1',
+              problem: 'Invalid value in route content',
+            },
+          },
+        },
+      }),
+      false
+    );
+    assert.equal(
+      isCommunityMetadataReadinessFailure(
+        deployResult(COMMUNITY_DEPLOYMENT_ID, 'Failed')
+      ),
+      false
+    );
+  });
+
+  it('starts a fresh logical attempt for the known readiness failure', async () => {
+    const telemetryLines: string[] = [];
+    const submittedIds = [
+      COMMUNITY_DEPLOYMENT_ID,
+      SECOND_COMMUNITY_DEPLOYMENT_ID,
+    ];
+    let communityStarts = 0;
+    const resumedIds: string[] = [];
+    const dependencies = createDependencies(telemetryLines, {
+      sfdx: {
+        deployCommunityMetadata: async () =>
+          asyncSubmission(submittedIds[communityStarts++]),
+        resumeMetadataDeployment: async ({deploymentId}) => {
+          if (deploymentId === SOURCE_DEPLOYMENT_ID) {
+            return deployResult(deploymentId);
+          }
+          resumedIds.push(deploymentId);
+          if (deploymentId === COMMUNITY_DEPLOYMENT_ID) {
+            throw readinessFailure();
+          }
+          return deployResult(deploymentId);
+        },
+      },
+    });
+
+    await runCommunityDeployment(OPTIONS, 'test-org', dependencies);
+
+    assert.equal(communityStarts, 2);
+    assert.deepEqual(resumedIds, [
+      COMMUNITY_DEPLOYMENT_ID,
+      SECOND_COMMUNITY_DEPLOYMENT_ID,
+    ]);
+  });
+
+  it('cleans up after a terminal content deployment failure without retrying it', async () => {
+    const telemetryLines: string[] = [];
+    const deletedAliases: string[] = [];
+    const terminalError = deployResult(COMMUNITY_DEPLOYMENT_ID, 'Failed');
+    let communityStarts = 0;
+    const dependencies = createDependencies(telemetryLines, {
+      sfdx: {
+        deleteOrg: async (alias) => {
+          deletedAliases.push(alias);
+        },
+        deployCommunityMetadata: async () => {
+          communityStarts++;
+          return asyncSubmission(COMMUNITY_DEPLOYMENT_ID);
+        },
+        resumeMetadataDeployment: async ({deploymentId}) => {
+          if (deploymentId === COMMUNITY_DEPLOYMENT_ID) {
+            throw terminalError;
+          }
+          return deployResult(deploymentId);
+        },
+      },
+    });
+
+    await assert.rejects(
+      runCommunityDeployment(OPTIONS, 'test-org', dependencies),
+      (error) => error === terminalError
+    );
+    assert.equal(communityStarts, 1);
+    assert.deepEqual(deletedAliases, ['test-org']);
+    assert.match(
+      telemetryLines.join('\n'),
+      /"status":"failure","step":"community_metadata_deployment"/
+    );
+  });
+
+  it('preserves the original deployment error when cleanup also fails', async () => {
+    const terminalError = deployResult(COMMUNITY_DEPLOYMENT_ID, 'Failed');
+    const cleanupError = new Error('cleanup failed');
+    const reportedCleanupErrors: unknown[] = [];
+    const dependencies = createDependencies([], {
+      reportCleanupError: (error) => reportedCleanupErrors.push(error),
+      sfdx: {
+        deleteOrg: async () => {
+          throw cleanupError;
+        },
+        resumeMetadataDeployment: async ({deploymentId}) => {
+          if (deploymentId === COMMUNITY_DEPLOYMENT_ID) {
+            throw terminalError;
+          }
+          return deployResult(deploymentId);
+        },
+      },
+    });
+
+    await assert.rejects(
+      runCommunityDeployment(OPTIONS, 'test-org', dependencies),
+      (error) => error === terminalError
+    );
+    assert.deepEqual(reportedCleanupErrors, [cleanupError]);
+  });
+
+  it('cleans up after resume exhaustion', async () => {
+    const deletedAliases: string[] = [];
+    const dependencies = createDependencies([], {
+      metadataDeploymentPolicy: {...POLICY, maxResumeAttempts: 1},
+      sfdx: {
+        deleteOrg: async (alias) => {
+          deletedAliases.push(alias);
+        },
+        resumeMetadataDeployment: async ({deploymentId}) => {
+          if (deploymentId === COMMUNITY_DEPLOYMENT_ID) {
+            throw {
+              data: {id: deploymentId},
+              message: 'Metadata API request failed: The client has timed out',
+            };
+          }
+          return deployResult(deploymentId);
+        },
+      },
+    });
+
+    await assert.rejects(
+      runCommunityDeployment(OPTIONS, 'test-org', dependencies),
+      MetadataDeploymentRetryError
+    );
+    assert.deepEqual(deletedAliases, ['test-org']);
+  });
+
+  it('cleans up after the hard overall deadline', async () => {
+    let currentTime = 0;
+    const deletedAliases: string[] = [];
+    const dependencies = createDependencies([], {
+      metadataDeploymentPolicy: {
+        ...POLICY,
+        overallTimeoutMs: 20,
+        retryDelayMs: 5,
+      },
+      now: () => currentTime,
+      sfdx: {
+        deleteOrg: async (alias) => {
+          deletedAliases.push(alias);
+        },
+        resumeMetadataDeployment: async ({deploymentId}) => {
+          if (deploymentId === COMMUNITY_DEPLOYMENT_ID) {
+            currentTime = 20;
+            throw Object.assign(new Error('socket hang up'), {
+              code: 'ECONNRESET',
+            });
+          }
+          return deployResult(deploymentId);
+        },
+      },
+    });
+
+    await assert.rejects(
+      runCommunityDeployment(OPTIONS, 'test-org', dependencies),
+      MetadataDeploymentRetryError
+    );
+    assert.deepEqual(deletedAliases, ['test-org']);
+  });
+});

--- a/packages/quantic/scripts/build/deploy-community.ts
+++ b/packages/quantic/scripts/build/deploy-community.ts
@@ -1,19 +1,41 @@
-// eslint-disable-next-line n/no-extraneous-import
-import {backOff} from 'exponential-backoff';
 import * as fs from 'fs';
 import * as path from 'path';
+import dotenv from 'dotenv';
 import waitOn from 'wait-on';
 import {StepLogger, StepsRunner} from './util/log';
+import {
+  MetadataDeploymentPolicy,
+  runMetadataDeployment,
+} from './util/metadata-deployment';
 import * as sfdx from './util/sfdx-commands';
-import {SfdxJWTAuth, authorizeOrg} from './util/sfdx-commands';
-import dotenv from 'dotenv';
+import {SfdxJWTAuth} from './util/sfdx-commands';
 import {
   getOrgNameFromScratchDefFile,
   getScratchOrgDefPath,
 } from './util/scratchOrgDefUtils';
-dotenv.config({path: path.resolve(__dirname, '.env')});
+import {DeploymentTelemetry} from './util/telemetry';
 
-interface Options {
+const COMMUNITY_CREATION_MAX_ATTEMPTS = 5;
+const COMMUNITY_CREATION_RETRY_DELAY_MS = 30000;
+const COMMUNITY_CREATION_TIMEOUT_MS = 5 * 60 * 1000;
+const COMMUNITY_METADATA_MAX_LOGICAL_ATTEMPTS = 11;
+const COMMUNITY_WAIT_TIMEOUT_MS = 5 * 60 * 1000;
+const METADATA_DEPLOYMENT_POLICY: MetadataDeploymentPolicy = {
+  maxResumeAttempts: 5,
+  overallTimeoutMs: 45 * 60 * 1000,
+  retryDelayMs: 40000,
+  waitMinutes: 10,
+};
+const COMMUNITY_EXPERIENCE_BUNDLE = 'Quantic_Examples1';
+const COMMUNITY_READINESS_PROBLEMS = new Set([
+  'In field: Network - no Network named Quantic Examples found',
+  'The ExperienceBundle Definition Quantic_Examples1 does not exist',
+]);
+const TRANSIENT_COMMUNITY_CREATE_ERROR =
+  'Error: Unable to create a new experience.';
+
+export interface Options {
+  ci: boolean;
   community: {
     name: string;
     path: string;
@@ -26,14 +48,35 @@ interface Options {
     alias: string;
     defFile: string;
     duration: number;
+    name: string;
   };
 }
 
-/**
- * Utility function to update or add environment variables in a .env file
- * @param {string} filePath - The path to the .env file
- * @param {object} newVariables - An object containing the key-value pairs of variables to update or add
- */
+type CommunitySfdxCommands = Pick<
+  typeof sfdx,
+  | 'authorizeOrg'
+  | 'createCommunity'
+  | 'createScratchOrg'
+  | 'deleteOldScratchOrgs'
+  | 'deleteOrg'
+  | 'deployCommunityMetadata'
+  | 'deploySource'
+  | 'orgExists'
+  | 'publishCommunity'
+  | 'resumeMetadataDeployment'
+>;
+
+export interface DeploymentDependencies {
+  metadataDeploymentPolicy: MetadataDeploymentPolicy;
+  now: () => number;
+  reportCleanupError: (error: unknown) => void;
+  sfdx: CommunitySfdxCommands;
+  sleep: (durationMs: number) => Promise<void>;
+  waitForUrl: (url: string, timeoutMs: number) => Promise<void>;
+  writeCommunityUrl: (communityUrl: string, orgName: string) => Promise<void>;
+  writeTelemetry: (line: string) => void;
+}
+
 function updateEnvFile(filePath: string, newVariables: Record<string, string>) {
   try {
     if (!fs.existsSync(filePath)) {
@@ -42,7 +85,6 @@ function updateEnvFile(filePath: string, newVariables: Record<string, string>) {
     }
 
     const envData = fs.readFileSync(filePath, 'utf8');
-
     const lines = envData.split('\n');
     const envVariables: Record<string, string> = {};
 
@@ -68,263 +110,173 @@ function updateEnvFile(filePath: string, newVariables: Record<string, string>) {
   }
 }
 
+async function writeCommunityUrl(
+  communityUrl: string,
+  orgName: string
+): Promise<void> {
+  const envFilePath = path.join(
+    __dirname,
+    '..',
+    '..',
+    '.env',
+    `${orgName}.env`
+  );
+  updateEnvFile(envFilePath, {[`${orgName}_URL`]: communityUrl});
+}
+
+const defaultDependencies: DeploymentDependencies = {
+  metadataDeploymentPolicy: METADATA_DEPLOYMENT_POLICY,
+  now: Date.now,
+  reportCleanupError: (error) => console.error(error),
+  sfdx,
+  sleep: (durationMs) =>
+    new Promise((resolve) => setTimeout(resolve, durationMs)),
+  waitForUrl: async (url, timeoutMs) => {
+    await waitOn({resources: [url], timeout: timeoutMs});
+  },
+  writeCommunityUrl,
+  writeTelemetry: console.log,
+};
+
 function ensureEnvVariables() {
   [
     'COMMIT_SHA',
     'SFDX_AUTH_CLIENT_ID',
     'SFDX_AUTH_JWT_KEY_FILE',
     'SFDX_AUTH_JWT_USERNAME',
-  ].forEach((v) => {
-    if (!process.env[v]) {
-      throw new Error(`The environment variable ${v} must be defined.`);
+  ].forEach((variable) => {
+    if (!process.env[variable]) {
+      throw new Error(`The environment variable ${variable} must be defined.`);
     }
   });
 }
 
-function isCi() {
-  return process.argv.some((arg) => arg === '--ci');
-}
-
-function getBranchName() {
-  return process.env.COMMIT_SHA!.substring(0, 6);
+function isCi(argv: string[]) {
+  return argv.some((arg) => arg === '--ci');
 }
 
 function getCiOrgName() {
-  return `quantic-${getBranchName()}`;
+  return `quantic-${process.env.COMMIT_SHA!.substring(0, 6)}`;
+}
+
+async function readDefinitionFile(file: string): Promise<object> {
+  return JSON.parse(await fs.promises.readFile(file, 'utf8')) as object;
 }
 
 async function prepareScratchOrgDefinitionFile(
-  baseDefinitionFile: string
+  baseDefinitionFile: string,
+  ci: boolean
 ): Promise<string> {
-  if (!isCi()) {
+  if (!ci) {
     return baseDefinitionFile;
   }
-
-  const orgName = getCiOrgName();
-  const baseDefinition = await readDefinitionFile(baseDefinitionFile);
 
   const ciDefinitionFile = path.resolve(
     path.dirname(baseDefinitionFile),
     'scratch-def.ci.json'
   );
-  await writeDefinitionFile(ciDefinitionFile, {
-    ...baseDefinition,
-    orgName,
-  });
-
+  await fs.promises.writeFile(
+    ciDefinitionFile,
+    JSON.stringify(
+      {
+        ...(await readDefinitionFile(baseDefinitionFile)),
+        orgName: getCiOrgName(),
+      },
+      null,
+      2
+    )
+  );
   return ciDefinitionFile;
 }
 
-async function readDefinitionFile(file: string): Promise<Object> {
-  return new Promise((resolve, reject) => {
-    fs.readFile(file, (err, data) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(JSON.parse(data.toString()));
-      }
-    });
-  });
-}
-
-async function writeDefinitionFile(
-  file: string,
-  definition: Object
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    fs.writeFile(file, JSON.stringify(definition, null, 2), (err) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve();
-      }
-    });
-  });
-}
-
-async function buildOptions(scratchOrgDefPath: string): Promise<Options> {
-  const ci = isCi();
+async function buildOptions(
+  scratchOrgDefPath: string,
+  argv: string[]
+): Promise<Options> {
+  const ci = isCi(argv);
   const orgName = getOrgNameFromScratchDefFile(scratchOrgDefPath);
-
   if (ci) {
     ensureEnvVariables();
   }
 
   return {
+    ci,
     community: {
       name: 'Quantic Examples',
       path: 'examples',
       template: 'Build Your Own',
     },
-    scratchOrg: {
-      alias: orgName,
-      defFile: await prepareScratchOrgDefinitionFile(
-        path.resolve(scratchOrgDefPath)
-      ),
-      duration: ci ? 1 : 7,
-    },
+    deleteOldOrgs: ci,
+    deleteOrgOnError: ci,
     jwt: {
       clientId: process.env.SFDX_AUTH_CLIENT_ID!,
       keyFile: process.env.SFDX_AUTH_JWT_KEY_FILE!,
       username: process.env.SFDX_AUTH_JWT_USERNAME!,
     },
-    deleteOldOrgs: ci,
-    deleteOrgOnError: ci,
+    scratchOrg: {
+      alias: orgName,
+      defFile: await prepareScratchOrgDefinitionFile(
+        path.resolve(scratchOrgDefPath),
+        ci
+      ),
+      duration: ci ? 1 : 7,
+      name: ci ? getCiOrgName() : orgName,
+    },
   };
 }
 
-async function deleteOldOrgs(log: StepLogger, options: Options): Promise<void> {
-  log('Deleting old scratch organizations...');
-
-  const nbDeleted = await sfdx.deleteOldScratchOrgs({
-    devHubUsername: options.jwt.username,
-    scratchOrgName: getCiOrgName(),
-    jwtClientId: options.jwt.clientId,
-    jwtKeyFile: options.jwt.keyFile,
-  });
-
-  log(`${nbDeleted} scratch organizations deleted.`);
-}
-
-async function ensureScratchOrgExists(log: StepLogger, options: Options) {
-  log(`Searching for ${options.scratchOrg.alias} organization...`);
-
-  if (await sfdx.orgExists(options.scratchOrg.alias)) {
-    log(`${options.scratchOrg.alias} organization found.`);
-  } else {
-    log(
-      `${options.scratchOrg.alias} organization not found. Creating organization.`
-    );
-    await sfdx.createScratchOrg(options.scratchOrg);
-    log('Organization created successfully.');
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
   }
-}
-
-// Occasionally, community creation fails with an unknown error on the Salesforce side.
-// Retrying after a short delay often resolves it.
-const TRANSIENT_COMMUNITY_CREATE_ERROR =
-  'Error: Unable to create a new experience.';
-
-async function ensureCommunityExists(
-  log: StepLogger,
-  options: Options
-): Promise<void> {
-  log(`Searching for '${options.community.name}' community`);
-  try {
-    await backOff(
-      async () => {
-        await sfdx.createCommunity({
-          alias: options.scratchOrg.alias,
-          community: options.community,
-        });
-      },
-      {
-        numOfAttempts: 5,
-        startingDelay: 30000,
-        retry: (error) => {
-          const isTransient =
-            (error as Error).message === TRANSIENT_COMMUNITY_CREATE_ERROR;
-          if (isTransient) {
-            log(
-              'Community creation failed because the org domain is not ready yet. Retrying...'
-            );
-          }
-          return isTransient;
-        },
-      }
-    );
-    log('Community created successfully.');
-  } catch (error) {
-    if ((error as Error).message === 'Enter a different name. That one already exists.') {
-      log('Community found.');
-    } else {
-      throw error;
-    }
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return error.message;
   }
+  return '';
 }
 
-async function deployComponents(
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function isCommunityMetadataReadinessFailure(error: unknown) {
+  const root = asRecord(error);
+  const result = asRecord(root?.result) ?? root;
+  if (result?.status !== 'Failed' && result?.status !== 'FinalizingFailed') {
+    return false;
+  }
+
+  const details = asRecord(result.details);
+  const failuresValue = details?.componentFailures;
+  const failures = (
+    Array.isArray(failuresValue) ? failuresValue : [failuresValue]
+  )
+    .map(asRecord)
+    .filter((failure): failure is Record<string, unknown> => !!failure);
+
+  return (
+    failures.length === 1 &&
+    failures[0].componentType === 'ExperienceBundle' &&
+    failures[0].fullName === COMMUNITY_EXPERIENCE_BUNDLE &&
+    typeof failures[0].problem === 'string' &&
+    COMMUNITY_READINESS_PROBLEMS.has(failures[0].problem)
+  );
+}
+
+async function authorizeDevOrg(
   log: StepLogger,
-  options: Options
-): Promise<void> {
-  log('Deploying components...');
-
-  return backOff(async () => {
-    await sfdx.deploySource({
-      alias: options.scratchOrg.alias,
-      packagePaths: [
-        'force-app/main',
-        'force-app/examples',
-        'force-app/solutionExamples',
-      ],
-    });
-
-    log('Components deployed.');
-  });
-}
-
-async function deployCommunity(
-  log: StepLogger,
-  options: Options
-): Promise<void> {
-  log('Deploying community metadata...');
-
-  // There is no easy way to know when the community is ready.
-  // The first deploy attempt may fail.
-  let retry = 0;
-  let success = false;
-  const maxRetries = 10;
-  do {
-    try {
-      await sfdx.deployCommunityMetadata({
-        alias: options.scratchOrg.alias,
-        communityMetadataPath: 'quantic-examples-community',
-        timeout: 10,
-      });
-
-      success = true;
-    } catch (error) {
-      if (retry === maxRetries) {
-        throw error;
-      }
-      // The deployment may fail because the community is still being created.
-      // Wait for 40 seconds then retry.
-      await new Promise((resolve) => setTimeout(resolve, 40000));
-      retry++;
-    }
-  } while (!success && retry <= maxRetries);
-
-  log('Community metadata deployed.');
-}
-
-async function publishCommunity(
-  log: StepLogger,
-  options: Options
-): Promise<string> {
-  log('Publishing community...');
-
-  const response = await sfdx.publishCommunity({
-    alias: options.scratchOrg.alias,
-    communityName: options.community.name,
-  });
-  log('Community published.');
-
-  return response.result.url;
-}
-
-async function setCommunityBaseUrlAsEnvVariable(log: StepLogger, communityUrl: string, orgName: string) {
-  const pathSegments = [__dirname, '..', '..', '.env', `${orgName}.env`];
-  const envFilePath = path.join(...pathSegments);
-  const newEnvVariables = {
-    [`${orgName}_URL`]: communityUrl,
-  };
-
-  updateEnvFile(envFilePath, newEnvVariables);
-}
-
-async function authorizeDevOrg(log: StepLogger, options: Options) {
+  options: Options,
+  dependencies: DeploymentDependencies
+) {
   log(`Authorizing user: ${options.jwt.username}`);
-  await authorizeOrg({
+  await dependencies.sfdx.authorizeOrg({
     username: options.jwt.username,
     isScratchOrg: false,
     jwtClientId: options.jwt.clientId,
@@ -333,78 +285,274 @@ async function authorizeDevOrg(log: StepLogger, options: Options) {
   log('Authorization successful');
 }
 
+async function deleteOldOrgs(
+  log: StepLogger,
+  options: Options,
+  dependencies: DeploymentDependencies
+): Promise<void> {
+  log('Deleting old scratch organizations...');
+  const deletedCount = await dependencies.sfdx.deleteOldScratchOrgs({
+    devHubUsername: options.jwt.username,
+    scratchOrgName: options.scratchOrg.name,
+    jwtClientId: options.jwt.clientId,
+    jwtKeyFile: options.jwt.keyFile,
+  });
+  log(`${deletedCount} scratch organizations deleted.`);
+}
+
+async function ensureScratchOrgExists(
+  log: StepLogger,
+  options: Options,
+  dependencies: DeploymentDependencies
+) {
+  log(`Searching for ${options.scratchOrg.alias} organization...`);
+  if (await dependencies.sfdx.orgExists(options.scratchOrg.alias)) {
+    log(`${options.scratchOrg.alias} organization found.`);
+    return;
+  }
+
+  log(
+    `${options.scratchOrg.alias} organization not found. Creating organization.`
+  );
+  await dependencies.sfdx.createScratchOrg(options.scratchOrg);
+  log('Organization created successfully.');
+}
+
+async function ensureCommunityExists(
+  log: StepLogger,
+  options: Options,
+  dependencies: DeploymentDependencies
+): Promise<void> {
+  log(`Searching for '${options.community.name}' community`);
+  const deadline = dependencies.now() + COMMUNITY_CREATION_TIMEOUT_MS;
+
+  for (let attempt = 1; attempt <= COMMUNITY_CREATION_MAX_ATTEMPTS; attempt++) {
+    try {
+      await dependencies.sfdx.createCommunity({
+        alias: options.scratchOrg.alias,
+        community: options.community,
+      });
+      log('Community created successfully.');
+      return;
+    } catch (error) {
+      const message = getErrorMessage(error);
+      if (message === 'Enter a different name. That one already exists.') {
+        log('Community found.');
+        return;
+      }
+      if (message !== TRANSIENT_COMMUNITY_CREATE_ERROR) {
+        throw error;
+      }
+      if (
+        attempt >= COMMUNITY_CREATION_MAX_ATTEMPTS ||
+        dependencies.now() + COMMUNITY_CREATION_RETRY_DELAY_MS >= deadline
+      ) {
+        throw error;
+      }
+
+      log(
+        'Community creation failed because the org domain is not ready yet. Retrying...'
+      );
+      await dependencies.sleep(COMMUNITY_CREATION_RETRY_DELAY_MS);
+    }
+  }
+}
+
+async function deployComponents(
+  log: StepLogger,
+  options: Options,
+  dependencies: DeploymentDependencies
+): Promise<void> {
+  log('Deploying components...');
+  await runMetadataDeployment({
+    dependencies: {
+      log,
+      now: dependencies.now,
+      resume: async (deploymentId, waitMinutes, executionTimeoutMs) =>
+        dependencies.sfdx.resumeMetadataDeployment({
+          deploymentId,
+          executionTimeoutMs,
+          waitMinutes,
+        }),
+      sleep: dependencies.sleep,
+      start: async (executionTimeoutMs) =>
+        dependencies.sfdx.deploySource({
+          alias: options.scratchOrg.alias,
+          executionTimeoutMs,
+          packagePaths: [
+            'force-app/main',
+            'force-app/examples',
+            'force-app/solutionExamples',
+          ],
+        }),
+    },
+    policy: dependencies.metadataDeploymentPolicy,
+    step: 'source_deployment',
+  });
+  log('Components deployed.');
+}
+
+async function deployCommunityMetadata(
+  log: StepLogger,
+  options: Options,
+  dependencies: DeploymentDependencies
+): Promise<void> {
+  log('Deploying community metadata...');
+  await runMetadataDeployment({
+    dependencies: {
+      log,
+      now: dependencies.now,
+      resume: async (deploymentId, waitMinutes, executionTimeoutMs) =>
+        dependencies.sfdx.resumeMetadataDeployment({
+          deploymentId,
+          executionTimeoutMs,
+          waitMinutes,
+        }),
+      sleep: dependencies.sleep,
+      start: async (executionTimeoutMs) =>
+        dependencies.sfdx.deployCommunityMetadata({
+          alias: options.scratchOrg.alias,
+          communityMetadataPath: 'quantic-examples-community',
+          executionTimeoutMs,
+        }),
+    },
+    isRetryableTerminalFailure: isCommunityMetadataReadinessFailure,
+    maxLogicalAttempts: COMMUNITY_METADATA_MAX_LOGICAL_ATTEMPTS,
+    policy: dependencies.metadataDeploymentPolicy,
+    step: 'community_metadata_deployment',
+  });
+  log('Community metadata deployed.');
+}
+
+async function publishCommunity(
+  log: StepLogger,
+  options: Options,
+  dependencies: DeploymentDependencies
+): Promise<string> {
+  log('Publishing community...');
+  const response = await dependencies.sfdx.publishCommunity({
+    alias: options.scratchOrg.alias,
+    communityName: options.community.name,
+  });
+  log('Community published.');
+  return response.result.url;
+}
+
 async function waitForCommunity(
   log: StepLogger,
-  communityUrl: string
+  communityUrl: string,
+  dependencies: DeploymentDependencies
 ): Promise<void> {
   log(`Waiting for community at URL: ${communityUrl} ...`);
-
-  await waitOn({
-    resources: [communityUrl],
-    timeout: 5 * 60 * 1000,
-  });
+  await dependencies.waitForUrl(communityUrl, COMMUNITY_WAIT_TIMEOUT_MS);
   log('Community is now available');
 }
 
 async function deleteScratchOrg(
   log: StepLogger,
-  options: Options
+  options: Options,
+  dependencies: DeploymentDependencies
 ): Promise<void> {
   log(`Deleting ${options.scratchOrg.alias} organization...`);
-  await sfdx.deleteOrg(options.scratchOrg.alias);
+  await dependencies.sfdx.deleteOrg(options.scratchOrg.alias);
   log('Organization deleted successfully.');
 }
 
-(async function () {
-  const scratchOrgDefPath = getScratchOrgDefPath(process.argv);
-  const orgName = getOrgNameFromScratchDefFile(scratchOrgDefPath);
-
-  const options = await buildOptions(scratchOrgDefPath);
-
-  let scratchOrgCreated = false;
+export async function runCommunityDeployment(
+  options: Options,
+  orgName: string,
+  dependencies: DeploymentDependencies = defaultDependencies
+): Promise<string> {
+  let communityUrl = '';
+  let scratchOrgAvailable = false;
   const runner = new StepsRunner();
+  const telemetry = new DeploymentTelemetry(
+    dependencies.writeTelemetry,
+    dependencies.now
+  );
 
   try {
-    let communityUrl = '';
-    if (isCi()) {
-      runner.add(async (log) => await authorizeDevOrg(log, options));
+    if (options.ci) {
+      runner.add(async (log) =>
+        telemetry.measure('authorization', () =>
+          authorizeDevOrg(log, options, dependencies)
+        )
+      );
     }
     if (options.deleteOldOrgs) {
-      runner.add(async (log) => {
-        await deleteOldOrgs(log, options);
-      });
+      runner.add(async (log) =>
+        telemetry.measure('old_org_deletion', () =>
+          deleteOldOrgs(log, options, dependencies)
+        )
+      );
     }
     runner
-      .add(async (log) => {
-        await ensureScratchOrgExists(log, options);
-        scratchOrgCreated = true;
-      })
-      .add(async (log) => await ensureCommunityExists(log, options))
-      .add(async (log) => await deployComponents(log, options))
-      .add(async (log) => await deployCommunity(log, options))
-      .add(async (log) => {
-        communityUrl = await publishCommunity(log, options);
-      })
-      .add(
-        async (log) =>
-          await setCommunityBaseUrlAsEnvVariable(log, communityUrl, orgName)
+      .add(async (log) =>
+        telemetry.measure('scratch_org_creation', async () => {
+          await ensureScratchOrgExists(log, options, dependencies);
+          scratchOrgAvailable = true;
+        })
       )
-      .add(async (log) => await waitForCommunity(log, communityUrl));
+      .add(async (log) =>
+        telemetry.measure('community_creation', () =>
+          ensureCommunityExists(log, options, dependencies)
+        )
+      )
+      .add(async (log) =>
+        telemetry.measure('source_deployment', () =>
+          deployComponents(log, options, dependencies)
+        )
+      )
+      .add(async (log) =>
+        telemetry.measure('community_metadata_deployment', () =>
+          deployCommunityMetadata(log, options, dependencies)
+        )
+      )
+      .add(async (log) =>
+        telemetry.measure('publication', async () => {
+          communityUrl = await publishCommunity(log, options, dependencies);
+        })
+      )
+      .add(async () => {
+        await dependencies.writeCommunityUrl(communityUrl, orgName);
+      })
+      .add(async (log) =>
+        telemetry.measure('availability_checks', () =>
+          waitForCommunity(log, communityUrl, dependencies)
+        )
+      );
 
     await runner.run();
-
-    console.log(
-      `\nThe '${options.community.name}' community is ready, you can access it at the following URL:`
-    );
-    console.log(communityUrl);
+    return communityUrl;
   } catch (error) {
-    console.error('Failed to complete');
-    console.error(error);
-
-    if (options.deleteOrgOnError && scratchOrgCreated) {
-      await deleteScratchOrg(runner.getLogger(), options);
+    if (options.deleteOrgOnError && scratchOrgAvailable) {
+      try {
+        await deleteScratchOrg(runner.getLogger(), options, dependencies);
+      } catch (cleanupError) {
+        dependencies.reportCleanupError(cleanupError);
+      }
     }
-
     throw error;
   }
-})();
+}
+
+export async function main(argv: string[] = process.argv): Promise<void> {
+  dotenv.config({path: path.resolve(__dirname, '.env')});
+  const scratchOrgDefPath = getScratchOrgDefPath(argv);
+  const orgName = getOrgNameFromScratchDefFile(scratchOrgDefPath);
+  const options = await buildOptions(scratchOrgDefPath, argv);
+  const communityUrl = await runCommunityDeployment(options, orgName);
+
+  console.log(
+    `\nThe '${options.community.name}' community is ready, you can access it at the following URL:`
+  );
+  console.log(communityUrl);
+}
+
+if (require.main === module) {
+  void main().catch((error) => {
+    console.error('Failed to complete');
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/packages/quantic/scripts/build/util/metadata-deployment.node-test.ts
+++ b/packages/quantic/scripts/build/util/metadata-deployment.node-test.ts
@@ -1,0 +1,445 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+import {
+  MetadataDeploymentDependencies,
+  MetadataDeploymentPolicy,
+  MetadataDeploymentProtocolError,
+  MetadataDeploymentRetryError,
+  MetadataDeploymentSubmissionError,
+  runMetadataDeployment,
+} from './metadata-deployment';
+
+const DEPLOYMENT_ID = '0Af000000000001AAA';
+const OTHER_DEPLOYMENT_ID = '0Af000000000002AAA';
+const POLICY: MetadataDeploymentPolicy = {
+  maxResumeAttempts: 3,
+  overallTimeoutMs: 1000,
+  retryDelayMs: 10,
+  waitMinutes: 10,
+};
+
+function asyncSubmission(deploymentId: string = DEPLOYMENT_ID) {
+  return {
+    result: {
+      done: false,
+      files: [],
+      id: deploymentId,
+      status: 'Queued',
+    },
+    status: 0,
+  };
+}
+
+function activeStart(deploymentId: string = DEPLOYMENT_ID) {
+  return {
+    result: {done: false, id: deploymentId, status: 'InProgress'},
+    status: 69,
+  };
+}
+
+function resumeTimeout(deploymentId: string = DEPLOYMENT_ID) {
+  return {
+    data: {id: deploymentId},
+    message: 'Metadata API request failed: The client has timed out',
+  };
+}
+
+function deployResult(status: string, deploymentId: string = DEPLOYMENT_ID) {
+  const succeeded = status === 'Succeeded';
+  const active = ['Canceling', 'Finalizing', 'InProgress', 'Pending'].includes(
+    status
+  );
+  return {
+    result: {
+      done: !active,
+      id: deploymentId,
+      status,
+      success: succeeded,
+    },
+    status: active ? 69 : succeeded ? 0 : 1,
+  };
+}
+
+function createDependencies(
+  overrides: Partial<MetadataDeploymentDependencies> = {}
+) {
+  let currentTime = 0;
+  const logs: string[] = [];
+  const dependencies: MetadataDeploymentDependencies = {
+    log: (message) => logs.push(message),
+    now: () => currentTime,
+    resume: async () => deployResult('Succeeded'),
+    sleep: async (durationMs) => {
+      currentTime += durationMs;
+    },
+    start: async () => asyncSubmission(),
+    ...overrides,
+  };
+  return {
+    advance: (durationMs: number) => {
+      currentTime += durationMs;
+    },
+    dependencies,
+    logs,
+  };
+}
+
+describe('runMetadataDeployment', () => {
+  it('submits one async deployment and resumes only its exact ID', async () => {
+    const startTimeouts: number[] = [];
+    const resumeCalls: Array<{
+      deploymentId: string;
+      executionTimeoutMs: number;
+      waitMinutes: number;
+    }> = [];
+    const {dependencies, logs} = createDependencies({
+      resume: async (deploymentId, waitMinutes, executionTimeoutMs) => {
+        resumeCalls.push({deploymentId, executionTimeoutMs, waitMinutes});
+        return deployResult('Succeeded');
+      },
+      start: async (executionTimeoutMs) => {
+        startTimeouts.push(executionTimeoutMs);
+        return asyncSubmission();
+      },
+    });
+
+    await runMetadataDeployment({
+      dependencies,
+      policy: POLICY,
+      step: 'source_deployment',
+    });
+
+    assert.deepEqual(startTimeouts, [1000]);
+    assert.deepEqual(resumeCalls, [
+      {deploymentId: DEPLOYMENT_ID, executionTimeoutMs: 1000, waitMinutes: 10},
+    ]);
+    assert.equal(
+      logs.filter(
+        (line) =>
+          line.includes('"action":"start"') &&
+          line.includes('"event":"attempt"')
+      ).length,
+      1
+    );
+  });
+
+  it('recovers the exact ID from a pinned-CLI active start response', async () => {
+    let starts = 0;
+    const resumedIds: string[] = [];
+    const {dependencies} = createDependencies({
+      resume: async (deploymentId) => {
+        resumedIds.push(deploymentId);
+        return deployResult('Succeeded');
+      },
+      start: async () => {
+        starts++;
+        throw activeStart();
+      },
+    });
+
+    await runMetadataDeployment({
+      dependencies,
+      policy: POLICY,
+      step: 'source_deployment',
+    });
+
+    assert.equal(starts, 1);
+    assert.deepEqual(resumedIds, [DEPLOYMENT_ID]);
+  });
+
+  it('handles real client-timeout shapes with repeated same-ID resumes', async () => {
+    let starts = 0;
+    const resumedIds: string[] = [];
+    const {dependencies} = createDependencies({
+      resume: async (deploymentId) => {
+        resumedIds.push(deploymentId);
+        if (resumedIds.length < 3) {
+          throw resumeTimeout();
+        }
+        return deployResult('Succeeded');
+      },
+      start: async () => {
+        starts++;
+        return asyncSubmission();
+      },
+    });
+
+    await runMetadataDeployment({
+      dependencies,
+      policy: POLICY,
+      step: 'community_metadata_deployment',
+    });
+
+    assert.equal(starts, 1);
+    assert.deepEqual(resumedIds, [DEPLOYMENT_ID, DEPLOYMENT_ID, DEPLOYMENT_ID]);
+  });
+
+  it('fails after bounded resume exhaustion without starting again', async () => {
+    let starts = 0;
+    let resumes = 0;
+    const {dependencies} = createDependencies({
+      resume: async () => {
+        resumes++;
+        throw resumeTimeout();
+      },
+      start: async () => {
+        starts++;
+        return asyncSubmission();
+      },
+    });
+
+    await assert.rejects(
+      runMetadataDeployment({
+        dependencies,
+        policy: {...POLICY, maxResumeAttempts: 2},
+        step: 'community_metadata_deployment',
+      }),
+      MetadataDeploymentRetryError
+    );
+    assert.equal(starts, 1);
+    assert.equal(resumes, 2);
+  });
+
+  it('rejects changed, invalid, and missing IDs from active resume responses', async () => {
+    const errors = [
+      resumeTimeout(OTHER_DEPLOYMENT_ID),
+      resumeTimeout('not-a-salesforce-id'),
+      {data: {}, message: resumeTimeout().message},
+    ];
+
+    for (const resumeError of errors) {
+      let starts = 0;
+      let resumes = 0;
+      const {dependencies} = createDependencies({
+        resume: async () => {
+          resumes++;
+          throw resumeError;
+        },
+        start: async () => {
+          starts++;
+          return asyncSubmission();
+        },
+      });
+
+      await assert.rejects(
+        runMetadataDeployment({
+          dependencies,
+          policy: POLICY,
+          step: 'community_metadata_deployment',
+        }),
+        MetadataDeploymentProtocolError
+      );
+      assert.equal(starts, 1);
+      assert.equal(resumes, 1);
+    }
+  });
+
+  it('rejects missing and invalid IDs from async submission responses', async () => {
+    for (const result of [
+      {result: {done: false, status: 'Queued'}, status: 0},
+      asyncSubmission('invalid-id'),
+    ]) {
+      let starts = 0;
+      const {dependencies} = createDependencies({
+        start: async () => {
+          starts++;
+          return result;
+        },
+      });
+
+      await assert.rejects(
+        runMetadataDeployment({
+          dependencies,
+          policy: POLICY,
+          step: 'source_deployment',
+        }),
+        MetadataDeploymentProtocolError
+      );
+      assert.equal(starts, 1);
+    }
+  });
+
+  it('continues through Finalizing and completes on the same ID', async () => {
+    const resumedIds: string[] = [];
+    const {dependencies} = createDependencies({
+      resume: async (deploymentId) => {
+        resumedIds.push(deploymentId);
+        return deployResult(
+          resumedIds.length === 1 ? 'Finalizing' : 'Succeeded'
+        );
+      },
+    });
+
+    await runMetadataDeployment({
+      dependencies,
+      policy: POLICY,
+      step: 'source_deployment',
+    });
+
+    assert.deepEqual(resumedIds, [DEPLOYMENT_ID, DEPLOYMENT_ID]);
+  });
+
+  it('treats FinalizingFailed as terminal without another submission', async () => {
+    const terminalError = deployResult('FinalizingFailed');
+    let starts = 0;
+    let resumes = 0;
+    const {dependencies} = createDependencies({
+      resume: async () => {
+        resumes++;
+        throw terminalError;
+      },
+      start: async () => {
+        starts++;
+        return asyncSubmission();
+      },
+    });
+
+    await assert.rejects(
+      runMetadataDeployment({
+        dependencies,
+        policy: POLICY,
+        step: 'source_deployment',
+      }),
+      (error) => error === terminalError
+    );
+    assert.equal(starts, 1);
+    assert.equal(resumes, 1);
+  });
+
+  it('retries transient resume transport failures against the same ID', async () => {
+    let sleeps = 0;
+    const resumedIds: string[] = [];
+    const {dependencies} = createDependencies({
+      resume: async (deploymentId) => {
+        resumedIds.push(deploymentId);
+        if (resumedIds.length === 1) {
+          throw Object.assign(new Error('socket hang up'), {
+            code: 'ECONNRESET',
+          });
+        }
+        return deployResult('Succeeded');
+      },
+      sleep: async () => {
+        sleeps++;
+      },
+    });
+
+    await runMetadataDeployment({
+      dependencies,
+      policy: POLICY,
+      step: 'source_deployment',
+    });
+
+    assert.deepEqual(resumedIds, [DEPLOYMENT_ID, DEPLOYMENT_ID]);
+    assert.equal(sleeps, 1);
+  });
+
+  it('fails closed after an ambiguous async submission transport error', async () => {
+    let starts = 0;
+    let resumes = 0;
+    const {dependencies} = createDependencies({
+      resume: async () => {
+        resumes++;
+        return deployResult('Succeeded');
+      },
+      start: async () => {
+        starts++;
+        throw Object.assign(new Error('socket hang up'), {code: 'ECONNRESET'});
+      },
+    });
+
+    await assert.rejects(
+      runMetadataDeployment({
+        dependencies,
+        policy: POLICY,
+        step: 'source_deployment',
+      }),
+      MetadataDeploymentSubmissionError
+    );
+    assert.equal(starts, 1);
+    assert.equal(resumes, 0);
+  });
+
+  it('starts a fresh bounded logical attempt only for classified readiness failures', async () => {
+    const readinessFailure = deployResult('Failed');
+    const submittedIds = [DEPLOYMENT_ID, OTHER_DEPLOYMENT_ID];
+    const resumedIds: string[] = [];
+    let starts = 0;
+    let sleeps = 0;
+    const {dependencies} = createDependencies({
+      resume: async (deploymentId) => {
+        resumedIds.push(deploymentId);
+        if (deploymentId === DEPLOYMENT_ID) {
+          throw readinessFailure;
+        }
+        return deployResult('Succeeded', OTHER_DEPLOYMENT_ID);
+      },
+      sleep: async () => {
+        sleeps++;
+      },
+      start: async () => asyncSubmission(submittedIds[starts++]),
+    });
+
+    await runMetadataDeployment({
+      dependencies,
+      isRetryableTerminalFailure: (error) => error === readinessFailure,
+      maxLogicalAttempts: 2,
+      policy: POLICY,
+      step: 'community_metadata_deployment',
+    });
+
+    assert.equal(starts, 2);
+    assert.deepEqual(resumedIds, [DEPLOYMENT_ID, OTHER_DEPLOYMENT_ID]);
+    assert.equal(sleeps, 1);
+  });
+
+  it('does not retry unclassified completed deployment failures', async () => {
+    const contentFailure = deployResult('Failed');
+    let starts = 0;
+    const {dependencies} = createDependencies({
+      resume: async () => {
+        throw contentFailure;
+      },
+      start: async () => {
+        starts++;
+        return asyncSubmission();
+      },
+    });
+
+    await assert.rejects(
+      runMetadataDeployment({
+        dependencies,
+        isRetryableTerminalFailure: () => false,
+        maxLogicalAttempts: 3,
+        policy: POLICY,
+        step: 'community_metadata_deployment',
+      }),
+      (error) => error === contentFailure
+    );
+    assert.equal(starts, 1);
+  });
+
+  it('passes exact remaining milliseconds and stops at the hard deadline', async () => {
+    const resumeTimeouts: number[] = [];
+    const {advance, dependencies} = createDependencies({
+      resume: async (_deploymentId, _waitMinutes, executionTimeoutMs) => {
+        resumeTimeouts.push(executionTimeoutMs);
+        throw Object.assign(new Error('socket hang up'), {code: 'ECONNRESET'});
+      },
+      start: async () => {
+        advance(20);
+        return asyncSubmission();
+      },
+    });
+
+    await assert.rejects(
+      runMetadataDeployment({
+        dependencies,
+        policy: {...POLICY, overallTimeoutMs: 25, retryDelayMs: 10},
+        step: 'source_deployment',
+      }),
+      MetadataDeploymentRetryError
+    );
+    assert.deepEqual(resumeTimeouts, [5]);
+  });
+});

--- a/packages/quantic/scripts/build/util/metadata-deployment.ts
+++ b/packages/quantic/scripts/build/util/metadata-deployment.ts
@@ -1,0 +1,607 @@
+import {isSalesforceDeploymentId} from './sfdx';
+
+const ACTIVE_DEPLOYMENT_STATUSES = new Set([
+  'Canceling',
+  'Finalizing',
+  'InProgress',
+  'Pending',
+  'Queued',
+]);
+const TERMINAL_DEPLOYMENT_STATUSES = new Set([
+  'Canceled',
+  'Failed',
+  'FinalizingFailed',
+  'SucceededPartial',
+]);
+const TRANSIENT_ERROR_CODES = new Set([
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ENETUNREACH',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+const TRANSIENT_ERROR_MESSAGES = [
+  'connection reset',
+  'connection timed out',
+  'fetch failed',
+  'gateway timeout',
+  'network request failed',
+  'service unavailable',
+  'socket hang up',
+  'temporary failure',
+  'too many requests',
+];
+const DEPLOYMENT_ID_IN_TEXT = /\b0Af[A-Za-z0-9]{12}(?:[A-Za-z0-9]{3})?\b/g;
+const RELATED_RECORD_KEYS = ['cause', 'data', 'error', 'response', 'result'];
+const ID_KEYS = [
+  'ID',
+  'Id',
+  'deployId',
+  'deploymentId',
+  'id',
+  'jobID',
+  'jobId',
+];
+
+type UnknownRecord = Record<string, unknown>;
+type DeploymentState = 'active' | 'succeeded' | 'terminal' | 'unknown';
+
+export interface MetadataDeploymentPolicy {
+  maxResumeAttempts: number;
+  overallTimeoutMs: number;
+  retryDelayMs: number;
+  waitMinutes: number;
+}
+
+export interface MetadataDeploymentDependencies {
+  log: (message: string) => void;
+  now: () => number;
+  resume: (
+    deploymentId: string,
+    waitMinutes: number,
+    executionTimeoutMs: number
+  ) => Promise<unknown>;
+  sleep: (durationMs: number) => Promise<void>;
+  start: (executionTimeoutMs: number) => Promise<unknown>;
+}
+
+export interface MetadataDeploymentOptions {
+  dependencies: MetadataDeploymentDependencies;
+  isRetryableTerminalFailure?: (error: unknown) => boolean;
+  maxLogicalAttempts?: number;
+  policy: MetadataDeploymentPolicy;
+  step: string;
+}
+
+export class MetadataDeploymentRetryError extends Error {
+  constructor(
+    message: string,
+    public readonly originalError?: unknown
+  ) {
+    super(message);
+    this.name = 'MetadataDeploymentRetryError';
+    Object.setPrototypeOf(this, MetadataDeploymentRetryError.prototype);
+  }
+}
+
+export class MetadataDeploymentProtocolError extends Error {
+  constructor(
+    message: string,
+    public readonly originalError?: unknown
+  ) {
+    super(message);
+    this.name = 'MetadataDeploymentProtocolError';
+    Object.setPrototypeOf(this, MetadataDeploymentProtocolError.prototype);
+  }
+}
+
+export class MetadataDeploymentSubmissionError extends Error {
+  constructor(public readonly originalError: unknown) {
+    super(
+      'The asynchronous metadata deployment submission failed without a valid deployment ID; refusing to submit it again.'
+    );
+    this.name = 'MetadataDeploymentSubmissionError';
+    Object.setPrototypeOf(this, MetadataDeploymentSubmissionError.prototype);
+  }
+}
+
+class TerminalDeploymentFailure extends Error {
+  constructor(public readonly originalError: unknown) {
+    super('The Salesforce metadata deployment failed terminally.');
+    this.name = 'TerminalDeploymentFailure';
+    Object.setPrototypeOf(this, TerminalDeploymentFailure.prototype);
+  }
+}
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return typeof value === 'object' && value !== null
+    ? (value as UnknownRecord)
+    : undefined;
+}
+
+function collectRelevantRecords(value: unknown): UnknownRecord[] {
+  const records: UnknownRecord[] = [];
+  const seen = new Set<UnknownRecord>();
+
+  const collect = (candidate: unknown, depth: number) => {
+    const record = asRecord(candidate);
+    if (!record || seen.has(record) || depth > 2) {
+      return;
+    }
+    seen.add(record);
+    records.push(record);
+    RELATED_RECORD_KEYS.forEach((key) => collect(record[key], depth + 1));
+  };
+
+  collect(value, 0);
+  return records;
+}
+
+function getString(record: UnknownRecord, key: string) {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getNumber(record: UnknownRecord, key: string) {
+  const value = record[key];
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    return Number(value);
+  }
+  return undefined;
+}
+
+function getMessages(value: unknown) {
+  return collectRelevantRecords(value)
+    .map((record) => getString(record, 'message'))
+    .filter((message): message is string => message !== undefined);
+}
+
+function getDeploymentIdCandidates(value: unknown): unknown[] {
+  const records = collectRelevantRecords(value);
+  const structuredCandidates = records.flatMap((record) =>
+    ID_KEYS.filter((key) => key in record).map((key) => record[key])
+  );
+  const messageCandidates = getMessages(value).flatMap(
+    (message) => message.match(DEPLOYMENT_ID_IN_TEXT) ?? []
+  );
+  return [...structuredCandidates, ...messageCandidates];
+}
+
+function readDeploymentId(
+  value: unknown,
+  context: string,
+  expectedId?: string,
+  required = true
+): string | undefined {
+  const candidates = getDeploymentIdCandidates(value);
+  if (candidates.length === 0) {
+    if (required) {
+      throw new MetadataDeploymentProtocolError(
+        `The ${context} response is missing its deployment ID.`,
+        value
+      );
+    }
+    return undefined;
+  }
+  if (!candidates.every(isSalesforceDeploymentId)) {
+    throw new MetadataDeploymentProtocolError(
+      `The ${context} response contains an invalid deployment ID.`,
+      value
+    );
+  }
+
+  const uniqueIds = Array.from(new Set(candidates));
+  if (uniqueIds.length !== 1) {
+    throw new MetadataDeploymentProtocolError(
+      `The ${context} response contains conflicting deployment IDs.`,
+      value
+    );
+  }
+  const [deploymentId] = uniqueIds;
+  if (expectedId && deploymentId !== expectedId) {
+    throw new MetadataDeploymentProtocolError(
+      `The ${context} response changed the deployment ID.`,
+      value
+    );
+  }
+  return deploymentId;
+}
+
+function getDeploymentState(value: unknown): DeploymentState {
+  const records = collectRelevantRecords(value);
+  const statuses = records
+    .map((record) => getString(record, 'status'))
+    .filter((status): status is string => status !== undefined);
+  if (statuses.some((status) => TERMINAL_DEPLOYMENT_STATUSES.has(status))) {
+    return 'terminal';
+  }
+  if (statuses.includes('Succeeded')) {
+    return 'succeeded';
+  }
+  if (statuses.some((status) => ACTIVE_DEPLOYMENT_STATUSES.has(status))) {
+    return 'active';
+  }
+  if (
+    records.some(
+      (record) =>
+        record.done === true &&
+        (record.success === false || record.success === undefined)
+    )
+  ) {
+    return 'terminal';
+  }
+  if (
+    records.some((record) => record.done === true && record.success === true)
+  ) {
+    return 'succeeded';
+  }
+  if (
+    records.some(
+      (record) =>
+        getNumber(record, 'status') === 69 ||
+        getNumber(record, 'exitCode') === 69 ||
+        getNumber(record, 'code') === 69
+    )
+  ) {
+    return 'active';
+  }
+
+  const messages = getMessages(value).map((message) => message.toLowerCase());
+  if (
+    messages.some(
+      (message) =>
+        message.includes('the client has timed out') ||
+        (message.includes('metadata api') && message.includes('timed out'))
+    )
+  ) {
+    return 'active';
+  }
+  return 'unknown';
+}
+
+function isTransientError(error: unknown): boolean {
+  const records = collectRelevantRecords(error);
+  if (
+    records.some((record) => {
+      const code = getString(record, 'code');
+      return code ? TRANSIENT_ERROR_CODES.has(code) : false;
+    })
+  ) {
+    return true;
+  }
+
+  const messages = getMessages(error).map((message) => message.toLowerCase());
+  return messages.some((message) =>
+    TRANSIENT_ERROR_MESSAGES.some((part) => message.includes(part))
+  );
+}
+
+function validatePolicy(
+  policy: MetadataDeploymentPolicy,
+  maxLogicalAttempts: number
+) {
+  if (
+    !Number.isInteger(policy.maxResumeAttempts) ||
+    policy.maxResumeAttempts < 1 ||
+    !Number.isInteger(maxLogicalAttempts) ||
+    maxLogicalAttempts < 1 ||
+    policy.overallTimeoutMs < 1 ||
+    policy.retryDelayMs < 0 ||
+    !Number.isInteger(policy.waitMinutes) ||
+    policy.waitMinutes < 1
+  ) {
+    throw new Error('Metadata deployment retry policy values are invalid.');
+  }
+}
+
+function deadlineError(step: string, originalError?: unknown) {
+  return new MetadataDeploymentRetryError(
+    `The ${step} metadata deployment exceeded its overall deadline.`,
+    originalError
+  );
+}
+
+function getRemainingMs(
+  dependencies: MetadataDeploymentDependencies,
+  deadline: number,
+  step: string,
+  originalError?: unknown
+) {
+  const remainingMs = Math.floor(deadline - dependencies.now());
+  if (remainingMs < 1) {
+    throw deadlineError(step, originalError);
+  }
+  return remainingMs;
+}
+
+async function sleepBeforeRetry(
+  dependencies: MetadataDeploymentDependencies,
+  deadline: number,
+  delayMs: number,
+  step: string,
+  originalError: unknown
+) {
+  if (delayMs === 0) {
+    return;
+  }
+  const remainingMs = getRemainingMs(
+    dependencies,
+    deadline,
+    step,
+    originalError
+  );
+  if (delayMs >= remainingMs) {
+    throw deadlineError(step, originalError);
+  }
+  await dependencies.sleep(delayMs);
+  getRemainingMs(dependencies, deadline, step, originalError);
+}
+
+function resumeExhaustedError(step: string, originalError?: unknown) {
+  return new MetadataDeploymentRetryError(
+    `The ${step} metadata deployment exhausted its resume attempts.`,
+    originalError
+  );
+}
+
+async function submitLogicalDeployment(
+  dependencies: MetadataDeploymentDependencies,
+  deadline: number,
+  logicalAttempt: number,
+  step: string
+): Promise<{completed: boolean; deploymentId: string}> {
+  const executionTimeoutMs = getRemainingMs(dependencies, deadline, step);
+  dependencies.log(
+    `metadata-deployment ${JSON.stringify({
+      action: 'start',
+      event: 'attempt',
+      logicalAttempt,
+      step,
+    })}`
+  );
+
+  try {
+    const response = await dependencies.start(executionTimeoutMs);
+    const state = getDeploymentState(response);
+    const deploymentId = readDeploymentId(response, 'asynchronous submission')!;
+    if (state === 'terminal') {
+      throw new TerminalDeploymentFailure(response);
+    }
+    dependencies.log(
+      `metadata-deployment ${JSON.stringify({
+        action: 'start',
+        deploymentId,
+        event: 'submitted',
+        logicalAttempt,
+        step,
+      })}`
+    );
+    return {completed: state === 'succeeded', deploymentId};
+  } catch (error) {
+    if (
+      error instanceof MetadataDeploymentProtocolError ||
+      error instanceof TerminalDeploymentFailure
+    ) {
+      throw error;
+    }
+
+    getRemainingMs(dependencies, deadline, step, error);
+
+    const state = getDeploymentState(error);
+    if (state === 'terminal') {
+      readDeploymentId(error, 'asynchronous submission');
+      throw new TerminalDeploymentFailure(error);
+    }
+    const deploymentId = readDeploymentId(
+      error,
+      'asynchronous submission',
+      undefined,
+      state === 'active' || state === 'succeeded'
+    );
+    if (!deploymentId) {
+      throw new MetadataDeploymentSubmissionError(error);
+    }
+    dependencies.log(
+      `metadata-deployment ${JSON.stringify({
+        action: 'start',
+        deploymentId,
+        event: 'submitted',
+        logicalAttempt,
+        recoveredFromError: true,
+        step,
+      })}`
+    );
+    return {completed: state === 'succeeded', deploymentId};
+  }
+}
+
+async function resumeLogicalDeployment(
+  dependencies: MetadataDeploymentDependencies,
+  deadline: number,
+  deploymentId: string,
+  logicalAttempt: number,
+  policy: MetadataDeploymentPolicy,
+  step: string
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= policy.maxResumeAttempts; attempt++) {
+    const executionTimeoutMs = getRemainingMs(
+      dependencies,
+      deadline,
+      step,
+      lastError
+    );
+    dependencies.log(
+      `metadata-deployment ${JSON.stringify({
+        action: 'resume',
+        attempt,
+        deploymentId,
+        event: 'attempt',
+        logicalAttempt,
+        step,
+      })}`
+    );
+
+    try {
+      const response = await dependencies.resume(
+        deploymentId,
+        policy.waitMinutes,
+        executionTimeoutMs
+      );
+      readDeploymentId(response, 'resume', deploymentId);
+      const state = getDeploymentState(response);
+      if (state === 'succeeded') {
+        dependencies.log(
+          `metadata-deployment ${JSON.stringify({
+            action: 'resume',
+            deploymentId,
+            event: 'completed',
+            logicalAttempt,
+            step,
+          })}`
+        );
+        return;
+      }
+      if (state === 'terminal') {
+        throw new TerminalDeploymentFailure(response);
+      }
+      if (state !== 'active') {
+        throw new MetadataDeploymentProtocolError(
+          'The resume response has no recognized deployment status.',
+          response
+        );
+      }
+      lastError = response;
+    } catch (error) {
+      if (
+        error instanceof MetadataDeploymentProtocolError ||
+        error instanceof TerminalDeploymentFailure
+      ) {
+        throw error;
+      }
+
+      getRemainingMs(dependencies, deadline, step, error);
+
+      const state = getDeploymentState(error);
+      if (state === 'terminal') {
+        readDeploymentId(error, 'resume', deploymentId);
+        throw new TerminalDeploymentFailure(error);
+      }
+      if (state === 'active') {
+        readDeploymentId(error, 'resume', deploymentId);
+        lastError = error;
+      } else if (isTransientError(error)) {
+        readDeploymentId(error, 'resume', deploymentId, false);
+        lastError = error;
+        if (attempt < policy.maxResumeAttempts) {
+          dependencies.log(
+            `metadata-deployment ${JSON.stringify({
+              action: 'resume',
+              deploymentId,
+              event: 'transient-error',
+              logicalAttempt,
+              nextAction: 'resume',
+              step,
+            })}`
+          );
+          await sleepBeforeRetry(
+            dependencies,
+            deadline,
+            policy.retryDelayMs,
+            step,
+            error
+          );
+          continue;
+        }
+      } else {
+        readDeploymentId(error, 'resume', deploymentId);
+        throw error;
+      }
+    }
+
+    if (attempt >= policy.maxResumeAttempts) {
+      throw resumeExhaustedError(step, lastError);
+    }
+    dependencies.log(
+      `metadata-deployment ${JSON.stringify({
+        action: 'resume',
+        deploymentId,
+        event: 'active',
+        logicalAttempt,
+        nextAction: 'resume',
+        step,
+      })}`
+    );
+  }
+}
+
+export async function runMetadataDeployment({
+  dependencies,
+  isRetryableTerminalFailure = () => false,
+  maxLogicalAttempts = 1,
+  policy,
+  step,
+}: MetadataDeploymentOptions): Promise<void> {
+  validatePolicy(policy, maxLogicalAttempts);
+  const deadline = dependencies.now() + policy.overallTimeoutMs;
+
+  for (
+    let logicalAttempt = 1;
+    logicalAttempt <= maxLogicalAttempts;
+    logicalAttempt++
+  ) {
+    try {
+      const submission = await submitLogicalDeployment(
+        dependencies,
+        deadline,
+        logicalAttempt,
+        step
+      );
+      if (!submission.completed) {
+        await resumeLogicalDeployment(
+          dependencies,
+          deadline,
+          submission.deploymentId,
+          logicalAttempt,
+          policy,
+          step
+        );
+      }
+      return;
+    } catch (error) {
+      if (!(error instanceof TerminalDeploymentFailure)) {
+        throw error;
+      }
+      if (!isRetryableTerminalFailure(error.originalError)) {
+        throw error.originalError;
+      }
+      if (logicalAttempt >= maxLogicalAttempts) {
+        throw new MetadataDeploymentRetryError(
+          `The ${step} metadata deployment exhausted its readiness attempts.`,
+          error.originalError
+        );
+      }
+
+      dependencies.log(
+        `metadata-deployment ${JSON.stringify({
+          event: 'readiness-retry',
+          logicalAttempt,
+          nextLogicalAttempt: logicalAttempt + 1,
+          step,
+        })}`
+      );
+      await sleepBeforeRetry(
+        dependencies,
+        deadline,
+        policy.retryDelayMs,
+        step,
+        error.originalError
+      );
+    }
+  }
+}

--- a/packages/quantic/scripts/build/util/sfdx-commands.ts
+++ b/packages/quantic/scripts/build/util/sfdx-commands.ts
@@ -1,4 +1,4 @@
-import {sfdx, SfdxResponse} from './sfdx';
+import {isSalesforceDeploymentId, sfdx, SfdxResponse, sfCommand} from './sfdx';
 
 export interface SfdxOrg {
   alias?: string;
@@ -188,7 +188,9 @@ export async function deleteActiveScratchOrgs(
       deletedOrgUsernames.push(username);
     } catch (error) {
       console.warn(`Failed to delete organization ${username}`);
-      console.warn(error instanceof Error ? error.stack ?? error.message : String(error));
+      console.warn(
+        error instanceof Error ? (error.stack ?? error.message) : String(error)
+      );
     }
   }
 
@@ -270,30 +272,93 @@ export async function createCommunity(
 
 export interface DeploySourceArguments {
   alias: string;
+  executionTimeoutMs: number;
   packagePaths: string[];
 }
 
-export async function deploySource(args: DeploySourceArguments): Promise<void> {
-  const sourceDirs = args.packagePaths
-    .map((p) => `--source-dir "${p}"`)
-    .join(' ');
+export interface SfdxMetadataDeployResponse extends SfdxResponse {
+  result: {
+    details?: unknown;
+    done?: boolean;
+    id?: string;
+    status?: string;
+    success?: boolean;
+  };
+}
 
-  await sfdx(
-    `project deploy start --ignore-conflicts --target-org ${args.alias} ${sourceDirs}`
+export async function deploySource(
+  args: DeploySourceArguments
+): Promise<SfdxMetadataDeployResponse> {
+  return sfCommand<SfdxMetadataDeployResponse>(
+    [
+      'project',
+      'deploy',
+      'start',
+      '--async',
+      '--ignore-conflicts',
+      '--target-org',
+      args.alias,
+      ...args.packagePaths.flatMap((packagePath) => [
+        '--source-dir',
+        packagePath,
+      ]),
+    ],
+    args.executionTimeoutMs
   );
 }
 
 export interface DeployCommunityMetadataArguments {
   alias: string;
   communityMetadataPath: string;
-  timeout: number;
+  executionTimeoutMs: number;
 }
 
 export async function deployCommunityMetadata(
   args: DeployCommunityMetadataArguments
-): Promise<void> {
-  await sfdx(
-    `project deploy start --target-org ${args.alias} --ignore-conflicts --metadata-dir "${args.communityMetadataPath}" --wait ${args.timeout}`
+): Promise<SfdxMetadataDeployResponse> {
+  return sfCommand<SfdxMetadataDeployResponse>(
+    [
+      'project',
+      'deploy',
+      'start',
+      '--async',
+      '--target-org',
+      args.alias,
+      '--ignore-conflicts',
+      '--metadata-dir',
+      args.communityMetadataPath,
+    ],
+    args.executionTimeoutMs
+  );
+}
+
+export interface ResumeMetadataDeploymentArguments {
+  deploymentId: string;
+  executionTimeoutMs: number;
+  waitMinutes: number;
+}
+
+export async function resumeMetadataDeployment(
+  args: ResumeMetadataDeploymentArguments
+): Promise<SfdxMetadataDeployResponse> {
+  if (!isSalesforceDeploymentId(args.deploymentId)) {
+    throw new Error('The Salesforce metadata deployment ID is invalid.');
+  }
+  if (!Number.isInteger(args.waitMinutes) || args.waitMinutes < 1) {
+    throw new Error('The Salesforce metadata deployment wait is invalid.');
+  }
+
+  return sfCommand<SfdxMetadataDeployResponse>(
+    [
+      'project',
+      'deploy',
+      'resume',
+      '--job-id',
+      args.deploymentId,
+      '--wait',
+      String(args.waitMinutes),
+    ],
+    args.executionTimeoutMs
   );
 }
 

--- a/packages/quantic/scripts/build/util/sfdx.node-test.ts
+++ b/packages/quantic/scripts/build/util/sfdx.node-test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+import {
+  sfdx,
+  SfCommandExecutionTimeoutError,
+  SfCommandExecutorOptions,
+  sfCommand,
+} from './sfdx';
+
+describe('sfdx', () => {
+  it('rejects when command execution fails without stdout', async () => {
+    const executionError = new Error('spawn failed');
+
+    await assert.rejects(
+      sfdx('org list', (_command, callback) => {
+        callback(executionError, '', 'failure');
+      }),
+      (error) => error === executionError
+    );
+  });
+
+  it('rejects parsed Salesforce JSON when the command exits unsuccessfully', async () => {
+    const response = {result: {id: '0Af000000000001AAA'}, status: 69};
+
+    await assert.rejects(
+      sfdx('project deploy start', (_command, callback) => {
+        callback(new Error('exit 69'), JSON.stringify(response), '');
+      }),
+      (error) => {
+        assert.deepEqual(error, response);
+        return true;
+      }
+    );
+  });
+
+  it('passes fixed arguments and the exact timeout to child_process execution', async () => {
+    const response = {
+      result: {
+        done: false,
+        files: [],
+        id: '0Af000000000001AAA',
+        status: 'Queued',
+      },
+      status: 0,
+    };
+    let executable = '';
+    let args: readonly string[] = [];
+    let options: SfCommandExecutorOptions | undefined;
+
+    const result = await sfCommand(
+      ['project', 'deploy', 'start', '--async'],
+      321,
+      (receivedExecutable, receivedArgs, receivedOptions, callback) => {
+        executable = receivedExecutable;
+        args = receivedArgs;
+        options = receivedOptions;
+        callback(null, JSON.stringify(response), '');
+        return {kill: () => true};
+      }
+    );
+
+    assert.deepEqual(result, response);
+    assert.equal(executable, 'sf');
+    assert.deepEqual(args, ['project', 'deploy', 'start', '--async', '--json']);
+    assert.equal(options?.timeout, 321);
+  });
+
+  it('kills and rejects a never-settling child at the hard deadline', async () => {
+    let killedWith: NodeJS.Signals | number | undefined;
+
+    await assert.rejects(
+      sfCommand(['project', 'deploy', 'resume'], 10, () => ({
+        kill: (signal) => {
+          killedWith = signal;
+          return true;
+        },
+      })),
+      SfCommandExecutionTimeoutError
+    );
+
+    assert.equal(killedWith, 'SIGTERM');
+  });
+});

--- a/packages/quantic/scripts/build/util/sfdx.ts
+++ b/packages/quantic/scripts/build/util/sfdx.ts
@@ -1,55 +1,186 @@
-import {exec} from 'child_process';
+import {exec, execFile} from 'child_process';
+
+const MAX_BUFFER = 1024 * 1024 * 1.5;
+const SALESFORCE_DEPLOYMENT_ID = /^0Af[A-Za-z0-9]{12}(?:[A-Za-z0-9]{3})?$/;
+
+export type SfdxExecutor = (
+  command: string,
+  callback: (error: Error | null, stdout: string, stderr: string) => void
+) => void;
+
+const defaultExecutor: SfdxExecutor = (command, callback) => {
+  exec(
+    command,
+    {
+      cwd: process.cwd(),
+      env: process.env,
+      maxBuffer: MAX_BUFFER,
+    },
+    (error, stdout, stderr) => callback(error, stdout, stderr)
+  );
+};
+
+export interface SfCommandExecutorOptions {
+  cwd: string;
+  encoding: BufferEncoding;
+  env: NodeJS.ProcessEnv;
+  maxBuffer: number;
+  timeout: number;
+}
+
+export interface KillableProcess {
+  kill: (signal?: NodeJS.Signals | number) => boolean;
+}
+
+export type SfCommandExecutor = (
+  executable: string,
+  args: readonly string[],
+  options: SfCommandExecutorOptions,
+  callback: (error: Error | null, stdout: string, stderr: string) => void
+) => KillableProcess;
+
+const defaultSfCommandExecutor: SfCommandExecutor = (
+  executable,
+  args,
+  options,
+  callback
+) =>
+  execFile(executable, [...args], options, (error, stdout, stderr) =>
+    callback(error, stdout, stderr)
+  );
 
 function stripColor(str: string) {
   return str.replace(/\x1B[[(?);]{0,2}(;?\d)*./g, '');
 }
 
-/**
- * A response from a successful sfdx command.
- */
 export interface SfdxResponse {
   status: number;
   result: object;
 }
 
-/**
- * Executes the given sfdx function and returns the result as an object.
- * @param command The command to be executed.
- * @returns {SfdxResponse} The result of the command, if successful.
- * @throws {Error} The error thrown by the sfdx command if unsuccessful.
- */
-export function sfdx<T = SfdxResponse>(command: string): Promise<T> {
+export class SfCommandExecutionTimeoutError extends Error {
+  constructor(public readonly timeoutMs: number) {
+    super(`The Salesforce CLI process exceeded its ${timeoutMs}ms deadline.`);
+    this.name = 'SfCommandExecutionTimeoutError';
+    Object.setPrototypeOf(this, SfCommandExecutionTimeoutError.prototype);
+  }
+}
+
+export function isSalesforceDeploymentId(value: unknown): value is string {
+  return typeof value === 'string' && SALESFORCE_DEPLOYMENT_ID.test(value);
+}
+
+function parseSfdxOutput<T>(error: Error | null, stdout: string): T {
+  if (!stdout) {
+    throw error ?? new Error('The Salesforce CLI returned no JSON output.');
+  }
+
+  let jsonOutput: T;
+  try {
+    jsonOutput = JSON.parse(stripColor(stdout)) as T;
+  } catch (jsonError) {
+    throw error ?? jsonError;
+  }
+
+  if (error) {
+    throw jsonOutput;
+  }
+  return jsonOutput;
+}
+
+function isChildProcessTimeout(error: Error): boolean {
+  const processError = error as Error & {
+    code?: string;
+    killed?: boolean;
+    signal?: NodeJS.Signals;
+  };
+  return (
+    processError.code === 'ETIMEDOUT' ||
+    (processError.killed === true && processError.signal === 'SIGTERM')
+  );
+}
+
+export function sfdx<T = SfdxResponse>(
+  command: string,
+  executor: SfdxExecutor = defaultExecutor
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    exec(
-      `sf ${command} --json`,
-      {
-        cwd: process.cwd(),
-        env: process.env,
-        maxBuffer: 1024 * 1024 * 1.5,
-      },
-      (error, stdout) => {
-        let jsonOutput: unknown;
-        if (error) {
-          console.log('Error with sfdx command execution.');
-          console.error(error);
-        }
-        if (stdout) {
+    executor(`sf ${command} --json`, (error, stdout) => {
+      try {
+        resolve(parseSfdxOutput<T>(error, stdout));
+      } catch (outputError) {
+        reject(outputError);
+      }
+    });
+  });
+}
+
+export function sfCommand<T = SfdxResponse>(
+  args: readonly string[],
+  timeoutMs: number,
+  executor: SfCommandExecutor = defaultSfCommandExecutor
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return Promise.reject(
+      new SfCommandExecutionTimeoutError(Math.max(0, timeoutMs))
+    );
+  }
+
+  const processTimeoutMs = Math.max(1, Math.floor(timeoutMs));
+  return new Promise<T>((resolve, reject) => {
+    let child: KillableProcess | undefined;
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+
+    const settle = (action: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      action();
+    };
+
+    try {
+      child = executor(
+        'sf',
+        [...args, '--json'],
+        {
+          cwd: process.cwd(),
+          encoding: 'utf8',
+          env: process.env,
+          maxBuffer: MAX_BUFFER,
+          timeout: processTimeoutMs,
+        },
+        (error, stdout) => {
+          if (error && isChildProcessTimeout(error)) {
+            settle(() =>
+              reject(new SfCommandExecutionTimeoutError(processTimeoutMs))
+            );
+            return;
+          }
           try {
-            jsonOutput = JSON.parse(stripColor(stdout));
-            if (error) {
-              console.error({
-                sfdxErrorStdout: stdout,
-              });
-              reject(jsonOutput || error);
-            }
-            resolve(jsonOutput as T);
-          } catch (err) {
-            // The output is not JSON. The command most likely failed outside the SFDX CLI.
-            console.log(stdout);
-            reject(err);
+            const output = parseSfdxOutput<T>(error, stdout);
+            settle(() => resolve(output));
+          } catch (outputError) {
+            settle(() => reject(outputError));
           }
         }
-      }
-    );
+      );
+    } catch (error) {
+      settle(() => reject(error));
+      return;
+    }
+
+    if (!settled) {
+      timer = setTimeout(() => {
+        child?.kill('SIGTERM');
+        settle(() =>
+          reject(new SfCommandExecutionTimeoutError(processTimeoutMs))
+        );
+      }, processTimeoutMs);
+    }
   });
 }

--- a/packages/quantic/scripts/build/util/telemetry.ts
+++ b/packages/quantic/scripts/build/util/telemetry.ts
@@ -1,0 +1,49 @@
+export const DEPLOYMENT_TELEMETRY_PREFIX = 'QUANTIC_DEPLOY_TELEMETRY ';
+
+export type DeploymentStep =
+  | 'authorization'
+  | 'availability_checks'
+  | 'community_creation'
+  | 'community_metadata_deployment'
+  | 'old_org_deletion'
+  | 'publication'
+  | 'scratch_org_creation'
+  | 'source_deployment';
+
+export class DeploymentTelemetry {
+  constructor(
+    private readonly writeLine: (line: string) => void = console.log,
+    private readonly now: () => number = Date.now
+  ) {}
+
+  public async measure<T>(
+    step: DeploymentStep,
+    action: () => Promise<T>
+  ): Promise<T> {
+    const startedAt = this.now();
+    try {
+      const result = await action();
+      this.writeDuration(step, 'success', startedAt);
+      return result;
+    } catch (error) {
+      this.writeDuration(step, 'failure', startedAt);
+      throw error;
+    }
+  }
+
+  private writeDuration(
+    step: DeploymentStep,
+    status: 'failure' | 'success',
+    startedAt: number
+  ) {
+    this.writeLine(
+      `${DEPLOYMENT_TELEMETRY_PREFIX}${JSON.stringify({
+        durationMs: Math.max(0, this.now() - startedAt),
+        event: 'step_duration',
+        status,
+        step,
+        version: 1,
+      })}`
+    );
+  }
+}

--- a/packages/quantic/turbo.json
+++ b/packages/quantic/turbo.json
@@ -33,7 +33,15 @@
     },
     "test": {
       "outputs": [],
-      "dependsOn": ["test:unit", "validate:types", "validate:types:build-scripts"]
+      "dependsOn": [
+        "test:build-scripts",
+        "test:unit",
+        "validate:types",
+        "validate:types:build-scripts"
+      ]
+    },
+    "test:build-scripts": {
+      "outputs": []
     },
     "test:unit": {
       "dependsOn": ["build"],


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6132

## Motivation

A timed-out Salesforce CLI wait could leave deployment completion ambiguous and encourage unsafe resubmission. Deployment polling needs to resume one validated job ID within a hard overall deadline.

## Changes

- Start each logical metadata deployment asynchronously once and resume only its validated `0Af...` job ID.
- Fail closed on ambiguous submissions and terminal failures, with bounded retries only for exact Experience Cloud readiness failures.
- Enforce subprocess deadlines, preserve primary errors during cleanup, and emit secret-free phase timing events.
- Add build-script tests and Turbo wiring for the deployment contract.

## Validation

- [x] `pnpm run lint:fix`
- [x] Build-script tests (24/24)
- [x] Build-script TypeScript validation
- [x] Quantic aggregate tests and lint
- [ ] Secret-backed two-LWS Quantic PR CI and real timeout log evidence

## Checklist

- [x] PR title follows Conventional Commits 1.0.0
- [x] Added a patch changeset for `@coveo/quantic`