### PR TITLE
fix(atomic): sort facets nested inside popovers in the facet manager

### DIFF
--- a/.changeset/kit-5268-facet-manager-popover-reordering.md
+++ b/.changeset/kit-5268-facet-manager-popover-reordering.md
@@ -1,0 +1,12 @@
+---
+'@coveo/atomic': patch
+---
+
+Reorder facets nested inside an `atomic-popover` in `atomic-facet-manager`.
+
+`atomic-facet-manager` only looked at its direct children when collecting facets, so facets slotted
+inside an `atomic-popover` were never sorted by the facet manager and Dynamic Navigation Experience
+re-ordering had no effect on them. Those facets are now discovered through their popover, and their
+popover is the element moved when reordering, so the facet stays slotted inside it. Facets nested in
+a popover are excluded from the `collapse-facets-after` logic, since a popover always displays its
+facet expanded.

--- a/packages/atomic/src/components/common/facets/facet-common.spec.ts
+++ b/packages/atomic/src/components/common/facets/facet-common.spec.ts
@@ -3,9 +3,11 @@ import {describe, expect, it} from 'vitest';
 import {
   collapseFacetsAfter,
   getAutomaticFacetGenerator,
+  getFacetElementToReorder,
   getFacetsInChildren,
   getFirstNewFacetValueIndex,
   isAutomaticFacetGenerator,
+  isFacetNestedInPopover,
   shouldDisplayInputForFacetRange,
   sortFacetVisibility,
   triageFacetsByParents,
@@ -167,6 +169,72 @@ describe('facet-common', () => {
       expect(result).toContain(facet1);
       expect(result).toContain(facet2);
       expect(result).not.toContain(notFacet);
+    });
+
+    it('should return facets nested inside a popover', () => {
+      const parent = document.createElement('div');
+      const facet = buildMockFacetElement({facetId: 'f1'});
+      const popover = document.createElement('atomic-popover');
+      popover.appendChild(facet);
+      parent.appendChild(popover);
+
+      expect(getFacetsInChildren(parent)).toEqual([facet]);
+    });
+
+    it('should preserve the DOM order of facets when some are nested inside a popover', () => {
+      const parent = document.createElement('div');
+      const facet1 = buildMockFacetElement({facetId: 'f1'});
+      const facet2 = buildMockFacetElement({facetId: 'f2'});
+      const popover = document.createElement('atomic-popover');
+      popover.appendChild(facet2);
+
+      parent.appendChild(facet1);
+      parent.appendChild(popover);
+
+      expect(getFacetsInChildren(parent)).toEqual([facet1, facet2]);
+    });
+
+    it('should not return the content of a popover without a facet', () => {
+      const parent = document.createElement('div');
+      const popover = document.createElement('atomic-popover');
+      popover.appendChild(document.createElement('div'));
+      parent.appendChild(popover);
+
+      expect(getFacetsInChildren(parent)).toEqual([]);
+    });
+  });
+
+  describe('#isFacetNestedInPopover', () => {
+    it('should return true when the facet is slotted in a popover', () => {
+      const popover = document.createElement('atomic-popover');
+      const facet = buildMockFacetElement({facetId: 'f1'});
+      popover.appendChild(facet);
+
+      expect(isFacetNestedInPopover(facet)).toBe(true);
+    });
+
+    it('should return false when the facet is not slotted in a popover', () => {
+      const parent = document.createElement('div');
+      const facet = buildMockFacetElement({facetId: 'f1'});
+      parent.appendChild(facet);
+
+      expect(isFacetNestedInPopover(facet)).toBe(false);
+    });
+  });
+
+  describe('#getFacetElementToReorder', () => {
+    it('should return the popover when the facet is slotted in one', () => {
+      const popover = document.createElement('atomic-popover');
+      const facet = buildMockFacetElement({facetId: 'f1'});
+      popover.appendChild(facet);
+
+      expect(getFacetElementToReorder(facet)).toBe(popover);
+    });
+
+    it('should return the facet itself when it is not slotted in a popover', () => {
+      const facet = buildMockFacetElement({facetId: 'f1'});
+
+      expect(getFacetElementToReorder(facet)).toBe(facet);
     });
   });
 

--- a/packages/atomic/src/components/common/facets/facet-common.ts
+++ b/packages/atomic/src/components/common/facets/facet-common.ts
@@ -95,12 +95,34 @@ function isPseudoFacet(el: Element): el is BaseFacetElement {
   return 'facetId' in el;
 }
 
-export function getFacetsInChildren(parent: HTMLElement): BaseFacetElement[] {
-  const facets = Array.from(parent.children).filter((child) =>
-    isPseudoFacet(child)
-  ) as BaseFacetElement[];
+function isPopover(element: Element) {
+  return element.tagName === 'ATOMIC-POPOVER';
+}
 
-  return facets;
+/**
+ * Whether the facet is slotted inside an `atomic-popover`.
+ */
+export function isFacetNestedInPopover(facet: BaseFacetElement) {
+  return !!facet.parentElement && isPopover(facet.parentElement);
+}
+
+/**
+ * Returns the element to move when reordering the given facet inside its manager.
+ *
+ * A facet nested in an `atomic-popover` must stay slotted inside it, so its popover is moved instead.
+ */
+export function getFacetElementToReorder(facet: BaseFacetElement): HTMLElement {
+  return isFacetNestedInPopover(facet) ? facet.parentElement! : facet;
+}
+
+export function getFacetsInChildren(parent: HTMLElement): BaseFacetElement[] {
+  return Array.from(parent.children).flatMap((child) => {
+    if (isPseudoFacet(child)) {
+      return [child];
+    }
+
+    return isPopover(child) ? Array.from(child.children).filter(isPseudoFacet) : [];
+  });
 }
 export function getAutomaticFacetGenerator(
   parent: HTMLElement

--- a/packages/atomic/src/components/search/atomic-facet-manager/atomic-facet-manager.spec.ts
+++ b/packages/atomic/src/components/search/atomic-facet-manager/atomic-facet-manager.spec.ts
@@ -55,6 +55,21 @@ describe('atomic-facet-manager', () => {
     };
   };
 
+  type MockFacet = HTMLElement & {facetId: string; isCollapsed: boolean};
+
+  const createMockFacet = (facetId: string): MockFacet => {
+    const facet = document.createElement('div') as unknown as MockFacet;
+    facet.facetId = facetId;
+    facet.isCollapsed = false;
+    return facet;
+  };
+
+  const createMockPopover = (facet: MockFacet) => {
+    const popover = document.createElement('atomic-popover');
+    popover.appendChild(facet);
+    return popover;
+  };
+
   it('should be defined', () => {
     const el = document.createElement('atomic-facet-manager');
     expect(el).toBeInstanceOf(AtomicFacetManager);
@@ -123,21 +138,6 @@ describe('atomic-facet-manager', () => {
   });
 
   describe('when managing collapse state', () => {
-    const createMockFacet = (
-      facetId: string
-    ): HTMLElement & {
-      facetId: string;
-      isCollapsed: boolean;
-    } => {
-      const facet = document.createElement('div') as unknown as HTMLElement & {
-        facetId: string;
-        isCollapsed: boolean;
-      };
-      facet.facetId = facetId;
-      facet.isCollapsed = false;
-      return facet;
-    };
-
     const createMockGenerator = () => {
       const generator = document.createElement(
         'atomic-automatic-facet-generator'
@@ -237,6 +237,106 @@ describe('atomic-facet-manager', () => {
       expect(mockGenerator.updateCollapseFacetsDependingOnFacetsVisibility).toHaveBeenCalledWith(
         3,
         2
+      );
+    });
+  });
+
+  describe('when facets are nested inside popovers', () => {
+    const reverseSort = <T>(payload: T[]) => [...payload].reverse();
+
+    it('should sort the facets nested inside popovers', async () => {
+      const mockSort = vi.fn(reverseSort);
+      const facet1 = createMockFacet('facet1');
+      const facet2 = createMockFacet('facet2');
+
+      const {element} = await renderComponent({
+        mockSortImplementation: mockSort as never,
+      });
+
+      element?.append(createMockPopover(facet1), createMockPopover(facet2));
+
+      await element?.sortFacets();
+
+      expect(mockSort).toHaveBeenCalledWith([
+        {facetId: 'facet1', payload: facet1},
+        {facetId: 'facet2', payload: facet2},
+      ]);
+    });
+
+    it('should reorder the popovers rather than their nested facets', async () => {
+      const facet1 = createMockFacet('facet1');
+      const facet2 = createMockFacet('facet2');
+      const popover1 = createMockPopover(facet1);
+      const popover2 = createMockPopover(facet2);
+
+      const {element} = await renderComponent({
+        mockSortImplementation: reverseSort as never,
+      });
+
+      element?.append(popover1, popover2);
+
+      await element?.sortFacets();
+
+      expect(popover1.previousElementSibling).toBe(popover2);
+      expect(facet1.parentElement).toBe(popover1);
+      expect(facet2.parentElement).toBe(popover2);
+    });
+
+    it('should reorder popovers alongside facets that are not nested', async () => {
+      const facet1 = createMockFacet('facet1');
+      const facet2 = createMockFacet('facet2');
+      const facet3 = createMockFacet('facet3');
+      const popover = createMockPopover(facet2);
+
+      const {element} = await renderComponent({
+        mockSortImplementation: reverseSort as never,
+      });
+
+      element?.append(facet1, popover, facet3);
+
+      await element?.sortFacets();
+
+      expect(popover.previousElementSibling).toBe(facet3);
+      expect(popover.nextElementSibling).toBe(facet1);
+    });
+
+    it('should not collapse facets nested inside popovers', async () => {
+      const facet = createMockFacet('facet1');
+
+      const {element} = await renderComponent({
+        props: {collapseFacetsAfter: 0},
+      });
+
+      element?.append(createMockPopover(facet));
+
+      await element?.sortFacets();
+
+      expect(facet.isCollapsed).toBe(false);
+    });
+
+    it('should exclude facets nested inside popovers from the automatic facet generator collapse count', async () => {
+      const mockGenerator = document.createElement(
+        'atomic-automatic-facet-generator'
+      ) as unknown as HTMLElement & {
+        updateCollapseFacetsDependingOnFacetsVisibility: ReturnType<typeof vi.fn>;
+      };
+      mockGenerator.updateCollapseFacetsDependingOnFacetsVisibility = vi.fn();
+
+      const {element} = await renderComponent({
+        props: {collapseFacetsAfter: 3},
+      });
+
+      element?.append(
+        createMockFacet('facet1'),
+        createMockPopover(createMockFacet('facet2')),
+        mockGenerator
+      );
+
+      await element?.sortFacets();
+
+      expect(mockGenerator.updateCollapseFacetsDependingOnFacetsVisibility).toHaveBeenCalledWith(
+        3,
+        1
       );
     });
   });

--- a/packages/atomic/src/components/search/atomic-facet-manager/atomic-facet-manager.ts
+++ b/packages/atomic/src/components/search/atomic-facet-manager/atomic-facet-manager.ts
@@ -6,7 +6,9 @@ import {
   type BaseFacetElement,
   collapseFacetsAfter,
   getAutomaticFacetGenerator,
+  getFacetElementToReorder,
   getFacetsInChildren,
+  isFacetNestedInPopover,
   sortFacetVisibility,
 } from '@/src/components/common/facets/facet-common';
 import {ValidatePropsController} from '@/src/components/common/validate-props-controller/validate-props-controller';
@@ -89,14 +91,19 @@ export class AtomicFacetManager
 
     const generator = getAutomaticFacetGenerator(this);
 
-    collapseFacetsAfter(visibleFacets, this.collapseFacetsAfter);
+    const collapsibleFacets = visibleFacets.filter((facet) => !isFacetNestedInPopover(facet));
+
+    collapseFacetsAfter(collapsibleFacets, this.collapseFacetsAfter);
 
     generator?.updateCollapseFacetsDependingOnFacetsVisibility?.(
       this.collapseFacetsAfter,
-      visibleFacets.length
+      collapsibleFacets.length
     );
 
-    this.append(...[...visibleFacets, ...invisibleFacets, ...(generator ? [generator] : [])]);
+    this.append(
+      ...[...visibleFacets, ...invisibleFacets].map((facet) => getFacetElementToReorder(facet)),
+      ...(generator ? [generator] : [])
+    );
   };
 
   private sortFacetsUsingManager(


### PR DESCRIPTION
[KIT-5268](https://coveord.atlassian.net/browse/KIT-5268)

## Problem

DNE (Dynamic Navigation Experience) facet re-ordering had no effect on facets placed inside an `atomic-popover`:

```html
<atomic-facet-manager>
  <atomic-popover><atomic-facet /></atomic-popover>
  <atomic-popover><atomic-facet /></atomic-popover>
</atomic-facet-manager>
```

`atomic-facet-manager` collected facets by filtering its **direct children** for a `facetId`. With a popover in between, the direct child is the `atomic-popover`, which has no `facetId`, so those facets were never handed to the facet manager controller and never reordered.

## Solution

- `getFacetsInChildren` now also looks inside `atomic-popover` children, so nested facets are discovered while keeping DOM order.
- Reordering moves the popover instead of the facet (`getFacetElementToReorder`), so the facet stays slotted inside its popover.
- Popover-nested facets are excluded from the `collapse-facets-after` logic and from the count passed to `atomic-automatic-facet-generator`, since a popover always displays its facet expanded — collapsing it would render an empty popover.

Unit tests were added to `facet-common.spec.ts` and `atomic-facet-manager.spec.ts`; the three reordering tests fail on `main` and pass with this change.

[KIT-5268]: https://coveord.atlassian.net/browse/KIT-5268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ