### PR TITLE
feat(meta): add catalogs for public packages

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,12 +6,24 @@ spec:
   type: url
   targets:
     - ./catalog-info.ui-kit.yaml
+    - ./packages/atomic-angular/projects/atomic-angular/catalog-info.yaml
     - ./packages/atomic-hosted-page/catalog-info.yaml
+    - ./packages/atomic-legacy/catalog-info.yaml
     - ./packages/atomic-react/catalog-info.yaml
     - ./packages/atomic/catalog-info.yaml
+    - ./packages/auth/catalog-info.yaml
     - ./packages/bueno/catalog-info.yaml
+    - ./packages/coveo-analytics/catalog-info.yaml
+    - ./packages/create-atomic-component-project/catalog-info.yaml
+    - ./packages/create-atomic-component/catalog-info.yaml
+    - ./packages/create-atomic-result-component/catalog-info.yaml
+    - ./packages/create-atomic-rollup-plugin/catalog-info.yaml
+    - ./packages/create-atomic/catalog-info.yaml
+    - ./packages/create-ui/catalog-info.yaml
     - ./packages/headless-react/catalog-info.yaml
     - ./packages/headless/catalog-info.yaml
     - ./packages/quantic/catalog-info.yaml
+    - ./packages/relay/catalog-info.yaml
     - ./packages/shopify/catalog-info.yaml
+    - ./packages/thermidor-schema/catalog-info.yaml
     - ./packages/thermidor/catalog-info.yaml

--- a/packages/atomic-angular/projects/atomic-angular/catalog-info.config.yaml
+++ b/packages/atomic-angular/projects/atomic-angular/catalog-info.config.yaml
@@ -1,0 +1,2 @@
+lifecycle: production
+owner: group:default/dxui

--- a/packages/atomic-angular/projects/atomic-angular/catalog-info.yaml
+++ b/packages/atomic-angular/projects/atomic-angular/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: atomic-angular
+  title: '@coveo/atomic-angular'
+  description: An Angular component library for building modern UIs interfacing with the Coveo platform, wrapping the core Atomic web components
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/dxui
+  system: ui-kit
+  dependsOn:
+    - component:atomic
+    - component:headless

--- a/packages/atomic-legacy/catalog-info.config.yaml
+++ b/packages/atomic-legacy/catalog-info.config.yaml
@@ -1,0 +1,2 @@
+lifecycle: production
+owner: group:default/dxui

--- a/packages/atomic-legacy/catalog-info.yaml
+++ b/packages/atomic-legacy/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: atomic-legacy
+  title: '@coveo/atomic-legacy'
+  description: Package used internally by @coveo/atomic for components using legacy technologies (e.g., Stencil). This package is not intended for public use.
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/dxui
+  system: ui-kit
+  dependsOn:
+    - component:headless

--- a/packages/atomic/catalog-info.yaml
+++ b/packages/atomic/catalog-info.yaml
@@ -10,5 +10,6 @@ spec:
   owner: group:default/dxui
   system: ui-kit
   dependsOn:
+    - component:atomic-legacy
     - component:bueno
     - component:headless

--- a/packages/auth/catalog-info.config.yaml
+++ b/packages/auth/catalog-info.config.yaml
@@ -1,0 +1,2 @@
+lifecycle: production
+owner: group:default/dxui

--- a/packages/auth/catalog-info.yaml
+++ b/packages/auth/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: auth
+  title: '@coveo/auth'
+  description: Functions to help authenticate with the Coveo platform.
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/dxui
+  system: ui-kit

--- a/packages/coveo-analytics/catalog-info.config.yaml
+++ b/packages/coveo-analytics/catalog-info.config.yaml
@@ -1,0 +1,2 @@
+lifecycle: production
+owner: group:default/dxui

--- a/packages/coveo-analytics/catalog-info.yaml
+++ b/packages/coveo-analytics/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: coveo.analytics
+  title: coveo.analytics
+  description: 📈 Coveo analytics client (node and browser compatible) 
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/dxui
+  system: ui-kit

--- a/packages/coveo-analytics/catalog-info.yaml
+++ b/packages/coveo-analytics/catalog-info.yaml
@@ -3,7 +3,7 @@ kind: Component
 metadata:
   name: coveo.analytics
   title: coveo.analytics
-  description: 📈 Coveo analytics client (node and browser compatible) 
+  description: 📈 Coveo analytics client (node and browser compatible)
 spec:
   type: library
   lifecycle: production

--- a/packages/create-atomic-component-project/catalog-info.config.yaml
+++ b/packages/create-atomic-component-project/catalog-info.config.yaml
@@ -1,0 +1,2 @@
+lifecycle: production
+owner: group:default/dxui

--- a/packages/create-atomic-component-project/catalog-info.yaml
+++ b/packages/create-atomic-component-project/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: create-atomic-component-project
+  title: '@coveo/create-atomic-component-project'
+  description: Initialize a Coveo Atomic Library Project
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/dxui
+  system: ui-kit

--- a/packages/create-atomic-component/catalog-info.config.yaml
+++ b/packages/create-atomic-component/catalog-info.config.yaml
@@ -1,0 +1,2 @@
+lifecycle: production
+owner: group:default/dxui

--- a/packages/create-atomic-component/catalog-info.yaml
+++ b/packages/create-atomic-component/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: create-atomic-component
+  title: '@coveo/create-atomic-component'
+  description: Initialize a Coveo Atomic Component
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/dxui
+  system: ui-kit
+  dependsOn:
+    - component:create-atomic-component-project

--- a/packages/create-atomic-result-component/catalog-info.config.yaml
+++ b/packages/create-atomic-result-component/catalog-info.config.yaml
@@ -1,0 +1,2 @@
+lifecycle: production
+owner: group:default/dxui

--- a/packages/create-atomic-result-component/catalog-info.yaml
+++ b/packages/create-atomic-result-component/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: create-atomic-result-component
+  title: '@coveo/create-atomic-result-component'
+  description: Initialize a Coveo Atomic Result Component
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/dxui
+  system: ui-kit
+  dependsOn:
+    - component:create-atomic-component-project

--- a/packages/create-atomic-rollup-plugin/catalog-info.config.yaml
+++ b/packages/create-atomic-rollup-plugin/catalog-info.config.yaml
@@ -1,0 +1,2 @@
+lifecycle: production
+owner: group:default/dxui

--- a/packages/create-atomic-rollup-plugin/catalog-info.yaml
+++ b/packages/create-atomic-rollup-plugin/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: create-atomic-rollup-plugin
+  title: '@coveo/create-atomic-rollup-plugin'
+  description: Rollup plugin for resolving Coveo Atomic dependencies from CDN or npm
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/dxui
+  system: ui-kit

--- a/packages/create-atomic/catalog-info.config.yaml
+++ b/packages/create-atomic/catalog-info.config.yaml
@@ -1,0 +1,2 @@
+lifecycle: production
+owner: group:default/dxui

--- a/packages/create-atomic/catalog-info.yaml
+++ b/packages/create-atomic/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: create-atomic
+  title: '@coveo/create-atomic'
+  description: Coveo Atomic Generator
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/dxui
+  system: ui-kit

--- a/packages/create-ui/catalog-info.config.yaml
+++ b/packages/create-ui/catalog-info.config.yaml
@@ -1,0 +1,2 @@
+lifecycle: production
+owner: group:default/dxui

--- a/packages/create-ui/catalog-info.yaml
+++ b/packages/create-ui/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: create-ui
+  title: '@coveo/create-ui'
+  description: Scaffold a Coveo UI project (Atomic or Headless) from the official samples.
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/dxui
+  system: ui-kit

--- a/packages/headless/catalog-info.yaml
+++ b/packages/headless/catalog-info.yaml
@@ -11,3 +11,5 @@ spec:
   system: ui-kit
   dependsOn:
     - component:bueno
+    - component:coveo.analytics
+    - component:relay

--- a/packages/quantic/catalog-info.yaml
+++ b/packages/quantic/catalog-info.yaml
@@ -11,4 +11,5 @@ spec:
   system: ui-kit
   dependsOn:
     - component:bueno
+    - component:coveo.analytics
     - component:headless

--- a/packages/relay/catalog-info.config.yaml
+++ b/packages/relay/catalog-info.config.yaml
@@ -1,0 +1,2 @@
+lifecycle: production
+owner: group:default/dxui

--- a/packages/relay/catalog-info.yaml
+++ b/packages/relay/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: relay
+  title: '@coveo/relay'
+  description: A library for sending analytics events using Coveo's Event protocol.
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/dxui
+  system: ui-kit

--- a/packages/shopify/catalog-info.yaml
+++ b/packages/shopify/catalog-info.yaml
@@ -11,3 +11,4 @@ spec:
   system: ui-kit
   dependsOn:
     - component:headless
+    - component:relay

--- a/packages/thermidor-schema/catalog-info.config.yaml
+++ b/packages/thermidor-schema/catalog-info.config.yaml
@@ -1,0 +1,2 @@
+lifecycle: production
+owner: group:default/dxui

--- a/packages/thermidor-schema/catalog-info.yaml
+++ b/packages/thermidor-schema/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: thermidor-schema
+  title: '@coveo/thermidor-schema'
+  description: Versioned JSON Schema-derived Zod contracts for Thermidor controllers
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/dxui
+  system: ui-kit

--- a/packages/thermidor/catalog-info.yaml
+++ b/packages/thermidor/catalog-info.yaml
@@ -9,3 +9,5 @@ spec:
   lifecycle: experimental
   owner: group:default/dxui
   system: ui-kit
+  dependsOn:
+    - component:thermidor-schema

--- a/scripts/generate/catalog-info.mjs
+++ b/scripts/generate/catalog-info.mjs
@@ -15,7 +15,7 @@
 import {readFileSync, writeFileSync, existsSync} from 'node:fs';
 import {resolve, relative} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {getAllPackageDirs} from '../packages.mjs';
+import {getAllPackageDirs, getPackageManifestFromPackagePath} from '../packages.mjs';
 
 const rootDir = resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const packagesDir = resolve(rootDir, 'packages');
@@ -47,6 +47,10 @@ function parseSimpleYaml(filePath) {
  */
 function getComponentName(name) {
   return name.replace(/^@[^/]+\//, '');
+}
+
+function isPublicPackage(manifest) {
+  return manifest.private !== true;
 }
 
 /**
@@ -196,18 +200,45 @@ function getWorkspaceDependsOn(manifest, catalogComponents) {
 
 function main() {
   const packageDirs = getAllPackageDirs(rootDir);
+  const exampleConfigPath = resolve(packagesDir, 'headless', 'catalog-info.config.yaml');
+  const exampleConfigRelativePath = relative(rootDir, exampleConfigPath);
+  const exampleConfig = readFileSync(exampleConfigPath, 'utf-8').trimEnd();
 
   /** @type {Map<string, {manifest: object, config: Record<string, string>}>} */
   const catalogPackages = new Map();
+  const missingPublicConfigs = [];
 
   for (const dir of packageDirs) {
-    const configPath = resolve(packagesDir, dir, 'catalog-info.config.yaml');
-    if (!existsSync(configPath)) continue;
+    const packagePath = resolve(packagesDir, dir);
+    const manifest = getPackageManifestFromPackagePath(packagePath);
+    const configPath = resolve(packagePath, 'catalog-info.config.yaml');
 
-    const manifestPath = resolve(packagesDir, dir, 'package.json');
-    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    if (!existsSync(configPath)) {
+      if (isPublicPackage(manifest)) {
+        missingPublicConfigs.push(dir);
+      }
+      continue;
+    }
+
     const config = parseSimpleYaml(configPath);
     catalogPackages.set(dir, {manifest, config});
+  }
+
+  if (missingPublicConfigs.length) {
+    const missingConfigs = missingPublicConfigs.map((dir) => `- ${dir}`).join('\n');
+    const errorMessage = [
+      'Packages missing catalog-info.config.yaml files:',
+      missingConfigs,
+      '',
+      'Create a catalog-info.config.yaml in each listed package.',
+      `For example, use the contents of ${exampleConfigRelativePath}:`,
+      '',
+      exampleConfig,
+      '',
+    ].join('\n');
+    console.error(errorMessage);
+
+    throw new Error('Some packages are missing catalog-info.config.yaml files');
   }
 
   const catalogComponents = new Set(

--- a/scripts/generate/catalog-info.mjs
+++ b/scripts/generate/catalog-info.mjs
@@ -12,9 +12,10 @@
  *   node scripts/generate/catalog-info.mjs
  */
 
-import {readFileSync, writeFileSync, readdirSync, statSync, existsSync} from 'node:fs';
+import {readFileSync, writeFileSync, existsSync} from 'node:fs';
 import {resolve, relative} from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {getAllPackageDirs} from '../packages.mjs';
 
 const rootDir = resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const packagesDir = resolve(rootDir, 'packages');
@@ -194,10 +195,7 @@ function getWorkspaceDependsOn(manifest, catalogComponents) {
 }
 
 function main() {
-  const packageDirs = readdirSync(packagesDir).filter((dir) => {
-    const fullPath = resolve(packagesDir, dir);
-    return statSync(fullPath).isDirectory() && existsSync(resolve(fullPath, 'package.json'));
-  });
+  const packageDirs = getAllPackageDirs(rootDir);
 
   /** @type {Map<string, {manifest: object, config: Record<string, string>}>} */
   const catalogPackages = new Map();

--- a/scripts/generate/catalog-info.mjs
+++ b/scripts/generate/catalog-info.mjs
@@ -115,7 +115,7 @@ function generateComponentYaml(manifest, config, relations) {
     metadata: {
       name: componentName,
       title: manifest.name,
-      description: manifest.description,
+      description: manifest.description.trim(),
     },
     spec: {
       type: config.type || 'library',


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-6152

## Motivation

The Backstage catalog covered only part of the UI Kit public package surface, and the generator silently skipped public packages without catalog configuration. This left ownership, lifecycle, and dependency metadata incomplete.

## Design decision

I decided to cover all public/published packages since those are the ones that may end up raising ownership questions. 

I understand it's a little broad, but considering that it's automated (it's even in the pre-commit hook), I figured the cost was negligible.

## Changes

- Reuse shared package discovery, including the nested Atomic Angular package.
- Fail generation when a public package lacks `catalog-info.config.yaml`, with remediation instructions.
- Add catalog configuration for all 12 previously missing public packages, including published Atomic Legacy.
- Generate catalog metadata for all 21 public packages and update dependency relations and the root Location.
- Normalize generated package descriptions to avoid formatting errors.

## Validation

- `pnpm run generate:catalog-info` runs idempotently.
- `pnpm run lint:check` passes.
- Targeted `node --check`, `oxfmt`, and `oxlint` checks pass.
- `git diff --check` passes.

## Checklist

- [x] PR title follows Conventional Commits 1.0.0 format (`feat(<scope>): <description>`)
- [ ] Added a changeset: not required because this changes catalog metadata and internal generation tooling, not public package source code.