### PR TITLE
feat(ci): scope lockfile affectedness for Quantic E2E

### DIFF
--- a/.github/actions/calculate-affected/action.yml
+++ b/.github/actions/calculate-affected/action.yml
@@ -10,7 +10,7 @@ inputs:
 outputs:
   fetch-depth:
     description: Minimum checkout depth required for the calculated commit range.
-    value: ${{ steps.git.outputs.fetch-depth }}
+    value: ${{ steps.calculate.outputs.fetch-depth }}
   tasks:
     description: Affected Turbo task identifiers as a single-line JSON array of strings.
     value: ${{ steps.calculate.outputs.tasks }}
@@ -28,20 +28,6 @@ runs:
       with:
         install: true
         cache: true
-
-    - name: Calculate Git fetch depth
-      id: git
-      shell: bash
-      env:
-        TURBO_SCM_BASE: ${{ inputs.base-sha }}
-        TURBO_SCM_HEAD: ${{ inputs.head-sha }}
-      run: |
-        GIT_NO_LAZY_FETCH=1 git rev-parse --verify "${TURBO_SCM_BASE}^{commit}"
-        GIT_NO_LAZY_FETCH=1 git rev-parse --verify "${TURBO_SCM_HEAD}^{commit}"
-
-        range_count="$(git rev-list --count "${TURBO_SCM_BASE}..${TURBO_SCM_HEAD}")"
-        fetch_depth=$((range_count + 1))
-        echo "fetch-depth=$fetch_depth" >> "$GITHUB_OUTPUT"
 
     - name: Calculate and publish affected data
       id: calculate

--- a/.github/actions/calculate-affected/affected-utils.mjs
+++ b/.github/actions/calculate-affected/affected-utils.mjs
@@ -1,0 +1,226 @@
+export const approvedTurboVersion = '2.10.9';
+export const quanticE2ETask = '@coveo/quantic#e2e';
+export const pnpmLockfileValidationArguments = Object.freeze([
+  'install',
+  '--lockfile-only',
+  '--frozen-lockfile',
+  '--ignore-scripts',
+]);
+
+const defaultGraphLimits = Object.freeze({
+  tasks: 20_000,
+  edges: 200_000,
+});
+const markdownValueLengthLimit = 512;
+const markdownEllipsis = '&#8230;';
+const rootTurboTaskPrefix = '//#';
+const turboTaskNameLengthLimit = 128;
+const turboTaskNamePattern = /^[a-z0-9]+(?:(?::|-)[a-z0-9]+)*$/u;
+
+const taskIdFromParts = (packageName, taskName) => `${packageName}#${taskName}`;
+
+const isControlCharacter = (character) => {
+  const codePoint = character.codePointAt(0);
+  return codePoint <= 31 || (codePoint >= 127 && codePoint <= 159);
+};
+
+export const assertApprovedTurboVersion = (configuredVersion) => {
+  if (configuredVersion !== approvedTurboVersion) {
+    throw new Error(
+      'package.json must declare the repository-approved Turbo version exactly as 2.10.9.'
+    );
+  }
+};
+
+export const normalizeTurboTaskKey = (taskKey) => {
+  if (typeof taskKey !== 'string' || taskKey.length === 0) {
+    throw new Error('Turbo task keys must be non-empty strings.');
+  }
+  if ([...taskKey].some(isControlCharacter)) {
+    throw new Error('Turbo task keys must not contain control characters.');
+  }
+
+  const taskName = taskKey.startsWith(rootTurboTaskPrefix)
+    ? taskKey.slice(rootTurboTaskPrefix.length)
+    : taskKey;
+  if (taskName.startsWith('-') || taskName.includes('=')) {
+    throw new Error('Turbo task keys must not use CLI-option syntax.');
+  }
+  if (taskName.length > turboTaskNameLengthLimit || !turboTaskNamePattern.test(taskName)) {
+    throw new Error('Turbo task key does not match the repository task-name grammar.');
+  }
+
+  return taskName;
+};
+
+const validateString = (value, label) => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Invalid Turbo graph ${label}.`);
+  }
+};
+
+const traverse = (roots, edgesByTask, edgeLimit) => {
+  const visited = new Set(roots);
+  const queue = [...roots];
+  const traversalLimit = edgesByTask.size + edgeLimit;
+  let traversalSteps = 0;
+  let visitedEdges = 0;
+
+  for (let index = 0; index < queue.length; index += 1) {
+    traversalSteps += 1;
+    const task = queue[index];
+    for (const adjacentTask of edgesByTask.get(task)) {
+      traversalSteps += 1;
+      visitedEdges += 1;
+      if (traversalSteps > traversalLimit || visitedEdges > edgeLimit) {
+        throw new Error('Turbo graph traversal exceeded its validated V+E bound.');
+      }
+      if (!visited.has(adjacentTask)) {
+        visited.add(adjacentTask);
+        queue.push(adjacentTask);
+      }
+    }
+  }
+
+  if (queue.length > edgesByTask.size) {
+    throw new Error('Turbo graph traversal exceeded its validated task bound.');
+  }
+
+  return visited;
+};
+
+export const analyzeTaskGraph = (
+  turboTasks,
+  directlyAffectedTaskNames,
+  target = quanticE2ETask,
+  limits = defaultGraphLimits
+) => {
+  if (!Array.isArray(turboTasks) || turboTasks.length > limits.tasks) {
+    throw new Error('Turbo returned an invalid or oversized task graph.');
+  }
+
+  const dependentsByTask = new Map();
+  const dependenciesByTask = new Map();
+  let edgeCount = 0;
+
+  for (const turboTask of turboTasks) {
+    const {dependents, package: packageName, task: taskName, taskId} = turboTask ?? {};
+    validateString(packageName, 'package name');
+    validateString(taskName, 'task name');
+    validateString(taskId, 'task identifier');
+    if (taskId !== taskIdFromParts(packageName, taskName)) {
+      throw new Error(`Turbo graph task identifier does not match its package and task: ${taskId}`);
+    }
+    if (
+      !Array.isArray(dependents) ||
+      dependents.some((dependent) => typeof dependent !== 'string')
+    ) {
+      throw new Error(`Turbo graph task has invalid dependents: ${taskId}`);
+    }
+    if (new Set(dependents).size !== dependents.length) {
+      throw new Error(`Turbo graph task has duplicate dependents: ${taskId}`);
+    }
+    if (dependentsByTask.has(taskId)) {
+      throw new Error(`Turbo graph contains a duplicate task: ${taskId}`);
+    }
+
+    edgeCount += dependents.length;
+    if (edgeCount > limits.edges) {
+      throw new Error('Turbo returned an oversized task graph.');
+    }
+    dependentsByTask.set(taskId, [...dependents]);
+    dependenciesByTask.set(taskId, []);
+  }
+
+  validateString(target, 'target task');
+  if (!dependentsByTask.has(target)) {
+    throw new Error(`Turbo graph is missing the selection target: ${target}`);
+  }
+
+  for (const [taskId, dependents] of dependentsByTask) {
+    for (const dependent of dependents) {
+      if (!dependentsByTask.has(dependent)) {
+        throw new Error(`Turbo graph contains a dangling dependent: ${taskId} -> ${dependent}`);
+      }
+      dependenciesByTask.get(dependent).push(taskId);
+    }
+  }
+
+  if (!Array.isArray(directlyAffectedTaskNames)) {
+    throw new Error('Turbo returned invalid directly affected tasks.');
+  }
+  const directlyAffected = new Set();
+  for (const taskId of directlyAffectedTaskNames) {
+    validateString(taskId, 'directly affected task');
+    if (!dependentsByTask.has(taskId)) {
+      throw new Error(`Directly affected task is missing from the Turbo graph: ${taskId}`);
+    }
+    directlyAffected.add(taskId);
+  }
+
+  const affected = traverse(directlyAffected, dependentsByTask, edgeCount);
+  const targetAncestors = traverse([target], dependenciesByTask, edgeCount);
+  const triggerTaskNames = [...directlyAffected].filter((taskId) => targetAncestors.has(taskId));
+  const selected = affected.has(target);
+
+  if (selected && triggerTaskNames.length === 0) {
+    throw new Error(`Turbo selected ${target} without an affected dependency path.`);
+  }
+
+  return {
+    affectedTaskNames: [...affected].sort(),
+    selected,
+    triggerTaskNames: triggerTaskNames.sort(),
+  };
+};
+
+export const packagesFromTasks = (taskIds) => {
+  const packageNames = taskIds.map((taskId) => {
+    const separator = taskId.lastIndexOf('#');
+    if (separator < 1 || separator === taskId.length - 1) {
+      throw new Error(`Invalid Turbo task identifier: ${taskId}`);
+    }
+    return taskId.slice(0, separator);
+  });
+
+  return [...new Set(packageNames)].sort();
+};
+
+export const escapeMarkdownValue = (value) => {
+  const normalized = [...String(value ?? '')]
+    .map((character) => (isControlCharacter(character) ? ' ' : character))
+    .join('')
+    .replace(/\s+/gu, ' ')
+    .trim();
+  let escaped = '';
+
+  for (const character of normalized) {
+    const token = /^[a-z0-9 ]$/iu.test(character) ? character : `&#${character.codePointAt(0)};`;
+    if (escaped.length + token.length > markdownValueLengthLimit - markdownEllipsis.length) {
+      return `${escaped}${markdownEllipsis}`;
+    }
+    escaped += token;
+  }
+
+  return escaped;
+};
+
+export const markdownTable = (headers, rows) => {
+  const header = `| ${headers.map(escapeMarkdownValue).join(' | ')} |`;
+  const separator = `| ${headers.map(() => '---').join(' | ')} |`;
+  const body = rows.map((row) => `| ${row.map(escapeMarkdownValue).join(' | ')} |`).join('\n');
+
+  return [header, separator, body, ''].join('\n');
+};
+
+export const getSummaryDescription = (reason) => {
+  if (reason.__typename === 'TaskDependencyTaskChanged') {
+    return `${reason.packageName}#${reason.taskName}`;
+  }
+
+  if (reason.__typename === 'TaskPackageDependencyChanged') {
+    return reason.packageName;
+  }
+
+  return reason.description ?? reason.filePath ?? '';
+};

--- a/.github/actions/calculate-affected/affected.mjs
+++ b/.github/actions/calculate-affected/affected.mjs
@@ -1,6 +1,19 @@
 import {execFileSync} from 'node:child_process';
-import {appendFileSync, existsSync, readFileSync} from 'node:fs';
+import {appendFileSync, existsSync, readFileSync, writeFileSync} from 'node:fs';
 import {join} from 'node:path';
+
+import {
+  analyzeTaskGraph,
+  approvedTurboVersion,
+  assertApprovedTurboVersion,
+  escapeMarkdownValue,
+  getSummaryDescription,
+  markdownTable,
+  normalizeTurboTaskKey,
+  packagesFromTasks,
+  pnpmLockfileValidationArguments,
+  quanticE2ETask,
+} from './affected-utils.mjs';
 
 const {
   GITHUB_OUTPUT,
@@ -13,15 +26,118 @@ const {
 } = process.env;
 
 const rootPackage = JSON.parse(readFileSync('package.json', 'utf8'));
-const turboVersion = rootPackage.devDependencies.turbo;
-const turboMaxBuffer = 100 * 1024 * 1024;
+const lockfilePath = 'pnpm-lock.yaml';
+const commandMaxBuffer = 100 * 1024 * 1024;
 
-const turboCommand = (...args) => {
-  return execFileSync('pnpm', ['dlx', `turbo@${turboVersion}`, ...args], {
-    encoding: 'utf8',
-    maxBuffer: turboMaxBuffer,
-  });
+assertApprovedTurboVersion(rootPackage.devDependencies?.turbo);
+
+const getAllTasks = (turboFiles) => {
+  const tasks = new Set();
+  for (const turboFile of turboFiles) {
+    const {tasks: packageTasks = {}} = JSON.parse(readFileSync(turboFile, 'utf8'));
+    for (const task of Object.keys(packageTasks)) {
+      tasks.add(normalizeTurboTaskKey(task));
+    }
+  }
+  return [...tasks].sort();
 };
+
+getAllTasks(['turbo.json']);
+
+const controlledCommandEnvironment = () => {
+  const environment = {...process.env};
+  for (const name of Object.keys(environment)) {
+    if (name.startsWith('GIT_') || name.startsWith('TURBO_')) {
+      delete environment[name];
+    }
+  }
+  environment.TURBO_TELEMETRY_DISABLED = '1';
+  environment.TURBO_UI = 'false';
+  return environment;
+};
+
+const gitCommand = (...args) =>
+  execFileSync('git', args, {
+    encoding: 'utf8',
+    env: {
+      ...controlledCommandEnvironment(),
+      GIT_NO_LAZY_FETCH: '1',
+    },
+    maxBuffer: commandMaxBuffer,
+  }).trim();
+
+const restoreLockfile = (originalLockfile) => {
+  let currentLockfile;
+  try {
+    currentLockfile = readFileSync(lockfilePath);
+  } catch {
+    writeFileSync(lockfilePath, originalLockfile);
+    return true;
+  }
+
+  if (!currentLockfile.equals(originalLockfile)) {
+    writeFileSync(lockfilePath, originalLockfile);
+    return true;
+  }
+
+  return false;
+};
+
+const validatePnpmLockfile = () => {
+  const originalLockfile = readFileSync(lockfilePath);
+  let validationError;
+
+  try {
+    execFileSync('pnpm', pnpmLockfileValidationArguments, {
+      env: controlledCommandEnvironment(),
+      stdio: 'inherit',
+    });
+  } catch (error) {
+    validationError = error;
+  }
+
+  const lockfileWasChanged = restoreLockfile(originalLockfile);
+  if (validationError) {
+    throw new Error(
+      'pnpm frozen lockfile validation failed; refusing to calculate or publish affected outputs.',
+      {cause: validationError}
+    );
+  }
+  if (lockfileWasChanged) {
+    throw new Error(
+      'pnpm frozen lockfile validation modified pnpm-lock.yaml; the original bytes were restored and no affected outputs were published.'
+    );
+  }
+};
+
+gitCommand('rev-parse', '--verify', '--end-of-options', `${TURBO_SCM_BASE}^{commit}`);
+gitCommand('rev-parse', '--verify', '--end-of-options', `${TURBO_SCM_HEAD}^{commit}`);
+const commitCount = Number.parseInt(
+  gitCommand('rev-list', '--count', '--end-of-options', `${TURBO_SCM_BASE}..${TURBO_SCM_HEAD}`),
+  10
+);
+if (!Number.isSafeInteger(commitCount) || commitCount < 0) {
+  throw new Error('Git returned an invalid affected-range commit count.');
+}
+const fetchDepth = commitCount + 1;
+
+validatePnpmLockfile();
+
+const lockfileVersion = readFileSync(lockfilePath, 'utf8').match(
+  /^lockfileVersion:\s*['"]?([^'"\s]+)['"]?\s*$/m
+)?.[1];
+if (lockfileVersion !== '9.0') {
+  throw new Error(
+    `Unsupported or malformed pnpm lockfile version: ${lockfileVersion ?? 'missing'}. Refusing to publish an indeterminate affected set.`
+  );
+}
+
+const turboCommand = (...args) =>
+  execFileSync('pnpm', ['dlx', `turbo@${approvedTurboVersion}`, ...args], {
+    encoding: 'utf8',
+    env: controlledCommandEnvironment(),
+    maxBuffer: commandMaxBuffer,
+  });
 
 const query = `
 query {
@@ -31,7 +147,7 @@ query {
       path
     }
   }
-  affectedTasks(base: "${TURBO_SCM_BASE}", head: "${TURBO_SCM_HEAD}") {
+  affectedTasks(base: ${JSON.stringify(TURBO_SCM_BASE)}, head: ${JSON.stringify(TURBO_SCM_HEAD)}) {
     items {
       name
       fullName
@@ -52,131 +168,87 @@ query {
 }
 `;
 const queryOutput = JSON.parse(turboCommand('query', '--no-update-notifier', query));
-
 const sortBy = (property) => (left, right) => left[property].localeCompare(right[property]);
+const affectedTasks = [...queryOutput.data.affectedTasks.items].sort(sortBy('fullName'));
+const lockfileResolutionFailure = affectedTasks.find(
+  ({reason}) =>
+    reason.__typename === 'TaskAllChanged' &&
+    reason.description === 'lockfile change detection failed'
+);
+if (lockfileResolutionFailure) {
+  throw new Error(
+    'Turbo lockfile change detection failed; refusing to publish an indeterminate affected set.'
+  );
+}
 
-const writeOutput = (name, value) => {
-  appendFileSync(GITHUB_OUTPUT, `${name}=${JSON.stringify(value)}\n`);
-};
-
-// All packages / tasks
-
-const getTurboFiles = (packages) => {
-  return packages.map(({path}) => join(path, 'turbo.json')).filter((path) => existsSync(path));
-};
-
-const getAllTasks = (turboFiles) => {
-  const tasks = new Set();
-
-  for (const turboFile of turboFiles) {
-    const {tasks: packageTasks = {}} = JSON.parse(readFileSync(turboFile, 'utf8'));
-    for (const task of Object.keys(packageTasks)) {
-      tasks.add(task.replace(/^\/\/#/, ''));
-    }
-  }
-
-  return [...tasks].sort();
-};
+const getTurboFiles = (packages) =>
+  packages.map(({path}) => join(path, 'turbo.json')).filter((path) => existsSync(path));
 
 const allPackages = [...queryOutput.data.packages.items].sort(sortBy('name'));
 const allTasks = getAllTasks(getTurboFiles(allPackages));
-
-// Task graph
-
-const getTasksGraph = (dryRun) => {
-  return dryRun.tasks
-    .sort(sortBy('taskId'))
-    .map(({package: packageName, task, dependents}) => ({
-      packageName,
-      task,
-      dependents,
-    }))
-    .reduce((graph, {packageName, task, dependents}) => {
-      graph[packageName] ??= {};
-      graph[packageName][task] = dependents;
-      return graph;
-    }, {});
-};
-
-const dryRun = JSON.parse(turboCommand('run', '--dry=json', ...allTasks));
-const tasksGraph = getTasksGraph(dryRun);
-
-// Affected tasks
-
-/**
- * If a task is affected, all its dependents tasks are.
- * This is important because Turbo doesn't return tasks without a "command" in the output of affectedTasks.
- * You must attempt to call the tasks to know which dependencies are actually called.
- */
-const expandAffectedTasks = (tasksGraph, affectedTasks) => {
-  const affected = new Set(affectedTasks);
-  const queue = [...affectedTasks];
-
-  while (queue.length > 0) {
-    const task = queue.shift();
-    const [packageName, taskName] = task.split('#');
-    const dependents = tasksGraph[packageName][taskName];
-
-    for (const dependent of dependents) {
-      if (!affected.has(dependent)) {
-        affected.add(dependent);
-        queue.push(dependent);
-      }
-    }
-  }
-
-  return [...affected].sort();
-};
-
-const packagesFromTasks = (taskIds) => {
-  const packageNames = taskIds.map((taskId) => taskId.split('#')[0]);
-
-  return [...new Set(packageNames)].sort();
-};
-
-const affectedTasks = [...queryOutput.data.affectedTasks.items].sort(sortBy('fullName'));
-const affectedTaskNames = expandAffectedTasks(
-  tasksGraph,
+const dryRun = JSON.parse(turboCommand('run', '--dry=json', '--cache=local:rw', ...allTasks));
+const graphAnalysis = analyzeTaskGraph(
+  dryRun.tasks,
   affectedTasks.map(({fullName}) => fullName)
 );
+const affectedTaskNames = graphAnalysis.affectedTaskNames;
 const affectedPackageNames = packagesFromTasks(affectedTaskNames);
 const affectedSamples = affectedTaskNames.filter((fullName) =>
   /^@(samples\/|coveo\/ui-kit-sample-)[^#]+#e2e$/.test(fullName)
 );
 
-writeOutput('tasks', affectedTaskNames);
-writeOutput('projects', affectedPackageNames);
-writeOutput('samples', affectedSamples);
-
-// Output markdown table for the run summary
-
-const markdownTable = (headers, rows, quote = '') => {
-  const header = `| ${headers.join(' | ')} |`;
-  const separator = `| ${headers.map(() => '---').join(' | ')} |`;
-  const processCell = (cell) => `${quote}${String(cell).replaceAll('|', '\\|')}${quote}`;
-  const body = rows.map((row) => `| ${row.map(processCell).join(' | ')} |`).join('\n');
-
-  return [header, separator, body, ''].join('\n');
-};
-
-const getSummaryDescription = (reason) => {
-  if (reason.__typename === 'TaskDependencyTaskChanged') {
-    return `${reason.packageName}#${reason.taskName}`;
+const getQuanticE2ESummary = () => {
+  if (!graphAnalysis.selected) {
+    return '### Quantic E2E selection\n\nSkipped `@coveo/quantic#e2e` because no directly affected Turbo task reaches it through declared task dependencies.\n';
   }
 
-  return reason.description ?? reason.filePath ?? '';
+  const affectedByFullName = new Map(affectedTasks.map((task) => [task.fullName, task]));
+  const displayedTriggers = graphAnalysis.triggerTaskNames.slice(0, 5).map((fullName) => {
+    const trigger = affectedByFullName.get(fullName);
+    if (!trigger) {
+      throw new Error(`Quantic E2E trigger is missing its Turbo affected reason: ${fullName}`);
+    }
+    const description = getSummaryDescription(trigger.reason);
+    const detail = description ? `: ${escapeMarkdownValue(description)}` : '';
+    return `- ${escapeMarkdownValue(fullName)} — ${escapeMarkdownValue(trigger.reason.__typename)}${detail}`;
+  });
+  const additionalTriggerCount = graphAnalysis.triggerTaskNames.length - displayedTriggers.length;
+  if (additionalTriggerCount > 0) {
+    displayedTriggers.push(
+      `- ${escapeMarkdownValue(additionalTriggerCount)} additional affected task path(s)`
+    );
+  }
+
+  return [
+    '### Quantic E2E selection',
+    '',
+    'Selected `@coveo/quantic#e2e` because these directly affected Turbo tasks reach it through declared task dependencies:',
+    ...displayedTriggers,
+    '',
+  ].join('\n');
 };
 
-// Don't use the "expanded" affected tasks here, it would far too noisy.
 const affectedRows = affectedTasks.map(({package: packageInfo, name, reason}) => [
   packageInfo.name,
   name,
   reason.__typename,
   getSummaryDescription(reason),
 ]);
+const summary = `${getQuanticE2ESummary()}\n${markdownTable(
+  ['package', 'task', 'reason', 'description'],
+  affectedRows
+)}`;
+const serializedOutputs = [
+  ['fetch-depth', fetchDepth],
+  ['tasks', affectedTaskNames],
+  ['projects', affectedPackageNames],
+  ['samples', affectedSamples],
+]
+  .map(([name, value]) => `${name}=${JSON.stringify(value)}\n`)
+  .join('');
 
-const summary = markdownTable(['package', 'task', 'reason', 'description'], affectedRows);
 appendFileSync(GITHUB_STEP_SUMMARY, summary);
+appendFileSync(GITHUB_OUTPUT, serializedOutputs);
 
 const githubRunUrl = `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
 console.log(`Affected tasks summary: ${githubRunUrl}`);

--- a/scripts/ci/validate-quantic-e2e-contracts.test.mjs
+++ b/scripts/ci/validate-quantic-e2e-contracts.test.mjs
@@ -520,30 +520,50 @@ const replaceOnce = (contents, original, replacement) => {
   )}`;
 };
 
-const replaceImporterVersion = (contents, importer, dependency, from, to) => {
-  const importerStart = contents.indexOf(`  ${importer}:\n`);
+const replaceImporterDependencyFields = (contents, importer, dependency, replacements) => {
+  const importerMarker = `  ${importer}:\n`;
+  const importerStart = contents.indexOf(importerMarker);
   assert.notEqual(importerStart, -1, `Missing lockfile importer: ${importer}`);
-  const remainingContents = contents.slice(importerStart + 3);
+  const importerBodyStart = importerStart + importerMarker.length;
+  const remainingContents = contents.slice(importerBodyStart);
   const nextImporterOffset = remainingContents.search(/\n  \S/);
   const importerEnd =
-    nextImporterOffset === -1 ? contents.length : importerStart + 3 + nextImporterOffset;
+    nextImporterOffset === -1 ? contents.length : importerBodyStart + nextImporterOffset;
   const importerContents = contents.slice(importerStart, importerEnd);
-  const dependencyStart = importerContents.indexOf(`      ${dependency}:\n`);
-  assert.notEqual(dependencyStart, -1, `Missing ${dependency} in ${importer}`);
-  const version = `        version: ${from}`;
-  const dependencyBodyStart = dependencyStart + `      ${dependency}:\n`.length;
+  const dependencyMarkers = [
+    `      ${dependency}:\n`,
+    `      '${dependency}':\n`,
+    `      "${dependency}":\n`,
+  ];
+  const matchingMarkers = dependencyMarkers.filter(
+    (marker) => importerContents.indexOf(marker) !== -1
+  );
+  assert.equal(matchingMarkers.length, 1, `Missing or ambiguous ${dependency} in ${importer}`);
+  const dependencyMarker = matchingMarkers[0];
+  const dependencyStart = importerContents.indexOf(dependencyMarker);
+  const dependencyBodyStart = dependencyStart + dependencyMarker.length;
   const nextDependencyOffset = importerContents.slice(dependencyBodyStart).search(/\n      \S/);
   const dependencyEnd =
     nextDependencyOffset === -1
       ? importerContents.length
       : dependencyBodyStart + nextDependencyOffset;
   const dependencyContents = importerContents.slice(dependencyStart, dependencyEnd);
-  const versionStart = dependencyContents.indexOf(version);
-  assert.notEqual(versionStart, -1, `Missing ${dependency}@${from} in ${importer}`);
-  const updatedDependency = `${dependencyContents.slice(0, versionStart)}        version: ${to}${dependencyContents.slice(versionStart + version.length)}`;
+  let updatedDependency = dependencyContents;
+  for (const [field, {from, to}] of Object.entries(replacements)) {
+    updatedDependency = replaceOnce(
+      updatedDependency,
+      `        ${field}: ${from}`,
+      `        ${field}: ${to}`
+    );
+  }
   const updatedImporter = `${importerContents.slice(0, dependencyStart)}${updatedDependency}${importerContents.slice(dependencyEnd)}`;
   return `${contents.slice(0, importerStart)}${updatedImporter}${contents.slice(importerEnd)}`;
 };
+
+const replaceImporterVersion = (contents, importer, dependency, from, to) =>
+  replaceImporterDependencyFields(contents, importer, dependency, {
+    version: {from, to},
+  });
 
 const fixtureManifestPaths = [
   'packages/atomic/package.json',
@@ -579,16 +599,12 @@ const createFrozenValidTurboSpecifierHead = (checkout, baseline, specifier, name
   const packageManifest = JSON.parse(readFileSync(packagePath, 'utf8'));
   packageManifest.devDependencies.turbo = specifier;
   writeFileSync(packagePath, `${JSON.stringify(packageManifest, null, 2)}\n`);
-  runPnpm(
-    [
-      'install',
-      '--lockfile-only',
-      '--no-frozen-lockfile',
-      '--ignore-scripts',
-      '--offline',
-      '--config.trust-lockfile=true',
-    ],
-    checkout
+  const lockfilePath = resolve(checkout, 'pnpm-lock.yaml');
+  writeFileSync(
+    lockfilePath,
+    replaceImporterDependencyFields(readFileSync(lockfilePath, 'utf8'), '.', 'turbo', {
+      specifier: {from: '2.10.9', to: specifier},
+    })
   );
   validateFrozenLockfile(checkout);
   const head = commitWorkingTree(checkout, baseline, ['package.json', 'pnpm-lock.yaml'], name);
@@ -656,17 +672,27 @@ const prepareLockfileFixtureBaseline = (checkout, baseline) => {
     '@ag-ui/core',
     '>=0.0.57 <=0.0.58'
   );
-  runPnpm(
+  const lockfilePath = resolve(checkout, 'pnpm-lock.yaml');
+  const replacements = [
+    ['packages/quantic', 'dompurify', {specifier: {from: "'catalog:'", to: '^3.4.0'}}],
+    ['packages/quantic', 'wait-on', {specifier: {from: '9.1.0', to: "'>=8.0.5 <10'"}}],
+    ['packages/quantic', 'dotenv', {specifier: {from: "'catalog:'", to: "'>=16.6.1 <18'"}}],
+    ['packages/atomic', 'prettier', {specifier: {from: "'catalog:'", to: "'>=2.8.8 <4'"}}],
     [
-      'install',
-      '--lockfile-only',
-      '--no-frozen-lockfile',
-      '--ignore-scripts',
-      '--offline',
-      '--config.trust-lockfile=true',
+      'packages/thermidor',
+      '@ag-ui/core',
+      {
+        specifier: {from: '0.0.57', to: "'>=0.0.57 <=0.0.58'"},
+        version: {from: '0.0.57', to: '0.0.58'},
+      },
     ],
-    checkout
+  ];
+  const fixtureLockfile = replacements.reduce(
+    (lockfile, [importer, dependency, fields]) =>
+      replaceImporterDependencyFields(lockfile, importer, dependency, fields),
+    readFileSync(lockfilePath, 'utf8')
   );
+  writeFileSync(lockfilePath, fixtureLockfile);
   validateFrozenLockfile(checkout);
   const fixtureBaseline = commitWorkingTree(
     checkout,
@@ -682,19 +708,16 @@ const prepareLockfileFixtureBaseline = (checkout, baseline) => {
 
 const generateLockfileOnlyHead = (checkout, fixtureBaseline, scenario) => {
   runGit(checkout, ['checkout', '--quiet', '--detach', fixtureBaseline]);
-  runPnpm(
-    [
-      '--filter',
-      scenario.filter,
-      'update',
-      `${scenario.dependency}@${scenario.version}`,
-      '--no-save',
-      '--lockfile-only',
-      '--ignore-scripts',
-      '--offline',
-      '--config.trust-lockfile=true',
-    ],
-    checkout
+  const lockfilePath = resolve(checkout, 'pnpm-lock.yaml');
+  writeFileSync(
+    lockfilePath,
+    replaceImporterVersion(
+      readFileSync(lockfilePath, 'utf8'),
+      scenario.importer,
+      scenario.dependency,
+      scenario.baselineVersion,
+      scenario.version
+    )
   );
   validateFrozenLockfile(checkout);
   assert.equal(runGit(checkout, ['status', '--short']).trim(), 'M pnpm-lock.yaml');
@@ -1344,7 +1367,9 @@ test('selects Quantic E2E only for frozen-valid lockfile-only CI dependency chan
     {
       name: 'Quantic runtime dependency',
       filter: '@coveo/quantic',
+      importer: 'packages/quantic',
       dependency: 'dompurify',
+      baselineVersion: '3.4.13',
       version: '3.4.8',
       ...quanticExpectations,
     },
@@ -1356,7 +1381,9 @@ test('selects Quantic E2E only for frozen-valid lockfile-only CI dependency chan
     {
       name: 'Quantic Playwright configuration dependency',
       filter: '@coveo/quantic',
+      importer: 'packages/quantic',
       dependency: 'dotenv',
+      baselineVersion: '17.2.3',
       version: '16.6.1',
       ...quanticExpectations,
     },
@@ -1383,7 +1410,9 @@ test('selects Quantic E2E only for frozen-valid lockfile-only CI dependency chan
     {
       name: 'unrelated Thermidor runtime dependency',
       filter: '@coveo/thermidor',
+      importer: 'packages/thermidor',
       dependency: '@ag-ui/core',
+      baselineVersion: '0.0.58',
       version: '0.0.57',
       mustInclude: {
         tasks: [

--- a/scripts/ci/validate-quantic-e2e-contracts.test.mjs
+++ b/scripts/ci/validate-quantic-e2e-contracts.test.mjs
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
-import {execFileSync} from 'node:child_process';
+import {execFileSync, spawnSync} from 'node:child_process';
 import {createHash} from 'node:crypto';
 import {
+  chmodSync,
   cpSync,
   existsSync,
   mkdirSync,
@@ -15,10 +16,20 @@ import {
 } from 'node:fs';
 import {createRequire} from 'node:module';
 import {tmpdir} from 'node:os';
-import {dirname, join, resolve} from 'node:path';
+import {delimiter, dirname, join, resolve} from 'node:path';
 import test from 'node:test';
 import {fileURLToPath} from 'node:url';
 import {parse} from 'yaml';
+
+import {
+  analyzeTaskGraph,
+  approvedTurboVersion,
+  assertApprovedTurboVersion,
+  escapeMarkdownValue,
+  markdownTable,
+  normalizeTurboTaskKey,
+  pnpmLockfileValidationArguments,
+} from '../../.github/actions/calculate-affected/affected-utils.mjs';
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const read = (path) => readFileSync(resolve(repositoryRoot, path), 'utf8');
@@ -27,11 +38,19 @@ const headlessTurbo = JSON.parse(read('packages/headless/turbo.json'));
 const quanticPackage = JSON.parse(read('packages/quantic/package.json'));
 const quanticTurbo = JSON.parse(read('packages/quantic/turbo.json'));
 const ciWorkflow = parse(read('.github/workflows/ci.yml'));
+const calculateAffectedAction = parse(read('.github/actions/calculate-affected/action.yml'));
 const e2eWorkflow = parse(read('.github/workflows/e2e-quantic.yml'));
 const e2eSetupAction = parse(read('.github/actions/e2e-quantic-setup/action.yml'));
 const playwrightConfig = read('packages/quantic/playwright.config.ts');
 const playwrightAction = parse(read('.github/actions/playwright-quantic/action.yml'));
+const rootPackage = JSON.parse(read('package.json'));
+const rootTurbo = JSON.parse(read('turbo.json'));
 const turboBinary = resolve(repositoryRoot, 'node_modules/.bin/turbo');
+const pnpmBinary = execFileSync(process.platform === 'win32' ? 'where' : 'which', ['pnpm'], {
+  encoding: 'utf8',
+})
+  .trim()
+  .split(/\r?\n/u)[0];
 const require = createRequire(import.meta.url);
 const {
   expectedHeadlessBundlePaths,
@@ -41,6 +60,9 @@ const {
   resolveHeadlessDefinitionsPath,
 } = require(resolve(repositoryRoot, 'packages/quantic/scripts/npm/headless-build-output.js'));
 const affectednessContractPaths = [
+  '.github/actions/calculate-affected/action.yml',
+  '.github/actions/calculate-affected/affected.mjs',
+  '.github/actions/calculate-affected/affected-utils.mjs',
   'packages/headless/.gitignore',
   'packages/headless/esbuild.mjs',
   'packages/headless/package.json',
@@ -52,6 +74,7 @@ const affectednessContractPaths = [
   'packages/quantic/scripts/npm/headless-build-output.js',
   'packages/quantic/turbo.json',
   'scripts/ci/validate-quantic-e2e-contracts.test.mjs',
+  'turbo.json',
 ];
 
 const playwrightOutputs = ['playwright-report/**', 'blob-report/**', 'test-results/**'];
@@ -124,6 +147,131 @@ test('selects Quantic E2E for workflow and action changes', () => {
     quanticTurbo.tasks.e2e.inputs.toSorted(),
     ['$TURBO_DEFAULT$', ...expectedRootInputs].toSorted()
   );
+});
+
+test('delegates lockfile affectedness to Turbo package resolution', () => {
+  assert.equal(rootTurbo.globalDependencies.includes('pnpm-lock.yaml'), false);
+});
+
+test('installs pinned pnpm before the single affected-output step', () => {
+  assert.equal(rootPackage.packageManager, 'pnpm@11.22.0');
+  assert.equal(approvedTurboVersion, '2.10.9');
+  assert.equal(rootPackage.devDependencies.turbo, approvedTurboVersion);
+  assert.match(read('mise.toml'), /^pnpm = "11\.22\.0"$/m);
+  assert.match(calculateAffectedAction.runs.steps[0].uses, /^step-security\/mise-action@/);
+  assert.equal(calculateAffectedAction.runs.steps[0].with.install, true);
+  assert.equal(calculateAffectedAction.runs.steps.length, 2);
+  assert.equal(
+    calculateAffectedAction.outputs['fetch-depth'].value,
+    '${{ steps.calculate.outputs.fetch-depth }}'
+  );
+});
+
+test('accepts only the approved Turbo specifier and repository task-key grammar', () => {
+  assert.doesNotThrow(() => assertApprovedTurboVersion('2.10.9'));
+  for (const specifier of [
+    'npm:turbo@2.10.9',
+    '^2.10.9',
+    'https://registry.npmjs.org/turbo/-/turbo-2.10.9.tgz',
+    'file:../turbo',
+    'workspace:*',
+    'v2.10.9',
+    '2.10.9 ',
+  ]) {
+    assert.throws(() => assertApprovedTurboVersion(specifier), /repository-approved Turbo version/);
+  }
+
+  for (const [taskKey, expected] of [
+    ['build', 'build'],
+    ['functional-test', 'functional-test'],
+    ['a11y:update-openacr', 'a11y:update-openacr'],
+    ['//#lint:check:all', 'lint:check:all'],
+  ]) {
+    assert.equal(normalizeTurboTaskKey(taskKey), expected);
+  }
+  for (const taskKey of ['--help', '-build', '//#--help', 'build=--cache', 'build:-cache']) {
+    assert.throws(() => normalizeTurboTaskKey(taskKey), /CLI-option syntax|task-name grammar/);
+  }
+  assert.throws(() => normalizeTurboTaskKey('build\n--help'), /control characters/);
+  for (const taskKey of ['', 'build::test', 'build_test', 'Build']) {
+    assert.throws(() => normalizeTurboTaskKey(taskKey), /non-empty strings|task-name grammar/);
+  }
+});
+
+test('analyzes the validated Turbo task graph once with bounded traversals', () => {
+  const graph = [
+    {
+      package: '@coveo/headless',
+      task: 'build:quantic',
+      taskId: '@coveo/headless#build:quantic',
+      dependents: ['@coveo/quantic#babel:headless'],
+    },
+    {
+      package: '@coveo/quantic',
+      task: 'babel:headless',
+      taskId: '@coveo/quantic#babel:headless',
+      dependents: ['@coveo/quantic#e2e'],
+    },
+    {
+      package: '@coveo/quantic',
+      task: 'e2e',
+      taskId: '@coveo/quantic#e2e',
+      dependents: [],
+    },
+  ];
+
+  assert.deepEqual(analyzeTaskGraph(graph, ['@coveo/headless#build:quantic']), {
+    affectedTaskNames: [
+      '@coveo/headless#build:quantic',
+      '@coveo/quantic#babel:headless',
+      '@coveo/quantic#e2e',
+    ],
+    selected: true,
+    triggerTaskNames: ['@coveo/headless#build:quantic'],
+  });
+  assert.throws(
+    () =>
+      analyzeTaskGraph(
+        graph.map((task, index) =>
+          index === 0 ? {...task, dependents: ['@coveo/missing#build']} : task
+        ),
+        ['@coveo/headless#build:quantic']
+      ),
+    /dangling dependent/
+  );
+  assert.throws(
+    () => analyzeTaskGraph(graph, ['@coveo/missing#build']),
+    /Directly affected task is missing/
+  );
+  assert.throws(
+    () => analyzeTaskGraph([...graph, graph[0]], ['@coveo/headless#build:quantic']),
+    /duplicate task/
+  );
+  assert.throws(
+    () => analyzeTaskGraph(graph.slice(0, 2), ['@coveo/headless#build:quantic']),
+    /missing the selection target/
+  );
+  assert.throws(
+    () => analyzeTaskGraph(graph, [], '@coveo/quantic#e2e', {tasks: 10, edges: 1}),
+    /oversized task graph/
+  );
+  assert.throws(
+    () => analyzeTaskGraph(graph, [], '@coveo/quantic#e2e', {tasks: 2, edges: 10}),
+    /oversized task graph/
+  );
+});
+
+test('escapes and bounds every dynamic Markdown value', () => {
+  const malicious = `first\r\n# forged <script>& \`code\` \\ | [link](target) ${'*_!'.repeat(300)}`;
+  const escaped = escapeMarkdownValue(malicious);
+  assert.ok(escaped.length <= 512);
+  assert.doesNotMatch(escaped, /[\r\n<>`\\|[\]()]/u);
+  assert.match(escaped, /&#60;script&#62;/);
+  assert.match(escaped, /&#8230;$/);
+
+  const table = markdownTable(['value'], [[malicious]]);
+  assert.doesNotMatch(table, /<script>|# forged|`code`|\[link\]/u);
+  assert.ok(table.includes(escaped));
 });
 
 test('routes each Quantic E2E stage through its task contract', () => {
@@ -226,6 +374,7 @@ const runGit = (cwd, arguments_, options = {}) =>
   execFileSync('git', arguments_, {
     cwd,
     encoding: 'utf8',
+    maxBuffer: 100 * 1024 * 1024,
     ...options,
   });
 
@@ -242,10 +391,14 @@ const runTurbo = (arguments_, cwd = repositoryRoot) =>
     maxBuffer: 100 * 1024 * 1024,
   });
 
-const runPnpm = (arguments_, cwd) => {
+const runPnpm = (arguments_, cwd, environmentOverrides = {}) => {
   const environment = {...process.env};
-  delete environment.TURBO_HASH;
-  delete environment.TURBO_TASK_ID;
+  for (const name of Object.keys(environment)) {
+    if (name.startsWith('GIT_') || name.startsWith('TURBO_')) {
+      delete environment[name];
+    }
+  }
+  Object.assign(environment, environmentOverrides);
   return execFileSync('pnpm', arguments_, {
     cwd,
     encoding: 'utf8',
@@ -260,7 +413,7 @@ const linkDirectory = (source, destination) => {
   symlinkSync(source, destination, 'dir');
 };
 
-const withIsolatedRepository = (callback) => {
+const withIsolatedRepository = (callback, {linkNodeModules = true} = {}) => {
   const temporaryDirectory = mkdtempSync(join(tmpdir(), 'quantic-e2e-repository-'));
 
   try {
@@ -290,15 +443,18 @@ const withIsolatedRepository = (callback) => {
     assert.equal(runGit(checkout, ['status', '--short']).trim(), '');
     assert.equal(existsSync(resolve(checkout, '.git/objects/info/alternates')), false);
 
-    linkDirectory(resolve(repositoryRoot, 'node_modules'), resolve(checkout, 'node_modules'));
-    linkDirectory(
-      resolve(repositoryRoot, 'packages/headless/node_modules'),
-      resolve(checkout, 'packages/headless/node_modules')
-    );
+    if (linkNodeModules) {
+      linkDirectory(resolve(repositoryRoot, 'node_modules'), resolve(checkout, 'node_modules'));
+      linkDirectory(
+        resolve(repositoryRoot, 'packages/headless/node_modules'),
+        resolve(checkout, 'packages/headless/node_modules')
+      );
+    }
 
     return callback({baseline, checkout});
   } finally {
     rmSync(temporaryDirectory, {recursive: true, force: true});
+    assert.equal(existsSync(temporaryDirectory), false);
   }
 };
 
@@ -320,10 +476,20 @@ const createCommit = (checkout, base, updateIndex, message) => {
     }).trim();
   } finally {
     rmSync(temporaryDirectory, {recursive: true, force: true});
+    assert.equal(existsSync(temporaryDirectory), false);
   }
 };
 
 const createScenarioCommit = (checkout, base, filePath, scenario) =>
+  createFileContentsScenarioCommit(
+    checkout,
+    base,
+    filePath,
+    (contents) => `${contents}\n// ${scenario}\n`,
+    scenario
+  );
+
+const createFileContentsScenarioCommit = (checkout, base, filePath, transformContents, scenario) =>
   createCommit(
     checkout,
     base,
@@ -333,9 +499,10 @@ const createScenarioCommit = (checkout, base, filePath, scenario) =>
       }).trim();
       assert.notEqual(stagedFile, '', `${filePath} must be tracked`);
       const [mode] = stagedFile.split(' ');
+      const contents = readFileSync(resolve(checkout, filePath), 'utf8');
       const blob = runGit(checkout, ['hash-object', '-w', '--stdin'], {
         env: environment,
-        input: `${readFileSync(resolve(checkout, filePath), 'utf8')}\n// ${scenario}\n`,
+        input: transformContents(contents),
       }).trim();
       runGit(checkout, ['update-index', '--add', '--cacheinfo', mode, blob, filePath], {
         env: environment,
@@ -343,6 +510,371 @@ const createScenarioCommit = (checkout, base, filePath, scenario) =>
     },
     scenario
   );
+
+const replaceOnce = (contents, original, replacement) => {
+  const firstMatch = contents.indexOf(original);
+  assert.notEqual(firstMatch, -1, `Expected to find:\n${original}`);
+  assert.equal(contents.indexOf(original, firstMatch + original.length), -1, `Expected one match`);
+  return `${contents.slice(0, firstMatch)}${replacement}${contents.slice(
+    firstMatch + original.length
+  )}`;
+};
+
+const replaceImporterVersion = (contents, importer, dependency, from, to) => {
+  const importerStart = contents.indexOf(`  ${importer}:\n`);
+  assert.notEqual(importerStart, -1, `Missing lockfile importer: ${importer}`);
+  const remainingContents = contents.slice(importerStart + 3);
+  const nextImporterOffset = remainingContents.search(/\n  \S/);
+  const importerEnd =
+    nextImporterOffset === -1 ? contents.length : importerStart + 3 + nextImporterOffset;
+  const importerContents = contents.slice(importerStart, importerEnd);
+  const dependencyStart = importerContents.indexOf(`      ${dependency}:\n`);
+  assert.notEqual(dependencyStart, -1, `Missing ${dependency} in ${importer}`);
+  const version = `        version: ${from}`;
+  const dependencyBodyStart = dependencyStart + `      ${dependency}:\n`.length;
+  const nextDependencyOffset = importerContents.slice(dependencyBodyStart).search(/\n      \S/);
+  const dependencyEnd =
+    nextDependencyOffset === -1
+      ? importerContents.length
+      : dependencyBodyStart + nextDependencyOffset;
+  const dependencyContents = importerContents.slice(dependencyStart, dependencyEnd);
+  const versionStart = dependencyContents.indexOf(version);
+  assert.notEqual(versionStart, -1, `Missing ${dependency}@${from} in ${importer}`);
+  const updatedDependency = `${dependencyContents.slice(0, versionStart)}        version: ${to}${dependencyContents.slice(versionStart + version.length)}`;
+  const updatedImporter = `${importerContents.slice(0, dependencyStart)}${updatedDependency}${importerContents.slice(dependencyEnd)}`;
+  return `${contents.slice(0, importerStart)}${updatedImporter}${contents.slice(importerEnd)}`;
+};
+
+const fixtureManifestPaths = [
+  'packages/atomic/package.json',
+  'packages/quantic/package.json',
+  'packages/thermidor/package.json',
+];
+
+const updateDependencyRange = (checkout, manifestPath, dependency, range) => {
+  const path = resolve(checkout, manifestPath);
+  const manifest = JSON.parse(readFileSync(path, 'utf8'));
+  const dependencyGroup = ['dependencies', 'devDependencies', 'optionalDependencies'].find(
+    (group) => manifest[group]?.[dependency]
+  );
+  assert.ok(dependencyGroup, `${manifestPath} must declare ${dependency}`);
+  manifest[dependencyGroup][dependency] = range;
+  writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+};
+
+const validateFrozenLockfile = (checkout) => {
+  const lockfilePath = resolve(checkout, 'pnpm-lock.yaml');
+  const before = readFileSync(lockfilePath);
+  runPnpm(
+    [...pnpmLockfileValidationArguments, '--offline', '--config.trust-lockfile=true'],
+    checkout
+  );
+  assert.deepEqual(readFileSync(lockfilePath), before);
+};
+
+const createFrozenValidTurboSpecifierHead = (checkout, baseline, specifier, name) => {
+  runGit(checkout, ['checkout', '--quiet', '--detach', baseline]);
+  validateFrozenLockfile(checkout);
+  const packagePath = resolve(checkout, 'package.json');
+  const packageManifest = JSON.parse(readFileSync(packagePath, 'utf8'));
+  packageManifest.devDependencies.turbo = specifier;
+  writeFileSync(packagePath, `${JSON.stringify(packageManifest, null, 2)}\n`);
+  runPnpm(
+    [
+      'install',
+      '--lockfile-only',
+      '--no-frozen-lockfile',
+      '--ignore-scripts',
+      '--offline',
+      '--config.trust-lockfile=true',
+    ],
+    checkout
+  );
+  validateFrozenLockfile(checkout);
+  const head = commitWorkingTree(checkout, baseline, ['package.json', 'pnpm-lock.yaml'], name);
+  assert.deepEqual(runGit(checkout, ['diff', '--name-only', baseline, head]).trim().split('\n'), [
+    'package.json',
+    'pnpm-lock.yaml',
+  ]);
+  runGit(checkout, ['checkout', '--quiet', '--detach', head]);
+  validateFrozenLockfile(checkout);
+  return head;
+};
+
+const createTurboTaskKeyHead = (checkout, baseline, taskKey, name) => {
+  runGit(checkout, ['checkout', '--quiet', '--detach', baseline]);
+  validateFrozenLockfile(checkout);
+  const head = createFileContentsScenarioCommit(
+    checkout,
+    baseline,
+    'turbo.json',
+    (contents) => {
+      const turboConfig = JSON.parse(contents);
+      turboConfig.tasks[taskKey] = {cache: false};
+      return `${JSON.stringify(turboConfig, null, 2)}\n`;
+    },
+    name
+  );
+  runGit(checkout, ['checkout', '--quiet', '--detach', head]);
+  validateFrozenLockfile(checkout);
+  return head;
+};
+
+const commitWorkingTree = (checkout, parent, paths, message) => {
+  runGit(checkout, ['add', '--', ...paths]);
+  const tree = runGit(checkout, ['write-tree']).trim();
+  return runGit(checkout, ['commit-tree', tree, '-p', parent], {
+    env: {...process.env, ...gitIdentityEnvironment},
+    input: `${message}\n`,
+  }).trim();
+};
+
+const assertOnlyLockfileChanged = (checkout, base, head) => {
+  const changed = runGit(checkout, ['diff', '--name-only', base, head])
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+  assert.deepEqual(changed, ['pnpm-lock.yaml']);
+  for (const manifestPath of fixtureManifestPaths) {
+    assert.equal(
+      runGit(checkout, ['rev-parse', `${base}:${manifestPath}`]).trim(),
+      runGit(checkout, ['rev-parse', `${head}:${manifestPath}`]).trim(),
+      manifestPath
+    );
+  }
+};
+
+const prepareLockfileFixtureBaseline = (checkout, baseline) => {
+  runGit(checkout, ['checkout', '--quiet', '--detach', baseline]);
+  updateDependencyRange(checkout, 'packages/quantic/package.json', 'dompurify', '^3.4.0');
+  updateDependencyRange(checkout, 'packages/quantic/package.json', 'wait-on', '>=8.0.5 <10');
+  updateDependencyRange(checkout, 'packages/quantic/package.json', 'dotenv', '>=16.6.1 <18');
+  updateDependencyRange(checkout, 'packages/atomic/package.json', 'prettier', '>=2.8.8 <4');
+  updateDependencyRange(
+    checkout,
+    'packages/thermidor/package.json',
+    '@ag-ui/core',
+    '>=0.0.57 <=0.0.58'
+  );
+  runPnpm(
+    [
+      'install',
+      '--lockfile-only',
+      '--no-frozen-lockfile',
+      '--ignore-scripts',
+      '--offline',
+      '--config.trust-lockfile=true',
+    ],
+    checkout
+  );
+  validateFrozenLockfile(checkout);
+  const fixtureBaseline = commitWorkingTree(
+    checkout,
+    baseline,
+    [...fixtureManifestPaths, 'pnpm-lock.yaml'],
+    'frozen-valid lockfile fixture baseline'
+  );
+  runGit(checkout, ['checkout', '--quiet', '--detach', fixtureBaseline]);
+  validateFrozenLockfile(checkout);
+  assert.equal(runGit(checkout, ['status', '--short']).trim(), '');
+  return fixtureBaseline;
+};
+
+const generateLockfileOnlyHead = (checkout, fixtureBaseline, scenario) => {
+  runGit(checkout, ['checkout', '--quiet', '--detach', fixtureBaseline]);
+  runPnpm(
+    [
+      '--filter',
+      scenario.filter,
+      'update',
+      `${scenario.dependency}@${scenario.version}`,
+      '--no-save',
+      '--lockfile-only',
+      '--ignore-scripts',
+      '--offline',
+      '--config.trust-lockfile=true',
+    ],
+    checkout
+  );
+  validateFrozenLockfile(checkout);
+  assert.equal(runGit(checkout, ['status', '--short']).trim(), 'M pnpm-lock.yaml');
+  const head = commitWorkingTree(checkout, fixtureBaseline, ['pnpm-lock.yaml'], scenario.name);
+  assertOnlyLockfileChanged(checkout, fixtureBaseline, head);
+  return head;
+};
+
+const createCapturedWaitOnHead = (checkout, fixtureBaseline, scenario) => {
+  runGit(checkout, ['checkout', '--quiet', '--detach', fixtureBaseline]);
+  const head = createFileContentsScenarioCommit(
+    checkout,
+    fixtureBaseline,
+    'pnpm-lock.yaml',
+    (lockfile) => replaceImporterVersion(lockfile, 'packages/quantic', 'wait-on', '9.1.0', '8.0.5'),
+    scenario.name
+  );
+  runGit(checkout, ['checkout', '--quiet', '--detach', head]);
+  validateFrozenLockfile(checkout);
+  assertOnlyLockfileChanged(checkout, fixtureBaseline, head);
+  return head;
+};
+
+const createCapturedAtomicPrettierHead = (checkout, fixtureBaseline, scenario) => {
+  runGit(checkout, ['checkout', '--quiet', '--detach', fixtureBaseline]);
+  const head = createFileContentsScenarioCommit(
+    checkout,
+    fixtureBaseline,
+    'pnpm-lock.yaml',
+    (lockfile) => replaceImporterVersion(lockfile, 'packages/atomic', 'prettier', '3.9.6', '2.8.8'),
+    scenario.name
+  );
+  runGit(checkout, ['checkout', '--quiet', '--detach', head]);
+  validateFrozenLockfile(checkout);
+  assertOnlyLockfileChanged(checkout, fixtureBaseline, head);
+  return head;
+};
+
+const removeLastYamlBlock = (contents, key) => {
+  const marker = `  ${key}:\n`;
+  const start = contents.lastIndexOf(marker);
+  assert.notEqual(start, -1, `Missing final YAML block ${key}`);
+  const nextBlockOffset = contents.slice(start + marker.length).search(/\n  \S/u);
+  const end =
+    nextBlockOffset === -1 ? contents.length : start + marker.length + nextBlockOffset + 1;
+  return `${contents.slice(0, start)}${contents.slice(end)}`;
+};
+
+const parseActionOutputs = (contents) =>
+  Object.fromEntries(
+    contents
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const separator = line.indexOf('=');
+        return [line.slice(0, separator), JSON.parse(line.slice(separator + 1))];
+      })
+  );
+
+const runAffectedCalculation = (checkout, base, head, environmentOverrides = {}) => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'quantic-affected-action-'));
+  let result;
+
+  try {
+    const binDirectory = resolve(temporaryDirectory, 'bin');
+    const invocationLogPath = resolve(temporaryDirectory, 'invocations.jsonl');
+    const outputPath = resolve(temporaryDirectory, 'output');
+    const summaryPath = resolve(temporaryDirectory, 'summary');
+    const fakePnpmPath = resolve(binDirectory, 'pnpm');
+    mkdirSync(binDirectory, {recursive: true});
+    writeFileSync(invocationLogPath, '');
+    writeFileSync(outputPath, '');
+    writeFileSync(summaryPath, '');
+    writeFileSync(
+      fakePnpmPath,
+      `#!/usr/bin/env node
+const {spawnSync} = require('node:child_process');
+const {appendFileSync} = require('node:fs');
+const arguments_ = process.argv.slice(2);
+appendFileSync(
+  process.env.KIT_6131_INVOCATION_LOG,
+  JSON.stringify({
+    arguments: arguments_,
+    environment: {
+      GIT_DIR: process.env.GIT_DIR,
+      GIT_INDEX_FILE: process.env.GIT_INDEX_FILE,
+      TURBO_API: process.env.TURBO_API,
+      TURBO_CACHE_DIR: process.env.TURBO_CACHE_DIR,
+      TURBO_HASH: process.env.TURBO_HASH,
+      TURBO_TEAM: process.env.TURBO_TEAM,
+      TURBO_TOKEN: process.env.TURBO_TOKEN,
+    },
+  }) + '\\n'
+);
+let executable;
+let delegatedArguments;
+if (arguments_[0] === 'install') {
+  executable = process.env.KIT_6131_PNPM_BINARY;
+  delegatedArguments = [...arguments_, '--offline', '--config.trust-lockfile=true'];
+} else {
+  const [command, turboSpecifier, ...turboArguments] = arguments_;
+  if (command !== 'dlx' || turboSpecifier !== 'turbo@${approvedTurboVersion}') {
+    throw new Error('Unexpected pnpm invocation');
+  }
+  executable = process.env.KIT_6131_TURBO_BINARY;
+  delegatedArguments = turboArguments;
+}
+const result = spawnSync(executable, delegatedArguments, {
+  env: process.env,
+  stdio: 'inherit',
+});
+if (result.error) {
+  throw result.error;
+}
+process.exit(result.status ?? 1);
+`
+    );
+    chmodSync(fakePnpmPath, 0o755);
+
+    const environment = {
+      ...process.env,
+      GITHUB_OUTPUT: outputPath,
+      GITHUB_REPOSITORY: 'coveo/ui-kit',
+      GITHUB_RUN_ID: '6131',
+      GITHUB_SERVER_URL: 'https://example.invalid',
+      GITHUB_STEP_SUMMARY: summaryPath,
+      GIT_DIR: '/untrusted/inherited/git-dir',
+      GIT_INDEX_FILE: '/untrusted/inherited/git-index',
+      KIT_6131_INVOCATION_LOG: invocationLogPath,
+      KIT_6131_PNPM_BINARY: pnpmBinary,
+      KIT_6131_TURBO_BINARY: turboBinary,
+      NO_COLOR: '1',
+      PATH: `${binDirectory}${delimiter}${process.env.PATH}`,
+      TURBO_API: 'https://untrusted.invalid',
+      TURBO_CACHE_DIR: '/untrusted/inherited/cache',
+      TURBO_HASH: 'untrusted-hash',
+      TURBO_SCM_BASE: base,
+      TURBO_SCM_HEAD: head,
+      TURBO_TEAM: 'untrusted-team',
+      TURBO_TOKEN: 'untrusted-token',
+      ...environmentOverrides,
+    };
+
+    const actionResult = spawnSync(
+      process.execPath,
+      [resolve(checkout, '.github/actions/calculate-affected/affected.mjs')],
+      {
+        cwd: checkout,
+        encoding: 'utf8',
+        env: environment,
+        maxBuffer: 100 * 1024 * 1024,
+      }
+    );
+    let error = actionResult.error;
+    if (!error && actionResult.status !== 0) {
+      error = Object.assign(new Error(`Affected calculation exited ${actionResult.status}`), {
+        status: actionResult.status,
+        stderr: actionResult.stderr,
+        stdout: actionResult.stdout,
+      });
+    }
+
+    result = {
+      error,
+      invocations: readFileSync(invocationLogPath, 'utf8')
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line)),
+      outputs: parseActionOutputs(readFileSync(outputPath, 'utf8')),
+      summary: readFileSync(summaryPath, 'utf8'),
+      temporaryDirectory,
+    };
+  } finally {
+    rmSync(temporaryDirectory, {recursive: true, force: true});
+    assert.equal(existsSync(temporaryDirectory), false);
+  }
+  return result;
+};
 
 const getAffectedTasks = (base, head, checkout) => {
   const query = `
@@ -375,8 +907,8 @@ const reachesQuanticE2E = (affectedTasks, dependentsByTask) => {
   const affected = new Set(affectedTasks);
   const queue = [...affectedTasks];
 
-  while (queue.length) {
-    const task = queue.shift();
+  for (let index = 0; index < queue.length; index += 1) {
+    const task = queue[index];
     for (const dependent of dependentsByTask.get(task) ?? []) {
       if (!affected.has(dependent)) {
         affected.add(dependent);
@@ -747,4 +1279,380 @@ test('selects Quantic E2E from Turbo affectedness of embedded Headless output', 
       );
     }
   });
+});
+
+const assertInvocationEnvironmentIsControlled = (invocations) => {
+  for (const invocation of invocations) {
+    assert.deepEqual(invocation.environment, {});
+  }
+};
+
+const assertSuccessfulInvocationOrder = (invocations) => {
+  assert.equal(invocations.length, 3);
+  assert.deepEqual(invocations[0].arguments, [...pnpmLockfileValidationArguments]);
+  assert.deepEqual(invocations[1].arguments.slice(0, 4), [
+    'dlx',
+    `turbo@${approvedTurboVersion}`,
+    'query',
+    '--no-update-notifier',
+  ]);
+  assert.deepEqual(invocations[2].arguments.slice(0, 5), [
+    'dlx',
+    `turbo@${approvedTurboVersion}`,
+    'run',
+    '--dry=json',
+    '--cache=local:rw',
+  ]);
+  assertInvocationEnvironmentIsControlled(invocations);
+};
+
+const assertIncludesAndExcludes = (scenario, outputs) => {
+  for (const outputName of ['tasks', 'projects', 'samples']) {
+    const values = new Set(outputs[outputName]);
+    for (const value of scenario.mustInclude[outputName]) {
+      assert.ok(values.has(value), `${scenario.name} ${outputName} should include ${value}`);
+    }
+    for (const value of scenario.mustExclude[outputName]) {
+      assert.ok(
+        !values.has(value),
+        `${scenario.name} ${outputName} should exclude ${value}; actual: ${JSON.stringify([...values])}`
+      );
+    }
+  }
+};
+
+test('selects Quantic E2E only for frozen-valid lockfile-only CI dependency changes', () => {
+  const quanticExpectations = {
+    mustInclude: {
+      tasks: [
+        '@coveo/quantic#build',
+        '@coveo/quantic#e2e',
+        '@coveo/quantic#lint:check:all',
+        '@coveo/quantic#promote:sfdx:ci',
+        '@coveo/quantic#test',
+      ],
+      projects: ['@coveo/quantic'],
+      samples: [],
+    },
+    mustExclude: {
+      tasks: ['@coveo/thermidor#build', '@coveo/thermidor#publint', '@coveo/thermidor#test'],
+      projects: ['@ag-ui/core'],
+      samples: ['@samples/thermidor-search-react#e2e'],
+    },
+  };
+  const scenarios = [
+    {
+      name: 'Quantic runtime dependency',
+      filter: '@coveo/quantic',
+      dependency: 'dompurify',
+      version: '3.4.8',
+      ...quanticExpectations,
+    },
+    {
+      name: 'Quantic deployment dependency from PR #7982',
+      capturedWaitOn: true,
+      ...quanticExpectations,
+    },
+    {
+      name: 'Quantic Playwright configuration dependency',
+      filter: '@coveo/quantic',
+      dependency: 'dotenv',
+      version: '16.6.1',
+      ...quanticExpectations,
+    },
+    {
+      name: 'unrelated Atomic development dependency',
+      filter: '@coveo/atomic',
+      capturedAtomicPrettier: true,
+      mustInclude: {
+        tasks: [
+          '@coveo/atomic#build',
+          '@coveo/atomic#lint:check:all',
+          '@coveo/atomic#publint',
+          '@coveo/atomic#test',
+        ],
+        projects: ['@coveo/atomic', '@coveo/ui-kit-sample-atomic-search-vite'],
+        samples: ['@coveo/ui-kit-sample-atomic-search-vite#e2e'],
+      },
+      mustExclude: {
+        tasks: ['@coveo/quantic#e2e', '@coveo/quantic#promote:sfdx:ci'],
+        projects: ['prettier'],
+        samples: ['@samples/thermidor-search-react#e2e'],
+      },
+    },
+    {
+      name: 'unrelated Thermidor runtime dependency',
+      filter: '@coveo/thermidor',
+      dependency: '@ag-ui/core',
+      version: '0.0.57',
+      mustInclude: {
+        tasks: [
+          '//#lint:check:all',
+          '@coveo/quantic#lint:check:all',
+          '@coveo/thermidor#build',
+          '@coveo/thermidor#publint',
+          '@coveo/thermidor#test',
+        ],
+        projects: ['@coveo/thermidor', '@samples/thermidor-search-react'],
+        samples: ['@samples/thermidor-search-react#e2e'],
+      },
+      mustExclude: {
+        tasks: ['@coveo/quantic#e2e', '@coveo/quantic#promote:sfdx:ci'],
+        projects: ['@ag-ui/core'],
+        samples: ['@coveo/ui-kit-sample-atomic-search-vite#e2e'],
+      },
+    },
+  ];
+
+  withIsolatedRepository(
+    ({baseline, checkout}) => {
+      const fixtureBaseline = prepareLockfileFixtureBaseline(checkout, baseline);
+      for (const [index, scenario] of scenarios.entries()) {
+        const head = scenario.capturedWaitOn
+          ? createCapturedWaitOnHead(checkout, fixtureBaseline, scenario)
+          : scenario.capturedAtomicPrettier
+            ? createCapturedAtomicPrettierHead(checkout, fixtureBaseline, scenario)
+            : generateLockfileOnlyHead(checkout, fixtureBaseline, scenario);
+        runGit(checkout, ['checkout', '--quiet', '--detach', head]);
+        const lockfileBeforeAction = readFileSync(resolve(checkout, 'pnpm-lock.yaml'));
+        const actionResult = runAffectedCalculation(checkout, fixtureBaseline, head, {
+          TURBO_CACHE_DIR: `/untrusted/cache/${index}`,
+          TURBO_TOKEN: `untrusted-token-${index}`,
+        });
+        const {error, invocations, outputs, summary, temporaryDirectory} = actionResult;
+
+        assert.equal(
+          error,
+          undefined,
+          `${scenario.name}: ${error?.stderr ?? error?.message ?? ''}`
+        );
+        assert.equal(existsSync(temporaryDirectory), false);
+        assert.deepEqual(readFileSync(resolve(checkout, 'pnpm-lock.yaml')), lockfileBeforeAction);
+        assert.equal(outputs['fetch-depth'], 2);
+        assertIncludesAndExcludes(scenario, outputs);
+        assertSuccessfulInvocationOrder(invocations);
+        assert.match(summary, /### Quantic E2E selection/);
+        assert.match(summary, /TaskPackageDependencyChanged/);
+
+        if (scenario.filter === '@coveo/quantic' || scenario.capturedWaitOn) {
+          assert.ok(
+            summary.includes(
+              'Selected `@coveo/quantic#e2e` because these directly affected Turbo tasks reach it through declared task dependencies:'
+            )
+          );
+          assert.ok(summary.includes(escapeMarkdownValue('@coveo/quantic#e2e')));
+          assert.ok(summary.includes(escapeMarkdownValue('@coveo/quantic')));
+        } else {
+          assert.ok(
+            summary.includes(
+              'Skipped `@coveo/quantic#e2e` because no directly affected Turbo task reaches it through declared task dependencies.'
+            )
+          );
+          assert.ok(summary.includes(escapeMarkdownValue(scenario.filter)));
+        }
+
+        if (index === 0) {
+          const warmResult = runAffectedCalculation(checkout, fixtureBaseline, head, {
+            GIT_WORK_TREE: '/untrusted/inherited/work-tree',
+            TURBO_CACHE_DIR: '/different/untrusted/cache',
+            TURBO_TOKEN: 'different-untrusted-token',
+          });
+          assert.equal(warmResult.error, undefined);
+          assert.deepEqual(warmResult.outputs, outputs);
+          assert.equal(warmResult.summary, summary);
+          assertSuccessfulInvocationOrder(warmResult.invocations);
+          assert.equal(existsSync(warmResult.temporaryDirectory), false);
+        }
+      }
+
+      rmSync(resolve(checkout, '.turbo'), {recursive: true, force: true});
+      assert.equal(existsSync(resolve(checkout, '.turbo')), false);
+      rmSync(resolve(checkout, 'node_modules'), {recursive: true, force: true});
+      assert.equal(existsSync(resolve(checkout, 'node_modules')), false);
+    },
+    {linkNodeModules: false}
+  );
+});
+
+test('sanitizes hostile Turbo reason paths in the action summary', () => {
+  withIsolatedRepository(
+    ({baseline, checkout}) => {
+      const maliciousPath = `packages/quantic/summary-\r\n# forged-<script>-\`code\`-\\-|-[x](y)-${'*'.repeat(80)}.txt`;
+      const head = createCommit(
+        checkout,
+        baseline,
+        (environment) => {
+          const blob = runGit(checkout, ['hash-object', '-w', '--stdin'], {
+            env: environment,
+            input: 'hostile summary fixture\n',
+          }).trim();
+          runGit(
+            checkout,
+            ['update-index', '--add', '--cacheinfo', '100644', blob, maliciousPath],
+            {
+              env: environment,
+            }
+          );
+        },
+        'hostile affected path'
+      );
+      runGit(checkout, ['checkout', '--quiet', '--detach', head]);
+      const {error, invocations, summary} = runAffectedCalculation(checkout, baseline, head);
+
+      assert.equal(error, undefined);
+      assertSuccessfulInvocationOrder(invocations);
+      assert.ok(summary.includes(escapeMarkdownValue(maliciousPath)));
+      assert.equal(summary.includes('<script>'), false);
+      assert.equal(summary.includes('# forged'), false);
+      assert.equal(summary.includes('[x](y)'), false);
+    },
+    {linkNodeModules: false}
+  );
+});
+
+test('rejects frozen-valid noncanonical Turbo specs before pnpm dlx and output', () => {
+  withIsolatedRepository(
+    ({baseline, checkout}) => {
+      const scenarios = [
+        {name: 'aliased Turbo dependency', specifier: 'npm:turbo@2.10.9'},
+        {name: 'ranged Turbo dependency', specifier: '^2.10.9'},
+      ];
+
+      for (const scenario of scenarios) {
+        const head = createFrozenValidTurboSpecifierHead(
+          checkout,
+          baseline,
+          scenario.specifier,
+          scenario.name
+        );
+        const lockfileBeforeAction = readFileSync(resolve(checkout, 'pnpm-lock.yaml'));
+        const {error, invocations, outputs, summary, temporaryDirectory} = runAffectedCalculation(
+          checkout,
+          baseline,
+          head
+        );
+
+        assert.ok(error, `${scenario.name} should fail before pnpm dlx`);
+        assert.match(
+          `${error.stderr ?? ''}${error.stdout ?? ''}`,
+          /repository-approved Turbo version/
+        );
+        assert.deepEqual(invocations, []);
+        assert.deepEqual(outputs, {});
+        assert.equal(summary, '');
+        assert.deepEqual(readFileSync(resolve(checkout, 'pnpm-lock.yaml')), lockfileBeforeAction);
+        assert.equal(existsSync(temporaryDirectory), false);
+      }
+      rmSync(resolve(checkout, 'node_modules'), {recursive: true, force: true});
+      assert.equal(existsSync(resolve(checkout, 'node_modules')), false);
+    },
+    {linkNodeModules: false}
+  );
+});
+
+test('rejects frozen-valid hostile task keys before Turbo and output', () => {
+  withIsolatedRepository(
+    ({baseline, checkout}) => {
+      const scenarios = [
+        {name: 'option-shaped task key', taskKey: '--cache=remote:rw', error: /CLI-option syntax/},
+        {
+          name: 'control-character task key',
+          taskKey: 'build\n--cache=remote:rw',
+          error: /control characters/,
+        },
+      ];
+
+      for (const scenario of scenarios) {
+        const head = createTurboTaskKeyHead(checkout, baseline, scenario.taskKey, scenario.name);
+        const lockfileBeforeAction = readFileSync(resolve(checkout, 'pnpm-lock.yaml'));
+        const {error, invocations, outputs, summary, temporaryDirectory} = runAffectedCalculation(
+          checkout,
+          baseline,
+          head
+        );
+
+        assert.ok(error, `${scenario.name} should fail before Turbo`);
+        assert.match(`${error.stderr ?? ''}${error.stdout ?? ''}`, scenario.error);
+        assert.deepEqual(invocations, []);
+        assert.deepEqual(outputs, {});
+        assert.equal(summary, '');
+        assert.deepEqual(readFileSync(resolve(checkout, 'pnpm-lock.yaml')), lockfileBeforeAction);
+        assert.equal(existsSync(temporaryDirectory), false);
+      }
+      rmSync(resolve(checkout, 'node_modules'), {recursive: true, force: true});
+      assert.equal(existsSync(resolve(checkout, 'node_modules')), false);
+    },
+    {linkNodeModules: false}
+  );
+});
+
+test('fails semantic lockfile validation before Turbo and all GitHub output', () => {
+  withIsolatedRepository(
+    ({baseline, checkout}) => {
+      const fixtureBaseline = prepareLockfileFixtureBaseline(checkout, baseline);
+      const fixtureLock = parse(runGit(checkout, ['show', `${fixtureBaseline}:pnpm-lock.yaml`]));
+      const dompurifyVersion =
+        fixtureLock.importers['packages/quantic'].dependencies.dompurify.version;
+      const scenarios = [
+        {
+          name: 'syntactically valid dangling snapshot',
+          base: fixtureBaseline,
+          transform: (lockfile) => removeLastYamlBlock(lockfile, `dompurify@${dompurifyVersion}`),
+        },
+        {
+          name: 'importer specifier mismatch against exact Quantic manifest',
+          base: baseline,
+          transform: (lockfile) =>
+            replaceImporterVersion(lockfile, 'packages/quantic', 'wait-on', '9.1.0', '8.0.5'),
+        },
+        {
+          name: 'malformed pnpm lockfile',
+          base: baseline,
+          transform: () => "lockfileVersion: '9.0'\nimporters: [\n",
+        },
+        {
+          name: 'unsupported pnpm lockfile version',
+          base: baseline,
+          transform: (lockfile) =>
+            replaceOnce(lockfile, "lockfileVersion: '9.0'", "lockfileVersion: '99.0'"),
+        },
+      ];
+
+      for (const scenario of scenarios) {
+        runGit(checkout, ['checkout', '--quiet', '--detach', scenario.base]);
+        const head = createFileContentsScenarioCommit(
+          checkout,
+          scenario.base,
+          'pnpm-lock.yaml',
+          scenario.transform,
+          scenario.name
+        );
+        runGit(checkout, ['checkout', '--quiet', '--detach', head]);
+        const lockfileBeforeAction = readFileSync(resolve(checkout, 'pnpm-lock.yaml'));
+        const {error, invocations, outputs, summary, temporaryDirectory} = runAffectedCalculation(
+          checkout,
+          scenario.base,
+          head
+        );
+
+        assert.ok(error, `${scenario.name} should fail semantic validation`);
+        assert.match(
+          `${error.stderr ?? ''}${error.stdout ?? ''}${error.message}`,
+          /pnpm frozen lockfile validation (failed|modified)/
+        );
+        assert.deepEqual(
+          invocations.map((invocation) => invocation.arguments),
+          [[...pnpmLockfileValidationArguments]]
+        );
+        assertInvocationEnvironmentIsControlled(invocations);
+        assert.deepEqual(outputs, {});
+        assert.equal(summary, '');
+        assert.deepEqual(readFileSync(resolve(checkout, 'pnpm-lock.yaml')), lockfileBeforeAction);
+        assert.equal(existsSync(temporaryDirectory), false);
+      }
+      rmSync(resolve(checkout, 'node_modules'), {recursive: true, force: true});
+      assert.equal(existsSync(resolve(checkout, 'node_modules')), false);
+    },
+    {linkNodeModules: false}
+  );
 });

--- a/turbo.json
+++ b/turbo.json
@@ -260,13 +260,7 @@
       "cache": false
     }
   },
-  "globalDependencies": [
-    "package.json",
-    "pnpm-lock.yaml",
-    "pnpm-workspace.yaml",
-    ".npmrc",
-    "tsconfig.json"
-  ],
+  "globalDependencies": ["package.json", "pnpm-workspace.yaml", ".npmrc", "tsconfig.json"],
   "globalEnv": ["DEPLOYMENT_ENVIRONMENT", "NODE_ENV", "CI", "CDN_COMMIT_SHA"],
   "globalPassThroughEnv": ["GITHUB_*", "RUNNER_*", "SFDX_*", "PLAYWRIGHT_BROWSERS_PATH"]
 }


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6131

## Motivation

Treating every `pnpm-lock.yaml` change as a global Turbo dependency starts Quantic Salesforce E2E for unrelated dependency maintenance. Lockfile-only changes should follow the package graph while malformed or unresolved states fail loudly.

## Changes

- Remove broad lockfile global invalidation and retain Turbo as the repository affectedness authority.
- Validate the frozen lockfile before calculating affected tasks, pin the trusted Turbo command boundary, and reject malformed task graphs or command-shaped task names.
- Explain why Quantic E2E was selected or skipped using sanitized Turbo dependency reasons.
- Add isolated frozen-valid scenarios for Quantic runtime, deployment, Playwright, unrelated dependencies, invalid lockfiles, and representative repository tasks/projects/samples.

## Validation

- [x] `pnpm run lint:fix`
- [x] Quantic E2E affectedness contracts (21/21, with empty pnpm metadata caches)
- [x] Frozen lockfile validation with pnpm 11.22.0
- [x] Canonical nine-task Quantic E2E dry-run graph
- [x] GitHub Actions affected-output and secret-backed Quantic PR CI ([run 33123879019](https://github.com/coveo/ui-kit/actions/runs/33123879019))

## Checklist

- [x] PR title follows Conventional Commits 1.0.0
- [x] Changeset not required for internal CI-only changes
