### PR TITLE
style(chromatic): clarify baseline selection expression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,7 +438,16 @@ jobs:
           # TurboSnap bypass pricing. If affected calculation fails, keep normal baseline selection.
           # Reachable same-branch builds are still found in Git history; this only drops Chromatic's
           # continuity fallback for an orphaned branch build.
-          ignoreLastBuildOnBranch: ${{ needs.affected.result == 'success' && !contains(needs.affected.outputs.tasks, '"@coveo/atomic#build"') && github.head_ref || '' }}
+          # GitHub expressions use `condition && value || fallback` as a ternary.
+          ignoreLastBuildOnBranch: >-
+            ${{
+              (
+                needs.affected.result == 'success' &&
+                !contains(needs.affected.outputs.tasks, '"@coveo/atomic#build"')
+              ) &&
+              github.head_ref ||
+              ''
+            }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/atomic
       - name: Skip Chromatic visual tests


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6137

## Motivation

PR #8392 introduced the correct conditional behavior for Chromatic baseline selection. This stacked follow-up addresses the readability suggestion from review without changing runtime behavior.

## Changes

- Formats the `ignoreLastBuildOnBranch` GitHub expression as an explicitly grouped multiline ternary-style expression.
- Documents GitHub's `condition && value || fallback` idiom.
- Preserves the required `${{ ... }}` expression wrapper and the existing three-state policy.

## Validation

- `pnpm run lint:fix`
- `pnpm run lint:check`
- `npm run build`
- `npm test`
- Parsed `.github/workflows/ci.yml` with the repository-pinned `yaml` package.
- Revalidated the exact normalized expression, skip-action wiring, and all three outcomes: Atomic unaffected selects the PR branch; Atomic affected or affected-calculation failure keeps normal baseline selection.
- `git diff --check KIT-6137-chromatic-single-ancestor..HEAD`

- [x] All existing tests pass without modification
- [x] Diff contains only formatting and explanatory documentation; no logic changes
- [x] No functional behavior is altered

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`style(<scope>): <description>`)
- [x] No changeset is included because no public package source code changed