### PR TITLE
chore(deps): enable Renovate auto-merge with a changesets opt-out

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,11 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   enabled: true,
-  extends: ['github>coveo/renovate-presets', 'helpers:pinGitHubActionDigests'],
+  extends: [
+    'github>coveo/renovate-presets',
+    'github>coveo/renovate-presets//auto-merge.json',
+    'helpers:pinGitHubActionDigests',
+  ],
   labels: ['dependencies'],
   dependencyDashboard: true,
   minimumReleaseAge: '7 days',
@@ -26,6 +30,7 @@
       groupSlug: 'changesets',
       description: 'Isolate @changesets/* since we rely on experimental options that may change in a patch update',
       matchPackageNames: ['@changesets/*'],
+      automerge: false,
     },
     {
       groupName: 'wc-toolkit storybook-helpers',


### PR DESCRIPTION
## Motivation

Renovate PRs are all merged by hand today, which is a steady manual cost for updates that CI already gates. Coveo publishes a shared auto-merge preset, so adopting it removes that toil without inventing repo-specific rules.

The `@changesets/*` packages are the one group that should not merge unattended: we depend on experimental options that can shift in a patch release, and the CLI is coupled to the `step-security/changeset-action` version pinned in `cd.yml`.

## Changes

- Extend `github>coveo/renovate-presets//auto-merge.json`, which sets `automerge: true` and adds `pinDigests` for third-party GitHub Actions.
- Keep `helpers:pinGitHubActionDigests` so digest pinning still covers the actions the preset excludes.
- Add `automerge: false` to the existing `Changesets` group so those updates continue to require manual review.

Auto-merge still runs inside the `automergeSchedule` inherited from `github>coveo/renovate-presets` (Tue–Thu, 9–12 America/Toronto), and merges only once required checks pass.

## Validation

- `renovate-config-validator renovate.json5` passes.
- Config-only change; no package source is touched, so no test or build behaviour changes.

- [x] All existing tests pass without modification
- [x] No new features or bug fixes are included in this PR
- [x] Public API surface is unchanged

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`chore(<scope>): <description>`)
- [x] [Added a changeset](https://changesets.dev/guide/getting-started) (`pnpm changeset`) if modifying public package source code — not applicable, no public package source changed