### PR TITLE
fix(ci): stop shard arguments from poisoning Turbo task hashes

### DIFF
--- a/.github/actions/playwright-quantic/action.yml
+++ b/.github/actions/playwright-quantic/action.yml
@@ -15,8 +15,14 @@ runs:
         pattern: quantic-playwright-env-*
         path: packages/quantic/.env
         merge-multiple: true
+    - name: Build Quantic and its dependencies
+      # Keep the build in its own argument-free Turbo invocation: passing
+      # `--shard` through `turbo run -- ...` folds the arguments into the hash
+      # of every task in the graph, defeating the remote cache for each shard.
+      run: pnpm exec turbo run '@coveo/quantic#build' --no-update-notifier
+      shell: bash
     - name: Run Playwright Tests
-      run: pnpm exec turbo run @coveo/quantic#e2e -- --shard=${INPUTS_SHARDINDEX}/${INPUTS_SHARDTOTAL}
+      run: pnpm --filter @coveo/quantic run e2e --shard=${INPUTS_SHARDINDEX}/${INPUTS_SHARDTOTAL}
       shell: bash
       env:
         INPUTS_SHARDINDEX: ${{ inputs.shardIndex }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,9 +478,15 @@ jobs:
           fetch-tags: false
           filter: blob:none
       - uses: ./.github/actions/setup
+      # Build in a separate, argument-free Turbo invocation. Passing `--shard`
+      # through `turbo run -- ...` folds the arguments into the hash of every
+      # task in the graph, so each shard produced unique build hashes and could
+      # never reuse the remote cache.
+      - name: Build Atomic and its dependencies
+        run: pnpm exec turbo run '@coveo/atomic#build' --no-update-notifier
       - name: Run Playwright tests
         id: playwright
-        run: pnpm exec turbo run '@coveo/atomic#e2e' -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: pnpm --filter @coveo/atomic run e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         continue-on-error: true
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
@@ -574,7 +580,11 @@ jobs:
           filter: blob:none
       - run: git branch main origin/main
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo run test:storybook --filter=@coveo/atomic -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      # See the Playwright job: keep the build invocation free of passthrough
+      # arguments so its task hashes are shared across shards.
+      - name: Build Atomic and its dependencies
+        run: pnpm exec turbo run build --filter=@coveo/atomic --no-update-notifier
+      - run: pnpm --filter @coveo/atomic run test:storybook --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: 'Upload a11y shard report'
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
## Motivation

`turbo run <task> -- --shard=N/T` folds the passthrough arguments into the hash of **every** task in the graph, not just the task receiving them. Verified locally with `--dry=json`, including repeated control measurements to rule out drift:

```
tasks: 20
CONTROL no-args vs no-args  : 0   (must be 0)
CONTROL shard3 vs shard3    : 0   (must be 0)
no-args vs shard3           : 20
shard3  vs shard10          : 20
```

So `@coveo/headless#build`, `@coveo/bueno#build` and every other upstream task get a different hash in each shard, and a different one again in the `Build` job, which uses no passthrough arguments.

Two consequences:

1. **Nothing is shared inside a run.** The `Build` job builds and uploads the whole graph, then all 12 Playwright shards, 10 Storybook shards, and 4 Quantic shards rebuild it. Whenever the global hash changes, that is a full rebuild per shard. Run [33529894304](https://github.com/coveo/ui-kit/actions/runs/33529894304) shows the worst case, where every shard reported `Cached: 0 cached, 18 total` and spent ~1m08s rebuilding before ~2m54s of tests.
2. **Cache entries are stored 26 times over**, once per shard index, because each index has its own hash namespace.

### Correction to an earlier version of this description

An earlier draft claimed the remote cache was "effectively dead" for these jobs and attributed that run's `0 cached` to the argument poisoning. That was wrong, and worth stating plainly.

That run was PR #8435, the Angular v22 bump, which changes `pnpm-lock.yaml` and `pnpm-workspace.yaml`. Both are in turbo's `globalDependencies`, so the global hash changed and every task in the repo was new — nothing could have been cached in any namespace. A PR that leaves the lockfile alone does hit the cache today: run [33533064693](https://github.com/coveo/ui-kit/actions/runs/33533064693) reports `Cached: 14 cached, 18 total` in each shard, because shard N reuses what shard N of an earlier run uploaded.

The argument poisoning is real and the fix is still worthwhile, but the accurate framing is narrower: the shards cannot reuse the `Build` job's output from the same run, and cannot reuse each other's. That costs a full rebuild in all 26 shard jobs every time the global hash moves — which, with Renovate touching the lockfile regularly, is often.

## Changes

Split each sharded job into two invocations: an argument-free Turbo build, then the test runner invoked directly with the shard flag.

- `playwright-atomic`: `turbo run '@coveo/atomic#build'` then `pnpm --filter @coveo/atomic run e2e --shard=…`
- `storybook-atomic`: `turbo run build --filter=@coveo/atomic` then `pnpm --filter @coveo/atomic run test:storybook --shard=…`
- `playwright-quantic` action: `turbo run '@coveo/quantic#build'` then `pnpm --filter @coveo/quantic run e2e --shard=…`

Argument-free invocations agree on hashes across entry points, so shards can now share entries with each other and with `Build`:

```
@coveo/headless#build   atomic#build: 2638e62a4830131a   build: 2638e62a4830131a   storybook: 2638e62a4830131a
shared tasks: 19  identical: 19
```

Nothing is lost by not routing the test task through Turbo: those task hashes were unique per shard, Quantic's `e2e` already sets `cache: false`, and reports are published as artifacts rather than restored from cache.

## Validation

- Hash comparison above, with controls.
- Confirmed the shard flag reaches the runner. `pnpm run <script> -- --shard=…` forwards the `--` literally, producing `playwright test -- --shard=1/12`, which Playwright reads as a positional filter and would have silently run the wrong tests. The committed form omits `--` and yields `playwright test --shard=1/12`.
- The a11y reporter derives the shard from `process.argv` (`packages/atomic-a11y/src/reporter/shard-resolution.ts`), so `a11y-report.shard-N.json` naming is unaffected.
- YAML parses for both files; `pnpm run lint:fix` clean.

Note that this PR's own CI cannot exercise the change: it touches only CI config, so the affected-task calculation leaves every sharded job `skipped`. Validated separately in #8438, a throwaway PR carrying this branch plus a one-line touch in `packages/atomic` to schedule those jobs.

### Unrelated issue, not fixed here

Some artifacts fail to upload to the remote cache at all:

```
413 Request Entity Too Large -> 3 Next.js sample builds
502 Bad Gateway              -> @coveo/headless:build, @coveo/cdn:build
```

`/v8/artifacts/status` returns `{"status":"enabled"}`, so the service is up; this looks like a payload-size limit on the Lambda Function URL. It needs a change on the cache service rather than in this repo, and `@coveo/headless:build` is exactly the artifact these jobs most want to restore.