### PR TITLE
ci(areas): bump areas action to areas@0.2.0 (paginated ruleset sync)

### DIFF
--- a/.areas/atomic.yml
+++ b/.areas/atomic.yml
@@ -2,6 +2,7 @@ description: Atomic UI components package
 file_patterns:
   - packages/atomic/**
   - packages/atomic-angular/**
+  - packages/atomic-legacy/**
   - packages/atomic-playground/**
   - packages/atomic-react/**
   - packages/atomic-hosted-page/**

--- a/.areas/thermidor.yml
+++ b/.areas/thermidor.yml
@@ -1,7 +1,6 @@
 description: Thermidor package
 file_patterns:
   - packages/thermidor/**
-  - packages/thermidor-schema/**
 
 reviewers:
   dxui: ~

--- a/.areas/thermidor.yml
+++ b/.areas/thermidor.yml
@@ -1,6 +1,7 @@
 description: Thermidor package
 file_patterns:
   - packages/thermidor/**
+  - packages/thermidor-schema/**
 
 reviewers:
   dxui: ~

--- a/.github/workflows/areas-label-pr.yml
+++ b/.github/workflows/areas-label-pr.yml
@@ -29,7 +29,7 @@ jobs:
           app-id: ${{ vars.CODE_AREAS_APP_ID }}
           private-key: ${{ secrets.CODE_AREAS_PEM }}
 
-      - uses: coveooss/areas@b3ca247fb24809a01a25dc009f6754dd5c06f314 # v0
+      - uses: coveooss/areas@f8f6f24e80b13e412de4132d81e2c17713b41ca7 # areas@0.2.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           command: label-pr

--- a/.github/workflows/areas-ruleset-sync.yml
+++ b/.github/workflows/areas-ruleset-sync.yml
@@ -30,7 +30,7 @@ jobs:
           app-id: ${{ vars.CODE_AREAS_APP_ID }}
           private-key: ${{ secrets.CODE_AREAS_PEM }}
 
-      - uses: coveooss/areas@b3ca247fb24809a01a25dc009f6754dd5c06f314 # v0
+      - uses: coveooss/areas@f8f6f24e80b13e412de4132d81e2c17713b41ca7 # areas@0.2.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           command: ruleset-sync


### PR DESCRIPTION
[KIT-282](https://coveord.atlassian.net/browse/KIT-282)

## Problem

After #8467 fixed the Renovate bypass actor id, `areas-ruleset-sync` got past the actor error but failed with `Validation Failed: "Name must be unique"`. Root cause was a bug in the pinned `coveooss/areas` action: `RulesetManager.getRulesets()` listed rulesets without pagination, so it only saw the first 30. `ui-kit` now has 34 rulesets, so `area:thermidor` (created 2026-07-10, the last successful sync) fell off page 1. The action's `createOrUpdateRuleset` then failed to find it, took the create branch, and GitHub rejected the duplicate name — aborting the whole sync so no bypass was applied.

The fix (paginate `getRulesets`) shipped in `coveooss/areas` **v0.2.0** (coveooss/areas#100), released as tag `areas@0.2.0` → commit `f8f6f24`.

## Solution

1. **Bump the pinned action SHA** in both `areas-ruleset-sync.yml` and `areas-label-pr.yml` from `b3ca247` (`# v0`) to `f8f6f24` (`# areas@0.2.0`). Verified the fix is present in both `src/ruleset-manager.ts` and the bundled `dist/index.js` at that commit.
2. **Add `packages/atomic-legacy/**` to the `atomic` area.** `@coveo/atomic-legacy` is a public package that had no area coverage. This also serves a second purpose: `areas-ruleset-sync` only triggers on pushes touching `.areas/**`, so this change makes the merge self-trigger the resync — using the newly-pinned `f8f6f24` action.

Once merged, `areas-ruleset-sync` runs the paginated action, applies the Renovate `pull_request` bypass to all 23 area rulesets, and Renovate merges the stuck dependency PRs (e.g. #8455) on its next cycle.

> [!NOTE]
> This touches `.github/workflows/**` (the `github` area), so this PR itself requires DXUI review — the bypass is for Renovate, not human contributors.

[KIT-282]: https://coveord.atlassian.net/browse/KIT-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ