### PR TITLE
fix(ci): restore Codespaces prebuilds j:kit-282

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get update && apt-get install -y \
 # Enable corepack globally
 RUN corepack enable
 
-# Configure pnpm home and path
+# Configure pnpm home and path, including pnpm 11's global bin directory
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
 
 # Configure pnpm to use the mounted store directory
 ENV PNPM_STORE_PATH="/pnpm/store"


### PR DESCRIPTION
## Jira

https://coveord.atlassian.net/browse/KIT-282

## Motivation

Codespaces prebuilds have failed while creating the devcontainer image since pnpm 11 was introduced. The image build stops before dependencies or workspace packages can be prebuilt.

## Root Cause

pnpm 11 resolves its global executable directory to `/pnpm/bin`, while the devcontainer only added `/pnpm` to `PATH`. As a result, `pnpm add -g turbo@2.5.5` refuses to install Turbo because its configured global bin directory is not reachable from `PATH`.

## Changes

Add pnpm 11's `/pnpm/bin` global executable directory to the devcontainer `PATH`, while retaining `/pnpm` for Corepack's pnpm shim.

## Validation

- Built the complete devcontainer Dockerfile successfully with the same pinned Node image and pnpm 11.24.0.
- Confirmed the image installs Turbo 2.5.5 into `/pnpm/bin` and resolves it from `PATH`.
- Ran `pnpm run lint:fix` successfully.
- Ran `git diff --check` successfully.

## Checklist

- [x] PR title follows [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) format (`fix(<scope>): <description>`)
- [x] [Added a changeset](https://changesets.dev/guide/getting-started) if modifying public package source code (N/A: devcontainer-only fix)
