### PR TITLE
ci(areas): fix renovate bypass actor to GitHub App id

### DIFF
--- a/.areas/agents.yml
+++ b/.areas/agents.yml
@@ -10,6 +10,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/atomic.yml
+++ b/.areas/atomic.yml
@@ -17,6 +17,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/bueno.yml
+++ b/.areas/bueno.yml
@@ -5,6 +5,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/case-assist.yml
+++ b/.areas/case-assist.yml
@@ -13,6 +13,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/commerce.yml
+++ b/.areas/commerce.yml
@@ -12,6 +12,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/coveo-analytics.yml
+++ b/.areas/coveo-analytics.yml
@@ -5,6 +5,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/create-ui.yml
+++ b/.areas/create-ui.yml
@@ -5,6 +5,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/dev.yml
+++ b/.areas/dev.yml
@@ -11,6 +11,6 @@ reviewers:
     minimum_approvals: 1
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/documentation.yml
+++ b/.areas/documentation.yml
@@ -11,6 +11,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/generated-answer.yml
+++ b/.areas/generated-answer.yml
@@ -17,6 +17,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/github.yml
+++ b/.areas/github.yml
@@ -11,6 +11,6 @@ reviewers:
     minimum_approvals: 1
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/headless.yml
+++ b/.areas/headless.yml
@@ -10,6 +10,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/insight.yml
+++ b/.areas/insight.yml
@@ -17,6 +17,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/internal-docs.yml
+++ b/.areas/internal-docs.yml
@@ -6,6 +6,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/ipx.yml
+++ b/.areas/ipx.yml
@@ -7,6 +7,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/lint.yml
+++ b/.areas/lint.yml
@@ -9,6 +9,6 @@ reviewers:
     minimum_approvals: 1
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/node-dependencies.yml
+++ b/.areas/node-dependencies.yml
@@ -14,6 +14,6 @@ reviewers:
     minimum_approvals: 1
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/quantic.yml
+++ b/.areas/quantic.yml
@@ -8,6 +8,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/relay.yml
+++ b/.areas/relay.yml
@@ -6,6 +6,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/root.yml
+++ b/.areas/root.yml
@@ -23,6 +23,6 @@ reviewers:
     minimum_approvals: 1
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/shopify.yml
+++ b/.areas/shopify.yml
@@ -7,6 +7,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/ssr.yml
+++ b/.areas/ssr.yml
@@ -9,6 +9,6 @@ reviewers:
     minimum_approvals: 1
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request

--- a/.areas/thermidor.yml
+++ b/.areas/thermidor.yml
@@ -6,6 +6,6 @@ reviewers:
   dxui: ~
 
 review_bypass:
-  # Renovate @ Coveo (installation id 30846434). Dependency PRs are gated on
+  # Renovate @ Coveo (GitHub App id 245330). Dependency PRs are gated on
   # green CI instead of a DXUI review.
-  integration/30846434: pull_request
+  integration/245330: pull_request


### PR DESCRIPTION
[KIT-282](https://coveord.atlassian.net/browse/KIT-282)

## Problem

#8465 configured a Renovate review bypass on all 23 areas, but the `areas-ruleset-sync` run on `main` failed and no ruleset was ever updated (`area:node-dependencies` still shows `updated_at: 2026-07-10`, no `bypass_actors`). As a result, Renovate dependency PRs (e.g. #8455) stay `BLOCKED` on the required DXUI review despite green CI.

The sync failed with:

```
Validation Failed: "Actor  integration must be part of the ruleset source or owner organization",
"Invalid bypass actor: '{{actor_id: 30846434}, {actor_type: Integration}}'"
```

The value `30846434` is Renovate @ Coveo's **installation id**. The `coveooss/areas` action passes the number after `integration/` straight through to GitHub's rulesets API as `actor_id` with `actor_type: Integration` (see `src/bypass-rule-parser.ts`), and GitHub requires the **GitHub App id** for `Integration` bypass actors, not the installation id. The areas README is wrong on this point (it says "installation id"); a follow-up correction PR is being opened against `coveooss/areas`.

## Solution

Swap the bypass actor from the installation id `30846434` to the GitHub App id **`245330`** (`GET /apps/renovate-coveo` → `{"id":245330,"name":"Renovate @ Coveo"}`) across all 23 `.areas/*.yml` files, and correct the accompanying comment wording.

Once merged, `areas-ruleset-sync` re-runs on `main`, applies the bypass to the rulesets, and Renovate merges the open dependency PRs on its next cycle.

[KIT-282]: https://coveord.atlassian.net/browse/KIT-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ