### PR TITLE
fix(atomic-a11y): stop a partial a11y report from rewriting openacr.yaml

### DIFF
--- a/packages/atomic-a11y/README.md
+++ b/packages/atomic-a11y/README.md
@@ -82,6 +82,8 @@ Replace `<RUN_ID>` with the GitHub Actions run ID from the failing check (shown 
 
 > Requires the [GitHub CLI](https://cli.github.com/) (`gh`) to be installed and authenticated.
 
+The command refuses to run when the chosen run covers fewer components than the committed `openacr.yaml` does, which is how an incomplete set of Storybook a11y shards would silently downgrade conformance levels. Pick a run whose `Run Storybook tests` shards all succeeded, or pass `--allow-coverage-drop` when the reduction is genuinely intended (for example after removing components).
+
 ### Option 2: Run tests locally
 
 If you prefer to regenerate from scratch:

--- a/packages/atomic-a11y/scripts/check-openacr-drift.mjs
+++ b/packages/atomic-a11y/scripts/check-openacr-drift.mjs
@@ -23,8 +23,17 @@ if (!existsSync(COMMITTED_OPENACR)) {
 const INPUT_REPORT = resolve(REPO_ROOT, 'packages/atomic/reports/a11y-report.json');
 
 if (!existsSync(INPUT_REPORT)) {
-  console.log('⏭️  No a11y-report.json found. Skipping drift check.');
-  process.exit(0);
+  console.error(`
+❌ No a11y-report.json found at ${INPUT_REPORT}.
+
+The drift check cannot validate openacr.yaml without a merged a11y report.
+Skipping silently here is what allowed a partial report to be committed, so
+this is now a hard failure. Run the Storybook suite (or the merge step) first:
+
+  pnpm exec turbo run test:storybook --filter=@coveo/atomic
+  pnpm exec turbo run a11y:merge-shards --filter=@coveo/atomic-a11y -- ../atomic/reports/a11y-report.json
+`);
+  process.exit(1);
 }
 
 // Generate fresh openacr from the merged a11y report

--- a/packages/atomic-a11y/scripts/update-openacr.mjs
+++ b/packages/atomic-a11y/scripts/update-openacr.mjs
@@ -4,7 +4,7 @@
  * Downloads the a11y-report.json from a CI run and regenerates openacr.yaml.
  */
 import {execFileSync} from 'node:child_process';
-import {rmSync} from 'node:fs';
+import {existsSync, readFileSync, rmSync} from 'node:fs';
 import {resolve} from 'node:path';
 import {transformJsonToOpenAcr} from '../dist/index.js';
 import {formatWithOxfmt} from './format-with-oxfmt.mjs';
@@ -14,6 +14,7 @@ const REPO_ROOT = resolve(PKG_ROOT, '../..');
 const REPORT_PATH = resolve(REPO_ROOT, 'packages/atomic/reports/a11y-report.json');
 
 const runId = process.argv.find((a) => a.startsWith('--run-id='))?.split('=')[1];
+const allowCoverageDrop = process.argv.includes('--allow-coverage-drop');
 if (!runId) {
   console.error(
     'Usage: pnpm exec turbo run a11y:update-openacr --filter=@coveo/atomic-a11y -- --run-id=<RUN_ID>'
@@ -29,8 +30,42 @@ execFileSync(
   {cwd: REPO_ROOT, stdio: 'inherit'}
 );
 
-console.log('[update-openacr] Regenerating openacr.yaml...');
 const OPENACR_PATH = resolve(PKG_ROOT, 'reports/openacr.yaml');
+
+/**
+ * A report merged from an incomplete set of shards covers far fewer components
+ * than the committed report, which silently downgrades WCAG conformance levels.
+ * Compare against the coverage the committed openacr.yaml was generated from
+ * before overwriting it.
+ */
+function assertNoCoverageDrop() {
+  if (!existsSync(OPENACR_PATH)) {
+    return;
+  }
+  const report = JSON.parse(readFileSync(REPORT_PATH, 'utf-8'));
+  const incoming = report.summary?.totalComponents ?? 0;
+  const committedCounts = [
+    ...readFileSync(OPENACR_PATH, 'utf-8').matchAll(/component\(s\) \((\d+)\)/g),
+  ].map((match) => Number.parseInt(match[1], 10));
+  const committed = committedCounts.length ? Math.max(...committedCounts) : 0;
+
+  if (incoming >= committed) {
+    return;
+  }
+  console.error(
+    `\n❌ Run ${runId} covers ${incoming} component(s), fewer than the ${committed} the committed openacr.yaml reflects.\n\n` +
+      'This usually means the run merged an incomplete set of a11y shard reports.\n' +
+      'Pick a run where all Storybook shards produced a report, or pass\n' +
+      '--allow-coverage-drop if the reduction is intentional.\n'
+  );
+  process.exit(1);
+}
+
+if (!allowCoverageDrop) {
+  assertNoCoverageDrop();
+}
+
+console.log('[update-openacr] Regenerating openacr.yaml...');
 await transformJsonToOpenAcr({
   inputFile: REPORT_PATH,
   outputFile: OPENACR_PATH,


### PR DESCRIPTION
Rung 5 of 5. Depends on rung 4 (#8410), which guarantees a complete report exists by the time these guards run.

## Problem

Two guards failed open, which is how the coverage regression actually reached `main`:

- `check-openacr-drift.mjs` printed `⏭️ No a11y-report.json found. Skipping drift check.` and exited 0. On the final run of #8320 every shard was a cache hit, so no report existed and the check waved a 19-component `openacr.yaml` through.
- `update-openacr.mjs` regenerated `openacr.yaml` from whatever run ID it was handed, including one covering 19 components instead of 179.

## Solution

- `check-openacr-drift.mjs` now fails when no report is present, and names the two commands that produce one.
- `update-openacr.mjs` compares the incoming report's `summary.totalComponents` against the coverage the committed `openacr.yaml` reflects and refuses to write when it regressed. `--allow-coverage-drop` covers intentional reductions such as removing components.
- README documents both, in the section developers land on when the drift check fails.

Verified the guard rejects the run that caused this (33175361544: 19 vs 179) and accepts the complete run (33401333805), and that the drift check exits 1 with no report present and passes against the complete one.

One caveat worth a reviewer's judgement: the guard reads component counts out of the generated prose (`component(s) (N)`) because coverage isn't stored as a structured field in `openacr.yaml`. The cleaner alternative is adding a real field, which changes the committed artifact and the VPAT output — I opted not to widen the blast radius here.