### PR TITLE
ci(areas): let renovate bypass DXUI review on all areas

### DIFF
--- a/.areas/agents.yml
+++ b/.areas/agents.yml
@@ -8,3 +8,8 @@ file_patterns:
 
 reviewers:
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/atomic.yml
+++ b/.areas/atomic.yml
@@ -15,3 +15,8 @@ file_patterns:
   - samples/atomic/**
 reviewers:
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/bueno.yml
+++ b/.areas/bueno.yml
@@ -3,3 +3,8 @@ file_patterns:
   - packages/bueno/**
 reviewers:
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/case-assist.yml
+++ b/.areas/case-assist.yml
@@ -11,3 +11,8 @@ file_patterns:
 reviewers:
   knowledge-ui-kit-reviewers: ~
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/commerce.yml
+++ b/.areas/commerce.yml
@@ -10,3 +10,8 @@ file_patterns:
 reviewers:
   commerce-routemasters: ~
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/coveo-analytics.yml
+++ b/.areas/coveo-analytics.yml
@@ -3,3 +3,8 @@ file_patterns:
   - packages/coveo-analytics/**
 reviewers:
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/create-ui.yml
+++ b/.areas/create-ui.yml
@@ -3,3 +3,8 @@ file_patterns:
   - packages/create-ui/**
 reviewers:
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/dev.yml
+++ b/.areas/dev.yml
@@ -9,3 +9,8 @@ file_patterns:
 reviewers:
   dxui:
     minimum_approvals: 1
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/documentation.yml
+++ b/.areas/documentation.yml
@@ -9,3 +9,8 @@ file_patterns:
 reviewers:
   dev-writers: ~
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/generated-answer.yml
+++ b/.areas/generated-answer.yml
@@ -15,3 +15,8 @@ file_patterns:
 reviewers:
   knowledge-ui-kit-reviewers: ~
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/github.yml
+++ b/.areas/github.yml
@@ -9,3 +9,8 @@ file_patterns:
 reviewers:
   dxui:
     minimum_approvals: 1
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/headless.yml
+++ b/.areas/headless.yml
@@ -8,3 +8,8 @@ file_patterns:
   - samples/headless/**
 reviewers:
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/insight.yml
+++ b/.areas/insight.yml
@@ -15,3 +15,8 @@ file_patterns:
 reviewers:
   knowledge-ui-kit-reviewers: ~
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/internal-docs.yml
+++ b/.areas/internal-docs.yml
@@ -4,3 +4,8 @@ file_patterns:
 reviewers:
   dev-writers: ~
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/ipx.yml
+++ b/.areas/ipx.yml
@@ -5,3 +5,8 @@ file_patterns:
 reviewers:
   knowledge-ui-kit-reviewers: ~
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/lint.yml
+++ b/.areas/lint.yml
@@ -7,3 +7,8 @@ file_patterns:
 reviewers:
   dxui:
     minimum_approvals: 1
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/node-dependencies.yml
+++ b/.areas/node-dependencies.yml
@@ -12,3 +12,8 @@ file_patterns:
 reviewers:
   dxui:
     minimum_approvals: 1
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/quantic.yml
+++ b/.areas/quantic.yml
@@ -6,3 +6,8 @@ reviewers:
   knowledge-ui-kit-reviewers: ~
   salesforce-integration: ~
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/relay.yml
+++ b/.areas/relay.yml
@@ -4,3 +4,8 @@ file_patterns:
   - packages/relay-playground/**
 reviewers:
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/root.yml
+++ b/.areas/root.yml
@@ -21,3 +21,8 @@ file_patterns:
 reviewers:
   dxui:
     minimum_approvals: 1
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/shopify.yml
+++ b/.areas/shopify.yml
@@ -5,3 +5,8 @@ file_patterns:
 reviewers:
   shopify: ~
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/ssr.yml
+++ b/.areas/ssr.yml
@@ -7,3 +7,8 @@ file_patterns:
 reviewers:
   dxui:
     minimum_approvals: 1
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request

--- a/.areas/thermidor.yml
+++ b/.areas/thermidor.yml
@@ -4,3 +4,8 @@ file_patterns:
 
 reviewers:
   dxui: ~
+
+review_bypass:
+  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # green CI instead of a DXUI review.
+  integration/30846434: pull_request


### PR DESCRIPTION
[KIT-282](https://coveord.atlassian.net/browse/KIT-282)

## Problem

Renovate auto-merge is fully configured but never fires. `coveo/ui-kit` was added to `allow_automerge` in [coveo-platform/renovate#781](https://github.com/coveo-platform/renovate/pull/781), and `renovate.json5` already extends `github>coveo/renovate-presets//auto-merge.json` (`automerge: true`). Despite that, every dependency PR sits open with all checks green.

The blocker is our own `.areas/*.yml` config. The areas action syncs each area into a repository ruleset carrying a `pull_request` rule with `required_reviewers` for team DXUI. Renovate is in no bypass list, so its PRs are `BLOCKED` pending approval.

Verified on #8455: no failing checks, `mergeable: MERGEABLE`, `mergeStateStatus: BLOCKED`, with a pending review request to `coveo/dxui`.

The org-level `Enforce Code Reviews` ruleset is not the problem — `coveo/devtools` shares it (ruleset `12090775`) and its Renovate PRs merge fine with `mergedBy: app/renovate-coveo`.

## Solution

Grant Renovate @ Coveo `pull_request` bypass on **all 23 areas**, via `integration/30846434`.

### Why uniform rather than only the blocking areas

Strictly, only 6 areas block today (`minimum_approvals: 1`): `node-dependencies`, `root`, `github`, `dev`, `ssr`, `lint`. The other 17 use `dxui: ~` (`minimum_approvals: 0`), which requests review without requiring approval, so a bypass there is a no-op *today*.

Applying it everywhere anyway, for three reasons:

1. **Renovate's reach is wider than anyone predicts.** Across the last 100 dependency PRs (96 carry `area:*` labels, applied by the same path matcher the ruleset sync uses), Renovate touched 15 distinct areas: `node-dependencies` (79), `root` (22), `github` (17), `atomic` (15), `dev` (5), `headless` (5), `quantic` (4), `thermidor` (4), `relay` / `coveo-analytics` / `create-ui` (2 each), `commerce` / `generated-answer` / `documentation` / `ssr` (1–2 each). Enumerating by hand is fragile.
2. **A single `minimum_approvals: 0` → `1` flip silently reintroduces the block.** Nothing signals the coupling to whoever edits an area file.
3. **No downside.** The bypass is scoped to one actor. Human contributors are unaffected and still need DXUI approval everywhere it is configured.

`lint` is included on that basis, even though Renovate has touched it 0 times in 96 PRs, so the rule stays "every area" with no carve-outs to reason about.

### One caveat worth recording

Every one of the 96 labelled PRs touched at least one blocking area — none touched only request-only areas. So I could not empirically test whether `require_extra_approval_for_unattributed_changes: true`, which is set on the `min=0` rulesets too, can block a bot PR on its own. Uniform coverage makes the question moot.

### On the actor ID

`30846434` is the **installation ID** of Renovate @ Coveo on the org, which is what [the areas documentation](https://github.com/coveooss/areas) specifies for the `integration/` prefix.

I initially used `245330`, the GitHub **App ID** from `GET /apps/renovate-coveo`, on the theory that the areas docs were wrong. That was not a safe assumption, and my supporting argument for it did not hold up: the `integration/139346` bypass I pointed at as a working precedent was removed from every area file in #7382 as obsolete and now survives only as a snippet in `.areas/README.md`, so nothing in this repo currently demonstrates a working `Integration` bypass either way. Going with what the areas docs say.

If the sync ends up rejecting the actor or the bypass does not take effect, the app ID is the fallback to try.

### Other notes

- `pull_request` rather than `always`, since Renovate only ever needs to bypass in a PR context.
- Dependency PRs remain gated on green CI, which is the safeguard the [Renovate Auto-Merge Guide](https://coveord.atlassian.net/wiki/spaces/RD/pages/3717169254/Renovate+Auto-Merge+Guide) relies on. That guide explicitly calls out this case: the org grants Renovate bypass, but "sometimes, teams have repository specific rules that also need to grant it."
- There is no `angular` area; `packages/atomic-angular/**` is covered by `atomic.yml`.

Merging this triggers `areas-ruleset-sync` on `main`. The currently open dependency PRs predate the `allow_automerge` change, so Renovate has to re-evaluate them before it will act.

[KIT-282]: https://coveord.atlassian.net/browse/KIT-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
