### PR TITLE
perf(atomic): [NOT VIABLE] two Playwright workers per shard in CI

### DIFF
--- a/packages/atomic/playwright.config.ts
+++ b/packages/atomic/playwright.config.ts
@@ -19,7 +19,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   snapshotPathTemplate: '{testDir}/{testFileDir}/__snapshots__/{arg}{ext}',
-  workers: process.env.CI ? 1 : undefined,
+  // CI runners have 4 vCPUs. The Storybook dev server shares them with the
+  // browsers, so this stays well below the core count rather than matching it.
+  workers: process.env.CI ? 2 : undefined,
   reporter: process.env.CI ? [['html'], ['list'], ['github'], ['blob']] : [['html'], ['list']],
   use: {
     trace: 'retain-on-failure',


### PR DESCRIPTION
## Result: do not merge

Measured in run [33533064693](https://github.com/coveo/ui-kit/actions/runs/33533064693). Two workers made things **worse on both axes**: no speedup, and substantial new flakiness. Keeping the PR open only as a record of the experiment.

## Measurements

Two shards failed outright and five more reported flaky tests. Baseline had zero of either.

| Shard | Result with 2 workers | Baseline (1 worker) |
| --- | --- | --- |
| 1 | 45 passed (3.9m) | — |
| 2 | 44 passed (2.9m) | — |
| 3 | **1 failed**, 39 passed, 4 flaky (4.9m) | 44 passed (3.6m) |
| 4 | 41 passed, 2 flaky (3.8m) | — |
| 5 | 43 passed, 1 flaky (3.4m) | — |
| 7 | 43 passed, 1 flaky (3.1m) | 44 passed (3.8m) |
| 8 | 42 passed, 2 flaky (3.7m) | — |
| 9 | 43 passed, 1 flaky (3.7m) | — |
| 10 | 39 passed (2.5m) | 39 passed (2.9m) |
| 12 | **3 failed**, 41 passed (3.9m) | — |

Test durations landed at 2.5–4.9m against a 2.9–3.8m baseline. No improvement, and the spread got worse once retries of flaky tests are counted.

## Why it does not work

The failures are all the same shape — `expect(locator).toBeVisible() failed` / `element(s) not found` — spread across unrelated components (`atomic-commerce-query-error`, `atomic-commerce-refine-modal`, `atomic-commerce-search-box`) and across the Storybook MDX doc pages in shard 12.

That points at the `webServer`, not at CPU. Both workers share one `storybook dev` instance, and Vite compiles stories on demand. A second worker does not get a second server; it queues behind the same one, so pages are requested before their modules are ready and locators never resolve. Adding workers adds contention rather than throughput, which explains why the wall clock did not move.

## Consequence

Raising workers is blocked on removing that shared bottleneck first. The relevant change is the one previously dismissed as "only ~6 seconds": `e2e` already builds `dist-storybook` via its dependency on `build`, but the tests run against `storybook dev` instead. Serving the static build removes on-demand compilation entirely, which is a prerequisite for any intra-shard parallelism — not merely a 6-second build saving.

Suggested order:
1. Serve the static Storybook build in the e2e `webServer` instead of `storybook dev`.
2. Re-run this experiment on top of that.