### PR TITLE
test(ci): TEMPORARY validation of PR 8436 - do not merge or review

### DIFF
--- a/.github/actions/playwright-quantic/action.yml
+++ b/.github/actions/playwright-quantic/action.yml
@@ -15,8 +15,14 @@ runs:
         pattern: quantic-playwright-env-*
         path: packages/quantic/.env
         merge-multiple: true
+    - name: Build Quantic and its dependencies
+      # Keep the build in its own argument-free Turbo invocation: passing
+      # `--shard` through `turbo run -- ...` folds the arguments into the hash
+      # of every task in the graph, defeating the remote cache for each shard.
+      run: pnpm exec turbo run '@coveo/quantic#build' --no-update-notifier
+      shell: bash
     - name: Run Playwright Tests
-      run: pnpm exec turbo run @coveo/quantic#e2e -- --shard=${INPUTS_SHARDINDEX}/${INPUTS_SHARDTOTAL}
+      run: pnpm --filter @coveo/quantic run e2e --shard=${INPUTS_SHARDINDEX}/${INPUTS_SHARDTOTAL}
       shell: bash
       env:
         INPUTS_SHARDINDEX: ${{ inputs.shardIndex }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,9 +478,15 @@ jobs:
           fetch-tags: false
           filter: blob:none
       - uses: ./.github/actions/setup
+      # Build in a separate, argument-free Turbo invocation. Passing `--shard`
+      # through `turbo run -- ...` folds the arguments into the hash of every
+      # task in the graph, so each shard produced unique build hashes and could
+      # never reuse the remote cache.
+      - name: Build Atomic and its dependencies
+        run: pnpm exec turbo run '@coveo/atomic#build' --no-update-notifier
       - name: Run Playwright tests
         id: playwright
-        run: pnpm exec turbo run '@coveo/atomic#e2e' -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: pnpm --filter @coveo/atomic run e2e --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         continue-on-error: true
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
@@ -574,7 +580,11 @@ jobs:
           filter: blob:none
       - run: git branch main origin/main
       - uses: ./.github/actions/setup
-      - run: pnpm exec turbo run test:storybook --filter=@coveo/atomic -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      # See the Playwright job: keep the build invocation free of passthrough
+      # arguments so its task hashes are shared across shards.
+      - name: Build Atomic and its dependencies
+        run: pnpm exec turbo run build --filter=@coveo/atomic --no-update-notifier
+      - run: pnpm --filter @coveo/atomic run test:storybook --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: 'Upload a11y shard report'
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/packages/atomic/playwright.config.ts
+++ b/packages/atomic/playwright.config.ts
@@ -12,6 +12,8 @@ const DEFAULT_DESKTOP_VIEWPORT = {
   height: 1080,
 };
 
+// TEMPORARY: touch this file so the affected-task calculation schedules the
+// sharded Atomic jobs, which a CI-config-only change does not. Not for merge.
 export default defineConfig({
   testDir: './src',
   testMatch: '*.e2e.ts',


### PR DESCRIPTION
Throwaway PR. Exists only so the sharded Atomic jobs actually run against the Turbo cache fix in #8436 — a CI-config-only change leaves those jobs `skipped`, so #8436's own green CI proves nothing.

Contains #8436 plus a comment in `packages/atomic/playwright.config.ts` to make the affected-task calculation schedule the jobs.

Will be closed and the branch deleted once measured.