### PR TITLE
fix(ci): remove three unrelated CI failures blocking dependency PRs

### DIFF
--- a/packages/coveo-analytics/src/plugins/link.spec.ts
+++ b/packages/coveo-analytics/src/plugins/link.spec.ts
@@ -4,16 +4,13 @@ import {CoveoLinkParam, LinkPlugin} from './link';
 import {createAnalyticsClientMock} from '../../tests/analyticsClientMock';
 import {v4 as uuidv4} from 'uuid';
 
-function currentSecsSinceEpoch() {
-  return Math.floor(Date.now() / 1000);
-}
-
 describe('CoveoLinkParam class', () => {
   it('can create a new link using a uuid', () => {
     const uuid = uuidv4();
-    const link: CoveoLinkParam = new CoveoLinkParam(uuid, Date.now());
+    const creationTimestamp = Date.now();
+    const link: CoveoLinkParam = new CoveoLinkParam(uuid, creationTimestamp);
     expect(link.clientId).toBe(uuid);
-    expect(link.creationDate).toBe(currentSecsSinceEpoch());
+    expect(link.creationDate).toBe(Math.floor(creationTimestamp / 1000));
   });
 
   it('can create a new link using a uuid and timestamp', () => {
@@ -55,14 +52,15 @@ describe('CoveoLinkParam class', () => {
   });
 
   it('can serialize a link to a string', () => {
+    const creationTimestamp = Date.now();
     const coveoLink: CoveoLinkParam = new CoveoLinkParam(
       '074af291-224b-4705-9dc5-a47bd80a8db9',
-      Date.now()
+      creationTimestamp
     );
     const link = coveoLink.toString();
     const parts = link.split('.');
     expect(parts[0]).toBe('074af291224b47059dc5a47bd80a8db9');
-    expect(Number.parseInt(parts[1])).toBe(currentSecsSinceEpoch());
+    expect(Number.parseInt(parts[1])).toBe(Math.floor(creationTimestamp / 1000));
   });
 
   it('checks for expiration on a link', () => {
@@ -113,10 +111,15 @@ describe('CoveoLinkParam class', () => {
 });
 
 describe('CoveoLinkPlugin', () => {
+  // decorate() reads Date.now() internally, so the clock is frozen to keep the
+  // serialized timestamp comparable.
+  const frozenNow = 1700000000000;
+  const frozenSecsSinceEpoch = Math.floor(frozenNow / 1000);
   let link: LinkPlugin;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(Date, 'now').mockReturnValue(frozenNow);
     const analyticsClient = createAnalyticsClientMock();
     analyticsClient.getCurrentVisitorId = vi.fn(() =>
       Promise.resolve('85698661-efdf-4c6d-9cad-c4632bf81ce3')
@@ -124,11 +127,15 @@ describe('CoveoLinkPlugin', () => {
     link = new LinkPlugin({client: analyticsClient});
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('decorates links with valid urls and no params', async () => {
     const url: string = 'https://coveo.com';
     const result: string = await link.decorate(url);
     expect(result).toBe(
-      'https://coveo.com/?cvo_cid=85698661efdf4c6d9cadc4632bf81ce3.' + currentSecsSinceEpoch()
+      'https://coveo.com/?cvo_cid=85698661efdf4c6d9cadc4632bf81ce3.' + frozenSecsSinceEpoch
     );
   });
 
@@ -137,7 +144,7 @@ describe('CoveoLinkPlugin', () => {
     const result: string = await link.decorate(url);
     expect(result).toBe(
       'https://coveo.com/some/path/?cvo_cid=85698661efdf4c6d9cadc4632bf81ce3.' +
-        currentSecsSinceEpoch()
+        frozenSecsSinceEpoch
     );
   });
 
@@ -146,7 +153,7 @@ describe('CoveoLinkPlugin', () => {
     const result: string = await link.decorate(url);
     expect(result).toBe(
       'https://coveo.com/query?q=something&p=param&cvo_cid=85698661efdf4c6d9cadc4632bf81ce3.' +
-        currentSecsSinceEpoch()
+        frozenSecsSinceEpoch
     );
   });
 
@@ -155,7 +162,7 @@ describe('CoveoLinkPlugin', () => {
     const result: string = await link.decorate(url);
     expect(result).toBe(
       'https://coveo.com/?q=something&cvo_cid=85698661efdf4c6d9cadc4632bf81ce3.' +
-        currentSecsSinceEpoch() +
+        frozenSecsSinceEpoch +
         '#frag'
     );
   });
@@ -164,7 +171,7 @@ describe('CoveoLinkPlugin', () => {
     const url: string = 'https://coveo.com/?cvo_cid=c0b48880743e484f8044d7c37910c55b.1676298678';
     const result: string = await link.decorate(url);
     expect(result).toBe(
-      'https://coveo.com/?cvo_cid=85698661efdf4c6d9cadc4632bf81ce3.' + currentSecsSinceEpoch()
+      'https://coveo.com/?cvo_cid=85698661efdf4c6d9cadc4632bf81ce3.' + frozenSecsSinceEpoch
     );
   });
 

--- a/packages/thermidor-schema/tests/freshness.test.ts
+++ b/packages/thermidor-schema/tests/freshness.test.ts
@@ -6,6 +6,8 @@ import {describe, expect, it} from 'vitest';
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 describe('artifact freshness', () => {
+  // Spawns a TS-stripping node process that regenerates every artifact, which
+  // routinely exceeds vitest's 5s default on CI runners.
   it('src/generated/ is fresh (matches what generate would produce)', () => {
     expect(() => {
       execFileSync(
@@ -17,5 +19,5 @@ describe('artifact freshness', () => {
         }
       );
     }).not.toThrow();
-  });
+  }, 60_000);
 });

--- a/samples/headless-ssr/commerce-react-router/lib/client-id.server.ts
+++ b/samples/headless-ssr/commerce-react-router/lib/client-id.server.ts
@@ -59,7 +59,7 @@ export const getAnalyticsContext = async (request: Request): Promise<CoveoAnalyt
     visitorIdCookieValue = await coveo_visitorId.parse(request.headers.get('Cookie'));
   }
 
-  // When `shouldCapture(request)` evaluates to `true`, the `visitorIdCookieValue` will be defined unless the user has
+  // When `shouldCapture(request)` evaluates to `true`, the `visitorIdCookieValue` will be defined unless the user has
   // deleted the `coveo_visitorId` cookie but not the `coveo_capture` cookie. This is the only case where generating a
   // new `clientId` on the server is useful, as otherwise the server-side request would have to be made with
   // `capture: false` due to the lack of a `clientId`.


### PR DESCRIPTION
## Problem

Four renovate PRs are red — #8383, #8380, #8329, #8331 — for three causes, none of which is an actual incompatibility with the dependencies being bumped. (`Confirm build is valid` on all four is just the aggregator gate reporting `success="false"`, not a failure of its own.)

**1. Irregular whitespace — blocks #8329**

`samples/headless-ssr/commerce-react-router/lib/client-id.server.ts:62:48` has carried a non-breaking space (U+00A0) inside a comment. oxlint 1.78.0 on `main` doesn't flag it; oxlint 1.80.0, which #8329 bumps to, reports `Unexpected irregular whitespace` and the lint job fails. So the bump can't land until the character is replaced. Verified it's the only NBSP left in linted sources.

**2. Second-boundary race in `link.spec.ts` — blocks #8383**

```
FAIL src/plugins/link.spec.ts > CoveoLinkParam class > can create a new link using a uuid
AssertionError: expected 1788250787 to be 1788250788
```

The test built a `CoveoLinkParam` from one `Date.now()` and then compared `creationDate` against a *second, later* `Date.now()` via a `currentSecsSinceEpoch()` helper. Crossing a second boundary between the two calls fails the assertion — the two values in the log are exactly one second apart. Nothing to do with puppeteer v25.

**3. Freshness test timeout — blocks #8329 and #8331**

```
FAIL tests/freshness.test.ts > artifact freshness > src/generated/ is fresh
Error: Test timed out in 5000ms.
```

The test `execFileSync`s a TS-stripping node process that regenerates every artifact. It took **5216ms** against vitest's 5000ms default — marginal, so it passes or fails depending on runner load. It's 311ms locally, which is why it hasn't been noticed.

## Solution

- Replace the NBSP with a regular space.
- Reuse the captured timestamp in the two `CoveoLinkParam` tests that can, and freeze the clock via `vi.spyOn(Date, 'now')` for the `CoveoLinkPlugin` tests, whose `decorate()` reads `Date.now()` internally and therefore can't reuse a caller-supplied value. `link.ts` uses no timers, only `Date.now()`, so no timer semantics are involved. The frozen value is deliberately distinct from the `1676298678` literal already used by the "updates an existing decoration" test, so that test keeps proving the timestamp is rewritten.
- Give the freshness test an explicit 60s timeout.

Verified: `lint:check` clean across the monorepo, `coveo.analytics` 715 tests passing (link spec run 3× for determinism), `@coveo/thermidor-schema` 75 passing.

## Not addressed here

#8380 also fails one Playwright test, `atomic-commerce-category-facet.e2e.ts:17`, expecting `aria-pressed="true"` and getting `false` (stable across 18 polls and a retry). That PR only bumps `@vitejs/plugin-react`, `dompurify`, `rollup` and `vite` patch/minor versions, none of which plausibly changes a facet's `aria-pressed`, and the same shard passes on #8383, #8329 and #8409. It looks like a click landing during a re-render rather than a real regression, but I didn't want to bundle a speculative e2e change in here. Re-running that shard is the next step; if it reproduces, it deserves its own investigation.