### PR TITLE
fix(atomic-a11y): fail the openacr gate when the a11y shard set is incomplete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,7 +582,7 @@ jobs:
           name: a11y-report-shard-${{ matrix.shardIndex }}
           path: packages/atomic/reports/a11y-report.shard-${{ matrix.shardIndex }}.json
           retention-days: 1
-          if-no-files-found: warn
+          if-no-files-found: error
   merge-storybook-a11y-reports:
     name: 'Merge Storybook a11y reports and validate OpenACR'
     needs: [affected, storybook-atomic]
@@ -592,6 +592,9 @@ jobs:
         contains(needs.affected.outputs.tasks, '"@coveo/atomic#test:storybook"')
       }}
     runs-on: ubuntu-latest
+    env:
+      # Must match strategy.matrix.shardTotal of the storybook-atomic job above.
+      A11Y_SHARD_TOTAL: 10
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -603,15 +606,19 @@ jobs:
           fetch-depth: 1
           filter: blob:none
       - uses: ./.github/actions/setup
+      # The merged report stays best-effort so it remains downloadable when a
+      # shard's a11y tests fail, which is when it is most useful. Only the
+      # openacr.yaml gate below demands a complete shard set.
       - name: 'Download a11y shard reports'
-        continue-on-error: true
+        if: always()
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: a11y-report-shard-*
           path: packages/atomic/reports
           merge-multiple: true
       - name: 'Merge a11y shard reports'
-        run: pnpm exec turbo run a11y:merge-shards --filter=@coveo/atomic-a11y -- ../atomic/reports/a11y-report.json
+        if: always()
+        run: pnpm exec turbo run a11y:merge-shards --filter=@coveo/atomic-a11y -- ../atomic/reports/a11y-report.json ${{ needs.storybook-atomic.result == 'success' && format('--expected-shards={0}', env.A11Y_SHARD_TOTAL) || '' }}
       - name: 'Upload merged a11y report'
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -621,6 +628,7 @@ jobs:
           retention-days: 7
           if-no-files-found: warn
       - name: 'Check openacr.yaml is up to date'
+        if: needs.storybook-atomic.result == 'success'
         run: node scripts/check-openacr-drift.mjs
         working-directory: packages/atomic-a11y
 

--- a/packages/atomic-a11y/scripts/merge-shards-cli.mjs
+++ b/packages/atomic-a11y/scripts/merge-shards-cli.mjs
@@ -1,6 +1,23 @@
 import path from 'node:path';
 import {mergeA11yShardReports} from '../dist/index.js';
 
-const outputFile = process.argv[2] ?? path.resolve('reports', 'a11y-report.json');
+const args = process.argv.slice(2);
+const positional = args.filter((arg) => !arg.startsWith('--'));
+const expectedShardsArg = args.find((arg) => arg.startsWith('--expected-shards='))?.split('=')[1];
 
-await mergeA11yShardReports({outputFile});
+const outputFile = positional[0] ?? path.resolve('reports', 'a11y-report.json');
+const expectedShards = expectedShardsArg ? Number.parseInt(expectedShardsArg, 10) : undefined;
+
+if (expectedShardsArg && !Number.isInteger(expectedShards)) {
+  console.error(
+    `[merge-shards] --expected-shards must be an integer, received "${expectedShardsArg}".`
+  );
+  process.exit(1);
+}
+
+const merged = await mergeA11yShardReports({outputFile, expectedShards});
+
+if (!merged && expectedShards !== undefined) {
+  console.error('[merge-shards] No merged report was produced.');
+  process.exit(1);
+}

--- a/packages/atomic-a11y/src/reporter/merge-shards.ts
+++ b/packages/atomic-a11y/src/reporter/merge-shards.ts
@@ -17,6 +17,12 @@ const SHARD_FILE_PATTERN = /^a11y-report\.shard-(\d+)\.json$/;
 interface MergeShardOptions {
   /** Full path (directory + filename) where the merged report is written. Shard files are read from the same directory. */
   outputFile: string;
+  /**
+   * Number of shard reports the caller expects to find. When set and the actual
+   * count differs, the merge throws instead of silently producing a report with
+   * partial component coverage.
+   */
+  expectedShards?: number;
 }
 
 interface MutableAutomatedResults extends Omit<
@@ -319,6 +325,12 @@ export async function mergeA11yShardReports(
   try {
     directoryEntries = await readdir(inputDir);
   } catch {
+    if (options.expectedShards !== undefined) {
+      throw new Error(
+        `[merge-shards] Expected ${options.expectedShards} shard report(s) but ${inputDir} does not exist. ` +
+          'Shard reports are produced by @coveo/atomic#test:storybook; a missing directory means no shard ran or uploaded its report.'
+      );
+    }
     console.warn(`[merge-shards] Could not read directory: ${inputDir}`);
     return null;
   }
@@ -332,6 +344,13 @@ export async function mergeA11yShardReports(
     .sort((first, second) => first.index - second.index)
     .map(({entry}) => path.join(inputDir, entry));
 
+  if (options.expectedShards !== undefined && shardFiles.length !== options.expectedShards) {
+    throw new Error(
+      `[merge-shards] Expected ${options.expectedShards} shard report(s) in ${inputDir} but found ${shardFiles.length}. ` +
+        'Merging a partial set would understate component coverage in openacr.yaml.'
+    );
+  }
+
   if (shardFiles.length === 0) {
     console.warn(`[merge-shards] No shard reports were found in ${inputDir}`);
     return null;
@@ -340,6 +359,11 @@ export async function mergeA11yShardReports(
   console.log(`[merge-shards] Found ${shardFiles.length} shard files, reading...`);
 
   const shardReports = await readShardReports(shardFiles);
+  if (options.expectedShards !== undefined && shardReports.length !== shardFiles.length) {
+    throw new Error(
+      `[merge-shards] Only ${shardReports.length} of ${shardFiles.length} shard report(s) in ${inputDir} could be parsed.`
+    );
+  }
   if (shardReports.length === 0) {
     console.warn('[merge-shards] No valid shard report could be loaded.');
     return null;

--- a/packages/atomic-a11y/test/merge-shards.test.ts
+++ b/packages/atomic-a11y/test/merge-shards.test.ts
@@ -1,5 +1,12 @@
+import {mkdtemp, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import path from 'node:path';
 import {describe, expect, it} from 'vitest';
-import {mergeComponents, mergeCriteria} from '../src/reporter/merge-shards.js';
+import {
+  mergeA11yShardReports,
+  mergeComponents,
+  mergeCriteria,
+} from '../src/reporter/merge-shards.js';
 import {createSummary} from '../src/reporter/summary.js';
 import type {A11yComponentReport, A11yCriterionReport, A11yReport} from '../src/shared/types.js';
 
@@ -239,5 +246,46 @@ describe('createSummary() integration with merge-shards', () => {
     expect(summary.totalComponents).toBe(2);
     expect(summary.storyCoverage.total).toBe(5);
     expect(summary.automatedCoverage).toBe('7%');
+  });
+});
+
+describe('mergeA11yShardReports()', () => {
+  async function createShardDir(shardIndices: number[]) {
+    const dir = await mkdtemp(path.join(tmpdir(), 'a11y-shards-'));
+    for (const index of shardIndices) {
+      await writeFile(
+        path.join(dir, `a11y-report.shard-${index}.json`),
+        JSON.stringify(createReport([createComponent()], [createCriterion()]))
+      );
+    }
+    return path.join(dir, 'a11y-report.json');
+  }
+
+  it('should merge when the number of shard reports matches expectedShards', async () => {
+    const outputFile = await createShardDir([1, 2, 3]);
+
+    await expect(mergeA11yShardReports({outputFile, expectedShards: 3})).resolves.not.toBeNull();
+  });
+
+  it('should throw when fewer shard reports are found than expectedShards', async () => {
+    const outputFile = await createShardDir([1]);
+
+    await expect(mergeA11yShardReports({outputFile, expectedShards: 10})).rejects.toThrow(
+      'Expected 10 shard report(s)'
+    );
+  });
+
+  it('should throw when the shard directory does not exist and expectedShards is set', async () => {
+    const outputFile = path.join(tmpdir(), 'a11y-missing-dir', 'a11y-report.json');
+
+    await expect(mergeA11yShardReports({outputFile, expectedShards: 10})).rejects.toThrow(
+      'does not exist'
+    );
+  });
+
+  it('should stay lenient when expectedShards is omitted', async () => {
+    const outputFile = path.join(tmpdir(), 'a11y-missing-dir', 'a11y-report.json');
+
+    await expect(mergeA11yShardReports({outputFile})).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
Rung 4 of 5. Depends on rung 3 (#8409): without cached shard reports being restored, the strict path here would fire on every cache hit.

## Problem

The tolerant settings in this job were **not** sloppiness — they were correct for the job's original purpose, and the job's purpose changed under them.

- #7515 introduced `merge-storybook-a11y-reports` as pure reporting, named "Merge Storybook a11y reports". It produced an artifact for humans and deliberately never failed CI: `if-no-files-found: warn` on the uploads, `continue-on-error: true` on the download, and a `null`-returning merge (`#7137` documents the design as "invalid shards are skipped with a warning"). An a11y shard failing its tests shouldn't add a second red X on a reporting job.
- #7799 then added `check-openacr-drift.mjs` to that same job and renamed it "…and validate OpenACR", turning best-effort reporting into a **gate** — while leaving all the best-effort plumbing in place and adding a `Skipping drift check` early exit.

So a merge of 1 shard out of 10 looks identical to a complete one, and silently understates component coverage in the report that feeds `openacr.yaml`. That is how a 19-component report became the committed baseline.

## Solution

Make the gate strict, keep the reporting best-effort:

- `mergeA11yShardReports` accepts `expectedShards` and throws when the reports directory is absent, the shard count differs, or a shard exists but fails to parse. Without the option it keeps returning `null` with a warning, so the original lenient contract is preserved for other callers.
- `merge-shards-cli` separates flags from positionals (so `--expected-shards=` can't be read as the output path), validates the value, and exits non-zero **only** in strict mode.
- CI passes `--expected-shards` only when every shard job succeeded, and gates the drift check the same way. The download, merge, and upload still run on `always()`, so the merged report stays downloadable when a shard's a11y tests fail — which is exactly when you want to inspect it. Losing that artifact was a regression in my first draft of this PR.
- Drop `continue-on-error` from the download. Worth noting for the record: it wasn't protecting a real failure mode. `download-artifact` does not fail when a `pattern` matches nothing — it logs `Total of 0 artifact(s) downloaded` and succeeds (verified in the action source). The flag only masked digest-mismatch and API errors.
- Keep `if-no-files-found: warn` on the merged-report upload, since that step is best-effort now; the strict merge fails first when completeness matters. The **shard** upload moves to `error`, because after #8409 a successful shard always has a report, so an empty one is a real signal.

Verified both CLI modes locally: lenient exits 0 with a warning on an empty directory, strict exits 1 with `Expected 10 shard report(s) … but found 0`.

Note: `A11Y_SHARD_TOTAL: 10` duplicates `strategy.matrix.shardTotal` from the job above, hence the comment tying them together. GitHub doesn't let a matrix read `env`, and plumbing a job output out of a 10-way matrix to carry a constant seemed worse than the duplication — happy to change if you disagree.

4 new tests cover the enforcement (matching count, too few shards, missing directory, lenient when the option is omitted). Suite: 29 tests passing.