### PR TITLE
docs(create-ui): add the create-a-project guide to --docs output

### DIFF
--- a/.changeset/create-ui-docs-link.md
+++ b/.changeset/create-ui-docs-link.md
@@ -1,0 +1,7 @@
+---
+'@coveo/create-ui': patch
+---
+
+Add the "Create a Coveo search interface project" guide to the `--docs` output.
+
+`create-ui --docs` now lists https://docs.coveo.com/en/q8qh2338 under "Create a project", alongside the docs home, Atomic, and Headless links.

--- a/packages/create-ui/src/index.test.ts
+++ b/packages/create-ui/src/index.test.ts
@@ -112,6 +112,7 @@ describe('main', () => {
     out.mockRestore();
     const output = chunks.join('');
     expect(output).toContain('https://docs.coveo.com');
+    expect(output).toContain('https://docs.coveo.com/en/q8qh2338');
     expect(output).toContain('https://docs.coveo.com/en/atomic/latest');
     expect(output).toContain('https://docs.coveo.com/en/headless/latest');
   });

--- a/packages/create-ui/src/index.ts
+++ b/packages/create-ui/src/index.ts
@@ -18,14 +18,13 @@ import {describeTemplate, getTemplates} from './templates.js';
 import {buildCrashDisclosure, isTrackingDisabled} from './telemetry.js';
 import {formatError} from './utils.js';
 
-// TODO: (KIT-5833): add a link to the "How to use @coveo/create-ui" guide here
-// once that documentation page is published.
 const DOCS = `
 Coveo documentation:
 
-  Docs home   https://docs.coveo.com
-  Atomic      https://docs.coveo.com/en/atomic/latest
-  Headless    https://docs.coveo.com/en/headless/latest
+  Docs home          https://docs.coveo.com
+  Create a project   https://docs.coveo.com/en/q8qh2338
+  Atomic             https://docs.coveo.com/en/atomic/latest
+  Headless           https://docs.coveo.com/en/headless/latest
 `;
 
 function buildProgram(): Command {


### PR DESCRIPTION
[KIT-5833](https://coveord.atlassian.net/browse/KIT-5833)

## Problem

`create-ui --docs` printed only the docs home, Atomic, and Headless links. There was no pointer to a guide explaining what to do with the project the CLI just scaffolded, because no such page existed when the flag was written — a `TODO: (KIT-5833)` in `packages/create-ui/src/index.ts` held the spot until one was published.

That guide now exists: [Create a Coveo search interface project](https://docs.coveo.com/en/q8qh2338).

## Solution

Added the guide to the `DOCS` constant under the label "Create a project", matching the page title and the wording already used in the Atomic docs navigation, and removed the resolved TODO:

```
  Docs home          https://docs.coveo.com
  Create a project   https://docs.coveo.com/en/q8qh2338
  Atomic             https://docs.coveo.com/en/atomic/latest
  Headless           https://docs.coveo.com/en/headless/latest
```

Label column re-padded to keep the URLs aligned. Extended the existing `--docs` assertion in `index.test.ts` to cover the new link.

[KIT-5833]: https://coveord.atlassian.net/browse/KIT-5833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ