### PR TITLE
feat(ci): isolate Headless output for Quantic E2E

### DIFF
--- a/.changeset/calm-taxis-build.md
+++ b/.changeset/calm-taxis-build.md
@@ -1,0 +1,6 @@
+---
+"@coveo/headless": patch
+"@coveo/quantic": patch
+---
+
+Separate the Headless build output embedded in Quantic from unrelated Headless build artifacts and verify its integrity before consumption.

--- a/packages/headless/.gitignore
+++ b/packages/headless/.gitignore
@@ -1,5 +1,6 @@
 docs/js
 temp/
+.tmp/
 doc-parser/build
 
 src/external-builds

--- a/packages/headless/esbuild.mjs
+++ b/packages/headless/esbuild.mjs
@@ -20,7 +20,16 @@ const buildConfig = JSON.parse(readFileSync(buildConfigPath, 'utf-8'));
 const {useCaseEntries, quanticUseCaseEntries} = buildConfig;
 
 const require = createRequire(import.meta.url);
-const devMode = process.argv[2] === 'dev';
+const buildMode = process.argv[2];
+const devMode = buildMode === 'dev';
+const quanticMode = buildMode === 'quantic';
+const quanticOutputRoot = quanticMode ? '.tmp/quantic/bundles' : 'dist/quantic';
+const quanticStaticResourceUseCases = new Set([
+  'search',
+  'recommendation',
+  'case-assist',
+  'insight',
+]);
 
 const isNightly = process.env.IS_NIGHTLY === 'true';
 const commitSha = process.env.CDN_COMMIT_SHA;
@@ -85,7 +94,7 @@ const base = {
   banner: {js: apacheLicense()},
 };
 
-const browserEsm = Object.entries(useCaseEntries).map((entry) => {
+const browserEsm = Object.entries(useCaseEntries).map((entry) => () => {
   const [useCase, entryPoint] = entry;
   const outDir = getUseCaseDir('cdn', useCase);
   // ⚠️  Changing this filename affects CDN pointer files in ui-kit-cd.
@@ -111,7 +120,7 @@ const browserEsm = Object.entries(useCaseEntries).map((entry) => {
   return buildBrowserConfig(config, outDir);
 });
 
-const browserUmd = Object.entries(useCaseEntries).map((entry) => {
+const browserUmd = Object.entries(useCaseEntries).map((entry) => () => {
   const [useCase, entryPoint] = entry;
   const outDir = getUseCaseDir('cdn', useCase);
   const outfile = `${outDir}/headless.js`;
@@ -151,15 +160,17 @@ const codeReplacerPlugin = (filePath, target, replacement) => ({
   },
 });
 
-const quanticUmd = Object.entries(quanticUseCaseEntries).map((entry) => {
-  const [useCase, entryPoint] = entry;
-  const outDir = getUseCaseDir('dist/quantic/', useCase);
-  const outfile = `${outDir}/headless.js`;
-  const globalName = getUmdGlobalName(useCase);
+const quanticUmd = Object.entries(quanticUseCaseEntries)
+  .filter(([useCase]) => !quanticMode || quanticStaticResourceUseCases.has(useCase))
+  .map((entry) => () => {
+    const [useCase, entryPoint] = entry;
+    const outDir = getUseCaseDir(quanticOutputRoot, useCase);
+    const outfile = `${outDir}/headless.js`;
+    const globalName = getUmdGlobalName(useCase);
 
-  const target = /}\)\(updatedArgs, api, extraOptions\);/g;
+    const target = /}\)\(updatedArgs, api, extraOptions\);/g;
 
-  const replacement = `
+    const replacement = `
   fetchFn: async (request: Request | String) => {
     if (request instanceof String) {
       throw new Error("The provided 'request' must be a Request object.");
@@ -189,28 +200,29 @@ const quanticUmd = Object.entries(quanticUseCaseEntries).map((entry) => {
 })(updatedArgs,{...api, signal: null},extraOptions);
 `;
 
-  return buildBrowserConfig(
-    {
-      entryPoints: [entryPoint],
-      outfile,
-      format: 'cjs',
-      banner: {
-        js: `${base.banner.js}`,
+    return buildBrowserConfig(
+      {
+        entryPoints: [entryPoint],
+        outfile,
+        format: 'cjs',
+        ...(quanticMode ? {metafile: false, sourcemap: false} : {}),
+        banner: {
+          js: `${base.banner.js}`,
+        },
+        inject: [
+          'ponyfills/headers-shim.js',
+          'ponyfills/global-this-shim.js',
+          'ponyfills/abortable-fetch-shim.js',
+          require.resolve('navigator.sendbeacon/dist/navigator.sendbeacon.cjs.js'),
+        ],
+        plugins: [
+          umdWrapper({libraryName: globalName}),
+          codeReplacerPlugin('src/api/knowledge/answer-slice.ts', target, replacement),
+        ],
       },
-      inject: [
-        'ponyfills/headers-shim.js',
-        'ponyfills/global-this-shim.js',
-        'ponyfills/abortable-fetch-shim.js',
-        require.resolve('navigator.sendbeacon/dist/navigator.sendbeacon.cjs.js'),
-      ],
-      plugins: [
-        umdWrapper({libraryName: globalName}),
-        codeReplacerPlugin('src/api/knowledge/answer-slice.ts', target, replacement),
-      ],
-    },
-    outDir
-  );
-});
+      outDir
+    );
+  });
 
 /**
  * @param {string} moduleName
@@ -271,11 +283,13 @@ async function buildBrowserConfig(options, outDir) {
       ...(options.plugins || []),
     ],
   });
-  outputMetafile(`browser.${options.format}`, outDir, out.metafile);
+  if (out.metafile) {
+    outputMetafile(`browser.${options.format}`, outDir, out.metafile);
+  }
   return out;
 }
 
-const nodeCjs = Object.entries(useCaseEntries).map((entry) => {
+const nodeCjs = Object.entries(useCaseEntries).map((entry) => () => {
   const [useCase, entryPoint] = entry;
   const dir = getUseCaseDir('dist/cjs', useCase);
   const outfile = `${dir}/headless.cjs`;
@@ -319,7 +333,10 @@ function outputMetafile(platform, outDir, metafile) {
 }
 
 async function main() {
-  await Promise.all([...browserEsm, ...browserUmd, ...nodeCjs, ...quanticUmd]);
+  const builds = quanticMode
+    ? quanticUmd
+    : [...browserEsm, ...browserUmd, ...nodeCjs, ...quanticUmd];
+  await Promise.all(builds.map((runBuild) => runBuild()));
 }
 
 main();

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -77,6 +77,7 @@
     "publint": "publint",
     "dev": "concurrently \"pnpm run build:definitions -w\" \"pnpm run build:bundles dev\"",
     "build": "pnpm run build:definitions && pnpm run build:bundles && pnpm run build:esm",
+    "build:quantic": "node ../../utils/ci/rm-rf.mjs .tmp/quantic && tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir .tmp/quantic/definitions && node esbuild.mjs quantic && node scripts/write-quantic-manifest.mjs",
     "build:bundles": "node esbuild.mjs",
     "build:esm": "node ./scripts/build.mjs --config=tsconfig.build-esm.json",
     "build:definitions": "tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir dist/definitions",

--- a/packages/headless/scripts/write-quantic-manifest.mjs
+++ b/packages/headless/scripts/write-quantic-manifest.mjs
@@ -1,0 +1,92 @@
+import {createHash} from 'node:crypto';
+import {readFileSync, readdirSync, writeFileSync} from 'node:fs';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const outputRoot = resolve(packageRoot, '.tmp/quantic');
+const bundleRoot = resolve(outputRoot, 'bundles');
+const definitionsRoot = resolve(outputRoot, 'definitions');
+const manifestPath = resolve(outputRoot, 'manifest.json');
+const expectedBundlePaths = [
+  'headless.js',
+  'case-assist/headless.js',
+  'insight/headless.js',
+  'recommendation/headless.js',
+];
+const expectedDefinitionEntryPaths = [
+  'index.d.ts',
+  'case-assist.index.d.ts',
+  'insight.index.d.ts',
+  'recommendation.index.d.ts',
+];
+
+function compareNames({name: first}, {name: second}) {
+  return first < second ? -1 : first > second ? 1 : 0;
+}
+
+function listFiles(root) {
+  const files = [];
+
+  function visit(directory, prefix) {
+    for (const entry of readdirSync(directory, {withFileTypes: true}).sort(compareNames)) {
+      const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+      const absolutePath = join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        visit(absolutePath, relativePath);
+      } else if (entry.isFile()) {
+        files.push(relativePath);
+      } else {
+        throw new Error(`Unsupported Headless Quantic output: ${absolutePath}`);
+      }
+    }
+  }
+
+  visit(root, '');
+  return files;
+}
+
+function assertExactPaths(actual, expected, outputName) {
+  const sortedActual = [...actual].sort();
+  const sortedExpected = [...expected].sort();
+  if (JSON.stringify(sortedActual) !== JSON.stringify(sortedExpected)) {
+    throw new Error(
+      `Unexpected Headless Quantic ${outputName}. Expected ${sortedExpected.join(', ')}; received ${sortedActual.join(', ')}`
+    );
+  }
+}
+
+const bundlePaths = listFiles(bundleRoot);
+assertExactPaths(bundlePaths, expectedBundlePaths, 'runtime bundles');
+
+const definitionPaths = listFiles(definitionsRoot);
+const unexpectedDefinitionPaths = definitionPaths.filter((filePath) => !filePath.endsWith('.d.ts'));
+if (unexpectedDefinitionPaths.length) {
+  throw new Error(
+    `Unexpected Headless Quantic definition outputs: ${unexpectedDefinitionPaths.join(', ')}`
+  );
+}
+for (const entryPath of expectedDefinitionEntryPaths) {
+  if (!definitionPaths.includes(entryPath)) {
+    throw new Error(`Missing Headless Quantic definition entrypoint: ${entryPath}`);
+  }
+}
+
+const manifestedPaths = [
+  ...bundlePaths.map((filePath) => `bundles/${filePath}`),
+  ...definitionPaths.map((filePath) => `definitions/${filePath}`),
+].sort();
+const outputPaths = listFiles(outputRoot).filter((filePath) => filePath !== 'manifest.json');
+assertExactPaths(outputPaths, manifestedPaths, 'manifested output files');
+
+const files = manifestedPaths.map((filePath) => {
+  const contents = readFileSync(resolve(outputRoot, ...filePath.split('/')));
+  return {
+    path: filePath,
+    size: contents.byteLength,
+    sha256: createHash('sha256').update(contents).digest('hex'),
+  };
+});
+
+writeFileSync(manifestPath, `${JSON.stringify({schemaVersion: 1, files}, null, 2)}\n`);

--- a/packages/headless/turbo.json
+++ b/packages/headless/turbo.json
@@ -1,0 +1,24 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build:quantic": {
+      "dependsOn": ["@coveo/bueno#build", "@coveo/relay#build", "coveo.analytics#build"],
+      "inputs": [
+        "$TURBO_ROOT$/scripts/esbuild/**",
+        "$TURBO_ROOT$/scripts/license/apache.mjs",
+        "$TURBO_ROOT$/utils/ci/rm-rf.mjs",
+        "build.config.json",
+        "esbuild.mjs",
+        "package.json",
+        "ponyfills/**",
+        "scripts/write-quantic-manifest.mjs",
+        "src/**",
+        "tsconfig.json",
+        "!src/**/*.spec.*",
+        "!src/**/*.test.*",
+        "!src/**/__tests__/**"
+      ],
+      "outputs": [".tmp/quantic/**"]
+    }
+  }
+}

--- a/packages/quantic/build-static-resources.js
+++ b/packages/quantic/build-static-resources.js
@@ -1,5 +1,8 @@
 const fs = require('fs/promises');
 const path = require('path');
+const {
+  resolveHeadlessDefinitionsPath,
+} = require('./scripts/npm/headless-build-output');
 
 const STATIC_RESOURCES_PATH = './force-app/main/default/staticresources';
 const SOLUTION_EXAMPLES_STATIC_RESOURCES_PATH =
@@ -79,7 +82,7 @@ const LIBRARY_CONFIG = {
         dest: `${STATIC_RESOURCES_PATH}/coveoheadless/recommendation/headless.js`,
       },
       {
-        src: resolveLibraryPath('@coveo/headless', '../../dist/definitions'),
+        src: resolveHeadlessDefinitionsPath(),
         dest: `${STATIC_RESOURCES_PATH}/coveoheadless/definitions`,
       },
     ],

--- a/packages/quantic/package.json
+++ b/packages/quantic/package.json
@@ -58,7 +58,7 @@
     "promote:sfdx:ci": "pnpm run publish:sfdx -- --promote --ci",
     "preinstall": "node scripts/npm/check-sfdx-project.js",
     "postinstall": "node scripts/npm/setup-quantic.js",
-    "babel:headless": "babel ./node_modules/@coveo/headless/dist/quantic --delete-dir-on-start --out-dir .tmp/quantic-compiled --extensions .js --minified"
+    "babel:headless": "node scripts/npm/babel-headless.js"
   },
   "dependencies": {
     "@coveo/bueno": "workspace:*",

--- a/packages/quantic/scripts/npm/babel-headless.js
+++ b/packages/quantic/scripts/npm/babel-headless.js
@@ -1,0 +1,24 @@
+const {execFileSync} = require('node:child_process');
+const path = require('node:path');
+const {resolveHeadlessBundlesPath} = require('./headless-build-output');
+
+const source = resolveHeadlessBundlesPath();
+const babelPackageRoot = path.dirname(
+  require.resolve('@babel/cli/package.json')
+);
+const babelCli = path.join(babelPackageRoot, 'bin/babel.js');
+
+execFileSync(
+  process.execPath,
+  [
+    babelCli,
+    source,
+    '--delete-dir-on-start',
+    '--out-dir',
+    '.tmp/quantic-compiled',
+    '--extensions',
+    '.js',
+    '--minified',
+  ],
+  {stdio: 'inherit'}
+);

--- a/packages/quantic/scripts/npm/headless-build-output.js
+++ b/packages/quantic/scripts/npm/headless-build-output.js
@@ -1,0 +1,452 @@
+const {createHash} = require('node:crypto');
+const {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+} = require('node:fs');
+const path = require('node:path');
+
+const headlessQuanticManifestSchemaVersion = 1;
+
+const expectedHeadlessBundlePaths = Object.freeze([
+  'headless.js',
+  'case-assist/headless.js',
+  'insight/headless.js',
+  'recommendation/headless.js',
+]);
+
+const expectedHeadlessDefinitionPaths = Object.freeze([
+  'index.d.ts',
+  'case-assist.index.d.ts',
+  'insight.index.d.ts',
+  'recommendation.index.d.ts',
+]);
+
+function isDirectory(filePath) {
+  try {
+    return statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isFile(filePath) {
+  try {
+    return statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function assertCompleteOutput(root, expectedPaths, outputName) {
+  if (!isDirectory(root)) {
+    throw new Error(
+      `Headless ${outputName} output directory is missing: ${root}`
+    );
+  }
+
+  const missingPaths = expectedPaths.filter(
+    (relativePath) => !isFile(path.join(root, relativePath))
+  );
+  if (missingPaths.length) {
+    throw new Error(
+      `Headless ${outputName} output is incomplete at ${root}. Missing: ${missingPaths.join(', ')}`
+    );
+  }
+
+  return root;
+}
+
+function compareNames({name: first}, {name: second}) {
+  return first < second ? -1 : first > second ? 1 : 0;
+}
+
+function manifestError(manifestPath, message) {
+  return new Error(
+    `Invalid Headless Quantic output manifest at ${manifestPath}: ${message}`
+  );
+}
+
+function readPathStat(filePath, pathName, manifestPath) {
+  try {
+    return lstatSync(filePath);
+  } catch {
+    throw manifestError(manifestPath, `${pathName} is missing: ${filePath}`);
+  }
+}
+
+function assertDedicatedDirectory(directoryPath, directoryName, manifestPath) {
+  const directoryStat = readPathStat(
+    directoryPath,
+    directoryName,
+    manifestPath
+  );
+  if (directoryStat.isSymbolicLink()) {
+    throw manifestError(
+      manifestPath,
+      `${directoryName} cannot be a symbolic link`
+    );
+  }
+  if (!directoryStat.isDirectory()) {
+    throw manifestError(manifestPath, `${directoryName} must be a directory`);
+  }
+}
+
+function assertDedicatedFile(filePath, fileName, manifestPath) {
+  const fileStat = readPathStat(filePath, fileName, manifestPath);
+  if (fileStat.isSymbolicLink()) {
+    throw manifestError(manifestPath, `${fileName} cannot be a symbolic link`);
+  }
+  if (!fileStat.isFile()) {
+    throw manifestError(manifestPath, `${fileName} must be a regular file`);
+  }
+}
+
+function listFiles(root, outputName, manifestPath) {
+  const files = [];
+  function visit(directory, prefix) {
+    for (const entry of readdirSync(directory, {withFileTypes: true}).sort(
+      compareNames
+    )) {
+      const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+      const absolutePath = path.join(directory, entry.name);
+      const entryStat = readPathStat(
+        absolutePath,
+        `${outputName} path`,
+        manifestPath
+      );
+
+      if (entryStat.isSymbolicLink()) {
+        throw manifestError(
+          manifestPath,
+          `${outputName} cannot contain symbolic links: ${relativePath}`
+        );
+      } else if (entryStat.isDirectory()) {
+        visit(absolutePath, relativePath);
+      } else if (entryStat.isFile()) {
+        files.push(relativePath);
+      } else {
+        throw manifestError(
+          manifestPath,
+          `${outputName} contains an unsupported path: ${relativePath}`
+        );
+      }
+    }
+  }
+
+  visit(root, '');
+  return files;
+}
+
+function assertExactKeys(value, expectedKeys, valueName, manifestPath) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw manifestError(manifestPath, `${valueName} must be an object`);
+  }
+
+  const keys = Object.keys(value).sort();
+  if (JSON.stringify(keys) !== JSON.stringify([...expectedKeys].sort())) {
+    throw manifestError(
+      manifestPath,
+      `${valueName} must contain exactly: ${expectedKeys.join(', ')}`
+    );
+  }
+}
+
+function assertInsideRoot(root, candidate, manifestPath, filePath) {
+  const relativePath = path.relative(root, candidate);
+  if (
+    relativePath === '' ||
+    relativePath === '..' ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  ) {
+    throw manifestError(
+      manifestPath,
+      `file path escapes the dedicated root: ${filePath}`
+    );
+  }
+}
+
+function assertExactPaths(actual, expected, outputName, manifestPath) {
+  const sortedActual = [...actual].sort();
+  const sortedExpected = [...expected].sort();
+  if (JSON.stringify(sortedActual) !== JSON.stringify(sortedExpected)) {
+    throw manifestError(
+      manifestPath,
+      `${outputName} must be exactly: ${sortedExpected.join(', ')}`
+    );
+  }
+}
+
+function readManifest(manifestPath) {
+  let manifestContents;
+  try {
+    manifestContents = readFileSync(manifestPath, 'utf8');
+  } catch {
+    throw manifestError(manifestPath, 'manifest file is missing or unreadable');
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestContents);
+  } catch {
+    throw manifestError(manifestPath, 'manifest must be valid JSON');
+  }
+
+  assertExactKeys(
+    manifest,
+    ['schemaVersion', 'files'],
+    'manifest',
+    manifestPath
+  );
+  if (manifest.schemaVersion !== headlessQuanticManifestSchemaVersion) {
+    throw manifestError(
+      manifestPath,
+      `schemaVersion must be ${headlessQuanticManifestSchemaVersion}`
+    );
+  }
+  if (!Array.isArray(manifest.files) || manifest.files.length === 0) {
+    throw manifestError(manifestPath, 'files must be a non-empty array');
+  }
+
+  const filePaths = [];
+  for (const [index, file] of manifest.files.entries()) {
+    assertExactKeys(
+      file,
+      ['path', 'size', 'sha256'],
+      `files[${index}]`,
+      manifestPath
+    );
+    if (
+      typeof file.path !== 'string' ||
+      file.path === '' ||
+      file.path.includes('\\') ||
+      path.posix.isAbsolute(file.path) ||
+      file.path === '..' ||
+      file.path.startsWith('../') ||
+      path.posix.normalize(file.path) !== file.path
+    ) {
+      throw manifestError(
+        manifestPath,
+        `files[${index}].path must be a safe relative path`
+      );
+    }
+    if (!Number.isSafeInteger(file.size) || file.size < 0) {
+      throw manifestError(
+        manifestPath,
+        `files[${index}].size must be a non-negative integer`
+      );
+    }
+    if (
+      typeof file.sha256 !== 'string' ||
+      !/^[a-f0-9]{64}$/.test(file.sha256)
+    ) {
+      throw manifestError(
+        manifestPath,
+        `files[${index}].sha256 must be a SHA-256 digest`
+      );
+    }
+    filePaths.push(file.path);
+  }
+
+  for (let index = 1; index < filePaths.length; index++) {
+    if (filePaths[index - 1] >= filePaths[index]) {
+      throw manifestError(manifestPath, 'files must be sorted by unique path');
+    }
+  }
+
+  return manifest;
+}
+
+function validateDedicatedOutput(packageRoot) {
+  const outputRoot = path.join(packageRoot, '.tmp/quantic');
+  const bundleRoot = path.join(outputRoot, 'bundles');
+  const definitionsRoot = path.join(outputRoot, 'definitions');
+  const manifestPath = path.join(outputRoot, 'manifest.json');
+  assertDedicatedDirectory(outputRoot, 'dedicated output root', manifestPath);
+  assertDedicatedDirectory(bundleRoot, 'bundle root', manifestPath);
+  assertDedicatedDirectory(definitionsRoot, 'definition root', manifestPath);
+  assertDedicatedFile(manifestPath, 'manifest', manifestPath);
+  const actualOutputPaths = listFiles(
+    outputRoot,
+    'dedicated output',
+    manifestPath
+  );
+  const resolvedOutputRoot = path.resolve(outputRoot);
+  const realOutputRoot = realpathSync(outputRoot);
+  assertInsideRoot(
+    realOutputRoot,
+    realpathSync(bundleRoot),
+    manifestPath,
+    'bundles/'
+  );
+  assertInsideRoot(
+    realOutputRoot,
+    realpathSync(definitionsRoot),
+    manifestPath,
+    'definitions/'
+  );
+  assertInsideRoot(
+    realOutputRoot,
+    realpathSync(manifestPath),
+    manifestPath,
+    'manifest.json'
+  );
+
+  const manifest = readManifest(manifestPath);
+  const expectedBundleManifestPaths = expectedHeadlessBundlePaths.map(
+    (filePath) => `bundles/${filePath}`
+  );
+  const expectedDefinitionManifestPaths = expectedHeadlessDefinitionPaths.map(
+    (filePath) => `definitions/${filePath}`
+  );
+  const bundleManifestPaths = manifest.files
+    .map(({path: filePath}) => filePath)
+    .filter((filePath) => filePath.startsWith('bundles/'));
+  const definitionManifestPaths = manifest.files
+    .map(({path: filePath}) => filePath)
+    .filter((filePath) => filePath.startsWith('definitions/'));
+
+  if (
+    bundleManifestPaths.length + definitionManifestPaths.length !==
+    manifest.files.length
+  ) {
+    throw manifestError(
+      manifestPath,
+      'files must be under bundles/ or definitions/'
+    );
+  }
+  assertExactPaths(
+    bundleManifestPaths,
+    expectedBundleManifestPaths,
+    'runtime bundle paths',
+    manifestPath
+  );
+  if (
+    definitionManifestPaths.length === 0 ||
+    definitionManifestPaths.some((filePath) => !filePath.endsWith('.d.ts'))
+  ) {
+    throw manifestError(
+      manifestPath,
+      'definitions must contain only .d.ts files'
+    );
+  }
+  for (const entryPath of expectedDefinitionManifestPaths) {
+    if (!definitionManifestPaths.includes(entryPath)) {
+      throw manifestError(
+        manifestPath,
+        `missing definition entrypoint: ${entryPath}`
+      );
+    }
+  }
+
+  for (const file of manifest.files) {
+    const absolutePath = path.resolve(outputRoot, ...file.path.split('/'));
+    assertInsideRoot(resolvedOutputRoot, absolutePath, manifestPath, file.path);
+
+    let fileStat;
+    try {
+      fileStat = lstatSync(absolutePath);
+    } catch {
+      throw manifestError(
+        manifestPath,
+        `manifested file is missing: ${file.path}`
+      );
+    }
+    if (fileStat.isSymbolicLink()) {
+      throw manifestError(
+        manifestPath,
+        `manifested file cannot be a symbolic link: ${file.path}`
+      );
+    }
+    if (!fileStat.isFile()) {
+      throw manifestError(
+        manifestPath,
+        `manifested path is not a regular file: ${file.path}`
+      );
+    }
+    assertInsideRoot(
+      realOutputRoot,
+      realpathSync(absolutePath),
+      manifestPath,
+      file.path
+    );
+
+    const contents = readFileSync(absolutePath);
+    if (contents.byteLength !== file.size) {
+      throw manifestError(manifestPath, `size mismatch for ${file.path}`);
+    }
+    const digest = createHash('sha256').update(contents).digest('hex');
+    if (digest !== file.sha256) {
+      throw manifestError(manifestPath, `SHA-256 mismatch for ${file.path}`);
+    }
+  }
+
+  const actualBundlePaths = actualOutputPaths
+    .filter((filePath) => filePath.startsWith('bundles/'))
+    .map((filePath) => filePath.slice('bundles/'.length));
+  assertExactPaths(
+    actualBundlePaths,
+    expectedHeadlessBundlePaths,
+    'runtime bundle tree',
+    manifestPath
+  );
+  assertExactPaths(
+    actualOutputPaths.filter((filePath) => filePath.startsWith('definitions/')),
+    definitionManifestPaths,
+    'definition paths',
+    manifestPath
+  );
+  assertExactPaths(
+    actualOutputPaths,
+    [...manifest.files.map(({path: filePath}) => filePath), 'manifest.json'],
+    'dedicated output paths',
+    manifestPath
+  );
+
+  return {bundleRoot, definitionsRoot};
+}
+
+function resolveHeadlessPackageRoot() {
+  return path.dirname(require.resolve('@coveo/headless/package.json'));
+}
+
+function resolveHeadlessBundlesPath({
+  packageRoot = resolveHeadlessPackageRoot(),
+  turboHash = process.env.TURBO_HASH,
+} = {}) {
+  if (turboHash) {
+    return validateDedicatedOutput(packageRoot).bundleRoot;
+  }
+
+  return assertCompleteOutput(
+    path.join(packageRoot, 'dist/quantic'),
+    expectedHeadlessBundlePaths,
+    'bundle'
+  );
+}
+
+function resolveHeadlessDefinitionsPath({
+  packageRoot = resolveHeadlessPackageRoot(),
+  turboHash = process.env.TURBO_HASH,
+} = {}) {
+  if (turboHash) {
+    return validateDedicatedOutput(packageRoot).definitionsRoot;
+  }
+
+  return assertCompleteOutput(
+    path.join(packageRoot, 'dist/definitions'),
+    expectedHeadlessDefinitionPaths,
+    'definition'
+  );
+}
+
+module.exports = {
+  expectedHeadlessBundlePaths,
+  expectedHeadlessDefinitionPaths,
+  headlessQuanticManifestSchemaVersion,
+  resolveHeadlessBundlesPath,
+  resolveHeadlessDefinitionsPath,
+};

--- a/packages/quantic/turbo.json
+++ b/packages/quantic/turbo.json
@@ -6,7 +6,7 @@
       "outputs": []
     },
     "build:staticresources": {
-      "dependsOn": ["^build", "babel:headless"],
+      "dependsOn": ["@coveo/bueno#build", "babel:headless", "coveo.analytics#build"],
       "outputs": [
         "force-app/main/default/staticresources/coveobueno/**",
         "force-app/main/default/staticresources/coveoheadless/**",
@@ -20,7 +20,7 @@
       "outputs": ["docs/out/**"]
     },
     "babel:headless": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["@coveo/headless#build:quantic"],
       "outputs": [".tmp/quantic-compiled/**"]
     },
     "promote:sfdx": {
@@ -73,9 +73,17 @@
       "cache": false
     },
     "validate:e2e-task-contracts": {
+      "dependsOn": ["@coveo/headless#build:quantic"],
       "inputs": [
+        "build-static-resources.js",
         "package.json",
+        "scripts/npm/babel-headless.js",
+        "scripts/npm/headless-build-output.js",
         "turbo.json",
+        "$TURBO_ROOT$/packages/headless/esbuild.mjs",
+        "$TURBO_ROOT$/packages/headless/package.json",
+        "$TURBO_ROOT$/packages/headless/scripts/write-quantic-manifest.mjs",
+        "$TURBO_ROOT$/packages/headless/turbo.json",
         "$TURBO_ROOT$/scripts/ci/validate-quantic-e2e-contracts.test.mjs"
       ],
       "outputs": [],

--- a/scripts/ci/validate-quantic-e2e-contracts.test.mjs
+++ b/scripts/ci/validate-quantic-e2e-contracts.test.mjs
@@ -1,12 +1,29 @@
 import assert from 'node:assert/strict';
-import {readFileSync} from 'node:fs';
-import {dirname, resolve} from 'node:path';
+import {execFileSync} from 'node:child_process';
+import {createHash} from 'node:crypto';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import {createRequire} from 'node:module';
+import {tmpdir} from 'node:os';
+import {dirname, join, resolve} from 'node:path';
 import test from 'node:test';
 import {fileURLToPath} from 'node:url';
 import {parse} from 'yaml';
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const read = (path) => readFileSync(resolve(repositoryRoot, path), 'utf8');
+const headlessPackage = JSON.parse(read('packages/headless/package.json'));
+const headlessTurbo = JSON.parse(read('packages/headless/turbo.json'));
 const quanticPackage = JSON.parse(read('packages/quantic/package.json'));
 const quanticTurbo = JSON.parse(read('packages/quantic/turbo.json'));
 const ciWorkflow = parse(read('.github/workflows/ci.yml'));
@@ -14,6 +31,28 @@ const e2eWorkflow = parse(read('.github/workflows/e2e-quantic.yml'));
 const e2eSetupAction = parse(read('.github/actions/e2e-quantic-setup/action.yml'));
 const playwrightConfig = read('packages/quantic/playwright.config.ts');
 const playwrightAction = parse(read('.github/actions/playwright-quantic/action.yml'));
+const turboBinary = resolve(repositoryRoot, 'node_modules/.bin/turbo');
+const require = createRequire(import.meta.url);
+const {
+  expectedHeadlessBundlePaths,
+  expectedHeadlessDefinitionPaths,
+  headlessQuanticManifestSchemaVersion,
+  resolveHeadlessBundlesPath,
+  resolveHeadlessDefinitionsPath,
+} = require(resolve(repositoryRoot, 'packages/quantic/scripts/npm/headless-build-output.js'));
+const affectednessContractPaths = [
+  'packages/headless/.gitignore',
+  'packages/headless/esbuild.mjs',
+  'packages/headless/package.json',
+  'packages/headless/scripts/write-quantic-manifest.mjs',
+  'packages/headless/turbo.json',
+  'packages/quantic/build-static-resources.js',
+  'packages/quantic/package.json',
+  'packages/quantic/scripts/npm/babel-headless.js',
+  'packages/quantic/scripts/npm/headless-build-output.js',
+  'packages/quantic/turbo.json',
+  'scripts/ci/validate-quantic-e2e-contracts.test.mjs',
+];
 
 const playwrightOutputs = ['playwright-report/**', 'blob-report/**', 'test-results/**'];
 
@@ -49,6 +88,35 @@ test('defines separate Quantic E2E task contracts', () => {
   assert.deepEqual(quanticTurbo.tasks['e2e:playwright'].inputs, ['$TURBO_DEFAULT$']);
   assert.deepEqual(quanticTurbo.tasks['e2e:playwright'].outputs, playwrightOutputs);
   assert.equal(quanticTurbo.tasks['e2e:playwright'].cache, false);
+});
+
+test('builds the Headless output consumed by Quantic through a dedicated task', () => {
+  assert.equal(
+    headlessPackage.scripts['build:quantic'],
+    'node ../../utils/ci/rm-rf.mjs .tmp/quantic && tsc -p src/tsconfig.build.json -d --emitDeclarationOnly --declarationDir .tmp/quantic/definitions && node esbuild.mjs quantic && node scripts/write-quantic-manifest.mjs'
+  );
+  assert.deepEqual(headlessTurbo.tasks['build:quantic'].dependsOn, [
+    '@coveo/bueno#build',
+    '@coveo/relay#build',
+    'coveo.analytics#build',
+  ]);
+  assert.deepEqual(headlessTurbo.tasks['build:quantic'].outputs, ['.tmp/quantic/**']);
+  assert.ok(
+    headlessTurbo.tasks['build:quantic'].inputs.includes('scripts/write-quantic-manifest.mjs')
+  );
+  assert.equal(quanticPackage.scripts['babel:headless'], 'node scripts/npm/babel-headless.js');
+  assert.ok(quanticPackage.files.includes('scripts/npm'));
+  assert.deepEqual(quanticTurbo.tasks['babel:headless'].dependsOn, [
+    '@coveo/headless#build:quantic',
+  ]);
+  assert.deepEqual(quanticTurbo.tasks['build:staticresources'].dependsOn, [
+    '@coveo/bueno#build',
+    'babel:headless',
+    'coveo.analytics#build',
+  ]);
+  assert.deepEqual(quanticTurbo.tasks['validate:e2e-task-contracts'].dependsOn, [
+    '@coveo/headless#build:quantic',
+  ]);
 });
 
 test('selects Quantic E2E for workflow and action changes', () => {
@@ -145,4 +213,538 @@ test('preserves the Quantic E2E topology', () => {
 
   assert.match(playwrightConfig, /name: 'LWS-enabled'/);
   assert.match(playwrightConfig, /name: 'LWS-disabled'/);
+});
+
+const gitIdentityEnvironment = {
+  GIT_AUTHOR_EMAIL: 'quantic-e2e-contract@example.invalid',
+  GIT_AUTHOR_NAME: 'Quantic E2E contract',
+  GIT_COMMITTER_EMAIL: 'quantic-e2e-contract@example.invalid',
+  GIT_COMMITTER_NAME: 'Quantic E2E contract',
+};
+
+const runGit = (cwd, arguments_, options = {}) =>
+  execFileSync('git', arguments_, {
+    cwd,
+    encoding: 'utf8',
+    ...options,
+  });
+
+const runTurbo = (arguments_, cwd = repositoryRoot) =>
+  execFileSync(turboBinary, arguments_, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+      TURBO_TELEMETRY_DISABLED: '1',
+      TURBO_UI: 'false',
+    },
+    maxBuffer: 100 * 1024 * 1024,
+  });
+
+const runPnpm = (arguments_, cwd) => {
+  const environment = {...process.env};
+  delete environment.TURBO_HASH;
+  delete environment.TURBO_TASK_ID;
+  return execFileSync('pnpm', arguments_, {
+    cwd,
+    encoding: 'utf8',
+    env: environment,
+    maxBuffer: 100 * 1024 * 1024,
+  });
+};
+
+const linkDirectory = (source, destination) => {
+  assert.ok(existsSync(source), `${source} must exist`);
+  mkdirSync(dirname(destination), {recursive: true});
+  symlinkSync(source, destination, 'dir');
+};
+
+const withIsolatedRepository = (callback) => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'quantic-e2e-repository-'));
+
+  try {
+    const checkout = join(temporaryDirectory, 'ui-kit');
+    execFileSync(
+      'git',
+      ['clone', '--no-local', '--depth=1', '--no-checkout', repositoryRoot, checkout],
+      {encoding: 'utf8'}
+    );
+    runGit(checkout, ['checkout', '--detach', 'HEAD']);
+
+    for (const filePath of affectednessContractPaths) {
+      const destination = resolve(checkout, filePath);
+      mkdirSync(dirname(destination), {recursive: true});
+      cpSync(resolve(repositoryRoot, filePath), destination);
+    }
+
+    runGit(checkout, ['add', '--', ...affectednessContractPaths]);
+    const parent = runGit(checkout, ['rev-parse', 'HEAD']).trim();
+    const tree = runGit(checkout, ['write-tree']).trim();
+    const baseline = runGit(checkout, ['commit-tree', tree, '-p', parent], {
+      env: {...process.env, ...gitIdentityEnvironment},
+      input: 'current Quantic E2E contract\n',
+    }).trim();
+    runGit(checkout, ['update-ref', 'HEAD', baseline]);
+
+    assert.equal(runGit(checkout, ['status', '--short']).trim(), '');
+    assert.equal(existsSync(resolve(checkout, '.git/objects/info/alternates')), false);
+
+    linkDirectory(resolve(repositoryRoot, 'node_modules'), resolve(checkout, 'node_modules'));
+    linkDirectory(
+      resolve(repositoryRoot, 'packages/headless/node_modules'),
+      resolve(checkout, 'packages/headless/node_modules')
+    );
+
+    return callback({baseline, checkout});
+  } finally {
+    rmSync(temporaryDirectory, {recursive: true, force: true});
+  }
+};
+
+const createCommit = (checkout, base, updateIndex, message) => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'quantic-e2e-index-'));
+  const environment = {
+    ...process.env,
+    ...gitIdentityEnvironment,
+    GIT_INDEX_FILE: join(temporaryDirectory, 'index'),
+  };
+
+  try {
+    runGit(checkout, ['read-tree', base], {env: environment});
+    updateIndex(environment);
+    const tree = runGit(checkout, ['write-tree'], {env: environment}).trim();
+    return runGit(checkout, ['commit-tree', tree, '-p', base], {
+      env: environment,
+      input: `${message}\n`,
+    }).trim();
+  } finally {
+    rmSync(temporaryDirectory, {recursive: true, force: true});
+  }
+};
+
+const createScenarioCommit = (checkout, base, filePath, scenario) =>
+  createCommit(
+    checkout,
+    base,
+    (environment) => {
+      const stagedFile = runGit(checkout, ['ls-files', '--stage', '--', filePath], {
+        env: environment,
+      }).trim();
+      assert.notEqual(stagedFile, '', `${filePath} must be tracked`);
+      const [mode] = stagedFile.split(' ');
+      const blob = runGit(checkout, ['hash-object', '-w', '--stdin'], {
+        env: environment,
+        input: `${readFileSync(resolve(checkout, filePath), 'utf8')}\n// ${scenario}\n`,
+      }).trim();
+      runGit(checkout, ['update-index', '--add', '--cacheinfo', mode, blob, filePath], {
+        env: environment,
+      });
+    },
+    scenario
+  );
+
+const getAffectedTasks = (base, head, checkout) => {
+  const query = `
+    query {
+      affectedTasks(base: "${base}", head: "${head}") {
+        items {
+          fullName
+          reason {
+            __typename
+            ... on TaskFileChanged { filePath }
+            ... on TaskDependencyTaskChanged { taskName packageName }
+            ... on TaskPackageDependencyChanged { packageName }
+            ... on TaskGlobalFileChanged { filePath }
+            ... on TaskGlobalDepsChanged { filePath }
+          }
+        }
+      }
+    }
+  `;
+  const result = JSON.parse(runTurbo(['query', '--no-update-notifier', query], checkout));
+  return result.data.affectedTasks.items;
+};
+
+const getQuanticE2EDependents = (checkout) => {
+  const dryRun = JSON.parse(runTurbo(['run', '@coveo/quantic#e2e', '--dry=json'], checkout));
+  return new Map(dryRun.tasks.map(({taskId, dependents}) => [taskId, dependents]));
+};
+
+const reachesQuanticE2E = (affectedTasks, dependentsByTask) => {
+  const affected = new Set(affectedTasks);
+  const queue = [...affectedTasks];
+
+  while (queue.length) {
+    const task = queue.shift();
+    for (const dependent of dependentsByTask.get(task) ?? []) {
+      if (!affected.has(dependent)) {
+        affected.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+
+  return affected.has('@coveo/quantic#e2e');
+};
+
+const writeExpectedFiles = (root, expectedPaths) => {
+  for (const relativePath of expectedPaths) {
+    const filePath = resolve(root, relativePath);
+    mkdirSync(dirname(filePath), {recursive: true});
+    writeFileSync(filePath, relativePath);
+  }
+};
+
+const listFiles = (root, prefix = '') =>
+  readdirSync(resolve(root, prefix), {withFileTypes: true})
+    .flatMap((entry) => {
+      const relativePath = join(prefix, entry.name);
+      return entry.isDirectory() ? listFiles(root, relativePath) : [relativePath];
+    })
+    .sort();
+
+const assertDirectoriesEqual = (actualRoot, expectedRoot) => {
+  const actualFiles = listFiles(actualRoot);
+  const expectedFiles = listFiles(expectedRoot);
+  assert.deepEqual(actualFiles, expectedFiles);
+  for (const relativePath of expectedFiles) {
+    assert.deepEqual(
+      readFileSync(resolve(actualRoot, relativePath)),
+      readFileSync(resolve(expectedRoot, relativePath)),
+      relativePath
+    );
+  }
+};
+
+const writeManifest = (packageRoot, transform = (manifest) => manifest) => {
+  const outputRoot = resolve(packageRoot, '.tmp/quantic');
+  const definitionPaths = listFiles(resolve(outputRoot, 'definitions')).map(
+    (filePath) => `definitions/${filePath.replaceAll('\\', '/')}`
+  );
+  const filePaths = [
+    ...expectedHeadlessBundlePaths.map((filePath) => `bundles/${filePath}`),
+    ...definitionPaths,
+  ].sort();
+  const files = filePaths.map((filePath) => {
+    const contents = readFileSync(resolve(outputRoot, ...filePath.split('/')));
+    return {
+      path: filePath,
+      size: contents.byteLength,
+      sha256: createHash('sha256').update(contents).digest('hex'),
+    };
+  });
+  const manifestPath = resolve(outputRoot, 'manifest.json');
+  const manifest = transform({
+    schemaVersion: headlessQuanticManifestSchemaVersion,
+    files,
+  });
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return {manifest, manifestPath};
+};
+
+test('fails closed on missing or corrupt manifested declarations and falls back directly to dist', () => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'quantic-headless-output-'));
+
+  try {
+    const packageRoot = join(temporaryDirectory, 'headless');
+    const directBundles = resolve(packageRoot, 'dist/quantic');
+    const directDefinitions = resolve(packageRoot, 'dist/definitions');
+    const taskBundles = resolve(packageRoot, '.tmp/quantic/bundles');
+    const taskDefinitions = resolve(packageRoot, '.tmp/quantic/definitions');
+    const transitiveDefinition = resolve(
+      taskDefinitions,
+      'controllers/result-list/headless-result-list.d.ts'
+    );
+
+    writeExpectedFiles(directBundles, expectedHeadlessBundlePaths);
+    writeExpectedFiles(directDefinitions, expectedHeadlessDefinitionPaths);
+    assert.equal(resolveHeadlessBundlesPath({packageRoot, turboHash: ''}), directBundles);
+    assert.equal(resolveHeadlessDefinitionsPath({packageRoot, turboHash: ''}), directDefinitions);
+
+    writeExpectedFiles(taskBundles, expectedHeadlessBundlePaths);
+    writeExpectedFiles(taskDefinitions, expectedHeadlessDefinitionPaths);
+    mkdirSync(dirname(transitiveDefinition), {recursive: true});
+    writeFileSync(transitiveDefinition, 'transitive declaration');
+    writeManifest(packageRoot);
+    assert.equal(resolveHeadlessBundlesPath({packageRoot, turboHash: 'task-hash'}), taskBundles);
+    assert.equal(
+      resolveHeadlessDefinitionsPath({packageRoot, turboHash: 'task-hash'}),
+      taskDefinitions
+    );
+
+    const originalContents = readFileSync(transitiveDefinition);
+    rmSync(transitiveDefinition);
+    assert.throws(
+      () => resolveHeadlessBundlesPath({packageRoot, turboHash: 'task-hash'}),
+      /manifested file is missing: definitions\/controllers\/result-list\/headless-result-list\.d\.ts/
+    );
+    assert.throws(
+      () => resolveHeadlessDefinitionsPath({packageRoot, turboHash: 'task-hash'}),
+      /manifested file is missing: definitions\/controllers\/result-list\/headless-result-list\.d\.ts/
+    );
+
+    const corruptContents = Buffer.from(originalContents);
+    corruptContents[0] ^= 1;
+    writeFileSync(transitiveDefinition, corruptContents);
+    assert.throws(
+      () => resolveHeadlessBundlesPath({packageRoot, turboHash: 'task-hash'}),
+      /SHA-256 mismatch for definitions\/controllers\/result-list\/headless-result-list\.d\.ts/
+    );
+    assert.throws(
+      () => resolveHeadlessDefinitionsPath({packageRoot, turboHash: 'task-hash'}),
+      /SHA-256 mismatch for definitions\/controllers\/result-list\/headless-result-list\.d\.ts/
+    );
+    assert.equal(resolveHeadlessBundlesPath({packageRoot, turboHash: ''}), directBundles);
+    assert.equal(resolveHeadlessDefinitionsPath({packageRoot, turboHash: ''}), directDefinitions);
+  } finally {
+    rmSync(temporaryDirectory, {recursive: true, force: true});
+  }
+});
+
+test('rejects invalid or incomplete dedicated Headless manifests', () => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'quantic-headless-manifest-'));
+
+  try {
+    const packageRoot = join(temporaryDirectory, 'headless');
+    const taskBundles = resolve(packageRoot, '.tmp/quantic/bundles');
+    const taskDefinitions = resolve(packageRoot, '.tmp/quantic/definitions');
+    writeExpectedFiles(taskBundles, expectedHeadlessBundlePaths);
+    writeExpectedFiles(taskDefinitions, expectedHeadlessDefinitionPaths);
+    const {manifest, manifestPath} = writeManifest(packageRoot);
+
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({...manifest, schemaVersion: headlessQuanticManifestSchemaVersion + 1})
+    );
+    assert.throws(
+      () => resolveHeadlessBundlesPath({packageRoot, turboHash: 'task-hash'}),
+      /schemaVersion must be 1/
+    );
+
+    const escapedManifest = structuredClone(manifest);
+    escapedManifest.files[0].path = '../outside.js';
+    writeFileSync(manifestPath, JSON.stringify(escapedManifest));
+    assert.throws(
+      () => resolveHeadlessBundlesPath({packageRoot, turboHash: 'task-hash'}),
+      /path must be a safe relative path/
+    );
+
+    const incompleteBundleManifest = structuredClone(manifest);
+    incompleteBundleManifest.files = incompleteBundleManifest.files.filter(
+      ({path: filePath}) => filePath !== 'bundles/recommendation/headless.js'
+    );
+    writeFileSync(manifestPath, JSON.stringify(incompleteBundleManifest));
+    assert.throws(
+      () => resolveHeadlessBundlesPath({packageRoot, turboHash: 'task-hash'}),
+      /runtime bundle paths must be exactly/
+    );
+
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+    writeFileSync(resolve(taskBundles, 'headless.js.map'), 'extra bundle output');
+    assert.throws(
+      () => resolveHeadlessBundlesPath({packageRoot, turboHash: 'task-hash'}),
+      /runtime bundle tree must be exactly/
+    );
+    rmSync(resolve(taskBundles, 'headless.js.map'));
+
+    writeFileSync(resolve(taskDefinitions, 'extra.d.ts'), 'extra declaration');
+    assert.throws(
+      () => resolveHeadlessDefinitionsPath({packageRoot, turboHash: 'task-hash'}),
+      /definition paths must be exactly/
+    );
+  } finally {
+    rmSync(temporaryDirectory, {recursive: true, force: true});
+  }
+});
+
+test('rejects symlinked dedicated Headless roots and files', () => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'quantic-headless-symlink-'));
+
+  try {
+    const packageRoot = join(temporaryDirectory, 'headless');
+    const outputRoot = resolve(packageRoot, '.tmp/quantic');
+    const taskBundles = resolve(outputRoot, 'bundles');
+    const taskDefinitions = resolve(outputRoot, 'definitions');
+    const transitiveDirectory = resolve(taskDefinitions, 'controllers/result-list');
+    writeExpectedFiles(taskBundles, expectedHeadlessBundlePaths);
+    writeExpectedFiles(taskDefinitions, expectedHeadlessDefinitionPaths);
+    mkdirSync(transitiveDirectory, {recursive: true});
+    writeFileSync(resolve(transitiveDirectory, 'headless-result-list.d.ts'), 'transitive');
+    const {manifestPath} = writeManifest(packageRoot);
+
+    const manifestTarget = resolve(temporaryDirectory, 'manifest-target.json');
+    renameSync(manifestPath, manifestTarget);
+    symlinkSync(manifestTarget, manifestPath, 'file');
+    assert.throws(
+      () => resolveHeadlessBundlesPath({packageRoot, turboHash: 'task-hash'}),
+      /manifest cannot be a symbolic link/
+    );
+    rmSync(manifestPath);
+    renameSync(manifestTarget, manifestPath);
+
+    const bundlesTarget = resolve(temporaryDirectory, 'bundles-target');
+    renameSync(taskBundles, bundlesTarget);
+    symlinkSync(bundlesTarget, taskBundles, 'dir');
+    assert.throws(
+      () => resolveHeadlessBundlesPath({packageRoot, turboHash: 'task-hash'}),
+      /bundle root cannot be a symbolic link/
+    );
+    rmSync(taskBundles);
+    renameSync(bundlesTarget, taskBundles);
+
+    const definitionsTarget = resolve(temporaryDirectory, 'definitions-target');
+    renameSync(taskDefinitions, definitionsTarget);
+    symlinkSync(definitionsTarget, taskDefinitions, 'dir');
+    assert.throws(
+      () => resolveHeadlessDefinitionsPath({packageRoot, turboHash: 'task-hash'}),
+      /definition root cannot be a symbolic link/
+    );
+    rmSync(taskDefinitions);
+    renameSync(definitionsTarget, taskDefinitions);
+
+    const subtreeTarget = resolve(temporaryDirectory, 'result-list-target');
+    renameSync(transitiveDirectory, subtreeTarget);
+    symlinkSync(subtreeTarget, transitiveDirectory, 'dir');
+    assert.throws(
+      () => resolveHeadlessDefinitionsPath({packageRoot, turboHash: 'task-hash'}),
+      /dedicated output cannot contain symbolic links: definitions\/controllers\/result-list/
+    );
+    rmSync(transitiveDirectory);
+    renameSync(subtreeTarget, transitiveDirectory);
+
+    const bundlePath = resolve(taskBundles, 'headless.js');
+    const bundleTarget = resolve(temporaryDirectory, 'headless-target.js');
+    renameSync(bundlePath, bundleTarget);
+    symlinkSync(bundleTarget, bundlePath, 'file');
+    assert.throws(
+      () => resolveHeadlessBundlesPath({packageRoot, turboHash: 'task-hash'}),
+      /dedicated output cannot contain symbolic links: bundles\/headless\.js/
+    );
+    rmSync(bundlePath);
+    renameSync(bundleTarget, bundlePath);
+
+    const outputTarget = resolve(temporaryDirectory, 'quantic-target');
+    renameSync(outputRoot, outputTarget);
+    symlinkSync(outputTarget, outputRoot, 'dir');
+    assert.throws(
+      () => resolveHeadlessBundlesPath({packageRoot, turboHash: 'task-hash'}),
+      /dedicated output root cannot be a symbolic link/
+    );
+  } finally {
+    rmSync(temporaryDirectory, {recursive: true, force: true});
+  }
+});
+
+test('builds only complete declared Headless output for Quantic', () => {
+  withIsolatedRepository(({checkout}) => {
+    const packageRoot = resolve(checkout, 'packages/headless');
+    runPnpm(['run', 'build:quantic'], packageRoot);
+
+    const bundleRoot = resolve(packageRoot, '.tmp/quantic/bundles');
+    const definitionsRoot = resolve(packageRoot, '.tmp/quantic/definitions');
+    const manifestPath = resolve(packageRoot, '.tmp/quantic/manifest.json');
+    const manifestContents = readFileSync(manifestPath, 'utf8');
+    const manifest = JSON.parse(manifestContents);
+    const runtimeBundles = listFiles(bundleRoot).sort();
+    const manifestedBundlePaths = manifest.files
+      .map(({path: filePath}) => filePath)
+      .filter((filePath) => filePath.startsWith('bundles/'))
+      .map((filePath) => filePath.slice('bundles/'.length));
+    const manifestedDefinitionPaths = manifest.files
+      .map(({path: filePath}) => filePath)
+      .filter((filePath) => filePath.startsWith('definitions/'))
+      .map((filePath) => filePath.slice('definitions/'.length));
+
+    assert.deepEqual(runtimeBundles, [...expectedHeadlessBundlePaths].sort());
+    assert.equal(manifest.schemaVersion, headlessQuanticManifestSchemaVersion);
+    assert.deepEqual(manifestedBundlePaths.sort(), [...expectedHeadlessBundlePaths].sort());
+    assert.deepEqual(
+      manifestedDefinitionPaths.sort(),
+      listFiles(definitionsRoot).map((filePath) => filePath.replaceAll('\\', '/'))
+    );
+    for (const definitionPath of expectedHeadlessDefinitionPaths) {
+      assert.ok(existsSync(resolve(definitionsRoot, definitionPath)), definitionPath);
+    }
+    assert.equal(resolveHeadlessBundlesPath({packageRoot, turboHash: 'task-hash'}), bundleRoot);
+    assert.equal(
+      resolveHeadlessDefinitionsPath({packageRoot, turboHash: 'task-hash'}),
+      definitionsRoot
+    );
+    execFileSync(process.execPath, ['scripts/write-quantic-manifest.mjs'], {cwd: packageRoot});
+    assert.equal(readFileSync(manifestPath, 'utf8'), manifestContents);
+    assert.equal(existsSync(resolve(packageRoot, 'cdn')), false);
+    assert.equal(existsSync(resolve(packageRoot, 'dist')), false);
+
+    runPnpm(['run', 'build:definitions'], packageRoot);
+    assertDirectoriesEqual(definitionsRoot, resolve(packageRoot, 'dist/definitions'));
+  });
+});
+
+test('selects Quantic E2E from Turbo affectedness of embedded Headless output', () => {
+  const scenarios = [
+    {
+      name: 'PR #8176 commerce test-only change',
+      path: 'packages/headless/src/controllers/commerce/instant-products/headless-instant-products.test.ts',
+      expected: false,
+    },
+    {
+      name: 'Headless ESM-only build change',
+      path: 'packages/headless/scripts/build.mjs',
+      expected: false,
+    },
+    {
+      name: 'Headless commerce TypeDoc-only change',
+      path: 'packages/headless/typedoc-configs/commerce.typedoc.json',
+      expected: false,
+    },
+    {
+      name: 'Headless source embedded in Quantic',
+      path: 'packages/headless/src/index.ts',
+      expected: true,
+    },
+    {
+      name: 'Headless Quantic manifest generator',
+      path: 'packages/headless/scripts/write-quantic-manifest.mjs',
+      expected: true,
+    },
+    {
+      name: 'production commerce source included in copied declarations',
+      path: 'packages/headless/src/controllers/commerce/instant-products/headless-instant-products.ts',
+      expected: true,
+    },
+    {
+      name: 'transitive Bueno source',
+      path: 'packages/bueno/src/index.ts',
+      expected: true,
+    },
+    {
+      name: 'transitive Relay source',
+      path: 'packages/relay/src/relay.ts',
+      expected: true,
+    },
+    {
+      name: 'transitive analytics source',
+      path: 'packages/coveo-analytics/src/coveoua/headless.ts',
+      expected: true,
+    },
+  ];
+
+  withIsolatedRepository(({baseline, checkout}) => {
+    const dependentsByTask = getQuanticE2EDependents(checkout);
+    for (const scenario of scenarios) {
+      const commit = createScenarioCommit(checkout, baseline, scenario.path, scenario.name);
+      const affected = getAffectedTasks(baseline, commit, checkout);
+      const affectedTasks = affected.map(({fullName}) => fullName);
+      assert.equal(
+        reachesQuanticE2E(affectedTasks, dependentsByTask),
+        scenario.expected,
+        `${scenario.name}\nAffected E2E DAG tasks:\n${JSON.stringify(
+          affected.filter(({fullName}) => dependentsByTask.has(fullName)),
+          null,
+          2
+        )}`
+      );
+    }
+  });
 });


### PR DESCRIPTION
# Do not review. Experimentation 🧪 ☢️
## Jira

https://coveord.atlassian.net/browse/KIT-6130

## Motivation

Quantic E2E consumed the normal Headless build output, coupling its affectedness and cache contract to unrelated public artifacts. This child PR builds on #8391 to give Turbo a narrow, explicit runtime dependency.

## Changes

- Add a dedicated `@coveo/headless#build:quantic` task that owns only `.tmp/quantic/**`, with four runtime bundles and a deterministic manifest for every consumed file.
- Validate the dedicated output before Quantic assembles static resources, while preserving direct-command fallback and unchanged public Headless builds.
- Extend contract coverage for affectedness, manifest integrity, extra paths, traversal, symlinks, and the existing E2E topology.

## Validation

- [x] `pnpm run lint:fix`
- [x] Quantic E2E contract tests (11/11)
- [x] Cold static-resource build and cache restoration
- [x] Normal public Headless build and direct fallback
- [ ] Secret-backed Quantic PR CI

## Checklist

- [x] PR title follows Conventional Commits 1.0.0
- [x] Added patch changesets for `@coveo/headless` and `@coveo/quantic`