### PR TITLE
fix(atomic): declare a11y shard reports as test:storybook outputs

### DIFF
--- a/packages/atomic/turbo.json
+++ b/packages/atomic/turbo.json
@@ -100,7 +100,7 @@
     },
     "test:storybook": {
       "dependsOn": ["^build", "build"],
-      "outputs": []
+      "outputs": ["reports/a11y-report.shard-*.json", "reports/a11y-report.json"]
     },
     "dev": {
       "extends": false,


### PR DESCRIPTION
Rung 3 of 5. The root cause, one line.

## Problem

`test:storybook` writes `reports/a11y-report.shard-N.json` as a side effect, but the task declared `"outputs": []`. Turbo therefore never cached the file, and any shard restored from cache reported success while leaving no report on disk.

That is how run [33175361544](https://github.com/coveo/ui-kit/actions/runs/33175361544) had 10 green shard jobs but produced only 1 shard report, and how the final run of #8320 produced zero — which in turn let the drift check skip itself and a 19-component `openacr.yaml` reach `main`.

## Solution

Declare the shard reports as outputs so cache hits restore them.

The correctness question is whether shards could restore each other's reports. They cannot: `--shard=N/10` is part of the task hash, verified with `turbo run test:storybook --dry=json`, which yields a distinct hash per shard (`39ffa05e…` for 1/10, `7b88523e…` for 2/10).

The unsuffixed `reports/a11y-report.json` is included so non-sharded local runs are cached the same way.