### PR TITLE
chore(renovate): group step-security/changeset-action with the changesets packages

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -28,8 +28,8 @@
     {
       groupName: 'Changesets',
       groupSlug: 'changesets',
-      description: 'Isolate @changesets/* since we rely on experimental options that may change in a patch update',
-      matchPackageNames: ['@changesets/*'],
+      description: 'Isolate @changesets/* since we rely on experimental options that may change in a patch update. step-security/changeset-action is included so the CLI and the action that runs it move in a single PR: @changesets/cli v3 needs the action v2, whose inputs are renamed, so they cannot be bumped separately',
+      matchPackageNames: ['@changesets/*', 'step-security/changeset-action'],
       automerge: false,
     },
     {


### PR DESCRIPTION
## Problem

`@changesets/cli` and `@changesets/changelog-github` are grouped as `Changesets`, but `step-security/changeset-action` (pinned in `.github/workflows/cd.yml`) is not. It falls into the shared preset's `group/github-actions-non-major.json` instead, so it arrives in a separate PR.

These three cannot be bumped independently. `@changesets/cli` v3 requires the action v2, and the action v2 renames every input `cd.yml` passes (`version` → `version-script`, `publish` → `publish-script`, `title` → `pr-title`, `commit` → `commit-message`, and `commitMode` is replaced by `push-with-git-cli`). Splitting them across PRs means neither can merge on its own.

## Solution

Add `step-security/changeset-action` to the existing `Changesets` group so the CLI and the action that runs it land in one PR. With `separateMajorMinor` at its default, non-majors go to `renovate/changesets` and majors to `renovate/major-changesets`, each carrying all three.

Validated with `renovate-config-validator`.

### Notes for reviewers

- This does not stop `renovate/major-changesets` from reopening today. `step-security/changeset-action` has no v2 tag yet (the mirror is on v1.9.0 while upstream `changesets/action` is at v2.1.1), and Renovate groups the updates that exist rather than waiting for a member that has none. The major PR will keep being recreated with just the two npm packages until the mirror publishes v2. If we want the churn to stop in the meantime, a `dependencyDashboardApproval` gate on the major would do it — happy to add it here or in a follow-up.
- Three intentional side effects, the third new since this PR was rebased onto #8419:
  1. Non-major bumps of the action move out of the "non-major github actions" PR into the Changesets PR.
  2. Because of `helpers:pinGitHubActionDigests`, digest updates for the action now route into the Changesets group too, so that group will open somewhat more often.
  3. #8419 added `github>coveo/renovate-presets//auto-merge.json`, which sets `automerge: true` globally, and gave the Changesets group `automerge: false`. Moving the action into that group therefore **opts its updates out of auto-merge** — including digest bumps, which would otherwise merge unattended. That reads as consistent with the intent (the action can't move without the CLI, and the CLI is deliberately manual), but it is a behaviour change on top of #8419 rather than something this PR originally set out to do. Flagging it in case you'd rather the action keep auto-merging, which would mean a separate rule instead of reusing this group.