### PR TITLE
fix(quantic): fixed support for citation anchoring for search agent

### DIFF
--- a/.changeset/chilly-mammals-wave.md
+++ b/.changeset/chilly-mammals-wave.md
@@ -1,0 +1,5 @@
+---
+"@coveo/quantic": patch
+---
+
+fixed support for citation anchoring for search agent

--- a/packages/quantic/force-app/main/default/lwc/quanticCitation/__tests__/quanticCitation.test.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCitation/__tests__/quanticCitation.test.js
@@ -343,6 +343,25 @@ describe('c-quantic-citation', () => {
       });
     });
 
+    describe('when the citation filetype is defined directly on the citation rather than in its fields', () => {
+      it('should generate a text fragment URL', async () => {
+        const element = createTestComponent({
+          ...defaultOptions,
+          citation: {
+            ...exampleCitation,
+            fields: {
+              filetype: undefined,
+            },
+            filetype: 'html',
+          },
+        });
+        await flushPromises();
+
+        const link = element.shadowRoot.querySelector(selectors.citationLink);
+        expect(link.href).toBe(`${exampleCitationUrl}${urlFragment}`);
+      });
+    });
+
     describe('when the citation filetype is not HTML', () => {
       it('should not generate a text fragment URL', async () => {
         const element = createTestComponent({

--- a/packages/quantic/force-app/main/default/lwc/quanticCitation/quanticCitation.js
+++ b/packages/quantic/force-app/main/default/lwc/quanticCitation/quanticCitation.js
@@ -21,7 +21,7 @@ export default class QuanticCitation extends NavigationMixin(LightningElement) {
   /**
    * The citation item information.
    * @api
-   * @type {{title: string, index: number, text: string, uri: string, clickUri: string, fields: object}}
+   * @type {{title: string, index: number, text: string, uri: string, clickUri: string, fields: object, filetype: string}}
    */
   @api citation;
   /**
@@ -78,7 +78,7 @@ export default class QuanticCitation extends NavigationMixin(LightningElement) {
   hideTimer = null;
 
   connectedCallback() {
-    const fileType = this.citation?.fields?.filetype;
+    const fileType = this.citation.filetype ?? this.citation.fields?.filetype;
     this.isHrefWithTextFragment =
       !this.disableCitationAnchoring &&
       supportedFileTypesForTextFragment.includes(fileType) &&


### PR DESCRIPTION
## [SFINT-6920](https://coveord.atlassian.net/browse/SFINT-6920)

## Summary 
For the Search Agent feature the agent API now returns the filetype of citations at the top level of the citation object like : citation.filetype rather than inside the `fields` object like the SearchAPI or the Answer API send.

This PR adjusts the QuanticCitation component to allow it to properly read the `filetype` in all situations allowing the citation anchoring to correctly work in the Search Agent feature.

## After the fix: 

https://github.com/user-attachments/assets/630813b4-f93e-47c5-80db-5676dab73f88





[SFINT-6920]: https://coveord.atlassian.net/browse/SFINT-6920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ