### PR TITLE
fix(atomic-a11y): restore openacr.yaml coverage to the full component set

### DIFF
--- a/packages/atomic-a11y/reports/openacr.yaml
+++ b/packages/atomic-a11y/reports/openacr.yaml
@@ -13,8 +13,8 @@ vendor:
   company_name: Coveo
   email: support@coveo.com
   website: https://www.coveo.com
-report_date: '2026-08-28'
-last_modified_date: '2026-08-28'
+report_date: '2026-08-31'
+last_modified_date: '2026-08-31'
 version: 1
 notes: Generated from a11y/reports/a11y-report.json. Conformance is derived from
   axe-core results, interactive keyboard tests, and manual audits.
@@ -37,7 +37,7 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 1.2.1
         components:
           - name: web
@@ -63,7 +63,8 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177); interactive keyboard testing passed across 2
+                component(s).
       - num: 1.3.2
         components:
           - name: web
@@ -86,7 +87,7 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 1.4.2
         components:
           - name: web
@@ -99,14 +100,16 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19); interactive keyboard testing passed across 3
-                component(s).
+                component(s) (179); interactive keyboard testing passed across
+                35 component(s).
       - num: 2.1.2
         components:
           - name: web
             adherence:
               level: supports
-              notes: Supports — manual audit found Supports.
+              notes: Supports — manual audit found Supports; automated axe-core found no
+                violations across applicable component(s) (10); interactive
+                keyboard testing passed across 10 component(s).
       - num: 2.1.4
         components:
           - name: web
@@ -167,7 +170,7 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 2.5.1
         components:
           - name: web
@@ -235,7 +238,7 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 3.3.7
         components:
           - name: web
@@ -249,7 +252,8 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177); interactive keyboard testing passed across 4
+                component(s).
   success_criteria_level_aa:
     notes: Conformance is based on automated Storybook + axe-core output and
       interactive keyboard testing.
@@ -281,21 +285,21 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 1.4.3
         components:
           - name: web
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 1.4.4
         components:
           - name: web
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 1.4.5
         components:
           - name: web
@@ -323,13 +327,15 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 1.4.13
         components:
           - name: web
             adherence:
-              level: does-not-support
-              notes: 'WCAG 1.4.13: no automated, interactive, or manual coverage.'
+              level: supports
+              notes: Supports — automated axe-core found no violations across applicable
+                component(s) (1); interactive keyboard testing passed across 1
+                component(s).
       - num: 2.4.5
         components:
           - name: web
@@ -372,14 +378,14 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 3.1.2
         components:
           - name: web
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (19).
+                component(s) (177).
       - num: 3.2.3
         components:
           - name: web
@@ -423,7 +429,7 @@ chapters:
             adherence:
               level: supports
               notes: Supports — automated axe-core found no violations across applicable
-                component(s) (4); interactive keyboard testing passed across 4
+                component(s) (24); interactive keyboard testing passed across 24
                 component(s).
   success_criteria_level_aaa:
     disabled: true


### PR DESCRIPTION
Rung 1 of 5. Bottom of the stack, and the only rung that unblocks CI today — reviewable on its own.

## Problem

`Check openacr.yaml is up to date` fails on every PR that has re-run CI since Aug 28 (#8405, #8404, #8401). The committed `openacr.yaml` derives WCAG conformance from **19 components** instead of the real **177/179**.

It was regenerated in #8320 from run [33175361544](https://github.com/coveo/ui-kit/actions/runs/33175361544), where the merge step logged `Found 1 shard files` → `Merged 19 components` even though all 10 `Run Storybook tests` jobs were green. PRs still showing a green check only do so because their last run predates that commit.

## Solution

Regenerated from run [33401333805](https://github.com/coveo/ui-kit/actions/runs/33401333805), which merged all 10 shards (179 components, 449 stories):

- 12 criteria go from `component(s) (19)` back to `component(s) (177)`
- interactive keyboard coverage returns from 3 to 35 components
- 1.4.13 (Content on Hover or Focus) reports `supports` again instead of `does-not-support` — the only criterion whose level changes

Verified locally with `check-openacr-drift.mjs` against the complete report: `✅ openacr.yaml is up to date`.

This rung only repairs the data. The rungs above stop a partial report from being committable again.