### PR TITLE
fix(atomic): migrate Storybook preview to msw-storybook-addon v3

### DIFF
--- a/packages/atomic/.storybook/preview.ts
+++ b/packages/atomic/.storybook/preview.ts
@@ -2,7 +2,8 @@ import '@/src/themes/coveo.css';
 import type {Preview} from '@storybook/web-components-vite';
 import {setCustomElementsManifest} from '@storybook/web-components-vite';
 import {setStorybookHelpersConfig} from '@wc-toolkit/storybook-helpers';
-import {initialize, mswLoader} from 'msw-storybook-addon';
+import {setupWorker} from 'msw/browser';
+import {mswLoader} from 'msw-storybook-addon/csf3';
 import {within} from 'shadow-dom-testing-library';
 import {create} from 'storybook/theming';
 import customElements from '../custom-elements.json';
@@ -17,11 +18,19 @@ if (!isChromatic() && import.meta.env.PROD) {
   import(url.href);
 }
 
-initialize({
-  quiet: true,
-  onUnhandledRequest: 'bypass',
-  serviceWorker: {url: './mockServiceWorker.js'},
-});
+// msw-storybook-addon v3 starts the worker itself, but its default setup warns on
+// unhandled requests and resolves the worker script from the server root. Keep the
+// previous behaviour: stay silent, and use a relative URL so Storybook keeps working
+// when served from a sub-path (CDN builds).
+const startWorker = async () => {
+  const worker = setupWorker();
+  await worker.start({
+    quiet: true,
+    onUnhandledRequest: 'bypass',
+    serviceWorker: {url: './mockServiceWorker.js'},
+  });
+  return worker;
+};
 
 setCustomElementsManifest(customElements);
 
@@ -31,7 +40,7 @@ setStorybookHelpersConfig({
 });
 
 const preview: Preview = {
-  loaders: [mswLoader],
+  loaders: [mswLoader(startWorker)],
   parameters: {
     options: {
       storySort: {


### PR DESCRIPTION
Stacked on top of #8433, which bumps `msw-storybook-addon` 2.0.7 → 3.0.0. Targets `renovate/major-dev` rather than `main` because the v3 API does not exist on `main` — landing this alone would break the Storybook build there.

## Problem

#8433 is red on `Build`, `Build CDN`, `Build Windows` and `Publish Preview Packages`. All four fail on the same task, `@coveo/atomic#build:storybook`:

```
[MISSING_EXPORT] "initialize" is not exported by msw-storybook-addon
[MISSING_EXPORT] "mswLoader" is not exported by msw-storybook-addon
  ╭─[ .storybook/preview.ts:4 ]
```

v3 removed both top-level exports. Its entire surface is now `.` → `addonMsw` (default), `./preview` → `createPreviewAnnotations`, `./csf3` → `mswLoader`, `./types`. The loader took over the worker lifecycle: `mswLoader` moved to the `csf3` subpath and became a factory (`mswLoader(setup?)`), and `initialize` was dropped.

The remaining two red checks on #8433 are just the `Confirm build is valid` aggregator reporting `success="false"`.

## Solution

Import `mswLoader` from `msw-storybook-addon/csf3` and pass it an explicit setup function.

I deliberately did **not** rely on v3's default setup, which differs from our previous `initialize()` config in two ways that matter:

| | previous / this PR | v3 default |
|---|---|---|
| unhandled requests | `'bypass'` (silent) | `print.warning()` unless a common asset/Storybook request |
| worker script URL | `'./mockServiceWorker.js'` (relative) | resolved from server root |

The relative URL is the important one — CDN builds serve Storybook from a sub-path, so a root-resolved worker script would 404 there.

I also stayed on the `csf3` entry point rather than migrating to the CSF Next `addonMsw()` API (what `npx msw-storybook-migrate` would do). `csf3` still resolves `parameters.msw` in both array and `{handlers}` notation, and **182 story files** use it; CSF Next drops `parameters.msw` in favour of `beforeEach`. That migration is worth doing, but not inside a dependency-unblocking PR.

Note I did not add `'msw-storybook-addon'` to `main.ts` `addons` despite the README's CSF 3.0 snippet suggesting it. The published package ships no preset entry and its `exports` map has no `./preset`, so registering it there would fail to resolve — and reading `csf3.mjs`, the loader is fully self-contained (it memoises the worker, resets handlers per story, and applies `parameters.msw` itself).

## Verification

Local, before pushing:

- `turbo run @coveo/atomic#build:storybook` — passes (13/13 tasks), the exact task that was failing
- `vitest --project=storybook --shard=1/10` and `--shard=2/10` — 38 files, 97 tests passing, exercising MSW interception through the real browser worker
- `lint:check` clean across the monorepo
- `tsc -p tsconfig.storybook.json --noEmit` goes from 1347 to 1345 errors: the two removed are exactly the missing-export errors, and no new ones appear. The remaining 1345 are pre-existing and unrelated (that config is not typechecked standalone in CI).

CI on this PR: **60 checks pass, 0 fail.** Critically, the 19 checks that were *skipped* on #8433 (because `Build` failed there) now run and pass — including all 10 `Run Storybook tests` shards, all 12 `Run Playwright tests for Atomic` shards, `Run unit tests`, `Look for unused code or dependencies`, and `Verify compatibility of packages`.

That also resolves an open question I had flagged: the other majors in #8433 that I expected might break the previously-hidden jobs — `fetch-mock` 9 → 12 (used by `packages/coveo-analytics/tests/fetchMock.ts`) and `fast-check` 3 → 4 (used across `packages/thermidor` and `packages/thermidor-schema`) — turn out to be fine. `Run unit tests` passes, so no follow-up is needed for them.

In other words, this one migration appears to be the only thing standing between #8433 and green.