### PR TITLE
fix(atomic-angular): assign inputs as properties instead of attributes

### DIFF
--- a/.changeset/atomic-angular-property-inputs.md
+++ b/.changeset/atomic-angular-property-inputs.md
@@ -1,0 +1,11 @@
+---
+'@coveo/atomic-angular': patch
+---
+
+Assign inputs as properties instead of attributes, so array and object inputs reach the underlying Atomic component intact.
+
+`proxyInputs` wrote every input through `setAttribute`. Attributes are strings, so an array binding such as `[fieldsToInclude]="['snrating']"` arrived as the string `"snrating"` and the component parsed it back as an empty array, while `[allowedValues]` arrived as `null`. `atomic-facet` then threw `TypeError: Cannot read properties of null (reading 'length')` and never rendered. Strings and numbers were unaffected, so the failure only appeared for the inputs that take structured values.
+
+Inputs are now assigned to the element as properties, which preserves their type.
+
+This also removes the wrapper's import of `@coveo/atomic/custom-elements-manifest`. It existed only to map property names to attribute names for the `setAttribute` call, and that mapping has no remaining consumer. The manifest is a 1.7 MB JSON document that bundlers inline into the application, so removing the import takes roughly 1 MB out of every consumer's bundle.

--- a/packages/atomic-angular/projects/atomic-angular/src/utils.ts
+++ b/packages/atomic-angular/projects/atomic-angular/src/utils.ts
@@ -1,32 +1,6 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any -- Copied file from stencil angular output */
 
-import customElementsManifest from '@coveo/atomic/custom-elements-manifest';
 import {fromEvent} from 'rxjs';
-
-const createPropertyToAttributeMap = (): Map<string, string> => {
-  const map = new Map<string, string>();
-
-  customElementsManifest.modules.forEach((module: any) => {
-    module.declarations?.forEach((declaration: any) => {
-      if (declaration.kind === 'class' && declaration.attributes) {
-        declaration.attributes.forEach((attr: any) => {
-          if (attr.fieldName && attr.name) {
-            map.set(attr.fieldName, attr.name);
-          }
-        });
-      }
-    });
-  });
-
-  return map;
-};
-
-const propertyToAttributeMap = createPropertyToAttributeMap();
-
-const getAttributeName = (propertyName: string): string => {
-  const mappedAttr = propertyToAttributeMap.get(propertyName);
-  return mappedAttr || propertyName.replace(/([A-Z])/g, '-$1').toLowerCase();
-};
 
 export const proxyInputs = (Cmp: any, inputs: string[]) => {
   const Prototype = Cmp.prototype;
@@ -37,8 +11,7 @@ export const proxyInputs = (Cmp: any, inputs: string[]) => {
       },
       set(val: any) {
         this.z.runOutsideAngular(() => {
-          const attrName = getAttributeName(item);
-          this.el.setAttribute(attrName, val);
+          this.el[item] = val;
         });
       },
       /**


### PR DESCRIPTION
[KIT-6126](https://coveord.atlassian.net/browse/KIT-6126)

## Problem

`proxyInputs` wrote inputs with `setAttribute`. Attributes are strings, so array and object bindings were stringified and could not be parsed back — `atomic-facet` gets `null` and throws. The manifest import existed only to compute those attribute names.

```diff
- const attrName = getAttributeName(item);
- this.el.setAttribute(attrName, val);
+ this.el[item] = val;
```

That one swap makes 27 lines and a 1 MB JSON import dead code.

## Before

```mermaid
graph TD
    A1["utils.ts"] -->|"import"| M1["custom-elements.json<br/><b>1,017.8 kB, inlined by the bundler</b>"]
    M1 --> C1["createPropertyToAttributeMap()<br/>976 modules walked at startup"]
    C1 --> P1["propertyToAttributeMap<br/>560 entries"]
    P1 --> G1["getAttributeName('allowedValues')<br/>→ 'allowed-values'"]
    G1 --> S1["<b>setAttribute('allowed-values', val)</b>"]
    S1 --> X1["attribute = <b>'BBC News,CNN'</b>"]
    X1 --> L1["Lit converter, type: Array<br/>JSON.parse throws"]
    L1 --> E1["allowedValues = <b>null</b>"]
    E1 --> T1["reads .length → <b>TypeError</b>"]

    style M1 fill:#ffdddd,stroke:#cc0000,color:#000
    style X1 fill:#ffdddd,stroke:#cc0000,color:#000
    style E1 fill:#ffdddd,stroke:#cc0000,color:#000
    style T1 fill:#ff9999,stroke:#cc0000,color:#000
```

## After

```mermaid
graph TD
    A2["utils.ts"] --> S2["<b>this.el[item] = val</b>"]
    S2 --> E2["allowedValues = <b>['BBC News','CNN']</b>"]
    E2 --> T2["reads .length → <b>renders</b>"]

    style S2 fill:#ddffdd,stroke:#00aa00,color:#000
    style E2 fill:#ddffdd,stroke:#00aa00,color:#000
    style T2 fill:#99ff99,stroke:#00aa00,color:#000
```

Every node above except `utils.ts` and the setter is deleted.

## Effect

| Binding | Before | After |
| --- | --- | --- |
| `[label]="'Source'"` | `"Source"` ✅ | `"Source"` ✅ |
| `[numberOfValues]="8"` | `8` ✅ | `8` ✅ |
| `[fieldsToInclude]="['a','b']"` | `[]` ❌ | `['a','b']` ✅ |
| `[allowedValues]="['BBC','CNN']"` | `null` ❌ throws | `['BBC','CNN']` ✅ |
| `[dateFormat]="{year:'numeric'}"` | `"[object Object]"` ❌ | `{year:'numeric'}` ✅ |

| `utils.ts` | Before | After |
| --- | --- | --- |
| Lines | 102 | 75 |
| Imports | 2 | 1 |
| Data imported | 1,017.8 kB | 0 |
| Exported API | 5 symbols | 5, identical |

```mermaid
pie showData title Consumer main chunk BEFORE — 2,859 kB
    "custom-elements.json (removed here)" : 1018
    "wrapper + elements + headless" : 1841
```

React's wrapper chunk is 1,308.7 kB, so the manifest is 66% of the gap. It appears in no other consumption path: `javascript-module` count is 976 in `angular-wrapper`, 0 in `react-wrapper`, `react-selective`, `angular-lazy` and `vanilla-lazy`.

## Verification

```
imports custom-elements-manifest: false
setAttribute in proxyInputs: false
getAttributeName gone: true
elements still registered: 179 defines
fesm: 369.3 kB (was 372.0)
```

Both Angular samples build. They bind nothing to an `atomic-*` element and pass `fields-to-include` as a static attribute, which is why they never hit this. Validated end-to-end earlier in a vendored copy: the facet renders.

## One behaviour change, and why it is correct

Inputs no longer pass through Lit's attribute converters, so binding a *string* to a typed input is no longer coerced: `[isCollapsed]="'false'"` used to arrive as boolean `false` and now arrives as the string `'false'`. That reverts the mechanism of #6082 ([KIT-5070](https://coveord.atlassian.net/browse/KIT-5070)), so it deserves a look — but it is how a framework wrapper is supposed to behave. Converters exist to turn markup strings into typed values; a binding already has the typed value and should set the property. Measured in the sample apps, `@coveo/atomic-react` gives byte-identical results to this branch on all three bindings, since `@lit/react` also assigns properties. This makes the two wrappers consistent rather than diverging.

Real values are unaffected — `[isCollapsed]="false"` yields `false`, and arrays now arrive intact where they previously did not. Passing a string where a boolean is declared is a type error `strictTemplates` would reject if it were not cast. The other string case, `[tabsIncluded]="'a,b'"`, is broken on the published wrapper too (it yields `[]`), so it is not a regression either.

## Notes

- **No regression test** — `atomic-angular` has no vitest project. `proxyInputs` is testable without TestBed. Happy to add it here.
- The [docs workaround](https://docs.coveo.com/en/atomic/latest/usage/frameworks/atomic-angular-wrapper/) also calls `setAttribute`, so it has the same defect and only works for strings. It should now collapse to a plain binding.
- Remaining fixed cost is the 178 element classes retained by `AtomicAngularModule` and `@ProxyCmp`. Separate, breaking. Analysis in `~/dev/project-docs/atomic-angular-investigation/fixed-bundle-cost.md`.

[KIT-6126]: https://coveord.atlassian.net/browse/KIT-6126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[KIT-5070]: https://coveord.atlassian.net/browse/KIT-5070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ