### PR TITLE
docs(atomic): document all-categories label localization keys

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.ts
@@ -48,6 +48,10 @@ import facetSearchStyles from '../../common/facets/facet-search/facet-search.tw.
  * A facet is a list of values for a certain field occurring in the products.
  * An `atomic-commerce-category-facet` displays a facet of values in a browsable, hierarchical fashion.
  *
+ * The label of the "All Categories" button comes from the `all-categories` localization key. To override it for a
+ * single facet, add an `all-categories-{facetId}` key, or an `all-categories-{field}` key to override it for every
+ * facet on a given field.
+ *
  * @part facet - The wrapper for the entire facet.
  * @part placeholder - The placeholder shown before the first search is executed.
  *

--- a/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.usage.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-category-facet/atomic-commerce-category-facet.usage.mdx
@@ -9,3 +9,32 @@ This component is not meant to be used directly in the layout. You should use th
   </atomic-layout-section>
 </atomic-commerce-interface>
 ```
+
+## Customizing the "All Categories" Label
+
+By default, every category facet in an interface shares the same "All Categories" label, which comes from the `all-categories` translation key. Because commerce facets are generated from the Commerce API response, you customize the label through i18n rather than through an attribute. The label is resolved in this order, and the first key that exists wins:
+
+1. `all-categories-{facetId}` — applies to the single facet with that ID
+2. `all-categories-{field}` — applies to every facet on that field
+3. `all-categories` — the default, applied to all remaining category facets
+
+```javascript
+const commerceInterface = document.querySelector('atomic-commerce-interface');
+await commerceInterface.initialize({/* ... */});
+
+// Applies only to the facet whose facet ID is "ec_category"
+commerceInterface.i18n.addResourceBundle('en', 'translation', {
+  'all-categories-ec_category': 'All Departments',
+});
+
+// Applies to every category facet without a more specific key
+commerceInterface.i18n.addResourceBundle('en', 'translation', {
+  'all-categories': 'All Products',
+});
+```
+
+Add one bundle per locale you support to translate the label along with the rest of the interface. See [Localize Atomic](https://docs.coveo.com/en/atomic/latest/usage/atomic-localization/) for the general localization workflow.
+
+The facet ID and field of a commerce facet are both dictated by the API response and are often identical, so either key works. Use the facet ID variant when several category facets are built on the same field.
+
+The resolved label is also used in the facet search results, where it represents the root of the hierarchy for values that have no parent.

--- a/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.ts
+++ b/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.ts
@@ -64,6 +64,10 @@ import {mapProperty} from '@/src/utils/props-utils';
 /**
  * The `atomic-category-facet` component displays a facet of values in a browsable, hierarchical fashion.
  *
+ * The label of the "All Categories" button comes from the `all-categories` localization key. To override it for a
+ * single facet, add an `all-categories-{facetId}` key, or an `all-categories-{field}` key to override it for every
+ * facet on a given field.
+ *
  * @part facet - The wrapper for the entire facet.
  * @part placeholder - The placeholder shown before the first search is executed.
  *
@@ -85,7 +89,7 @@ import {mapProperty} from '@/src/utils/props-utils';
  * @part parents - The container surrounding the whole hierarchy of values.
  * @part sub-parents - The container surrounding a sub-hierarchy of values.
  * @part values - The container surrounding either the children of the active value or the values at the base.
- * @part all-categories-button - The "View all" button displayed first within the parents.
+ * @part all-categories-button - The "All Categories" button displayed first within the parents.
  * @part parent-button - The clickable parent button displayed first within sub-parents.
  * @part active-parent - The clickable active parent displayed first within the last sub-parents.
  * @part value-link - The clickable value displayed first within values.

--- a/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.usage.mdx
+++ b/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.usage.mdx
@@ -79,7 +79,7 @@ searchInterface.i18n.addResourceBundle('en', 'translation', {
 
 Add one bundle per locale you support to translate the label along with the rest of the interface. See [Localize Atomic](https://docs.coveo.com/en/atomic/latest/usage/atomic-localization/) for the general localization workflow.
 
-When you don't set the `facet-id` attribute, the facet ID defaults to the field name, so `all-categories-{field}` is usually enough. Reach for `all-categories-{facetId}` when several category facets share the same field and need different labels. In that case, set `facet-id` explicitly on each of them: otherwise the extra facets get a generated, suffixed ID such as `geographicalhierarchy_1`.
+When you don't set the `facet-id` attribute, the facet ID defaults to the field name, as long as no other facet in the interface already uses that ID, so `all-categories-{field}` is usually enough. Reach for `all-categories-{facetId}` when several category facets share the same field and need different labels. In that case, set `facet-id` explicitly on each of them: the facets that don't get the bare field name fall back to a generated, suffixed ID such as `geographicalhierarchy_1`.
 
 The resolved label is also used in the facet search results, where it represents the root of the hierarchy for values that have no parent.
 

--- a/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.usage.mdx
+++ b/packages/atomic/src/components/search/atomic-category-facet/atomic-category-facet.usage.mdx
@@ -43,23 +43,45 @@ Search results display the full path to each matching value, helping users under
 
 ## Customizing the "All Categories" Label
 
-You can customize the "All Categories" button label using i18n. The component looks for translation keys in this order:
+By default, every category facet in an interface shares the same "All Categories" label, which comes from the `all-categories` translation key. You can override it globally, per field, or per facet by adding more specific keys to the interface's i18n instance. The label is resolved in this order, and the first key that exists wins:
 
-1. `all-categories-{facet-id}` - Custom label for a specific facet by ID
-2. `all-categories-{field}` - Custom label for facets using a specific field
-3. `all-categories` - Default fallback
+1. `all-categories-{facetId}` — applies to the single facet with that ID
+2. `all-categories-{field}` — applies to every facet on that field
+3. `all-categories` — the default, applied to all remaining category facets
+
+```html
+<atomic-category-facet
+  field="geographicalhierarchy"
+  facet-id="my-location-facet"
+  label="Location"
+></atomic-category-facet>
+```
 
 ```javascript
-// Customize by facet ID
+const searchInterface = document.querySelector('atomic-search-interface');
+await searchInterface.initialize({/* ... */});
+
+// Applies only to the facet whose facet-id is "my-location-facet"
 searchInterface.i18n.addResourceBundle('en', 'translation', {
-  'all-categories-my-location-facet': 'All Locations'
+  'all-categories-my-location-facet': 'All Locations',
 });
 
-// Or customize by field
+// Applies to every category facet on the "geographicalhierarchy" field
 searchInterface.i18n.addResourceBundle('en', 'translation', {
-  'all-categories-geographicalhierarchy': 'All Regions'
+  'all-categories-geographicalhierarchy': 'All Regions',
+});
+
+// Applies to every category facet without a more specific key
+searchInterface.i18n.addResourceBundle('en', 'translation', {
+  'all-categories': 'All Results',
 });
 ```
+
+Add one bundle per locale you support to translate the label along with the rest of the interface. See [Localize Atomic](https://docs.coveo.com/en/atomic/latest/usage/atomic-localization/) for the general localization workflow.
+
+When you don't set the `facet-id` attribute, the facet ID defaults to the field name, so `all-categories-{field}` is usually enough. Reach for `all-categories-{facetId}` when several category facets share the same field and need different labels. In that case, set `facet-id` explicitly on each of them: otherwise the extra facets get a generated, suffixed ID such as `geographicalhierarchy_1`.
+
+The resolved label is also used in the facet search results, where it represents the root of the hierarchy for values that have no parent.
 
 ## UX Best Practices
 


### PR DESCRIPTION
[KIT-5102](https://coveord.atlassian.net/browse/KIT-5102)

## Problem

KIT-5095 added per-facet customization of the category facet "All Categories" button label, resolved from `all-categories-{facetId}`, then `all-categories-{field}`, then `all-categories`. Where to document it was left undecided, and the commerce category facet had no mention of it at all.

## Solution

Decision: document it in the component-level docs that live with the code, so it shows up both in Storybook and in the generated component reference. The docs.coveo.com localization page stays a general guide and doesn't need a per-component key list.

- Expanded the "Customizing the All Categories Label" section of `atomic-category-facet.usage.mdx`: full resolution order, runnable `addResourceBundle` examples for each level, a note that the facet ID defaults to the field (and is suffixed when several facets share a field), a link to the localization guide, and a mention that the label is reused in facet search results.
- Added the equivalent section to `atomic-commerce-category-facet.usage.mdx`, framed around facet IDs coming from the Commerce API response.
- Added a short note about the three keys to the class JSDoc of both components, so the reference documentation carries it too.
- Fixed the `all-categories-button` part description on `atomic-category-facet`, which called it the "View all" button.

No behavior change; documentation only. Ran the category facet unit suites (149 passing) plus `lint:fix`.

[KIT-5102]: https://coveord.atlassian.net/browse/KIT-5102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ