### PR TITLE
docs(atomic): document display clickable behaviour for commerce recommendation list

### DIFF
--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.ts
@@ -157,6 +157,10 @@ export class AtomicCommerceRecommendationList
   /**
    * The layout to apply when displaying the products. This does not affect the display of the surrounding list itself.
    * To modify the number of products per column and row, modify the `--atomic-recs-number-of-columns` and `--atomic-recs-number-of-rows` CSS variables.
+   *
+   * This property also determines which part of a recommended product is clickable:
+   * - When set to `grid`, the entire product is wrapped in a link, so clicking anywhere on it navigates to the product.
+   * - When set to `list`, the product is not wrapped in a link, so you control where the interactive elements are by adding them to your product template (for example, an `atomic-product-link`).
    */
   @property({reflect: true, type: String})
   public display: ItemDisplayBasicLayout = 'list';

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.ts
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.ts
@@ -159,8 +159,8 @@ export class AtomicCommerceRecommendationList
    * To modify the number of products per column and row, modify the `--atomic-recs-number-of-columns` and `--atomic-recs-number-of-rows` CSS variables.
    *
    * This property also determines which part of a recommended product is clickable:
-   * - When set to `grid`, the entire product is wrapped in a link, so clicking anywhere on it navigates to the product.
-   * - When set to `list`, the product is not wrapped in a link, so you control where the interactive elements are by adding them to your product template (for example, an `atomic-product-link`).
+   * - When set to `grid`, the whole product is clickable: a click anywhere on it is forwarded to a product link rendered alongside your template content, which navigates to the product. Interactive elements in your template must stop click propagation to avoid triggering this navigation; `atomic-product-link` does so by default.
+   * - When set to `list`, clicks on the product are not forwarded to a product link, so you control where the interactive elements are by adding them to your product template (for example, an `atomic-product-link`).
    */
   @property({reflect: true, type: String})
   public display: ItemDisplayBasicLayout = 'list';

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.usage.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.usage.mdx
@@ -21,7 +21,9 @@ You can include multiple recommendation lists within a single interface:
 
 The `display` property changes more than the visual layout: it also determines what part of a recommended product is clickable.
 
-When `display` is set to `grid`, the whole product is wrapped in a link, so clicking anywhere on the product navigates to it. Interactive elements you place in your template still work, since their clicks are not forwarded to the surrounding link.
+When `display` is set to `grid`, the whole product is clickable: your template content is not nested inside an `<a>` element, but a click anywhere on the product is forwarded to a product link rendered alongside it, which navigates to the product.
+
+Interactive elements you place in your template still work, as long as they stop the click event from propagating to the product. `atomic-product-link` does this by default; for your own interactive elements, call `event.stopPropagation()` in their click handler.
 
 ```html
 <atomic-commerce-recommendation-list display="grid">
@@ -38,7 +40,7 @@ When `display` is set to `grid`, the whole product is wrapped in a link, so clic
 </atomic-commerce-recommendation-list>
 ```
 
-When `display` is set to `list`, the product is not wrapped in a link. You decide where the interactive elements are by adding them to your template, typically with an `atomic-product-link`. Only those elements are clickable.
+When `display` is set to `list`, clicks on the product are not forwarded to a product link. You decide where the interactive elements are by adding them to your template, typically with an `atomic-product-link`. Only those elements are clickable.
 
 ```html
 <atomic-commerce-recommendation-list display="list">

--- a/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.usage.mdx
+++ b/packages/atomic/src/components/commerce/atomic-commerce-recommendation-list/atomic-commerce-recommendation-list.usage.mdx
@@ -17,6 +17,44 @@ You can include multiple recommendation lists within a single interface:
 </atomic-commerce-recommendation-interface>
 ```
 
+### How the `display` property affects clickable areas
+
+The `display` property changes more than the visual layout: it also determines what part of a recommended product is clickable.
+
+When `display` is set to `grid`, the whole product is wrapped in a link, so clicking anywhere on the product navigates to it. Interactive elements you place in your template still work, since their clicks are not forwarded to the surrounding link.
+
+```html
+<atomic-commerce-recommendation-list display="grid">
+  <atomic-product-template>
+    <template>
+      <atomic-product-section-visual>
+        <atomic-product-image field="ec_thumbnails"></atomic-product-image>
+      </atomic-product-section-visual>
+      <atomic-product-section-name>
+        <atomic-product-text field="ec_name"></atomic-product-text>
+      </atomic-product-section-name>
+    </template>
+  </atomic-product-template>
+</atomic-commerce-recommendation-list>
+```
+
+When `display` is set to `list`, the product is not wrapped in a link. You decide where the interactive elements are by adding them to your template, typically with an `atomic-product-link`. Only those elements are clickable.
+
+```html
+<atomic-commerce-recommendation-list display="list">
+  <atomic-product-template>
+    <template>
+      <atomic-product-section-visual>
+        <atomic-product-image field="ec_thumbnails"></atomic-product-image>
+      </atomic-product-section-visual>
+      <atomic-product-section-name>
+        <atomic-product-link class="font-bold"></atomic-product-link>
+      </atomic-product-section-name>
+    </template>
+  </atomic-product-template>
+</atomic-commerce-recommendation-list>
+```
+
 ### Using `setRenderFunction` for custom rendering
 
 <SetRenderFunctionNote />


### PR DESCRIPTION
[KIT-5341](https://coveord.atlassian.net/browse/KIT-5341)

## Problem

The Storybook `docs` section for `atomic-commerce-recommendation-list` documents `display` as a purely visual layout choice. It does not mention that the property also determines what part of a recommended product is clickable: with `display="grid"` a click anywhere on the product is forwarded to a product link and navigates, while with `display="list"` no such forwarding happens and the integrator decides where the interactive elements live in the product template.

## Solution

- Added a "How the `display` property affects clickable areas" section to `atomic-commerce-recommendation-list.usage.mdx`, with a markup example for each display value.
- Expanded the `display` property JSDoc so the same explanation appears in the Storybook props table and in the generated reference documentation.
- Wording follows the actual DOM structure: in grid mode the template content is not nested inside an `<a>`; `atomic-product` renders a sibling link container and forwards clicks to it. Nested interactive elements must stop click propagation, which `atomic-product-link` does by default.

No behaviour change; documentation only.

[KIT-5341]: https://coveord.atlassian.net/browse/KIT-5341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ