### PR TITLE
fix(create-atomic): pass --experimental-detect-module on Node versions without default module detection

### DIFF
--- a/.changeset/kit-5160-stencil-detect-module.md
+++ b/.changeset/kit-5160-stencil-detect-module.md
@@ -1,0 +1,12 @@
+---
+'@coveo/create-atomic': patch
+---
+
+Make the generated project's `start` and `build` scripts work on Node versions that don't detect ES
+module syntax by default.
+
+Stencil transpiles `stencil.config.ts` to a `.js` file inside the generated project, which has no
+`"type": "module"` in its `package.json`. Node only treats such ambiguous files as ES modules by
+default as of 20.19.0 and 22.7.0, so on older versions the build failed with an ES module error. The
+scripts now invoke Stencil through `node --experimental-detect-module` when the project is scaffolded
+with one of those versions, and keep calling `stencil` directly otherwise.

--- a/packages/create-atomic/scripts/packageTemplate.json
+++ b/packages/create-atomic/scripts/packageTemplate.json
@@ -10,8 +10,8 @@
   "collection:main": "dist/index.js",
   "scripts": {
     "setup-cleanup": "node ./scripts/clean-up.js",
-    "start": "stencil build --dev --watch --serve",
-    "build": "stencil build && node deployment.esbuild.mjs",
+    "start": "{{{stencil}}} build --dev --watch --serve",
+    "build": "{{{stencil}}} build && node deployment.esbuild.mjs",
     "deploy": "npm run build && coveo ui:deploy",
     "postinstall": "npm run setup-cleanup && prettier --write . --loglevel warn"
   }

--- a/packages/create-atomic/src/plopfile.ts
+++ b/packages/create-atomic/src/plopfile.ts
@@ -8,7 +8,7 @@ import {createPlatformClient} from './client.js';
 import {defaultPageManifest} from './default/default-page.js';
 import {fetchPageManifest, type IManifest} from './fetch-page.js';
 import {listSearchPagesOptions} from './list-pages.js';
-import {getPackageManager} from './utils.js';
+import {getPackageManager, getStencilCommand} from './utils.js';
 
 interface PlopData {
   project: string;
@@ -66,6 +66,7 @@ export default function (plop: NodePlopAPI) {
   }
 
   plop.setHelper('inc', (value) => parseInt(value, 10) + 1);
+  plop.setHelper('stencil', () => getStencilCommand());
 
   plop.setGenerator('@coveo/atomic', {
     description: 'A Coveo Atomic Generator',

--- a/packages/create-atomic/src/utils.ts
+++ b/packages/create-atomic/src/utils.ts
@@ -1,6 +1,42 @@
 export const appendCmdIfWindows = (cmd: string) =>
   `${cmd}${process.platform === 'win32' ? '.ps1' : ''}`;
 
+const STENCIL_BIN = './node_modules/@stencil/core/bin/stencil';
+
+/**
+ * Stencil transpiles `stencil.config.ts` to a `.js` file inside the project, which has no
+ * `"type": "module"` in its `package.json`. Node only detects the ES module syntax in such
+ * ambiguous files by default as of 20.19.0 and 22.7.0; on older versions the file is treated as
+ * CommonJS and the build fails with an ES module error. Those versions need
+ * `--experimental-detect-module`, which exists as of 20.10.0 and 21.1.0.
+ *
+ * @see https://nodejs.org/en/blog/release/v20.19.0#module-syntax-detection-is-now-enabled-by-default
+ */
+export function needsModuleDetectionFlag(nodeVersion = process.versions.node) {
+  const [major, minor] = nodeVersion.split('.').map(Number);
+
+  switch (major) {
+    case 20:
+      return minor >= 10 && minor < 19;
+    case 21:
+      return minor >= 1;
+    case 22:
+      return minor < 7;
+    default:
+      return false;
+  }
+}
+
+/**
+ * The command the generated project uses to invoke Stencil, adapted to the Node version the
+ * project is scaffolded with.
+ */
+export function getStencilCommand(nodeVersion = process.versions.node) {
+  return needsModuleDetectionFlag(nodeVersion)
+    ? `node --experimental-detect-module ${STENCIL_BIN}`
+    : 'stencil';
+}
+
 const DEFAULT_PACKAGE_MANAGER = 'npm';
 
 export function getPackageManager(noCmd = false) {


### PR DESCRIPTION
[KIT-5160](https://coveord.atlassian.net/browse/KIT-5160)

## Problem

`npm run build` and `npm run start` fail with an ES module error in Atomic projects generated by the Coveo CLI when the project is scaffolded and run on Node < 20.19.0 (e.g. 20.18).

Stencil transpiles `stencil.config.ts` to a `.js` file inside the generated project, and that project's `package.json` has no `"type": "module"`. Node only inspects such ambiguous files for ES module syntax by default as of 20.19.0 and 22.7.0. On older versions the file is treated as CommonJS, so the `import` statements throw.

## Solution

`packageTemplate.json` now renders the Stencil invocation through a new `stencil` Handlebars helper instead of hardcoding `stencil`. The helper (`getStencilCommand` in `src/utils.ts`) inspects the Node version the project is scaffolded with:

- Versions where module syntax detection is not on by default but the flag exists (20.10–20.18, 21.1+, 22.0–22.6) get `node --experimental-detect-module ./node_modules/@stencil/core/bin/stencil`.
- Everything else keeps the plain `stencil` binary, so no behaviour change on 20.19+, 22.7+, or 24.

The command points at `@stencil/core/bin/stencil` rather than `./node_modules/.bin/stencil` (as in the ticket's workaround) because the latter is a POSIX shell script on Windows and can't be passed to `node`; the package's own bin is a Node script with a shebang and works on every platform.

## Testing

- `pnpm --filter @coveo/create-atomic build` — typechecks and regenerates `template/package.json.hbs`.
- Rendered the generated `package.json.hbs` through `node-plop`'s `renderString` with the helper pinned to `20.18.1` and `22.20.0`, confirming the flag is added only in the first case.
- Verified `node --experimental-detect-module` is accepted (as a no-op) on 20.12.2, 22.20.0, and 24.18.1, so the flag can't break newer runtimes.

[KIT-5160]: https://coveord.atlassian.net/browse/KIT-5160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ