### PR TITLE
fix(atomic-a11y): stop partial a11y shard reports from downgrading openacr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,7 +582,7 @@ jobs:
           name: a11y-report-shard-${{ matrix.shardIndex }}
           path: packages/atomic/reports/a11y-report.shard-${{ matrix.shardIndex }}.json
           retention-days: 1
-          if-no-files-found: warn
+          if-no-files-found: error
   merge-storybook-a11y-reports:
     name: 'Merge Storybook a11y reports and validate OpenACR'
     needs: [affected, storybook-atomic]
@@ -592,6 +592,9 @@ jobs:
         contains(needs.affected.outputs.tasks, '"@coveo/atomic#test:storybook"')
       }}
     runs-on: ubuntu-latest
+    env:
+      # Must match strategy.matrix.shardTotal of the storybook-atomic job above.
+      A11Y_SHARD_TOTAL: 10
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -603,24 +606,28 @@ jobs:
           fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
+      # Steps below only run when every shard succeeded: a partial set of shard
+      # reports understates component coverage and must never reach openacr.yaml.
       - name: 'Download a11y shard reports'
-        continue-on-error: true
+        if: needs.storybook-atomic.result == 'success'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: a11y-report-shard-*
           path: packages/atomic/reports
           merge-multiple: true
       - name: 'Merge a11y shard reports'
-        run: pnpm exec turbo run a11y:merge-shards --filter=@coveo/atomic-a11y -- ../atomic/reports/a11y-report.json
+        if: needs.storybook-atomic.result == 'success'
+        run: pnpm exec turbo run a11y:merge-shards --filter=@coveo/atomic-a11y -- ../atomic/reports/a11y-report.json --expected-shards=${{ env.A11Y_SHARD_TOTAL }}
       - name: 'Upload merged a11y report'
-        if: always()
+        if: needs.storybook-atomic.result == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: atomic-storybook-a11y-report
           path: packages/atomic/reports/a11y-report.json
           retention-days: 7
-          if-no-files-found: warn
+          if-no-files-found: error
       - name: 'Check openacr.yaml is up to date'
+        if: needs.storybook-atomic.result == 'success'
         run: node scripts/check-openacr-drift.mjs
         working-directory: packages/atomic-a11y
 

--- a/packages/atomic-a11y/README.md
+++ b/packages/atomic-a11y/README.md
@@ -82,6 +82,8 @@ Replace `<RUN_ID>` with the GitHub Actions run ID from the failing check (shown 
 
 > Requires the [GitHub CLI](https://cli.github.com/) (`gh`) to be installed and authenticated.
 
+The command refuses to run when the chosen run covers fewer components than the committed `openacr.yaml` does, which is how an incomplete set of Storybook a11y shards would silently downgrade conformance levels. Pick a run whose `Run Storybook tests` shards all succeeded, or pass `--allow-coverage-drop` when the reduction is genuinely intended (for example after removing components).
+
 ### Option 2: Run tests locally
 
 If you prefer to regenerate from scratch:

--- a/packages/atomic-a11y/reports/openacr.yaml
+++ b/packages/atomic-a11y/reports/openacr.yaml
@@ -13,8 +13,8 @@ vendor:
   company_name: Coveo
   email: support@coveo.com
   website: https://www.coveo.com
-report_date: '2026-08-28'
-last_modified_date: '2026-08-28'
+report_date: '2026-08-31'
+last_modified_date: '2026-08-31'
 version: 1
 notes: Generated from a11y/reports/a11y-report.json. Conformance is derived from
   axe-core results, interactive keyboard tests, and manual audits.
@@ -37,7 +37,7 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 1.2.1
         components:
           - name: web
@@ -63,7 +63,8 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177); interactive keyboard testing passed across 2
+                component(s).
       - num: 1.3.2
         components:
           - name: web
@@ -86,7 +87,7 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 1.4.2
         components:
           - name: web
@@ -99,14 +100,16 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19); interactive keyboard testing passed across 3
-                component(s).
+                component(s) (179); interactive keyboard testing passed across
+                35 component(s).
       - num: 2.1.2
         components:
           - name: web
             adherence:
               level: supports
-              notes: Supports — manual audit found Supports.
+              notes: Supports — manual audit found Supports; automated axe-core found no
+                violations across applicable component(s) (10); interactive
+                keyboard testing passed across 10 component(s).
       - num: 2.1.4
         components:
           - name: web
@@ -167,7 +170,7 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 2.5.1
         components:
           - name: web
@@ -235,7 +238,7 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 3.3.7
         components:
           - name: web
@@ -249,7 +252,8 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177); interactive keyboard testing passed across 4
+                component(s).
   success_criteria_level_aa:
     notes: Conformance is based on automated Storybook + axe-core output and
       interactive keyboard testing.
@@ -281,21 +285,21 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 1.4.3
         components:
           - name: web
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 1.4.4
         components:
           - name: web
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 1.4.5
         components:
           - name: web
@@ -323,13 +327,15 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 1.4.13
         components:
           - name: web
             adherence:
-              level: does-not-support
-              notes: 'WCAG 1.4.13: no automated, interactive, or manual coverage.'
+              level: supports
+              notes: Supports — automated axe-core found no violations across applicable
+                component(s) (1); interactive keyboard testing passed across 1
+                component(s).
       - num: 2.4.5
         components:
           - name: web
@@ -372,14 +378,14 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 3.1.2
         components:
           - name: web
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 3.2.3
         components:
           - name: web
@@ -423,7 +429,7 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (4); interactive keyboard testing passed across 4
+                component(s) (24); interactive keyboard testing passed across 24
                 component(s).
   success_criteria_level_aaa:
     disabled: true

--- a/packages/atomic-a11y/scripts/check-openacr-drift.mjs
+++ b/packages/atomic-a11y/scripts/check-openacr-drift.mjs
@@ -23,8 +23,17 @@ if (!existsSync(COMMITTED_OPENACR)) {
 const INPUT_REPORT = resolve(REPO_ROOT, 'packages/atomic/reports/a11y-report.json');
 
 if (!existsSync(INPUT_REPORT)) {
-  console.log('⏭️  No a11y-report.json found. Skipping drift check.');
-  process.exit(0);
+  console.error(`
+❌ No a11y-report.json found at ${INPUT_REPORT}.
+
+The drift check cannot validate openacr.yaml without a merged a11y report.
+Skipping silently here is what allowed a partial report to be committed, so
+this is now a hard failure. Run the Storybook suite (or the merge step) first:
+
+  pnpm exec turbo run test:storybook --filter=@coveo/atomic
+  pnpm exec turbo run a11y:merge-shards --filter=@coveo/atomic-a11y -- ../atomic/reports/a11y-report.json
+`);
+  process.exit(1);
 }
 
 // Generate fresh openacr from the merged a11y report

--- a/packages/atomic-a11y/scripts/merge-shards-cli.mjs
+++ b/packages/atomic-a11y/scripts/merge-shards-cli.mjs
@@ -1,6 +1,23 @@
 import path from 'node:path';
 import {mergeA11yShardReports} from '../dist/index.js';
 
-const outputFile = process.argv[2] ?? path.resolve('reports', 'a11y-report.json');
+const args = process.argv.slice(2);
+const positional = args.filter((arg) => !arg.startsWith('--'));
+const expectedShardsArg = args.find((arg) => arg.startsWith('--expected-shards='))?.split('=')[1];
 
-await mergeA11yShardReports({outputFile});
+const outputFile = positional[0] ?? path.resolve('reports', 'a11y-report.json');
+const expectedShards = expectedShardsArg ? Number.parseInt(expectedShardsArg, 10) : undefined;
+
+if (expectedShardsArg && !Number.isInteger(expectedShards)) {
+  console.error(
+    `[merge-shards] --expected-shards must be an integer, received "${expectedShardsArg}".`
+  );
+  process.exit(1);
+}
+
+const merged = await mergeA11yShardReports({outputFile, expectedShards});
+
+if (!merged) {
+  console.error('[merge-shards] No merged report was produced.');
+  process.exit(1);
+}

--- a/packages/atomic-a11y/scripts/update-openacr.mjs
+++ b/packages/atomic-a11y/scripts/update-openacr.mjs
@@ -4,7 +4,7 @@
  * Downloads the a11y-report.json from a CI run and regenerates openacr.yaml.
  */
 import {execFileSync} from 'node:child_process';
-import {rmSync} from 'node:fs';
+import {existsSync, readFileSync, rmSync} from 'node:fs';
 import {resolve} from 'node:path';
 import {transformJsonToOpenAcr} from '../dist/index.js';
 import {formatWithOxfmt} from './format-with-oxfmt.mjs';
@@ -14,6 +14,7 @@ const REPO_ROOT = resolve(PKG_ROOT, '../..');
 const REPORT_PATH = resolve(REPO_ROOT, 'packages/atomic/reports/a11y-report.json');
 
 const runId = process.argv.find((a) => a.startsWith('--run-id='))?.split('=')[1];
+const allowCoverageDrop = process.argv.includes('--allow-coverage-drop');
 if (!runId) {
   console.error(
     'Usage: pnpm exec turbo run a11y:update-openacr --filter=@coveo/atomic-a11y -- --run-id=<RUN_ID>'
@@ -29,8 +30,42 @@ execFileSync(
   {cwd: REPO_ROOT, stdio: 'inherit'}
 );
 
-console.log('[update-openacr] Regenerating openacr.yaml...');
 const OPENACR_PATH = resolve(PKG_ROOT, 'reports/openacr.yaml');
+
+/**
+ * A report merged from an incomplete set of shards covers far fewer components
+ * than the committed report, which silently downgrades WCAG conformance levels.
+ * Compare against the coverage the committed openacr.yaml was generated from
+ * before overwriting it.
+ */
+function assertNoCoverageDrop() {
+  if (!existsSync(OPENACR_PATH)) {
+    return;
+  }
+  const report = JSON.parse(readFileSync(REPORT_PATH, 'utf-8'));
+  const incoming = report.summary?.totalComponents ?? 0;
+  const committedCounts = [
+    ...readFileSync(OPENACR_PATH, 'utf-8').matchAll(/component\(s\) \((\d+)\)/g),
+  ].map((match) => Number.parseInt(match[1], 10));
+  const committed = committedCounts.length ? Math.max(...committedCounts) : 0;
+
+  if (incoming >= committed) {
+    return;
+  }
+  console.error(
+    `\n❌ Run ${runId} covers ${incoming} component(s), fewer than the ${committed} the committed openacr.yaml reflects.\n\n` +
+      'This usually means the run merged an incomplete set of a11y shard reports.\n' +
+      'Pick a run where all Storybook shards produced a report, or pass\n' +
+      '--allow-coverage-drop if the reduction is intentional.\n'
+  );
+  process.exit(1);
+}
+
+if (!allowCoverageDrop) {
+  assertNoCoverageDrop();
+}
+
+console.log('[update-openacr] Regenerating openacr.yaml...');
 await transformJsonToOpenAcr({
   inputFile: REPORT_PATH,
   outputFile: OPENACR_PATH,

--- a/packages/atomic-a11y/src/reporter/merge-shards.ts
+++ b/packages/atomic-a11y/src/reporter/merge-shards.ts
@@ -17,6 +17,12 @@ const SHARD_FILE_PATTERN = /^a11y-report\.shard-(\d+)\.json$/;
 interface MergeShardOptions {
   /** Full path (directory + filename) where the merged report is written. Shard files are read from the same directory. */
   outputFile: string;
+  /**
+   * Number of shard reports the caller expects to find. When set and the actual
+   * count differs, the merge throws instead of silently producing a report with
+   * partial component coverage.
+   */
+  expectedShards?: number;
 }
 
 interface MutableAutomatedResults extends Omit<
@@ -319,6 +325,12 @@ export async function mergeA11yShardReports(
   try {
     directoryEntries = await readdir(inputDir);
   } catch {
+    if (options.expectedShards !== undefined) {
+      throw new Error(
+        `[merge-shards] Expected ${options.expectedShards} shard report(s) but ${inputDir} does not exist. ` +
+          'Shard reports are produced by @coveo/atomic#test:storybook; a missing directory means no shard ran or uploaded its report.'
+      );
+    }
     console.warn(`[merge-shards] Could not read directory: ${inputDir}`);
     return null;
   }
@@ -332,6 +344,13 @@ export async function mergeA11yShardReports(
     .sort((first, second) => first.index - second.index)
     .map(({entry}) => path.join(inputDir, entry));
 
+  if (options.expectedShards !== undefined && shardFiles.length !== options.expectedShards) {
+    throw new Error(
+      `[merge-shards] Expected ${options.expectedShards} shard report(s) in ${inputDir} but found ${shardFiles.length}. ` +
+        'Merging a partial set would understate component coverage in openacr.yaml.'
+    );
+  }
+
   if (shardFiles.length === 0) {
     console.warn(`[merge-shards] No shard reports were found in ${inputDir}`);
     return null;
@@ -340,6 +359,11 @@ export async function mergeA11yShardReports(
   console.log(`[merge-shards] Found ${shardFiles.length} shard files, reading...`);
 
   const shardReports = await readShardReports(shardFiles);
+  if (options.expectedShards !== undefined && shardReports.length !== shardFiles.length) {
+    throw new Error(
+      `[merge-shards] Only ${shardReports.length} of ${shardFiles.length} shard report(s) in ${inputDir} could be parsed.`
+    );
+  }
   if (shardReports.length === 0) {
     console.warn('[merge-shards] No valid shard report could be loaded.');
     return null;

--- a/packages/atomic-a11y/test/merge-shards.test.ts
+++ b/packages/atomic-a11y/test/merge-shards.test.ts
@@ -1,7 +1,14 @@
+import {mkdtemp, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
 import {describe, expect, it} from 'vitest';
-import {mergeComponents, mergeCriteria} from '../reporter/merge-shards.js';
-import {createSummary} from '../reporter/summary.js';
-import type {A11yComponentReport, A11yCriterionReport, A11yReport} from '../shared/types.js';
+import {
+  mergeA11yShardReports,
+  mergeComponents,
+  mergeCriteria,
+} from '../src/reporter/merge-shards.js';
+import {createSummary} from '../src/reporter/summary.js';
+import type {A11yComponentReport, A11yCriterionReport, A11yReport} from '../src/shared/types.js';
 
 function createComponent(overrides: Partial<A11yComponentReport> = {}): A11yComponentReport {
   return {
@@ -239,5 +246,46 @@ describe('createSummary() integration with merge-shards', () => {
     expect(summary.totalComponents).toBe(2);
     expect(summary.storyCoverage.total).toBe(5);
     expect(summary.automatedCoverage).toBe('7%');
+  });
+});
+
+describe('mergeA11yShardReports()', () => {
+  async function createShardDir(shardIndices: number[]) {
+    const dir = await mkdtemp(path.join(tmpdir(), 'a11y-shards-'));
+    for (const index of shardIndices) {
+      await writeFile(
+        path.join(dir, `a11y-report.shard-${index}.json`),
+        JSON.stringify(createReport([createComponent()], [createCriterion()]))
+      );
+    }
+    return path.join(dir, 'a11y-report.json');
+  }
+
+  it('should merge when the number of shard reports matches expectedShards', async () => {
+    const outputFile = await createShardDir([1, 2, 3]);
+
+    await expect(mergeA11yShardReports({outputFile, expectedShards: 3})).resolves.not.toBeNull();
+  });
+
+  it('should throw when fewer shard reports are found than expectedShards', async () => {
+    const outputFile = await createShardDir([1]);
+
+    await expect(mergeA11yShardReports({outputFile, expectedShards: 10})).rejects.toThrow(
+      'Expected 10 shard report(s)'
+    );
+  });
+
+  it('should throw when the shard directory does not exist and expectedShards is set', async () => {
+    const outputFile = path.join(tmpdir(), 'a11y-missing-dir', 'a11y-report.json');
+
+    await expect(mergeA11yShardReports({outputFile, expectedShards: 10})).rejects.toThrow(
+      'does not exist'
+    );
+  });
+
+  it('should stay lenient when expectedShards is omitted', async () => {
+    const outputFile = path.join(tmpdir(), 'a11y-missing-dir', 'a11y-report.json');
+
+    await expect(mergeA11yShardReports({outputFile})).resolves.toBeNull();
   });
 });

--- a/packages/atomic-a11y/vitest.config.js
+++ b/packages/atomic-a11y/vitest.config.js
@@ -1,7 +1,0 @@
-import {defineConfig} from 'vitest/config';
-
-export default defineConfig({
-  test: {
-    include: ['**/*.test.?(c|m)[jt]s?(x)'],
-  },
-});

--- a/packages/atomic/turbo.json
+++ b/packages/atomic/turbo.json
@@ -100,7 +100,7 @@
     },
     "test:storybook": {
       "dependsOn": ["^build", "build"],
-      "outputs": []
+      "outputs": ["reports/a11y-report.shard-*.json", "reports/a11y-report.json"]
     },
     "dev": {
       "extends": false,


### PR DESCRIPTION
## Problem

`openacr.yaml` on `main` claims WCAG conformance based on **19 components** instead of the real **177/179**, so the `Check openacr.yaml is up to date` job fails on every PR that re-runs CI since Aug 28 (#8405, #8404, #8401 today). PRs still showing green only do so because their last run predates the regression.

Four stacked defects produced it:

1. `packages/atomic/turbo.json` declared `"outputs": []` for `test:storybook`. The a11y shard report (`reports/a11y-report.shard-N.json`) is an untracked side effect, so any shard restored from the Turbo cache reported success while writing no report.
2. `if-no-files-found: warn` on the shard upload plus `continue-on-error: true` on the download meant a missing shard was invisible. In run [33175361544](https://github.com/coveo/ui-kit/actions/runs/33175361544), all 10 shard jobs succeeded yet the merge logged `Found 1 shard files` → `Merged 19 components`.
3. `update-openacr.mjs` happily regenerated `openacr.yaml` from that 19-component report — committed as `482fc9c19 update openacr.yaml` in #8320, collapsing 12 criteria from `component(s) (177)` to `component(s) (19)`.
4. `check-openacr-drift.mjs` skipped itself with `⏭️ No a11y-report.json found` on the final pre-merge run of #8320 (all 10 shards were cache hits, so zero artifacts existed), so nothing caught the downgrade before merge.

## Solution

- **Cache correctness**: declare `reports/a11y-report.shard-*.json` and `reports/a11y-report.json` as `test:storybook` outputs. Verified via `turbo --dry=json` that the `--shard=N/10` argument is part of the task hash, so each shard caches and restores only its own report.
- **Fail loudly**: `if-no-files-found: error` on both uploads, drop `continue-on-error` on the download, and pass `--expected-shards` to the merge. `mergeA11yShardReports` now throws when the shard count, parse count, or directory does not match expectations instead of returning `null`.
- **No silent skip**: the drift check now exits 1 when no merged report exists. The merge job's steps are gated on `needs.storybook-atomic.result == 'success'`, so a partial shard set can never feed the drift check while unrelated failures stay unambiguous.
- **Coverage guard**: `update-openacr.mjs` refuses to regenerate from a run covering fewer components than the committed baseline, with `--allow-coverage-drop` for intentional reductions. Verified it rejects run 33175361544 (19 vs 179) and accepts run 33401333805.
- **Repair `main`**: regenerated `openacr.yaml` from complete run 33401333805 (179 components, 449 stories), restoring 177/179 coverage and removing the spurious `does-not-support` levels.
- **Test discovery**: `src/__tests__/merge-shards.test.ts` never ran, since `vitest.config.ts` (which shadows a stale `vitest.config.js`) only includes `test/**`. Moved it to `test/` and deleted the dead config; the suite goes from 20 to 29 tests, including 4 new ones for the shard-count enforcement.

Verified locally: `vitest run` green (6 files, 29 tests), `check-openacr-drift.mjs` reports `✅ openacr.yaml is up to date` against the complete report and exits 1 when the report is absent, and `pnpm run lint:fix` clean.